### PR TITLE
Automated cherry pick of #14624: Fix the API reference links to use v1beta2 instead of v1beta1.

### DIFF
--- a/site/content/en/docs/concepts/admission_check/_index.md
+++ b/site/content/en/docs/concepts/admission_check/_index.md
@@ -129,5 +129,5 @@ If any of the Workload's AdmissionCheck is in the `Rejected` state:
 
 ## What's next?
 
-- Read the [API reference](/docs/reference/kueue.v1beta1/#kueue-x-k8s-io-v1beta1-AdmissionCheck) for `AdmissionCheck`
+- Read the [API reference](/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-AdmissionCheck) for `AdmissionCheck`
 - Learn more from the built-in [Provisioning Admission Check Controller](/docs/concepts/admission_check/provisioning_request)

--- a/site/content/en/docs/concepts/admission_check/provisioning_request.md
+++ b/site/content/en/docs/concepts/admission_check/provisioning_request.md
@@ -155,7 +155,7 @@ specific) supports setting unique node label on the newly provisioned nodes.
 
 #### Reference
 
-Check the [API definition](https://github.com/kubernetes-sigs/kueue/blob/main/apis/kueue/v1beta1/provisioningrequestconfig_types.go) for more details.
+Check the [API definition](https://github.com/kubernetes-sigs/kueue/blob/main/apis/kueue/v1beta2/provisioningrequestconfig_types.go) for more details.
 
 ### Job annotations
 

--- a/site/content/en/docs/concepts/cluster_queue.md
+++ b/site/content/en/docs/concepts/cluster_queue.md
@@ -531,7 +531,7 @@ assignments are compared by setting `.spec.flavorFungibility.preference`:
 
 ## StopPolicy
 
-StopPolicy allows a cluster administrator to temporary stop the admission of workloads within a ClusterQueue by setting its value in the [spec](/docs/reference/kueue.v1beta1/#kueue-x-k8s-io-v1beta1-ClusterQueueSpec) like:
+StopPolicy allows a cluster administrator to temporary stop the admission of workloads within a ClusterQueue by setting its value in the [spec](/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-ClusterQueueSpec) like:
 
 ```yaml
 apiVersion: kueue.x-k8s.io/v1beta2
@@ -558,4 +558,4 @@ For an example ClusterQueue configuration using admission checks, see [Admission
 - Create [local queues](/docs/concepts/local_queue)
 - Create [resource flavors](/docs/concepts/resource_flavor) if you haven't already done so.
 - Learn how to [administer cluster quotas](/docs/tasks/manage/administer_cluster_quotas).
-- Read the [API reference](/docs/reference/kueue.v1beta1/#kueue-x-k8s-io-v1beta1-ClusterQueue) for `ClusterQueue`
+- Read the [API reference](/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-ClusterQueue) for `ClusterQueue`

--- a/site/content/en/docs/concepts/cohort.md
+++ b/site/content/en/docs/concepts/cohort.md
@@ -82,7 +82,7 @@ spec:
 Cohorts may be organized in a tree structure. We refer to the grouping of ClusterQueues and Cohorts that are part of the same tree as a **CohortTree**.
 
 ClusterQueues within a given CohortTree may use resources within it,
-subject to [Borrowing and Lending limits](/docs/reference/kueue.v1beta1/#kueue-x-k8s-io-v1beta1-ResourceQuota).
+subject to [Borrowing and Lending limits](/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-ResourceQuota).
 These Borrowing and Lending Limits can be specified for Cohorts, as well as for ClusterQueues.
 
 Here is a simple CohortTree, with three Cohorts:

--- a/site/content/en/docs/concepts/local_queue.md
+++ b/site/content/en/docs/concepts/local_queue.md
@@ -38,4 +38,4 @@ kubectl get -n my-namespace queues
 ## What's next?
 
 - Launch a [Workload](/docs/concepts/workload) through a local queue
-- Read the [API reference](/docs/reference/kueue.v1beta1/#kueue-x-k8s-io-v1beta1-LocalQueue) for `LocalQueue`
+- Read the [API reference](/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-LocalQueue) for `LocalQueue`

--- a/site/content/en/docs/concepts/preemption.md
+++ b/site/content/en/docs/concepts/preemption.md
@@ -20,7 +20,7 @@ and any of the following events happen:
 - The preemptee belongs to the same [cohort](/docs/concepts/cluster_queue#cohort) as the preemptor and the preemptee's ClusterQueue has a usage above
   the [nominal quota](/docs/concepts/cluster_queue#resources) for at least one resource that the preemptee and preemptor require.
 
-The configured settings for preemption in the [Kueue Configuration](/docs/reference/kueue-config.v1beta1#FairSharing)
+The configured settings for preemption in the [Kueue Configuration](/docs/reference/kueue-config.v1beta2/#config-kueue-x-k8s-io-v1beta2-FairSharing)
 and in the [ClusterQueue](/docs/concepts/cluster_queue#preemption) can limit whether a Workload can preempt others, in addition
 to the criteria above.
 

--- a/site/content/en/docs/concepts/resource_flavor.md
+++ b/site/content/en/docs/concepts/resource_flavor.md
@@ -93,4 +93,4 @@ Such ResourceFlavor is called an empty ResourceFlavor and its definition looks l
 ## What's next?
 
 - Learn about [cluster queues](/docs/concepts/cluster_queue).
-- Read the [API reference](/docs/reference/kueue.v1beta1/#kueue-x-k8s-io-v1beta1-ResourceFlavor) for `ResourceFlavor`
+- Read the [API reference](/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-ResourceFlavor) for `ResourceFlavor`

--- a/site/content/en/docs/concepts/workload.md
+++ b/site/content/en/docs/concepts/workload.md
@@ -55,7 +55,7 @@ spec:
 ```
 ## Active
 
-You can stop or resume a running workload by setting the [Active](/docs/reference/kueue.v1beta1#kueue-x-k8s-io-v1beta1-WorkloadSpec) field. The active field determines if a workload can be admitted into a queue or continue running, if already admitted.
+You can stop or resume a running workload by setting the [Active](/docs/reference/kueue.v1beta2#kueue-x-k8s-io-v1beta2-WorkloadSpec) field. The active field determines if a workload can be admitted into a queue or continue running, if already admitted.
 Changing `.spec.Active` from true to false will cause a running workload to be evicted and not be requeued.
 
 ## Queue name
@@ -213,4 +213,4 @@ This effectively prevent External Dispatching mechanism to work properly in mult
 
 - Learn about [workload priority class](/docs/concepts/workload_priority_class).
 - Learn how to [run jobs](/docs/tasks/run/jobs)
-- Read the [API reference](/docs/reference/kueue.v1beta1/#kueue-x-k8s-io-v1beta1-Workload) for `Workload`
+- Read the [API reference](/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-Workload) for `Workload`

--- a/site/content/en/docs/concepts/workload_priority_class.md
+++ b/site/content/en/docs/concepts/workload_priority_class.md
@@ -125,4 +125,4 @@ after the `QuotaReserved` condition is `True`.
 - Learn how to [run jobs](/docs/tasks/run/jobs)
 - Learn how to [run jobs with workload priority](/docs/tasks/manage/run_job_with_workload_priority)
 - Learn how to [setup a default WorkloadPriorityClass](/docs/tasks/manage/enforce_job_management/setup_default_workload_priority_class)
-- Read the [API reference](/docs/reference/kueue.v1beta1/#kueue-x-k8s-io-v1beta1-WorkloadPriorityClass) for `WorkloadPriorityClass`
+- Read the [API reference](/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-WorkloadPriorityClass) for `WorkloadPriorityClass`

--- a/site/content/en/docs/getting-started/installation.md
+++ b/site/content/en/docs/getting-started/installation.md
@@ -145,7 +145,7 @@ wget https://github.com/kubernetes-sigs/kueue/releases/download/{{< param "versi
 2. With an editor of your preference, open `manifests.yaml`.
 3. In the `kueue-manager-config` ConfigMap manifest, edit the
    `controller_manager_config.yaml` data entry. The entry represents
-   the default [KueueConfiguration](/docs/reference/kueue-config.v1beta1).
+   the default [KueueConfiguration](/docs/reference/kueue-config.v1beta2).
    The contents of the ConfigMap are similar to the following:
 
 ```yaml
@@ -262,7 +262,7 @@ metadata:
   namespace: kueue-system
 data:
   controller_manager_config.yaml: |
-    apiVersion: config.kueue.x-k8s.io/v1beta1
+    apiVersion: config.kueue.x-k8s.io/v1beta2
     kind: Configuration
     featureGates:
       ManagedJobsNamespaceSelectorAlwaysRespected: true
@@ -311,4 +311,4 @@ The ShortWorkloadNames features are available starting from versions 0.15.7 and 
 ## What's next
 
 - Follow the [Quick Start](/docs/getting-started/quick-start) guide to run your first Job with Kueue.
-- Read the [API reference](/docs/reference/kueue-config.v1beta1/#Configuration) for `Configuration`
+- Read the [API reference](/docs/reference/kueue-config.v1beta2/#config-kueue-x-k8s-io-v1beta2-Configuration) for `Configuration`

--- a/site/content/en/docs/tasks/dev/develop-acc.md
+++ b/site/content/en/docs/tasks/dev/develop-acc.md
@@ -19,7 +19,7 @@ The ACC can be built-in into Kueue or run in a different kubernetes controller m
 
 Monitors the AdmissionChecks in the cluster and maintains the `Active` condition of those that are associated with it (by `spec.controllerName`). 
 
-Optionally, it can watch custom [parameters](/docs/reference/kueue.v1beta1/#kueue-x-k8s-io-v1beta1-AdmissionCheckParametersReference) objects.
+Optionally, it can watch custom [parameters](/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-AdmissionCheckParametersReference) objects.
 
 The [Provisioning Admission Check Controller](/docs/concepts/admission_check/provisioning_request/) implements this in `pkg/controller/admissionchecks/provisioning/admissioncheck_reconciler.go`
 
@@ -32,9 +32,9 @@ The [Provisioning Admission Check Controller](/docs/concepts/admission_check/pro
 
 ### Parameters Object Type
 Optionally, you can define a cluster level object type to hold the Admission Check parameters specific to your implementation.
-Users can reference instances of this object type in the AdmissionCheck definition in [spec.parameters](/docs/reference/kueue.v1beta1/#kueue-x-k8s-io-v1beta1-AdmissionCheckParametersReference).
+Users can reference instances of this object type in the AdmissionCheck definition in [spec.parameters](/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-AdmissionCheckParametersReference).
 
-For example, the [Provisioning Admission Check Controller](/docs/concepts/admission_check/provisioning_request/) uses [ProvisioningRequestConfig](/docs/reference/kueue.v1beta1/#kueue-x-k8s-io-v1beta1-ProvisioningRequestConfig) for this purpose.
+For example, the [Provisioning Admission Check Controller](/docs/concepts/admission_check/provisioning_request/) uses [ProvisioningRequestConfig](/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-ProvisioningRequestConfig) for this purpose.
 
 ## Utility Code
 

--- a/site/content/en/docs/tasks/run/using_hami.md
+++ b/site/content/en/docs/tasks/run/using_hami.md
@@ -55,7 +55,7 @@ This configuration tells Kueue to multiply per-vGPU resource values by the numbe
 Configure your ClusterQueue to track both vGPU instance counts and total resources:
 
 ```yaml
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: vgpu-cluster-queue

--- a/site/content/en/docs/tasks/troubleshooting/troubleshooting_pods.md
+++ b/site/content/en/docs/tasks/troubleshooting/troubleshooting_pods.md
@@ -24,9 +24,9 @@ A Pod might not have the `kueue.x-k8s.io/managed` due to one of the following re
 
 1. The [Pod integration is disabled](/docs/tasks/run/plain_pods/#before-you-begin).
 2. The Pod belongs to a namespace that don't satisfy the requirements of
-   the [`managedJobsNamespaceSelector`](/docs/reference/kueue-config.v1beta1/#Configuration).
+   the [`managedJobsNamespaceSelector`](/docs/reference/kueue-config.v1beta2/#config-kueue-x-k8s-io-v1beta2-Configuration).
 3. The Pod is owned by a Job or equivalent CRD that is managed by Kueue.
-4. The Pod doesn't have a `kueue.x-k8s.io/queue-name` label and [`manageJobsWithoutQueueName`](/docs/reference/kueue-config.v1beta1/#Configuration)
+4. The Pod doesn't have a `kueue.x-k8s.io/queue-name` label and [`manageJobsWithoutQueueName`](/docs/reference/kueue-config.v1beta2/#config-kueue-x-k8s-io-v1beta2-Configuration)
    is set to `false`.
 
 {{% alert title="Note" color="primary" %}}

--- a/site/content/zh-CN/docs/admission-check-controllers/provisioning.md
+++ b/site/content/zh-CN/docs/admission-check-controllers/provisioning.md
@@ -137,7 +137,7 @@ ProvisioningRequestConfig 中的此代码片段指示 Kueue 在配置后更新�
 #### 参考 {#reference}
 
 有关更多详细信息，请查看
-[API 定义](https://github.com/kubernetes-sigs/kueue/blob/main/apis/kueue/v1beta1/provisioningrequestconfig_types.go)。
+[API 定义](https://github.com/kubernetes-sigs/kueue/blob/main/apis/kueue/v1beta2/provisioningrequestconfig_types.go)。
 
 ### Job 注解 {#job-annotations}
 

--- a/site/content/zh-CN/docs/concepts/admission_check.md
+++ b/site/content/zh-CN/docs/concepts/admission_check.md
@@ -125,5 +125,5 @@ Kueue 确保 Workload 的 AdmissionCheckStates 列表与其 ClusterQueue 的 Adm
 
 ## 接下来？ {#what-next}
 
-- 阅读 `AdmissionCheck` 的 [API 参考](/docs/reference/kueue.v1beta1/#kueue-x-k8s-io-v1beta1-AdmissionCheck)
+- 阅读 `AdmissionCheck` 的 [API 参考](/zh-cn/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-AdmissionCheck)
 - 了解更多内置的 [Provisioning Admission Check Controller](/docs/admission-check-controllers/provisioning)

--- a/site/content/zh-CN/docs/concepts/admission_check/_index.md
+++ b/site/content/zh-CN/docs/concepts/admission_check/_index.md
@@ -137,5 +137,5 @@ Kueue 确保 Workload 的 AdmissionCheckStates 列表与 Workload 的 ClusterQue
 
 ## 接下来是什么？
 
-- 阅读 [API 参考](/docs/reference/kueue.v1beta1/#kueue-x-k8s-io-v1beta1-AdmissionCheck)了解 `AdmissionCheck`
+- 阅读 [API 参考](/zh-cn/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-AdmissionCheck)了解 `AdmissionCheck`
 - 从内置的[准入检查控制器](/docs/concepts/admission_check/provisioning_request)学习更多

--- a/site/content/zh-CN/docs/concepts/cluster_queue.md
+++ b/site/content/zh-CN/docs/concepts/cluster_queue.md
@@ -477,7 +477,7 @@ spec:
 
 ## 停止策略 {#stoppolicy}
 
-StopPolicy 允许集群管理员通过在 [spec](/docs/reference/kueue.v1beta1/#kueue-x-k8s-io-v1beta1-ClusterQueueSpec) 中设置其值来临时停止 ClusterQueue 中工作负载的接纳，如下所示：
+StopPolicy 允许集群管理员通过在 [spec](/zh-cn/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-ClusterQueueSpec) 中设置其值来临时停止 ClusterQueue 中工作负载的接纳，如下所示：
 
 ```yaml
 apiVersion: kueue.x-k8s.io/v1beta2
@@ -504,4 +504,4 @@ AdmissionChecks 是一个机制，允许 Kueue 在接纳工作负载之前考虑
 - 创建 [local queues](/docs/concepts/local_queue)
 - 如果你还没有，请创建 [resource flavors](/docs/concepts/resource_flavor)
 - 学习如何 [administer cluster quotas](/docs/tasks/manage/administer_cluster_quotas)
-- 阅读 [API reference](/docs/reference/kueue.v1beta1/#kueue-x-k8s-io-v1beta1-ClusterQueue) for `ClusterQueue`
+- 阅读 [API reference](/zh-cn/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-ClusterQueue) for `ClusterQueue`

--- a/site/content/zh-CN/docs/concepts/cohort.md
+++ b/site/content/zh-CN/docs/concepts/cohort.md
@@ -84,7 +84,7 @@ Cohort 可以组织成树形结构。我们将属于同一棵树的 ClusterQueue
 Cohort 的组合称为 **CohortTree**。
 
 给定 CohortTree 中的 ClusterQueue 可以使用其中的资源，
-并遵循[借用和借出限制](/zh-CN/docs/reference/kueue.v1beta1/#kueue-x-k8s-io-v1beta1-ResourceQuota)。
+并遵循[借用和借出限制](/zh-CN/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-ResourceQuota)。
 这些借用和借出限制可以为 Cohort 以及 ClusterQueue 指定。
 
 这是一个简单的 CohortTree，包含三个 Cohort：

--- a/site/content/zh-CN/docs/concepts/concurrent_admission.md
+++ b/site/content/zh-CN/docs/concepts/concurrent_admission.md
@@ -148,4 +148,4 @@ Parent Workload 是作业集成观察准入状态的对象。Variant Workload �
 - [设置并发准入](/docs/tasks/manage/setup_concurrent_admission)。
 - 了解 [ClusterQueue 规格顺序](/docs/concepts/cluster_queue#resource-flavors-and-resources)。
 - 阅读[工作负载概念](/docs/concepts/workload)，了解 Parent Workload 和 Variant Workload。
-- 阅读 [`ConcurrentAdmissionPolicy` API 参考](/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-ConcurrentAdmissionPolicy)。
+- 阅读 [`ConcurrentAdmissionPolicy` API 参考](/zh-cn/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-ConcurrentAdmissionPolicy)。

--- a/site/content/zh-CN/docs/concepts/local_queue.md
+++ b/site/content/zh-CN/docs/concepts/local_queue.md
@@ -38,4 +38,4 @@ kubectl get -n my-namespace queues
 ## 下一步是什么？
 
 - 通过本地队列启动[工作负载](/zh-CN/docs/concepts/workload)
-- 阅读 `LocalQueue` 的 [API 参考](/zh-CN/docs/reference/kueue.v1beta1/#kueue-x-k8s-io-v1beta1-LocalQueue)
+- 阅读 `LocalQueue` 的 [API 参考](/zh-CN/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-LocalQueue)

--- a/site/content/zh-CN/docs/concepts/preemption.md
+++ b/site/content/zh-CN/docs/concepts/preemption.md
@@ -18,7 +18,7 @@ description: >
 - 被抢占者与抢占者属于同一个 [ClusterQueue](/docs/concepts/cluster_queue)，且被抢占者的优先级较低。
 - 被抢占者与抢占者属于同一个 [cohort](/docs/concepts/cluster_queue#cohort)，且被抢占者的 ClusterQueue 至少有一种资源的使用量高于[名义配额](/docs/concepts/cluster_queue#resources)，而该资源是被抢占者和抢占者都需要的。
 
-在 [Kueue 配置](/docs/reference/kueue-config.v1beta1#FairSharing) 和 [ClusterQueue](/docs/concepts/cluster_queue#preemption) 中配置的抢占设置，除了上述标准外，还可以限制 Workload 是否可以抢占其他 Workload。
+在 [Kueue 配置](/zh-cn/docs/reference/kueue-config.v1beta2#FairSharing) 和 [ClusterQueue](/docs/concepts/cluster_queue#preemption) 中配置的抢占设置，除了上述标准外，还可以限制 Workload 是否可以抢占其他 Workload。
 
 当抢占 Workload 时，Kueue 会在被抢占 Workload 的 `.status.conditions` 字段中添加类似如下的条目：
 
@@ -115,7 +115,7 @@ Kueue 配置中的各属性将在下文中说明。
 在抢占过程中，Kueue 优先从份额值最高的 ClusterQueue 中抢占 Workload。
 
 你可以在 `.status.fairSharing.weightedShare` 字段或通过查询
-[`kueue_cluster_queue_weighted_share` 指标](/docs/reference/metrics#optional-metrics)获取 ClusterQueue 的份额值。
+[`kueue_cluster_queue_weighted_share` 指标](/zh-cn/docs/reference/metrics#optional-metrics)获取 ClusterQueue 的份额值。
 
 ### 抢占策略
 

--- a/site/content/zh-CN/docs/concepts/resource_flavor.md
+++ b/site/content/zh-CN/docs/concepts/resource_flavor.md
@@ -90,4 +90,4 @@ Kueue 不会为 flavor 污点自动添加容忍度。
 ## 下一步？
 
 - 了解[集群队列（cluster queues）](/docs/concepts/cluster_queue)。
-- 阅读 `ResourceFlavor` 的 [API 参考](/docs/reference/kueue.v1beta1/#kueue-x-k8s-io-v1beta1-ResourceFlavor)。
+- 阅读 `ResourceFlavor` 的 [API 参考](/zh-cn/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-ResourceFlavor)。

--- a/site/content/zh-CN/docs/concepts/topology.md
+++ b/site/content/zh-CN/docs/concepts/topology.md
@@ -75,4 +75,4 @@ spec:
 ## 接下来是什么？
 
 - 学习如何使用 [拓扑感知调度](/docs/concepts/topology_aware_scheduling)
-- 阅读 `Topology` 的 [API 参考](/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-Topology)
+- 阅读 `Topology` 的 [API 参考](/zh-cn/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-Topology)

--- a/site/content/zh-CN/docs/concepts/workload.md
+++ b/site/content/zh-CN/docs/concepts/workload.md
@@ -52,7 +52,7 @@ spec:
 
 ## 活跃状态 {#active}
 
-您可以通过设置 [Active](/docs/reference/kueue.v1beta1#kueue-x-k8s-io-v1beta1-WorkloadSpec)
+您可以通过设置 [Active](/zh-cn/docs/reference/kueue.v1beta2#kueue-x-k8s-io-v1beta2-WorkloadSpec)
 字段来停止或恢复正在运行的工作负载。active 字段决定工作负载是否可以被准入到队列中
 或继续运行（如果已经被准入）。
 将 `.spec.Active` 从 true 更改为 false 将导致正在运行的工作负载被驱逐且不会
@@ -198,4 +198,4 @@ spec:
 
 - 了解[工作负载优先级类](/docs/concepts/workload_priority_class)。
 - 了解如何[运行作业](/docs/tasks/run/jobs)
-- 阅读 `Workload` 的 [API 参考](/docs/reference/kueue.v1beta1/#kueue-x-k8s-io-v1beta1-Workload)
+- 阅读 `Workload` 的 [API 参考](/zh-cn/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-Workload)

--- a/site/content/zh-CN/docs/concepts/workload_priority_class.md
+++ b/site/content/zh-CN/docs/concepts/workload_priority_class.md
@@ -109,4 +109,4 @@ Workload 的 `PriorityClassSource` 和 `PriorityClassName` 字段是不可变的
 
 - 了解如何[运行作业](/docs/tasks/run/jobs)
 - 了解如何[使用 Workload 优先级运行作业](/docs/tasks/manage/run_job_with_workload_priority)
-- 阅读 `WorkloadPriorityClass` 的 [API 参考](/docs/reference/kueue.v1beta1/#kueue-x-k8s-io-v1beta1-WorkloadPriorityClass)
+- 阅读 `WorkloadPriorityClass` 的 [API 参考](/zh-cn/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-WorkloadPriorityClass)

--- a/site/content/zh-CN/docs/installation/_index.md
+++ b/site/content/zh-CN/docs/installation/_index.md
@@ -37,7 +37,7 @@ description: >
 - 运行版本为 1.29 或更新的 Kubernetes 集群。了解如何[安装 Kubernetes 工具](https://kubernetes.io/docs/tasks/tools/)。
 - kubectl 命令行工具已与你的集群通信。
 
-Kueue 发布[指标](/docs/reference/metrics)以监控其控制器组件。
+Kueue 发布[指标](/zh-cn/docs/reference/metrics)以监控其控制器组件。
 你可以使用 Prometheus 采集这些指标。
 如果你没有自己的监控系统，请使用 [kube-prometheus](https://github.com/prometheus-operator/kube-prometheus)。
 
@@ -140,7 +140,7 @@ wget https://github.com/kubernetes-sigs/kueue/releases/download/{{< param "versi
 2. 使用你喜欢的编辑器打开 `manifests.yaml`。
 3. 在 `kueue-manager-config` ConfigMap 清单中，编辑
    `controller_manager_config.yaml` 数据条目。该条目代表默认的
-   [KueueConfiguration](/docs/reference/kueue-config.v1beta1)。
+   [KueueConfiguration](/zh-cn/docs/reference/kueue-config.v1beta2)。
    ConfigMap 的内容类似于以下内容：
 
 ```yaml
@@ -282,4 +282,4 @@ spec:
 
 ## 接下来是什么 {#whats-next}
 
-- 阅读 [`Configuration` 的 API 参考](/docs/reference/kueue-config.v1beta1/#Configuration)
+- 阅读 [`Configuration` 的 API 参考](/zh-cn/docs/reference/kueue-config.v1beta2/#Configuration)

--- a/site/content/zh-CN/docs/overview/_index.md
+++ b/site/content/zh-CN/docs/overview/_index.md
@@ -38,7 +38,7 @@ Kueue 的一个核心设计原则是避免重复 Kubernetes 组件和成熟的�
   [Kubeflow 训练作业](/docs/tasks/run/kubeflow/)、[RayJob](/docs/tasks/run/rayjobs/)、
   [RayCluster](/docs/tasks/run/rayclusters/)、[JobSet](/docs/tasks/run/jobsets/)、
   [AppWrappers](/docs/tasks/run/appwrappers/)、[普通 Pod 和 Pod 组](/docs/tasks/run/plain_pods/)。
-- **系统洞察：** 内置 [Prometheus 指标](/docs/reference/metrics/)帮助监控系统状态，并提供按需可见性端点用于[监控待处理工作负载](/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand/)。
+- **系统洞察：** 内置 [Prometheus 指标](/zh-cn/docs/reference/metrics/)帮助监控系统状态，并提供按需可见性端点用于[监控待处理工作负载](/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand/)。
 - **准入检查(AdmissionChecks)：** 一种供内部或外部组件影响工作负载是否可以被[接纳](/docs/concepts/admission_check/)的机制。
 - **高级自动扩缩支持：** 通过准入检查与 cluster-autoscaler 的 [provisioningRequest](/docs/admission-check-controllers/provisioning/#job-using-a-provisioningrequest) 集成。
 - **All-or-nothing 与就绪 Pod：** 一种基于超时的 [All-or-nothing 调度](/docs/tasks/manage/setup_wait_for_pods_ready/)实现。

--- a/site/content/zh-CN/docs/reference/kueue-config.v1beta2.md
+++ b/site/content/zh-CN/docs/reference/kueue-config.v1beta2.md
@@ -1,0 +1,1616 @@
+---
+title: Kueue Configuration v1beta2 API
+content_type: tool-reference
+package: config.kueue.x-k8s.io/v1beta2
+auto_generated: true
+description: Generated API reference documentation for config.kueue.x-k8s.io/v1beta2.
+---
+
+
+## Resource Types 
+
+
+- [Configuration](#config-kueue-x-k8s-io-v1beta2-Configuration)
+  
+
+## `Configuration`     {#config-kueue-x-k8s-io-v1beta2-Configuration}
+    
+
+
+<p>Configuration is the Schema for the kueueconfigurations API</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>config.kueue.x-k8s.io/v1beta2</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>Configuration</code></td></tr>
+    
+  
+<tr><td><code>namespace</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Namespace is the namespace in which kueue is deployed. It is used as part of DNSName of the webhook Service.
+If not set, the value is set from the file /var/run/secrets/kubernetes.io/serviceaccount/namespace
+If the file doesn't exist, default value is kueue-system.</p>
+</td>
+</tr>
+<tr><td><code>ControllerManager</code> <B>[Required]</B><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-ControllerManager"><code>ControllerManager</code></a>
+</td>
+<td>(Members of <code>ControllerManager</code> are embedded into this type.)
+   <p>ControllerManager returns the configurations for controllers</p>
+</td>
+</tr>
+<tr><td><code>manageJobsWithoutQueueName</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   <p>ManageJobsWithoutQueueName controls whether or not Kueue reconciles
+jobs that don't set the label kueue.x-k8s.io/queue-name.
+If set to true, then those jobs will be suspended and never started unless
+they are assigned a queue and eventually admitted. This also applies to
+jobs created before starting the kueue controller.
+Defaults to false; therefore, those jobs are not managed and if they are created
+unsuspended, they will start immediately.</p>
+</td>
+</tr>
+<tr><td><code>managedJobsNamespaceSelector</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#labelselector-v1-meta"><code>k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector</code></a>
+</td>
+<td>
+   <p>ManagedJobsNamespaceSelector provides a namespace-based mechanism to exempt jobs
+from management by Kueue.</p>
+<p>It provides a strong exemption for the Pod-based integrations (pod, deployment, statefulset, etc.),
+For Pod-based integrations, only jobs whose namespaces match ManagedJobsNamespaceSelector are
+eligible to be managed by Kueue.  Pods, deployments, etc. in non-matching namespaces will
+never be managed by Kueue, even if they have a kueue.x-k8s.io/queue-name label.
+This strong exemption ensures that Kueue will not interfere with the basic operation
+of system namespace.</p>
+<p>For all other integrations, ManagedJobsNamespaceSelector provides a weaker exemption
+by only modulating the effects of ManageJobsWithoutQueueName.  For these integrations,
+a job that has a kueue.x-k8s.io/queue-name label will always be managed by Kueue. Jobs without
+a kueue.x-k8s.io/queue-name label will be managed by Kueue only when ManageJobsWithoutQueueName is
+true and the job's namespace matches ManagedJobsNamespaceSelector.</p>
+</td>
+</tr>
+<tr><td><code>internalCertManagement</code> <B>[Required]</B><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-InternalCertManagement"><code>InternalCertManagement</code></a>
+</td>
+<td>
+   <p>InternalCertManagement is configuration for internalCertManagement</p>
+</td>
+</tr>
+<tr><td><code>waitForPodsReady</code> <B>[Required]</B><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-WaitForPodsReady"><code>WaitForPodsReady</code></a>
+</td>
+<td>
+   <p>WaitForPodsReady is configuration to provide a time-based all-or-nothing
+scheduling semantics for Jobs, by ensuring all pods are ready (running
+and passing the readiness probe) within the specified time. If the timeout
+is exceeded, then the workload is evicted.</p>
+</td>
+</tr>
+<tr><td><code>clientConnection</code> <B>[Required]</B><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-ClientConnection"><code>ClientConnection</code></a>
+</td>
+<td>
+   <p>ClientConnection provides additional configuration options for Kubernetes
+API server client.</p>
+</td>
+</tr>
+<tr><td><code>integrations</code> <B>[Required]</B><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-Integrations"><code>Integrations</code></a>
+</td>
+<td>
+   <p>Integrations provide configuration options for AI/ML/Batch frameworks
+integrations (including K8S job).</p>
+</td>
+</tr>
+<tr><td><code>multiKueue</code> <B>[Required]</B><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-MultiKueue"><code>MultiKueue</code></a>
+</td>
+<td>
+   <p>MultiKueue controls the behaviour of the MultiKueue AdmissionCheck Controller.</p>
+</td>
+</tr>
+<tr><td><code>fairSharing</code> <B>[Required]</B><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-FairSharing"><code>FairSharing</code></a>
+</td>
+<td>
+   <p>FairSharing controls the Fair Sharing semantics across the cluster.</p>
+</td>
+</tr>
+<tr><td><code>admissionFairSharing</code> <B>[Required]</B><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-AdmissionFairSharing"><code>AdmissionFairSharing</code></a>
+</td>
+<td>
+   <p>admissionFairSharing indicates configuration of FairSharing with the <code>AdmissionTime</code> mode on</p>
+</td>
+</tr>
+<tr><td><code>resources</code> <B>[Required]</B><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-Resources"><code>Resources</code></a>
+</td>
+<td>
+   <p>Resources provides additional configuration options for handling the resources.</p>
+</td>
+</tr>
+<tr><td><code>featureGates</code> <B>[Required]</B><br/>
+<code>map[string]bool</code>
+</td>
+<td>
+   <p>FeatureGates is a map of feature names to bools that allows to override the
+default enablement status of a feature. The map cannot be used in conjunction
+with passing the list of features via the command line argument &quot;--feature-gates&quot;
+for the Kueue Deployment.</p>
+</td>
+</tr>
+<tr><td><code>objectRetentionPolicies</code><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-ObjectRetentionPolicies"><code>ObjectRetentionPolicies</code></a>
+</td>
+<td>
+   <p>ObjectRetentionPolicies provides configuration options for automatic deletion
+of Kueue-managed objects. A nil value disables all automatic deletions.</p>
+</td>
+</tr>
+<tr><td><code>visibilityServer</code><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-VisibilityServerConfiguration"><code>VisibilityServerConfiguration</code></a>
+</td>
+<td>
+   <p>VisibilityServer configures the visibility server.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `AdmissionFairSharing`     {#config-kueue-x-k8s-io-v1beta2-AdmissionFairSharing}
+    
+
+**Appears in:**
+
+- [Configuration](#config-kueue-x-k8s-io-v1beta2-Configuration)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>usageHalfLifeTime</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta"><code>k8s.io/apimachinery/pkg/apis/meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>usageHalfLifeTime indicates the time after which the current usage will decay by a half
+If set to 0, usage will be reset to 0 immediately.</p>
+</td>
+</tr>
+<tr><td><code>usageSamplingInterval</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta"><code>k8s.io/apimachinery/pkg/apis/meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>usageSamplingInterval indicates how often Kueue updates consumedResources in FairSharingStatus
+Defaults to 5min.</p>
+</td>
+</tr>
+<tr><td><code>resourceWeights</code> <B>[Required]</B><br/>
+<code>map[ResourceName]float64</code>
+</td>
+<td>
+   <p>resourceWeights assigns weights to resources which then are used to calculate LocalQueue's
+resource usage and order Workloads.
+Defaults to 1.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ClientConnection`     {#config-kueue-x-k8s-io-v1beta2-ClientConnection}
+    
+
+**Appears in:**
+
+- [Configuration](#config-kueue-x-k8s-io-v1beta2-Configuration)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>qps</code> <B>[Required]</B><br/>
+<code>float32</code>
+</td>
+<td>
+   <p>QPS controls the number of queries per second allowed for K8S api server
+connection.</p>
+<p>Setting this to a negative value will disable client-side ratelimiting.</p>
+</td>
+</tr>
+<tr><td><code>burst</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>Burst allows extra queries to accumulate when a client is exceeding its rate.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ClusterProfile`     {#config-kueue-x-k8s-io-v1beta2-ClusterProfile}
+    
+
+**Appears in:**
+
+- [MultiKueue](#config-kueue-x-k8s-io-v1beta2-MultiKueue)
+
+
+<p>ClusterProfile defines configuration for using the ClusterProfile API in MultiKueue.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>accessProviders</code><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-ClusterProfileAccessProvider"><code>[]ClusterProfileAccessProvider</code></a>
+</td>
+<td>
+   <p>AccessProviders defines a list of providers to obtain access to worker clusters
+using the ClusterProfile API.</p>
+</td>
+</tr>
+<tr><td><code>credentialsProviders</code><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-ClusterProfileAccessProvider"><code>[]ClusterProfileAccessProvider</code></a>
+</td>
+<td>
+   <p>CredentialsProviders defines a list of providers to obtain credentials of worker clusters
+using the ClusterProfile API.</p>
+<p>Deprecated: Use AccessProviders instead. AccessProviders and CredentialsProviders
+are mutually exclusive.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ClusterProfileAccessProvider`     {#config-kueue-x-k8s-io-v1beta2-ClusterProfileAccessProvider}
+    
+
+**Appears in:**
+
+- [ClusterProfile](#config-kueue-x-k8s-io-v1beta2-ClusterProfile)
+
+
+<p>ClusterProfileAccessProvider defines an access provider in the ClusterProfile API.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Name is the name of the provider.</p>
+</td>
+</tr>
+<tr><td><code>execConfig</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/client-go/tools/clientcmd/api#ExecConfig"><code>k8s.io/client-go/tools/clientcmd/api.ExecConfig</code></a>
+</td>
+<td>
+   <p>ExecConfig is the exec configuration to obtain credentials.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ControllerConfigurationSpec`     {#config-kueue-x-k8s-io-v1beta2-ControllerConfigurationSpec}
+    
+
+**Appears in:**
+
+- [ControllerManager](#config-kueue-x-k8s-io-v1beta2-ControllerManager)
+
+
+<p>ControllerConfigurationSpec defines the global configuration for
+controllers registered with the manager.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>groupKindConcurrency</code><br/>
+<code>map[string]int</code>
+</td>
+<td>
+   <p>GroupKindConcurrency is a map from a Kind to the number of concurrent reconciliation
+allowed for that controller.</p>
+<p>When a controller is registered within this manager using the builder utilities,
+users have to specify the type the controller reconciles in the For(...) call.
+If the object's kind passed matches one of the keys in this map, the concurrency
+for that controller is set to the number specified.</p>
+<p>The key is expected to be consistent in form with GroupKind.String(),
+e.g. ReplicaSet in apps group (regardless of version) would be <code>ReplicaSet.apps</code>.</p>
+</td>
+</tr>
+<tr><td><code>cacheSyncTimeout</code><br/>
+<a href="https://pkg.go.dev/time#Duration"><code>time.Duration</code></a>
+</td>
+<td>
+   <p>CacheSyncTimeout refers to the time limit set to wait for syncing caches.
+Defaults to 2 minutes if not set.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ControllerHealth`     {#config-kueue-x-k8s-io-v1beta2-ControllerHealth}
+    
+
+**Appears in:**
+
+- [ControllerManager](#config-kueue-x-k8s-io-v1beta2-ControllerManager)
+
+
+<p>ControllerHealth defines the health configs.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>healthProbeBindAddress</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>HealthProbeBindAddress is the TCP address that the controller should bind to
+for serving health probes
+It can be set to &quot;0&quot; or &quot;&quot; to disable serving the health probe.</p>
+</td>
+</tr>
+<tr><td><code>readinessEndpointName</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>ReadinessEndpointName, defaults to &quot;readyz&quot;</p>
+</td>
+</tr>
+<tr><td><code>livenessEndpointName</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>LivenessEndpointName, defaults to &quot;healthz&quot;</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ControllerManager`     {#config-kueue-x-k8s-io-v1beta2-ControllerManager}
+    
+
+**Appears in:**
+
+- [Configuration](#config-kueue-x-k8s-io-v1beta2-Configuration)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>webhook</code><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-ControllerWebhook"><code>ControllerWebhook</code></a>
+</td>
+<td>
+   <p>Webhook contains the controllers webhook configuration</p>
+</td>
+</tr>
+<tr><td><code>leaderElection</code><br/>
+<a href="https://pkg.go.dev/k8s.io/component-base/config/v1alpha1#LeaderElectionConfiguration"><code>k8s.io/component-base/config/v1alpha1.LeaderElectionConfiguration</code></a>
+</td>
+<td>
+   <p>LeaderElection is the LeaderElection config to be used when configuring
+the manager.Manager leader election</p>
+</td>
+</tr>
+<tr><td><code>metrics</code><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-ControllerMetrics"><code>ControllerMetrics</code></a>
+</td>
+<td>
+   <p>Metrics contains the controller metrics configuration</p>
+</td>
+</tr>
+<tr><td><code>health</code><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-ControllerHealth"><code>ControllerHealth</code></a>
+</td>
+<td>
+   <p>Health contains the controller health configuration</p>
+</td>
+</tr>
+<tr><td><code>pprofBindAddress</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>PprofBindAddress is the TCP address that the controller should bind to
+for serving pprof.
+It can be set to &quot;&quot; or &quot;0&quot; to disable the pprof serving.
+Since pprof may contain sensitive information, make sure to protect it
+before exposing it to public.</p>
+</td>
+</tr>
+<tr><td><code>controller</code><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-ControllerConfigurationSpec"><code>ControllerConfigurationSpec</code></a>
+</td>
+<td>
+   <p>Controller contains global configuration options for controllers
+registered within this manager.</p>
+</td>
+</tr>
+<tr><td><code>tls</code><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-TLSOptions"><code>TLSOptions</code></a>
+</td>
+<td>
+   <p>TLS contains TLS security settings for all Kueue API servers
+(webhooks, metrics, and visibility).</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ControllerMetrics`     {#config-kueue-x-k8s-io-v1beta2-ControllerMetrics}
+    
+
+**Appears in:**
+
+- [ControllerManager](#config-kueue-x-k8s-io-v1beta2-ControllerManager)
+
+
+<p>ControllerMetrics defines the metrics configs.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>bindAddress</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>BindAddress is the TCP address that the controller should bind to
+for serving prometheus metrics.
+It can be set to &quot;0&quot; to disable the metrics serving.</p>
+</td>
+</tr>
+<tr><td><code>enableClusterQueueResources</code><br/>
+<code>bool</code>
+</td>
+<td>
+   <p>EnableClusterQueueResources, if true the cluster queue resource usage and quotas
+metrics will be reported.</p>
+</td>
+</tr>
+<tr><td><code>customLabels</code><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-ControllerMetricsCustomLabel"><code>[]ControllerMetricsCustomLabel</code></a>
+</td>
+<td>
+   <p>CustomLabels is a list of entries whose values will be added as extra
+Prometheus labels on supported metrics.
+A maximum of 6 labels are allowed per SourceKind (2 for Workloads), with up to 20 labels defined in total.</p>
+</td>
+</tr>
+<tr><td><code>localQueueMetrics</code><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-LocalQueueMetrics"><code>LocalQueueMetrics</code></a>
+</td>
+<td>
+   <p>LocalQueueMetrics is a configuration that provides LocalQueue metrics options.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ControllerMetricsCustomLabel`     {#config-kueue-x-k8s-io-v1beta2-ControllerMetricsCustomLabel}
+    
+
+**Appears in:**
+
+- [ControllerMetrics](#config-kueue-x-k8s-io-v1beta2-ControllerMetrics)
+
+
+<p>ControllerMetricsCustomLabel defines a Kubernetes label or annotation to promote
+as a Prometheus metric label with a &quot;custom_&quot; prefix.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Name is the Prometheus metric label name suffix.
+Prepended with &quot;custom_&quot; to form the full Prometheus label name
+(e.g., &quot;team&quot; becomes &quot;custom_team&quot;).
+Must contain only [a-zA-Z0-9_] characters and start with a letter.</p>
+</td>
+</tr>
+<tr><td><code>sourceLabelKey</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>SourceLabelKey is the Kubernetes label key to read the value from.
+Must be a valid Kubernetes qualified name.
+Mutually exclusive with SourceAnnotationKey.
+If neither is specified, defaults to Name.</p>
+</td>
+</tr>
+<tr><td><code>sourceAnnotationKey</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>SourceAnnotationKey is the Kubernetes annotation key to read the value from.
+Must be a valid Kubernetes qualified name.
+Mutually exclusive with SourceLabelKey.</p>
+</td>
+</tr>
+<tr><td><code>sourceKind</code><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-SourceKind"><code>SourceKind</code></a>
+</td>
+<td>
+   <p>SourceKind is the object kind from which the label value should be sourced.
+Up to 2 labels are allowed for Workloads and up to 6 for other source kinds.
+Defaults to ClusterQueue.
+The possible values are:</p>
+<ul>
+<li>Cohort</li>
+<li>LocalQueue</li>
+<li>ClusterQueue</li>
+<li>Workload</li>
+</ul>
+</td>
+</tr>
+<tr><td><code>trackedValues</code><br/>
+<code>[]string</code>
+</td>
+<td>
+   <p>TrackedValues is a list of the label's allowed values.
+When SourceKind is Workload, a closed list of 1-12 TrackedValues is required.
+Non-workload source kinds can have 0-16 TrackedValues. If the list is empty, any value is allowed.
+Label values not allowed by this field will be reported as &quot;kueue.x-k8s.io/<em>UNTRACKED_VALUE</em>&quot;.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ControllerWebhook`     {#config-kueue-x-k8s-io-v1beta2-ControllerWebhook}
+    
+
+**Appears in:**
+
+- [ControllerManager](#config-kueue-x-k8s-io-v1beta2-ControllerManager)
+
+
+<p>ControllerWebhook defines the webhook server for the controller.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>port</code><br/>
+<code>int</code>
+</td>
+<td>
+   <p>Port is the port that the webhook server serves at.
+It is used to set webhook.Server.Port.</p>
+</td>
+</tr>
+<tr><td><code>host</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Host is the hostname that the webhook server binds to.
+It is used to set webhook.Server.Host.</p>
+</td>
+</tr>
+<tr><td><code>certDir</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>CertDir is the directory that contains the server key and certificate.
+if not set, webhook server would look up the server key and certificate in
+{TempDir}/k8s-webhook-server/serving-certs. The server key and certificate
+must be named tls.key and tls.crt, respectively.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `DeviceClassCapacitySource`     {#config-kueue-x-k8s-io-v1beta2-DeviceClassCapacitySource}
+    
+
+**Appears in:**
+
+- [DeviceClassSourceConfig](#config-kueue-x-k8s-io-v1beta2-DeviceClassSourceConfig)
+
+
+<p>DeviceClassCapacitySource configures capacity-based quota tracking
+for devices that allow multiple allocations (KEP-5075).</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#qualifiedname-v1-resource"><code>k8s.io/api/resource/v1.QualifiedName</code></a>
+</td>
+<td>
+   <p>Name identifies the capacity dimension to track for quota
+(e.g., &quot;gpu.example.com/memory&quot;).
+Must be a valid DRA QualifiedName.</p>
+</td>
+</tr>
+<tr><td><code>driver</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Driver is the DRA driver name used to filter relevant ResourceSlices.
+Must match the spec.driver field on ResourceSlice objects.
+Must not exceed 63 characters.</p>
+</td>
+</tr>
+<tr><td><code>deviceSelector</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#deviceselector-v1-resource"><code>k8s.io/api/resource/v1.DeviceSelector</code></a>
+</td>
+<td>
+   <p>DeviceSelector scopes which devices are eligible for quota accounting.
+Matches devices whose capacity dimensions should be tracked against
+the quota pool.
+The selector is compiled at config load time using the upstream dracel
+compiler.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `DeviceClassCounterSource`     {#config-kueue-x-k8s-io-v1beta2-DeviceClassCounterSource}
+    
+
+**Appears in:**
+
+- [DeviceClassSourceConfig](#config-kueue-x-k8s-io-v1beta2-DeviceClassSourceConfig)
+
+
+<p>DeviceClassCounterSource identifies where to read counter data from and which counter to track.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Name is the counter name within the device's consumesCounters
+entries to track for quota. Must be a DNS label and match a counter
+name published by the driver in ResourceSlice devices' consumesCounters field.
+Counter set names are per-device identifiers (e.g., gpu-0-counter-set,
+gpu-1-counter-set), so name matches across all counter sets
+for a given driver without requiring one mapping per device.
+The total length must not exceed 63 characters.</p>
+</td>
+</tr>
+<tr><td><code>driver</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Driver is the DRA driver name used to filter relevant ResourceSlices.
+Must be a lowercase DNS subdomain and match the spec.driver field on ResourceSlice objects.
+The total length must not exceed 63 characters.</p>
+</td>
+</tr>
+<tr><td><code>deviceSelector</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#deviceselector-v1-resource"><code>k8s.io/api/resource/v1.DeviceSelector</code></a>
+</td>
+<td>
+   <p>DeviceSelector scopes which devices are eligible for counter-based
+quota accounting. Typically matches a GPU model (e.g., productName)
+so all partition profiles on that model share one quota pool.
+Per-workload charging is determined by the workload's own
+ResourceClaimTemplate selector, which narrows to the requested profile.
+The selector is compiled at config load time using the upstream dracel
+compiler.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `DeviceClassMapping`     {#config-kueue-x-k8s-io-v1beta2-DeviceClassMapping}
+    
+
+**Appears in:**
+
+- [Resources](#config-kueue-x-k8s-io-v1beta2-Resources)
+
+
+<p>DeviceClassMapping holds device class to logical resource mappings
+for Dynamic Resource Allocation support.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcename-v1-core"><code>k8s.io/api/core/v1.ResourceName</code></a>
+</td>
+<td>
+   <p>Name is referenced in ClusterQueue.nominalQuota and Workload status.
+Must be a valid fully qualified name consisting of an optional DNS subdomain prefix
+followed by a slash and a DNS label, or just a DNS label.
+DNS labels consist of lower-case alphanumeric characters or hyphens,
+and must start and end with an alphanumeric character.
+DNS subdomain prefixes follow the same rules as DNS labels but can contain periods.
+The total length must not exceed 253 characters.</p>
+</td>
+</tr>
+<tr><td><code>deviceClassNames</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcename-v1-core"><code>[]k8s.io/api/core/v1.ResourceName</code></a>
+</td>
+<td>
+   <p>DeviceClassNames enumerates the DeviceClasses represented by this resource name.
+Each device class name must be a valid qualified name consisting of an optional DNS subdomain prefix
+followed by a slash and a DNS label, or just a DNS label.
+DNS labels consist of lower-case alphanumeric characters or hyphens,
+and must start and end with an alphanumeric character.
+DNS subdomain prefixes follow the same rules as DNS labels but can contain periods.
+The total length of each name must not exceed 253 characters.</p>
+</td>
+</tr>
+<tr><td><code>sources</code><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-DeviceClassSourceConfig"><code>[]DeviceClassSourceConfig</code></a>
+</td>
+<td>
+   <p>Sources configures resource accounting sources for this mapping.
+Each source defines how quota is tracked for this DeviceClass.
+Extended resource requests that resolve to a DeviceClass with sources
+configured are marked inadmissible.
+Counter sources require KueueDRAIntegrationPartitionableDevices (enabled by default since v0.19).
+Capacity sources require KueueDRAIntegrationConsumableCapacity.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `DeviceClassSourceConfig`     {#config-kueue-x-k8s-io-v1beta2-DeviceClassSourceConfig}
+    
+
+**Appears in:**
+
+- [DeviceClassMapping](#config-kueue-x-k8s-io-v1beta2-DeviceClassMapping)
+
+
+<p>DeviceClassSourceConfig defines a resource accounting source for a DeviceClassMapping.
+Exactly one of the source types must be set per entry.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>counter</code><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-DeviceClassCounterSource"><code>DeviceClassCounterSource</code></a>
+</td>
+<td>
+   <p>Counter configures counter-based quota for partitionable devices.
+Maps a DRA driver counter to the parent DeviceClassMapping's Kueue quota resource.</p>
+</td>
+</tr>
+<tr><td><code>capacity</code><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-DeviceClassCapacitySource"><code>DeviceClassCapacitySource</code></a>
+</td>
+<td>
+   <p>Capacity configures capacity-based quota for devices that allow
+multiple allocations (consumable capacity, KEP-5075).
+Maps a device capacity dimension to the parent DeviceClassMapping's Kueue quota resource.
+Requires the KueueDRAIntegrationConsumableCapacity feature gate.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `FairSharing`     {#config-kueue-x-k8s-io-v1beta2-FairSharing}
+    
+
+**Appears in:**
+
+- [Configuration](#config-kueue-x-k8s-io-v1beta2-Configuration)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>preemptionStrategies</code> <B>[Required]</B><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-PreemptionStrategy"><code>[]PreemptionStrategy</code></a>
+</td>
+<td>
+   <p>preemptionStrategies indicates which constraints should a preemption satisfy.
+The preemption algorithm will only use the next strategy in the list if the
+incoming workload (preemptor) doesn't fit after using the previous strategies.
+Possible values are:</p>
+<ul>
+<li>LessThanOrEqualToFinalShare: Only preempt a workload if the share of the preemptor CQ
+with the preemptor workload is less than or equal to the share of the preemptee CQ
+without the workload to be preempted.
+This strategy might favor preemption of smaller workloads in the preemptee CQ,
+regardless of priority or start time, in an effort to keep the share of the CQ
+as high as possible.</li>
+<li>LessThanInitialShare: Only preempt a workload if the share of the preemptor CQ
+with the incoming workload is strictly less than the share of the preemptee CQ.
+This strategy doesn't depend on the share usage of the workload being preempted.
+As a result, the strategy chooses to preempt workloads with the lowest priority and
+newest start time first.</li>
+</ul>
+<p>Only the following lists are supported:</p>
+<ul>
+<li>[&quot;LessThanOrEqualToFinalShare&quot;]</li>
+<li>[&quot;LessThanInitialShare&quot;]</li>
+<li>[&quot;LessThanOrEqualToFinalShare&quot;, &quot;LessThanInitialShare&quot;]</li>
+</ul>
+<p>Any other combination or ordering fails configuration validation.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `IncrementalDispatcherConfig`     {#config-kueue-x-k8s-io-v1beta2-IncrementalDispatcherConfig}
+    
+
+**Appears in:**
+
+- [MultiKueue](#config-kueue-x-k8s-io-v1beta2-MultiKueue)
+
+
+<p>IncrementalDispatcherConfig holds configuration for the MultiKueue Incremental Dispatcher.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>stepSize</code><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>StepSize defines the number of worker clusters the Incremental Dispatcher
+will query simultaneously.
+Minimum value is 1. If not set, it defaults to 3.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `Integrations`     {#config-kueue-x-k8s-io-v1beta2-Integrations}
+    
+
+**Appears in:**
+
+- [Configuration](#config-kueue-x-k8s-io-v1beta2-Configuration)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>frameworks</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   <p>List of framework names to be enabled.
+Possible options:</p>
+<ul>
+<li>&quot;batch/job&quot;</li>
+<li>&quot;kubeflow.org/mpijob&quot;</li>
+<li>&quot;ray.io/rayjob&quot;</li>
+<li>&quot;ray.io/rayservice&quot;</li>
+<li>&quot;ray.io/raycluster&quot;</li>
+<li>&quot;jobset.x-k8s.io/jobset&quot;</li>
+<li>&quot;kubeflow.org/paddlejob&quot;</li>
+<li>&quot;kubeflow.org/pytorchjob&quot;</li>
+<li>&quot;kubeflow.org/tfjob&quot;</li>
+<li>&quot;kubeflow.org/xgboostjob&quot;</li>
+<li>&quot;kubeflow.org/jaxjob&quot;</li>
+<li>&quot;trainer.kubeflow.org/trainjob&quot;</li>
+<li>&quot;workload.codeflare.dev/appwrapper&quot;</li>
+<li>&quot;sparkoperator.k8s.io/sparkapplication&quot;</li>
+<li>&quot;pod&quot;</li>
+<li>&quot;deployment&quot;</li>
+<li>&quot;statefulset&quot;</li>
+<li>&quot;leaderworkerset.x-k8s.io/leaderworkerset&quot;</li>
+</ul>
+</td>
+</tr>
+<tr><td><code>externalFrameworks</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   <p>List of GroupVersionKinds that are managed for Kueue by external controllers;
+the expected format is <code>Kind.version.group.com</code>.</p>
+</td>
+</tr>
+<tr><td><code>labelKeysToCopy</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   <p>labelKeysToCopy is a list of label keys that should be copied from the job into the
+workload object. It is not required for the job to have all the labels from this
+list. If a job does not have some label with the given key from this list, the
+constructed workload object will be created without this label. In the case
+of creating a workload from a composable job (pod group), if multiple objects
+have labels with some key from the list, the values of these labels must
+match or otherwise the workload creation would fail. The labels are copied only
+during the workload creation and are not updated even if the labels of the
+underlying job are changed.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `InternalCertManagement`     {#config-kueue-x-k8s-io-v1beta2-InternalCertManagement}
+    
+
+**Appears in:**
+
+- [Configuration](#config-kueue-x-k8s-io-v1beta2-Configuration)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>enable</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   <p>Enable controls the use of internal cert management for the webhook,
+metrics and visibility endpoints.
+When enabled Kueue is using libraries to generate and
+self-sign the certificates.
+When disabled, you need to provide the certificates for
+the webhooks, metrics and visibility through a third party certificate
+This secret is mounted to the kueue controller manager pod. The mount
+path for webhooks is /tmp/k8s-webhook-server/serving-certs, for
+metrics endpoint the expected path is <code>/etc/kueue/metrics/certs</code> and for
+visibility endpoint the expected path is <code>/visibility</code>.
+The keys and certs are named tls.key and tls.crt.</p>
+</td>
+</tr>
+<tr><td><code>webhookServiceName</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>WebhookServiceName is the name of the Service used as part of the DNSName.
+Defaults to kueue-webhook-service.</p>
+</td>
+</tr>
+<tr><td><code>webhookSecretName</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>WebhookSecretName is the name of the Secret used to store CA and server certs.
+Defaults to kueue-webhook-server-cert.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `LocalQueueMetrics`     {#config-kueue-x-k8s-io-v1beta2-LocalQueueMetrics}
+    
+
+**Appears in:**
+
+- [ControllerMetrics](#config-kueue-x-k8s-io-v1beta2-ControllerMetrics)
+
+
+<p>LocalQueueMetrics defines the configuration options for local queue metrics.
+If left empty, then metrics will expose for all local queues across namespaces.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>enable</code><br/>
+<code>bool</code>
+</td>
+<td>
+   <p>Enable is a knob to allow metrics to be exposed for local queues. Defaults to true.</p>
+</td>
+</tr>
+<tr><td><code>localQueueSelector</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#labelselector-v1-meta"><code>k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector</code></a>
+</td>
+<td>
+   <p>LocalQueueSelector can be used to choose the local queues that need metrics to be collected.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `MultiKueue`     {#config-kueue-x-k8s-io-v1beta2-MultiKueue}
+    
+
+**Appears in:**
+
+- [Configuration](#config-kueue-x-k8s-io-v1beta2-Configuration)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>gcInterval</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta"><code>k8s.io/apimachinery/pkg/apis/meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>GCInterval defines the time interval between two consecutive garbage collection runs.
+Defaults to 1min. If 0, the garbage collection is disabled.</p>
+</td>
+</tr>
+<tr><td><code>origin</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Origin defines a label value used to track the creator of workloads in the worker
+clusters.
+This is used by multikueue in components like its garbage collector to identify
+remote objects that ware created by this multikueue manager cluster and delete
+them if their local counterpart no longer exists.</p>
+</td>
+</tr>
+<tr><td><code>workerLostTimeout</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta"><code>k8s.io/apimachinery/pkg/apis/meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>WorkerLostTimeout defines the time a local workload's multikueue admission check state is kept Ready
+if the connection with its reserving worker cluster is lost.</p>
+<p>Defaults to 15 minutes.</p>
+</td>
+</tr>
+<tr><td><code>dispatcherName</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>DispatcherName defines the dispatcher responsible for selecting worker clusters to handle the workload.</p>
+<ul>
+<li>If specified, the workload will be handled by the named dispatcher.</li>
+<li>If not specified, the workload will be handled by the default (&quot;kueue.x-k8s.io/multikueue-dispatcher-all-at-once&quot;) dispatcher.</li>
+</ul>
+</td>
+</tr>
+<tr><td><code>externalFrameworks</code><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-MultiKueueExternalFramework"><code>[]MultiKueueExternalFramework</code></a>
+</td>
+<td>
+   <p>ExternalFrameworks defines a list of external frameworks that should be supported
+by the generic MultiKueue adapter. Each entry defines how to handle a specific
+GroupVersionKind (GVK) for MultiKueue operations.</p>
+</td>
+</tr>
+<tr><td><code>clusterProfile</code><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-ClusterProfile"><code>ClusterProfile</code></a>
+</td>
+<td>
+   <p>ClusterProfile defines configuration for using the ClusterProfile API.</p>
+</td>
+</tr>
+<tr><td><code>incrementalDispatcherConfig</code><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-IncrementalDispatcherConfig"><code>IncrementalDispatcherConfig</code></a>
+</td>
+<td>
+   <p>IncrementalDispatcherConfig contains the configuration for the incremental dispatcher.
+This field is only valid when DispatcherName is set to the incremental dispatcher.
+Note: This field is going to be ignored when the MultiKueueIncrementalDispatcherConfig feature gate is disabled.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `MultiKueueExternalFramework`     {#config-kueue-x-k8s-io-v1beta2-MultiKueueExternalFramework}
+    
+
+**Appears in:**
+
+- [MultiKueue](#config-kueue-x-k8s-io-v1beta2-MultiKueue)
+
+
+<p>MultiKueueExternalFramework defines a framework that is not built-in.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Name is the GVK of the resource that are
+managed by external controllers
+the expected format is <code>kind.version.group</code>.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ObjectRetentionPolicies`     {#config-kueue-x-k8s-io-v1beta2-ObjectRetentionPolicies}
+    
+
+**Appears in:**
+
+- [Configuration](#config-kueue-x-k8s-io-v1beta2-Configuration)
+
+
+<p>ObjectRetentionPolicies holds retention settings for different object types.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>workloads</code><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-WorkloadRetentionPolicy"><code>WorkloadRetentionPolicy</code></a>
+</td>
+<td>
+   <p>Workloads configures retention for Workloads.
+A nil value disables automatic deletion of Workloads.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `PreemptionStrategy`     {#config-kueue-x-k8s-io-v1beta2-PreemptionStrategy}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [FairSharing](#config-kueue-x-k8s-io-v1beta2-FairSharing)
+
+
+
+
+
+## `QuotaCheckStrategy`     {#config-kueue-x-k8s-io-v1beta2-QuotaCheckStrategy}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [Resources](#config-kueue-x-k8s-io-v1beta2-Resources)
+
+
+<p>QuotaCheckStrategy determines how Kueue checks resources against quota
+during admission.</p>
+
+
+
+
+## `RequeuingStrategy`     {#config-kueue-x-k8s-io-v1beta2-RequeuingStrategy}
+    
+
+**Appears in:**
+
+- [WaitForPodsReady](#config-kueue-x-k8s-io-v1beta2-WaitForPodsReady)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>timestamp</code><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-RequeuingTimestamp"><code>RequeuingTimestamp</code></a>
+</td>
+<td>
+   <p>Timestamp defines the timestamp used for re-queuing a Workload
+that was evicted due to Pod readiness. The possible values are:</p>
+<ul>
+<li><code>Eviction</code> (default) indicates from Workload <code>Evicted</code> condition with <code>PodsReadyTimeout</code> reason.</li>
+<li><code>Creation</code> indicates from Workload .metadata.creationTimestamp.</li>
+</ul>
+</td>
+</tr>
+<tr><td><code>backoffLimitCount</code><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>BackoffLimitCount defines the maximum number of re-queuing retries.
+Once the number is reached, the workload is deactivated (<code>.spec.activate</code>=<code>false</code>).
+When it is null, the workloads will repeatedly and endless re-queueing.</p>
+<p>Every backoff duration is about &quot;b*2^(n-1)+Rand&quot; where:</p>
+<ul>
+<li>&quot;b&quot; represents the base set by &quot;BackoffBaseSeconds&quot; parameter,</li>
+<li>&quot;n&quot; represents the &quot;workloadStatus.requeueState.count&quot;,</li>
+<li>&quot;Rand&quot; represents the random jitter.
+During this time, the workload is taken as an inadmissible and
+other workloads will have a chance to be admitted.
+By default, the consecutive requeue delays are around: (60s, 120s, 240s, ...).</li>
+</ul>
+<p>Defaults to null.</p>
+</td>
+</tr>
+<tr><td><code>backoffBaseSeconds</code><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>BackoffBaseSeconds defines the base for the exponential backoff for
+re-queuing an evicted workload.</p>
+<p>Defaults to 60.</p>
+</td>
+</tr>
+<tr><td><code>backoffMaxSeconds</code><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>BackoffMaxSeconds defines the maximum backoff time to re-queue an evicted workload.</p>
+<p>Defaults to 3600.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `RequeuingTimestamp`     {#config-kueue-x-k8s-io-v1beta2-RequeuingTimestamp}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [RequeuingStrategy](#config-kueue-x-k8s-io-v1beta2-RequeuingStrategy)
+
+
+
+
+
+## `ResourceTransformation`     {#config-kueue-x-k8s-io-v1beta2-ResourceTransformation}
+    
+
+**Appears in:**
+
+- [Resources](#config-kueue-x-k8s-io-v1beta2-Resources)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>input</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcename-v1-core"><code>k8s.io/api/core/v1.ResourceName</code></a>
+</td>
+<td>
+   <p>Input is the name of the input resource.</p>
+</td>
+</tr>
+<tr><td><code>strategy</code> <B>[Required]</B><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-ResourceTransformationStrategy"><code>ResourceTransformationStrategy</code></a>
+</td>
+<td>
+   <p>Strategy specifies if the input resource should be replaced or retained.
+Defaults to Retain</p>
+</td>
+</tr>
+<tr><td><code>multiplyBy</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcename-v1-core"><code>k8s.io/api/core/v1.ResourceName</code></a>
+</td>
+<td>
+   <p>MultiplyBy indicates the resource name requested by a workload, if
+specified.
+The requested amount of the resource is used to multiply the requested
+amount of the resource indicated by the &quot;input&quot; field when computing
+&quot;outputs&quot;. It does not change the quantity retained under &quot;input&quot; when
+&quot;strategy&quot; is Retain.</p>
+</td>
+</tr>
+<tr><td><code>outputs</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcelist-v1-core"><code>k8s.io/api/core/v1.ResourceList</code></a>
+</td>
+<td>
+   <p>Outputs specifies the output resources and quantities per unit of input resource.
+An empty Outputs combined with a <code>Replace</code> Strategy causes the Input resource to be ignored by Kueue.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ResourceTransformationStrategy`     {#config-kueue-x-k8s-io-v1beta2-ResourceTransformationStrategy}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [ResourceTransformation](#config-kueue-x-k8s-io-v1beta2-ResourceTransformation)
+
+
+
+
+
+## `Resources`     {#config-kueue-x-k8s-io-v1beta2-Resources}
+    
+
+**Appears in:**
+
+- [Configuration](#config-kueue-x-k8s-io-v1beta2-Configuration)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>quotaCheckStrategy</code><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-QuotaCheckStrategy"><code>QuotaCheckStrategy</code></a>
+</td>
+<td>
+   <p>QuotaCheckStrategy determines which resources are considered during quota admission.</p>
+</td>
+</tr>
+<tr><td><code>excludeResourcePrefixes</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   <p>ExcludedResourcePrefixes defines which resources should be ignored by Kueue</p>
+</td>
+</tr>
+<tr><td><code>transformations</code> <B>[Required]</B><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-ResourceTransformation"><code>[]ResourceTransformation</code></a>
+</td>
+<td>
+   <p>Transformations defines how to transform PodSpec resources into Workload resource requests.
+This is intended to be a map with Input as the key (enforced by validation code)</p>
+</td>
+</tr>
+<tr><td><code>deviceClassMappings</code><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-DeviceClassMapping"><code>[]DeviceClassMapping</code></a>
+</td>
+<td>
+   <p>DeviceClassMappings defines mappings from device classes to logical resources
+for Dynamic Resource Allocation support.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `SourceKind`     {#config-kueue-x-k8s-io-v1beta2-SourceKind}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [ControllerMetricsCustomLabel](#config-kueue-x-k8s-io-v1beta2-ControllerMetricsCustomLabel)
+
+
+
+
+
+## `TLSOptions`     {#config-kueue-x-k8s-io-v1beta2-TLSOptions}
+    
+
+**Appears in:**
+
+- [ControllerManager](#config-kueue-x-k8s-io-v1beta2-ControllerManager)
+
+
+<p>TLSOptions defines TLS security settings for Kueue servers</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>minVersion</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>minVersion is the minimum TLS version supported.
+Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).
+This field is only valid when TLSOptions is set to true.
+The default would be to not set this value and inherit golang settings.</p>
+</td>
+</tr>
+<tr><td><code>cipherSuites</code><br/>
+<code>[]string</code>
+</td>
+<td>
+   <p>cipherSuites is the list of allowed cipher suites for the server.
+Note that TLS 1.3 ciphersuites are not configurable.
+Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).
+The default would be to not set this value and inherit golang settings.</p>
+</td>
+</tr>
+<tr><td><code>curvePreferences</code><br/>
+<code>[]int32</code>
+</td>
+<td>
+   <p>curvePreferences is the list of allowed TLS key exchange mechanisms (curves)
+for the server, specified as numeric IANA TLS Supported Group IDs.
+See https://pkg.go.dev/crypto/tls#CurveID for values supported by the current Go version.
+If omitted, Go defaults are used.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `VisibilityServerConfiguration`     {#config-kueue-x-k8s-io-v1beta2-VisibilityServerConfiguration}
+    
+
+**Appears in:**
+
+- [Configuration](#config-kueue-x-k8s-io-v1beta2-Configuration)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>bindAddress</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>BindAddress is the IP address the visibility server listens on.
+Defaults to 0.0.0.0 (all network interfaces).</p>
+</td>
+</tr>
+<tr><td><code>bindPort</code><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>BindPort is the port the visibility server listens on.
+Defaults to 8082.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `WaitForPodsReady`     {#config-kueue-x-k8s-io-v1beta2-WaitForPodsReady}
+    
+
+**Appears in:**
+
+- [Configuration](#config-kueue-x-k8s-io-v1beta2-Configuration)
+
+
+<p>WaitForPodsReady defines configuration for the Wait For Pods Ready feature,
+which is used to ensure that all Pods are ready within the specified time.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>timeout</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta"><code>k8s.io/apimachinery/pkg/apis/meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>Timeout defines the time for an admitted workload to reach the
+PodsReady=true condition. When the timeout is exceeded, the workload
+evicted and requeued in the same cluster queue.</p>
+</td>
+</tr>
+<tr><td><code>blockAdmission</code><br/>
+<code>bool</code>
+</td>
+<td>
+   <p>BlockAdmission when true, Kueue blocks admission of all workloads across
+all ClusterQueues until every previously-admitted workload reaches the
+PodsReady=true condition.
+Defaults to false.</p>
+</td>
+</tr>
+<tr><td><code>requeuingStrategy</code><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-RequeuingStrategy"><code>RequeuingStrategy</code></a>
+</td>
+<td>
+   <p>RequeuingStrategy defines the strategy for requeuing a Workload.</p>
+</td>
+</tr>
+<tr><td><code>recoveryTimeout</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta"><code>k8s.io/apimachinery/pkg/apis/meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>RecoveryTimeout defines a timeout, measured since the
+last transition to the PodsReady=false condition after a Workload is Admitted and running.
+Such a transition may happen when a Pod failed and the replacement Pod
+is awaited to be scheduled.
+After exceeding the timeout the corresponding job gets suspended again
+and requeued after the backoff delay.
+Defaults to the value of timeout. Setting to &quot;0s&quot; disables recovery timeout checking.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `WorkloadRetentionPolicy`     {#config-kueue-x-k8s-io-v1beta2-WorkloadRetentionPolicy}
+    
+
+**Appears in:**
+
+- [ObjectRetentionPolicies](#config-kueue-x-k8s-io-v1beta2-ObjectRetentionPolicies)
+
+
+<p>WorkloadRetentionPolicy defines the policies for when Workloads should be deleted.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>afterFinished</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta"><code>k8s.io/apimachinery/pkg/apis/meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>AfterFinished is the duration to wait after a Workload finishes
+before deleting it.
+A duration of 0 will delete immediately.
+A nil value disables automatic deletion.
+Represented using metav1.Duration (e.g. &quot;10m&quot;, &quot;1h30m&quot;).</p>
+</td>
+</tr>
+<tr><td><code>afterDeactivatedByKueue</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta"><code>k8s.io/apimachinery/pkg/apis/meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>AfterDeactivatedByKueue is the duration to wait after <em>any</em> Kueue-managed Workload
+(such as a Job, JobSet, or other custom workload types) has been marked
+as deactivated by Kueue before automatically deleting it.
+Deletion of deactivated workloads may cascade to objects not created by
+Kueue, since deleting the parent Workload owner (e.g. JobSet) can trigger
+garbage-collection of dependent resources.
+A duration of 0 will delete immediately.
+A nil value disables automatic deletion.
+Represented using metav1.Duration (e.g. &quot;10m&quot;, &quot;1h30m&quot;).</p>
+</td>
+</tr>
+</tbody>
+</table>
+  

--- a/site/content/zh-CN/docs/reference/kueue.v1beta2.md
+++ b/site/content/zh-CN/docs/reference/kueue.v1beta2.md
@@ -1,0 +1,3882 @@
+---
+title: Kueue v1beta2 API
+content_type: tool-reference
+package: kueue.x-k8s.io/v1beta2
+auto_generated: true
+description: Generated API reference documentation for kueue.x-k8s.io/v1beta2.
+---
+
+
+## Resource Types 
+
+
+- [AdmissionCheck](#kueue-x-k8s-io-v1beta2-AdmissionCheck)
+- [ClusterQueue](#kueue-x-k8s-io-v1beta2-ClusterQueue)
+- [Cohort](#kueue-x-k8s-io-v1beta2-Cohort)
+- [LocalQueue](#kueue-x-k8s-io-v1beta2-LocalQueue)
+- [MultiKueueCluster](#kueue-x-k8s-io-v1beta2-MultiKueueCluster)
+- [MultiKueueConfig](#kueue-x-k8s-io-v1beta2-MultiKueueConfig)
+- [ProvisioningRequestConfig](#kueue-x-k8s-io-v1beta2-ProvisioningRequestConfig)
+- [ResourceFlavor](#kueue-x-k8s-io-v1beta2-ResourceFlavor)
+- [Topology](#kueue-x-k8s-io-v1beta2-Topology)
+- [Workload](#kueue-x-k8s-io-v1beta2-Workload)
+- [WorkloadPriorityClass](#kueue-x-k8s-io-v1beta2-WorkloadPriorityClass)
+  
+
+## `AdmissionCheck`     {#kueue-x-k8s-io-v1beta2-AdmissionCheck}
+    
+
+**Appears in:**
+
+
+
+<p>AdmissionCheck is the Schema for the admissionchecks API</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kueue.x-k8s.io/v1beta2</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>AdmissionCheck</code></td></tr>
+    
+  
+<tr><td><code>spec</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-AdmissionCheckSpec"><code>AdmissionCheckSpec</code></a>
+</td>
+<td>
+   <p>spec is the specification of the AdmissionCheck.</p>
+</td>
+</tr>
+<tr><td><code>status</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-AdmissionCheckStatus"><code>AdmissionCheckStatus</code></a>
+</td>
+<td>
+   <p>status is the status of the AdmissionCheck.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ClusterQueue`     {#kueue-x-k8s-io-v1beta2-ClusterQueue}
+    
+
+**Appears in:**
+
+
+
+<p>ClusterQueue is the Schema for the clusterQueue API.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kueue.x-k8s.io/v1beta2</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>ClusterQueue</code></td></tr>
+    
+  
+<tr><td><code>spec</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-ClusterQueueSpec"><code>ClusterQueueSpec</code></a>
+</td>
+<td>
+   <p>spec is the specification of the ClusterQueue.</p>
+</td>
+</tr>
+<tr><td><code>status</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-ClusterQueueStatus"><code>ClusterQueueStatus</code></a>
+</td>
+<td>
+   <p>status is the status of the ClusterQueue.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `Cohort`     {#kueue-x-k8s-io-v1beta2-Cohort}
+    
+
+**Appears in:**
+
+
+
+<p>Cohort defines the Cohorts API.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kueue.x-k8s.io/v1beta2</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>Cohort</code></td></tr>
+    
+  
+<tr><td><code>spec</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-CohortSpec"><code>CohortSpec</code></a>
+</td>
+<td>
+   <p>spec is the specification of the Cohort.</p>
+</td>
+</tr>
+<tr><td><code>status</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-CohortStatus"><code>CohortStatus</code></a>
+</td>
+<td>
+   <p>status is the status of the Cohort.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `LocalQueue`     {#kueue-x-k8s-io-v1beta2-LocalQueue}
+    
+
+**Appears in:**
+
+
+
+<p>LocalQueue is the Schema for the localQueues API</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kueue.x-k8s.io/v1beta2</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>LocalQueue</code></td></tr>
+    
+  
+<tr><td><code>spec</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-LocalQueueSpec"><code>LocalQueueSpec</code></a>
+</td>
+<td>
+   <p>spec is the specification of the LocalQueue.</p>
+</td>
+</tr>
+<tr><td><code>status</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-LocalQueueStatus"><code>LocalQueueStatus</code></a>
+</td>
+<td>
+   <p>status is the status of the LocalQueue.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `MultiKueueCluster`     {#kueue-x-k8s-io-v1beta2-MultiKueueCluster}
+    
+
+**Appears in:**
+
+
+
+<p>MultiKueueCluster is the Schema for the multikueue API</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kueue.x-k8s.io/v1beta2</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>MultiKueueCluster</code></td></tr>
+    
+  
+<tr><td><code>spec,omitempty,omitzero</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-MultiKueueClusterSpec"><code>MultiKueueClusterSpec</code></a>
+</td>
+<td>
+   <p>spec is the specification of the MultiKueueCluster.</p>
+</td>
+</tr>
+<tr><td><code>status</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-MultiKueueClusterStatus"><code>MultiKueueClusterStatus</code></a>
+</td>
+<td>
+   <p>status is the status of the MultiKueueCluster.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `MultiKueueConfig`     {#kueue-x-k8s-io-v1beta2-MultiKueueConfig}
+    
+
+**Appears in:**
+
+
+
+<p>MultiKueueConfig is the Schema for the multikueue API</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kueue.x-k8s.io/v1beta2</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>MultiKueueConfig</code></td></tr>
+    
+  
+<tr><td><code>spec</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-MultiKueueConfigSpec"><code>MultiKueueConfigSpec</code></a>
+</td>
+<td>
+   <p>spec is the specification of the MultiKueueConfig.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ProvisioningRequestConfig`     {#kueue-x-k8s-io-v1beta2-ProvisioningRequestConfig}
+    
+
+**Appears in:**
+
+
+
+<p>ProvisioningRequestConfig is the Schema for the provisioningrequestconfig API</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kueue.x-k8s.io/v1beta2</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>ProvisioningRequestConfig</code></td></tr>
+    
+  
+<tr><td><code>spec</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-ProvisioningRequestConfigSpec"><code>ProvisioningRequestConfigSpec</code></a>
+</td>
+<td>
+   <p>spec is the specification of the ProvisioningRequestConfig.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ResourceFlavor`     {#kueue-x-k8s-io-v1beta2-ResourceFlavor}
+    
+
+**Appears in:**
+
+
+
+<p>ResourceFlavor is the Schema for the resourceflavors API.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kueue.x-k8s.io/v1beta2</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>ResourceFlavor</code></td></tr>
+    
+  
+<tr><td><code>spec</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-ResourceFlavorSpec"><code>ResourceFlavorSpec</code></a>
+</td>
+<td>
+   <p>spec is the specification of the ResourceFlavor.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `Topology`     {#kueue-x-k8s-io-v1beta2-Topology}
+    
+
+**Appears in:**
+
+
+
+<p>Topology is the Schema for the topology API</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kueue.x-k8s.io/v1beta2</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>Topology</code></td></tr>
+    
+  
+<tr><td><code>spec</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-TopologySpec"><code>TopologySpec</code></a>
+</td>
+<td>
+   <p>spec is the specification of the Topology.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `Workload`     {#kueue-x-k8s-io-v1beta2-Workload}
+    
+
+**Appears in:**
+
+
+
+<p>Workload is the Schema for the workloads API</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kueue.x-k8s.io/v1beta2</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>Workload</code></td></tr>
+    
+  
+<tr><td><code>spec</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-WorkloadSpec"><code>WorkloadSpec</code></a>
+</td>
+<td>
+   <p>spec is the specification of the Workload.</p>
+</td>
+</tr>
+<tr><td><code>status</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-WorkloadStatus"><code>WorkloadStatus</code></a>
+</td>
+<td>
+   <p>status is the status of the Workload.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `WorkloadPriorityClass`     {#kueue-x-k8s-io-v1beta2-WorkloadPriorityClass}
+    
+
+**Appears in:**
+
+
+
+<p>WorkloadPriorityClass is the Schema for the workloadPriorityClass API</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kueue.x-k8s.io/v1beta2</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>WorkloadPriorityClass</code></td></tr>
+    
+  
+<tr><td><code>value</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>value represents the integer value of this workloadPriorityClass. This is the actual priority that workloads
+receive when jobs have the name of this class in their workloadPriorityClass label.
+Changing the value of workloadPriorityClass doesn't affect the priority of workloads that were already created.</p>
+</td>
+</tr>
+<tr><td><code>description</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>description is an arbitrary string that usually provides guidelines on
+when this workloadPriorityClass should be used.
+The description is limited to a maximum of 2048 characters.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `Admission`     {#kueue-x-k8s-io-v1beta2-Admission}
+    
+
+**Appears in:**
+
+- [WorkloadStatus](#kueue-x-k8s-io-v1beta2-WorkloadStatus)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>clusterQueue</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-ClusterQueueReference"><code>ClusterQueueReference</code></a>
+</td>
+<td>
+   <p>clusterQueue is the name of the ClusterQueue that admitted this workload.</p>
+</td>
+</tr>
+<tr><td><code>podSetAssignments</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-PodSetAssignment"><code>[]PodSetAssignment</code></a>
+</td>
+<td>
+   <p>podSetAssignments hold the admission results for each of the .spec.podSets entries.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `AdmissionCheckParametersReference`     {#kueue-x-k8s-io-v1beta2-AdmissionCheckParametersReference}
+    
+
+**Appears in:**
+
+- [AdmissionCheckSpec](#kueue-x-k8s-io-v1beta2-AdmissionCheckSpec)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>apiGroup</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>apiGroup is the group for the resource being referenced.</p>
+</td>
+</tr>
+<tr><td><code>kind</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>kind is the type of the resource being referenced.</p>
+</td>
+</tr>
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>name is the name of the resource being referenced.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `AdmissionCheckReference`     {#kueue-x-k8s-io-v1beta2-AdmissionCheckReference}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [AdmissionCheckState](#kueue-x-k8s-io-v1beta2-AdmissionCheckState)
+
+- [AdmissionCheckStrategyRule](#kueue-x-k8s-io-v1beta2-AdmissionCheckStrategyRule)
+
+
+<p>AdmissionCheckReference is the name of an AdmissionCheck.</p>
+
+
+
+
+## `AdmissionCheckSpec`     {#kueue-x-k8s-io-v1beta2-AdmissionCheckSpec}
+    
+
+**Appears in:**
+
+- [AdmissionCheck](#kueue-x-k8s-io-v1beta2-AdmissionCheck)
+
+
+<p>AdmissionCheckSpec defines the desired state of AdmissionCheck</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>controllerName</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>controllerName identifies the controller that processes the AdmissionCheck,
+not necessarily a Kubernetes Pod or Deployment name. Cannot be empty.</p>
+</td>
+</tr>
+<tr><td><code>parameters</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-AdmissionCheckParametersReference"><code>AdmissionCheckParametersReference</code></a>
+</td>
+<td>
+   <p>parameters identifies a configuration with additional parameters for the
+check.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `AdmissionCheckState`     {#kueue-x-k8s-io-v1beta2-AdmissionCheckState}
+    
+
+**Appears in:**
+
+- [WorkloadStatus](#kueue-x-k8s-io-v1beta2-WorkloadStatus)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<a href="#kueue-x-k8s-io-v1beta2-AdmissionCheckReference"><code>AdmissionCheckReference</code></a>
+</td>
+<td>
+   <p>name identifies the admission check.</p>
+</td>
+</tr>
+<tr><td><code>state</code> <B>[Required]</B><br/>
+<a href="#kueue-x-k8s-io-v1beta2-CheckState"><code>CheckState</code></a>
+</td>
+<td>
+   <p>state of the admissionCheck, one of Pending, Ready, Retry, Rejected</p>
+</td>
+</tr>
+<tr><td><code>lastTransitionTime,omitempty,omitzero</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta"><code>k8s.io/apimachinery/pkg/apis/meta/v1.Time</code></a>
+</td>
+<td>
+   <p>lastTransitionTime is the last time the condition transitioned from one status to another.
+This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.</p>
+</td>
+</tr>
+<tr><td><code>message</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>message is a human readable message indicating details about the transition.
+This may be an empty string.</p>
+</td>
+</tr>
+<tr><td><code>requeueAfterSeconds</code><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>requeueAfterSeconds indicates how long to wait at least before
+retrying to admit the workload.
+The admission check controllers can set this field when State=Retry
+to implement delays between retry attempts.</p>
+<p>If nil when State=Retry, Kueue will retry immediately.
+If set, Kueue will add the workload back to the queue after
+lastTransitionTime + RequeueAfterSeconds is over.</p>
+</td>
+</tr>
+<tr><td><code>retryCount</code><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>retryCount tracks retry attempts for this admission check.
+Kueue automatically increments the counter whenever the
+state transitions to Retry.</p>
+</td>
+</tr>
+<tr><td><code>podSetUpdates</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-PodSetUpdate"><code>[]PodSetUpdate</code></a>
+</td>
+<td>
+   <p>podSetUpdates contains a list of pod set modifications suggested by AdmissionChecks.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `AdmissionCheckStatus`     {#kueue-x-k8s-io-v1beta2-AdmissionCheckStatus}
+    
+
+**Appears in:**
+
+- [AdmissionCheck](#kueue-x-k8s-io-v1beta2-AdmissionCheck)
+
+
+<p>AdmissionCheckStatus defines the observed state of AdmissionCheck</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>conditions</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta"><code>[]k8s.io/apimachinery/pkg/apis/meta/v1.Condition</code></a>
+</td>
+<td>
+   <p>conditions hold the latest available observations of the AdmissionCheck
+current state.
+This is limited to at most 16 separate conditions.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `AdmissionCheckStrategyRule`     {#kueue-x-k8s-io-v1beta2-AdmissionCheckStrategyRule}
+    
+
+**Appears in:**
+
+- [AdmissionChecksStrategy](#kueue-x-k8s-io-v1beta2-AdmissionChecksStrategy)
+
+
+<p>AdmissionCheckStrategyRule defines rules for a single AdmissionCheck</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<a href="#kueue-x-k8s-io-v1beta2-AdmissionCheckReference"><code>AdmissionCheckReference</code></a>
+</td>
+<td>
+   <p>name is an AdmissionCheck's name.</p>
+</td>
+</tr>
+<tr><td><code>onFlavors</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-ResourceFlavorReference"><code>[]ResourceFlavorReference</code></a>
+</td>
+<td>
+   <p>onFlavors is a list of ResourceFlavors' names that this AdmissionCheck should run for.
+If empty, the AdmissionCheck will run for all workloads submitted to the ClusterQueue.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `AdmissionChecksStrategy`     {#kueue-x-k8s-io-v1beta2-AdmissionChecksStrategy}
+    
+
+**Appears in:**
+
+- [ClusterQueueSpec](#kueue-x-k8s-io-v1beta2-ClusterQueueSpec)
+
+
+<p>AdmissionChecksStrategy defines a strategy for a AdmissionCheck.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>admissionChecks</code> <B>[Required]</B><br/>
+<a href="#kueue-x-k8s-io-v1beta2-AdmissionCheckStrategyRule"><code>[]AdmissionCheckStrategyRule</code></a>
+</td>
+<td>
+   <p>admissionChecks is a list of strategies for AdmissionChecks</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `AdmissionMode`     {#kueue-x-k8s-io-v1beta2-AdmissionMode}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [AdmissionScope](#kueue-x-k8s-io-v1beta2-AdmissionScope)
+
+
+
+
+
+## `AdmissionScope`     {#kueue-x-k8s-io-v1beta2-AdmissionScope}
+    
+
+**Appears in:**
+
+- [ClusterQueueSpec](#kueue-x-k8s-io-v1beta2-ClusterQueueSpec)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>admissionMode</code> <B>[Required]</B><br/>
+<a href="#kueue-x-k8s-io-v1beta2-AdmissionMode"><code>AdmissionMode</code></a>
+</td>
+<td>
+   <p>admissionMode indicates which mode for AdmissionFairSharing should be used
+in the AdmissionScope. Possible values are:</p>
+<ul>
+<li>UsageBasedAdmissionFairSharing</li>
+<li>NoAdmissionFairSharing</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `BorrowWithinCohort`     {#kueue-x-k8s-io-v1beta2-BorrowWithinCohort}
+    
+
+**Appears in:**
+
+- [ClusterQueuePreemption](#kueue-x-k8s-io-v1beta2-ClusterQueuePreemption)
+
+
+<p>BorrowWithinCohort contains configuration which allows to preempt workloads
+within cohort while borrowing. It only works with Classical Preemption,
+<strong>not</strong> with Fair Sharing.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>policy</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-BorrowWithinCohortPolicy"><code>BorrowWithinCohortPolicy</code></a>
+</td>
+<td>
+   <p>policy determines the policy for preemption to reclaim quota within cohort while borrowing.
+Possible values are:</p>
+<ul>
+<li><code>Never</code> (default): do not allow for preemption, in other
+ClusterQueues within the cohort, for a borrowing workload.</li>
+<li><code>LowerPriority</code>: allow preemption, in other ClusterQueues
+within the cohort, for a borrowing workload, but only if
+the preempted workloads are of lower priority.</li>
+</ul>
+</td>
+</tr>
+<tr><td><code>maxPriorityThreshold</code><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>maxPriorityThreshold allows to restrict the set of workloads which
+might be preempted by a borrowing workload, to only workloads with
+priority less than or equal to the specified threshold priority.
+When the threshold is not specified, then any workload satisfying the
+policy can be preempted by the borrowing workload.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `BorrowWithinCohortPolicy`     {#kueue-x-k8s-io-v1beta2-BorrowWithinCohortPolicy}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [BorrowWithinCohort](#kueue-x-k8s-io-v1beta2-BorrowWithinCohort)
+
+
+
+
+
+## `CheckState`     {#kueue-x-k8s-io-v1beta2-CheckState}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [AdmissionCheckState](#kueue-x-k8s-io-v1beta2-AdmissionCheckState)
+
+
+
+
+
+## `ClusterProfileReference`     {#kueue-x-k8s-io-v1beta2-ClusterProfileReference}
+    
+
+**Appears in:**
+
+- [ClusterSource](#kueue-x-k8s-io-v1beta2-ClusterSource)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>name of the ClusterProfile.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ClusterQueuePreemption`     {#kueue-x-k8s-io-v1beta2-ClusterQueuePreemption}
+    
+
+**Appears in:**
+
+- [ClusterQueueSpec](#kueue-x-k8s-io-v1beta2-ClusterQueueSpec)
+
+
+<p>ClusterQueuePreemption contains policies to preempt Workloads from this
+ClusterQueue or the ClusterQueue's cohort.</p>
+<p>Preemption may be configured to work in the following scenarios:</p>
+<ul>
+<li>When a Workload fits within the nominal quota of the ClusterQueue, but
+the quota is currently borrowed by other ClusterQueues in the cohort.
+We preempt workloads in other ClusterQueues to allow this ClusterQueue to
+reclaim its nominal quota. Configured using reclaimWithinCohort.</li>
+<li>When a Workload doesn't fit within the nominal quota of the ClusterQueue
+and there are admitted Workloads in the ClusterQueue with lower priority.
+Configured using withinClusterQueue.</li>
+<li>When a Workload may fit while both borrowing and preempting
+low priority workloads in the Cohort. Configured using borrowWithinCohort.</li>
+<li>When FairSharing is enabled, to maintain fair distribution of
+unused resources. See FairSharing documentation.</li>
+</ul>
+<p>The preemption algorithm tries to find a minimal set of Workloads to
+preempt to accomomdate the pending Workload, preempting Workloads with
+lower priority first.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>reclaimWithinCohort</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-PreemptionPolicy"><code>PreemptionPolicy</code></a>
+</td>
+<td>
+   <p>reclaimWithinCohort determines whether a pending Workload can preempt
+Workloads from other ClusterQueues in the cohort that are using more than
+their nominal quota. The possible values are:</p>
+<ul>
+<li><code>Never</code> (default): do not preempt Workloads in the cohort.</li>
+<li><code>LowerPriority</code>: <strong>Classic Preemption</strong> if the pending Workload
+fits within the nominal quota of its ClusterQueue, only preempt
+Workloads in the cohort that have lower priority than the pending
+Workload. <strong>Fair Sharing</strong> only preempt Workloads in the cohort that
+have lower priority than the pending Workload and that satisfy the
+Fair Sharing preemptionStategies.</li>
+<li><code>Any</code>: <strong>Classic Preemption</strong> if the pending Workload fits within
+the nominal quota of its ClusterQueue, preempt any Workload in the
+cohort, irrespective of priority. <strong>Fair Sharing</strong> preempt Workloads
+in the cohort that satisfy the Fair Sharing preemptionStrategies.</li>
+</ul>
+</td>
+</tr>
+<tr><td><code>borrowWithinCohort</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-BorrowWithinCohort"><code>BorrowWithinCohort</code></a>
+</td>
+<td>
+   <p>borrowWithinCohort determines whether a pending Workload can preempt
+Workloads from other ClusterQueues in the cohort if the workload requires borrowing.
+May only be configured with Classical Preemption, and <strong>not</strong> with Fair Sharing.</p>
+</td>
+</tr>
+<tr><td><code>withinClusterQueue</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-PreemptionPolicy"><code>PreemptionPolicy</code></a>
+</td>
+<td>
+   <p>withinClusterQueue determines whether a pending Workload that doesn't fit
+within the nominal quota for its ClusterQueue, can preempt active Workloads in
+the ClusterQueue. The possible values are:</p>
+<ul>
+<li><code>Never</code> (default): do not preempt Workloads in the ClusterQueue.</li>
+<li><code>LowerPriority</code>: only preempt Workloads in the ClusterQueue that have
+lower priority than the pending Workload.</li>
+<li><code>LowerOrNewerEqualPriority</code>: only preempt Workloads in the ClusterQueue that
+either have a lower priority than the pending workload or equal priority
+and are newer than the pending workload.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ClusterQueueReference`     {#kueue-x-k8s-io-v1beta2-ClusterQueueReference}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [Admission](#kueue-x-k8s-io-v1beta2-Admission)
+
+- [LocalQueueSpec](#kueue-x-k8s-io-v1beta2-LocalQueueSpec)
+
+
+<p>ClusterQueueReference is the name of the ClusterQueue.
+It must be a DNS (RFC 1123) and has the maximum length of 253 characters.</p>
+
+
+
+
+## `ClusterQueueSpec`     {#kueue-x-k8s-io-v1beta2-ClusterQueueSpec}
+    
+
+**Appears in:**
+
+- [ClusterQueue](#kueue-x-k8s-io-v1beta2-ClusterQueue)
+
+
+<p>ClusterQueueSpec defines the desired state of ClusterQueue</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>resourceGroups</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-ResourceGroup"><code>[]ResourceGroup</code></a>
+</td>
+<td>
+   <p>resourceGroups describes groups of resources.
+Each resource group defines the list of resources and a list of flavors
+that provide quotas for these resources.
+Each resource and each flavor can only form part of one resource group.
+resourceGroups can be up to 16, with a max of 256 total flavors across all groups.</p>
+</td>
+</tr>
+<tr><td><code>cohortName</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-CohortReference"><code>CohortReference</code></a>
+</td>
+<td>
+   <p>cohortName that this ClusterQueue belongs to. CQs that belong to the
+same cohort can borrow unused resources from each other.</p>
+<p>A CQ can be a member of a single borrowing cohort. A workload submitted
+to a queue referencing this CQ can borrow quota from any CQ in the cohort.
+Only quota for the [resource, flavor] pairs listed in the CQ can be
+borrowed.
+If empty, this ClusterQueue cannot borrow from any other ClusterQueue and
+vice versa.</p>
+<p>A cohort is a name that links CQs together, but it doesn't reference any
+object.</p>
+</td>
+</tr>
+<tr><td><code>queueingStrategy</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-QueueingStrategy"><code>QueueingStrategy</code></a>
+</td>
+<td>
+   <p>queueingStrategy indicates the queueing strategy of the workloads
+across the queues in this ClusterQueue.
+Current Supported Strategies:</p>
+<ul>
+<li>StrictFIFO: workloads are ordered strictly by creation time.
+Older workloads that can't be admitted will block admitting newer
+workloads even if they fit available quota.</li>
+<li>BestEffortFIFO: workloads are ordered by creation time,
+however older workloads that can't be admitted will not block
+admitting newer workloads that fit existing quota.</li>
+</ul>
+</td>
+</tr>
+<tr><td><code>namespaceSelector</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#labelselector-v1-meta"><code>k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector</code></a>
+</td>
+<td>
+   <p>namespaceSelector defines which namespaces are allowed to submit workloads to
+this clusterQueue. Beyond this basic support for policy, a policy agent like
+Gatekeeper should be used to enforce more advanced policies.
+Defaults to null which is a nothing selector (no namespaces eligible).
+If set to an empty selector <code>{}</code>, then all namespaces are eligible.</p>
+</td>
+</tr>
+<tr><td><code>flavorFungibility</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-FlavorFungibility"><code>FlavorFungibility</code></a>
+</td>
+<td>
+   <p>flavorFungibility defines whether a workload should try the next flavor
+before borrowing or preempting in the flavor being evaluated.</p>
+</td>
+</tr>
+<tr><td><code>preemption</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-ClusterQueuePreemption"><code>ClusterQueuePreemption</code></a>
+</td>
+<td>
+   <p>preemption defines the preemption policies.</p>
+</td>
+</tr>
+<tr><td><code>admissionChecksStrategy</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-AdmissionChecksStrategy"><code>AdmissionChecksStrategy</code></a>
+</td>
+<td>
+   <p>admissionChecksStrategy defines a list of strategies to determine which ResourceFlavors require AdmissionChecks.</p>
+</td>
+</tr>
+<tr><td><code>stopPolicy</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-StopPolicy"><code>StopPolicy</code></a>
+</td>
+<td>
+   <p>stopPolicy - if set to a value different from None, the ClusterQueue is considered Inactive, no new reservation being
+made.</p>
+<p>Depending on its value, its associated workloads will:</p>
+<ul>
+<li>None - Workloads are admitted</li>
+<li>HoldAndDrain - Admitted workloads are evicted and Reserving workloads will cancel the reservation.</li>
+<li>Hold - Admitted workloads will run to completion and Reserving workloads will cancel the reservation.</li>
+</ul>
+</td>
+</tr>
+<tr><td><code>fairSharing</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-FairSharing"><code>FairSharing</code></a>
+</td>
+<td>
+   <p>fairSharing defines the properties of the ClusterQueue when
+participating in FairSharing.  The values are only relevant
+if FairSharing is enabled in the Kueue configuration.</p>
+</td>
+</tr>
+<tr><td><code>admissionScope</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-AdmissionScope"><code>AdmissionScope</code></a>
+</td>
+<td>
+   <p>admissionScope indicates whether ClusterQueue uses the Admission Fair Sharing</p>
+</td>
+</tr>
+<tr><td><code>concurrentAdmissionPolicy</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-ConcurrentAdmissionPolicy"><code>ConcurrentAdmissionPolicy</code></a>
+</td>
+<td>
+   <p>concurrentAdmissionPolicy defines the configuration for ConcurrentAdmission feature.
+Its main capability is to allow Workloads pursuing multiple flavors at the same time, and starting on the first flavor that led to admission.
+Additionally after the admission, Workloads can still try to pursue capacity on the more preferable flavors while running.
+It enables them to migrate to more preferable, whenever capacity appears.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ClusterQueueStatus`     {#kueue-x-k8s-io-v1beta2-ClusterQueueStatus}
+    
+
+**Appears in:**
+
+- [ClusterQueue](#kueue-x-k8s-io-v1beta2-ClusterQueue)
+
+
+<p>ClusterQueueStatus defines the observed state of ClusterQueue</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>conditions</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta"><code>[]k8s.io/apimachinery/pkg/apis/meta/v1.Condition</code></a>
+</td>
+<td>
+   <p>conditions hold the latest available observations of the ClusterQueue
+current state.
+conditions are limited to 16 elements.</p>
+</td>
+</tr>
+<tr><td><code>flavorsReservation</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-FlavorUsage"><code>[]FlavorUsage</code></a>
+</td>
+<td>
+   <p>flavorsReservation are the reserved quotas, by flavor, currently in use by the
+workloads assigned to this ClusterQueue.
+flavorsReservation are limited to 64 elements.</p>
+</td>
+</tr>
+<tr><td><code>flavorsUsage</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-FlavorUsage"><code>[]FlavorUsage</code></a>
+</td>
+<td>
+   <p>flavorsUsage are the used quotas, by flavor, currently in use by the
+workloads admitted in this ClusterQueue.</p>
+</td>
+</tr>
+<tr><td><code>pendingWorkloads</code><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>pendingWorkloads is the number of workloads currently waiting to be
+admitted to this clusterQueue.</p>
+</td>
+</tr>
+<tr><td><code>reservingWorkloads</code><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>reservingWorkloads is the number of workloads currently reserving quota in this
+clusterQueue.</p>
+</td>
+</tr>
+<tr><td><code>admittedWorkloads</code><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>admittedWorkloads is the number of workloads currently admitted to this
+clusterQueue and haven't finished yet.</p>
+</td>
+</tr>
+<tr><td><code>fairSharing</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-FairSharingStatus"><code>FairSharingStatus</code></a>
+</td>
+<td>
+   <p>fairSharing contains the current state for this ClusterQueue
+when participating in Fair Sharing.
+This is recorded only when Fair Sharing is enabled in the Kueue configuration.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ClusterSource`     {#kueue-x-k8s-io-v1beta2-ClusterSource}
+    
+
+**Appears in:**
+
+- [MultiKueueClusterSpec](#kueue-x-k8s-io-v1beta2-MultiKueueClusterSpec)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>kubeConfig,omitempty,omitzero</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-KubeConfig"><code>KubeConfig</code></a>
+</td>
+<td>
+   <p>kubeConfig is information on how to connect to the cluster.</p>
+</td>
+</tr>
+<tr><td><code>clusterProfileRef</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-ClusterProfileReference"><code>ClusterProfileReference</code></a>
+</td>
+<td>
+   <p>clusterProfileRef is the reference to the ClusterProfile object used to connect to the cluster.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `CohortReference`     {#kueue-x-k8s-io-v1beta2-CohortReference}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [ClusterQueueSpec](#kueue-x-k8s-io-v1beta2-ClusterQueueSpec)
+
+- [CohortSpec](#kueue-x-k8s-io-v1beta2-CohortSpec)
+
+
+<p>CohortReference is the name of the Cohort.</p>
+<p>Validation of a cohort name is equivalent to that of object names:
+subdomain in DNS (RFC 1123).</p>
+
+
+
+
+## `CohortSpec`     {#kueue-x-k8s-io-v1beta2-CohortSpec}
+    
+
+**Appears in:**
+
+- [Cohort](#kueue-x-k8s-io-v1beta2-Cohort)
+
+
+<p>CohortSpec defines the desired state of Cohort</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>parentName</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-CohortReference"><code>CohortReference</code></a>
+</td>
+<td>
+   <p>parentName references the name of the Cohort's parent, if
+any. It satisfies one of three cases:</p>
+<ol>
+<li>Unset. This Cohort is the root of its Cohort tree.</li>
+<li>References a non-existent Cohort. We use default Cohort (no borrowing/lending limits).</li>
+<li>References an existent Cohort.</li>
+</ol>
+<p>If a cycle is created, we disable all members of the
+Cohort, including ClusterQueues, until the cycle is
+removed.  We prevent further admission while the cycle
+exists.</p>
+</td>
+</tr>
+<tr><td><code>resourceGroups</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-ResourceGroup"><code>[]ResourceGroup</code></a>
+</td>
+<td>
+   <p>resourceGroups describes groupings of Resources and
+Flavors.  Each ResourceGroup defines a list of Resources
+and a list of Flavors which provide quotas for these
+Resources. Each Resource and each Flavor may only form part
+of one ResourceGroup.  There may be up to 16 ResourceGroups
+within a Cohort.</p>
+<p>Please note that nominalQuota defined at the Cohort level
+represents additional resources on top of those defined by
+ClusterQueues within the Cohort. The Cohort's nominalQuota
+may be thought of as a shared pool for the ClusterQueues
+within it. Additionally, this quota may also be lent out to
+parent Cohort(s), subject to LendingLimit.</p>
+<p>BorrowingLimit limits how much members of this Cohort
+subtree can borrow from the parent subtree.</p>
+<p>LendingLimit limits how much members of this Cohort subtree
+can lend to the parent subtree.</p>
+<p>Borrowing and Lending limits must only be set when the
+Cohort has a parent.  Otherwise, the Cohort create/update
+will be rejected by the webhook.</p>
+</td>
+</tr>
+<tr><td><code>fairSharing</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-FairSharing"><code>FairSharing</code></a>
+</td>
+<td>
+   <p>fairSharing defines the properties of the Cohort when
+participating in FairSharing. The values are only relevant
+if FairSharing is enabled in the Kueue configuration.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `CohortStatus`     {#kueue-x-k8s-io-v1beta2-CohortStatus}
+    
+
+**Appears in:**
+
+- [Cohort](#kueue-x-k8s-io-v1beta2-Cohort)
+
+
+<p>CohortStatus defines the observed state of Cohort.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>fairSharing</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-FairSharingStatus"><code>FairSharingStatus</code></a>
+</td>
+<td>
+   <p>fairSharing contains the current state for this Cohort
+when participating in Fair Sharing.
+The is recorded only when Fair Sharing is enabled in the Kueue configuration.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ConcurrentAdmissionConstraints`     {#kueue-x-k8s-io-v1beta2-ConcurrentAdmissionConstraints}
+    
+
+**Appears in:**
+
+- [ConcurrentAdmissionMigration](#kueue-x-k8s-io-v1beta2-ConcurrentAdmissionMigration)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>lastAcceptableFlavorName</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-ResourceFlavorReference"><code>ResourceFlavorReference</code></a>
+</td>
+<td>
+   <p>lastAcceptableFlavorName defines the last acceptable flavor a Workload can migrate to.
+The order is based on the order of flavors in ClusterQueue.
+It can only be used if the Mode is <code>TryPreferredFlavors</code>.
+If the Mode is <code>TryPreferredFlavors</code> and LastAcceptableFlavorName is not specified, then
+Workload can migrate to any flavor that is more preferable than the one it was admitted to.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ConcurrentAdmissionMigration`     {#kueue-x-k8s-io-v1beta2-ConcurrentAdmissionMigration}
+    
+
+**Appears in:**
+
+- [ConcurrentAdmissionPolicy](#kueue-x-k8s-io-v1beta2-ConcurrentAdmissionPolicy)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>mode</code> <B>[Required]</B><br/>
+<a href="#kueue-x-k8s-io-v1beta2-ConcurrentAdmissionMigrationMode"><code>ConcurrentAdmissionMigrationMode</code></a>
+</td>
+<td>
+   <p>mode defines the mode of Workload's migration.
+The possible values are:</p>
+<ul>
+<li><code>TryPreferredFlavors</code> (default): a Workload will try to migrate to the preferred flavor after it's admitted and running.</li>
+<li><code>RetainFirstAdmission</code>: a Workload, once admitted to a flavor, will stick to a flavor and will not be migrated.</li>
+</ul>
+</td>
+</tr>
+<tr><td><code>constraints</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-ConcurrentAdmissionConstraints"><code>ConcurrentAdmissionConstraints</code></a>
+</td>
+<td>
+   <p>constraints defines the constraints of Workload's migration.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ConcurrentAdmissionMigrationMode`     {#kueue-x-k8s-io-v1beta2-ConcurrentAdmissionMigrationMode}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [ConcurrentAdmissionMigration](#kueue-x-k8s-io-v1beta2-ConcurrentAdmissionMigration)
+
+
+
+
+
+## `ConcurrentAdmissionPolicy`     {#kueue-x-k8s-io-v1beta2-ConcurrentAdmissionPolicy}
+    
+
+**Appears in:**
+
+- [ClusterQueueSpec](#kueue-x-k8s-io-v1beta2-ClusterQueueSpec)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>migration,omitzero</code> <B>[Required]</B><br/>
+<a href="#kueue-x-k8s-io-v1beta2-ConcurrentAdmissionMigration"><code>ConcurrentAdmissionMigration</code></a>
+</td>
+<td>
+   <p>migration defines the constraints on Workload's migration.
+The mechanism itself creates &quot;Variants&quot; of the same Workload, each pursuing a different flavor.
+All Variants belong to the same &quot;Parent&quot; Workload, and are picked up by Kueue scheduler independently.
+Once one of the Variants is admitted, the Parent Workload gets also admitted. The Variants that pursue more
+favorable flavors keep trying to get admitted and if they succeed, the Workload migrates to the new flavor.
+The Variants that pursue less favorable flavors are deactivated.
+Flavor preferences are expressed through the order of flavors in the ClusterQueue.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `DelayedTopologyRequestState`     {#kueue-x-k8s-io-v1beta2-DelayedTopologyRequestState}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [PodSetAssignment](#kueue-x-k8s-io-v1beta2-PodSetAssignment)
+
+
+<p>DelayedTopologyRequestState indicates the state of the delayed TopologyRequest.</p>
+
+
+
+
+## `EvictionUnderlyingCause`     {#kueue-x-k8s-io-v1beta2-EvictionUnderlyingCause}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [WorkloadSchedulingStatsEviction](#kueue-x-k8s-io-v1beta2-WorkloadSchedulingStatsEviction)
+
+
+<p>EvictionUnderlyingCause represents the underlying cause of a workload eviction.</p>
+
+
+
+
+## `FairSharing`     {#kueue-x-k8s-io-v1beta2-FairSharing}
+    
+
+**Appears in:**
+
+- [ClusterQueueSpec](#kueue-x-k8s-io-v1beta2-ClusterQueueSpec)
+
+- [CohortSpec](#kueue-x-k8s-io-v1beta2-CohortSpec)
+
+- [LocalQueueSpec](#kueue-x-k8s-io-v1beta2-LocalQueueSpec)
+
+
+<p>FairSharing contains the properties of the ClusterQueue or Cohort,
+when participating in FairSharing.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>weight</code><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity"><code>k8s.io/apimachinery/pkg/api/resource.Quantity</code></a>
+</td>
+<td>
+   <p>weight gives a comparative advantage to this ClusterQueue
+or Cohort when competing for unused resources in the
+Cohort.  The share is based on the dominant resource usage
+above nominal quotas for each resource, divided by the
+weight.  Admission prioritizes scheduling workloads from
+ClusterQueues and Cohorts with the lowest share and
+preempting workloads from the ClusterQueues and Cohorts
+with the highest share.  A zero weight implies infinite
+share value, meaning that this Node will always be at
+disadvantage against other ClusterQueues and Cohorts.
+When not 0, Weight must be greater than 10^-9.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `FairSharingStatus`     {#kueue-x-k8s-io-v1beta2-FairSharingStatus}
+    
+
+**Appears in:**
+
+- [ClusterQueueStatus](#kueue-x-k8s-io-v1beta2-ClusterQueueStatus)
+
+- [CohortStatus](#kueue-x-k8s-io-v1beta2-CohortStatus)
+
+
+<p>FairSharingStatus contains the information about the current status of Fair Sharing.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>weightedShare</code> <B>[Required]</B><br/>
+<code>int64</code>
+</td>
+<td>
+   <p>weightedShare represents the maximum of the ratios of usage
+above nominal quota to the lendable resources in the
+Cohort, among all the resources provided by the Node, and
+divided by the weight.  If zero, it means that the usage of
+the Node is below the nominal quota.  If the Node has a
+weight of zero and is borrowing, this will return
+9223372036854775807, the maximum possible share value.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `FlavorFungibility`     {#kueue-x-k8s-io-v1beta2-FlavorFungibility}
+    
+
+**Appears in:**
+
+- [ClusterQueueSpec](#kueue-x-k8s-io-v1beta2-ClusterQueueSpec)
+
+
+<p>FlavorFungibility determines whether a workload should try the next flavor
+before borrowing or preempting in current flavor.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>whenCanBorrow</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-FlavorFungibilityPolicy"><code>FlavorFungibilityPolicy</code></a>
+</td>
+<td>
+   <p>whenCanBorrow determines whether a workload should try the next flavor
+before borrowing in current flavor. The possible values are:</p>
+<ul>
+<li><code>MayStopSearch</code> (default): stop the search for candidate flavors if workload
+fits or requires borrowing to fit.</li>
+<li><code>TryNextFlavor</code>: try next flavor if workload requires borrowing to fit.</li>
+</ul>
+</td>
+</tr>
+<tr><td><code>whenCanPreempt</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-FlavorFungibilityPolicy"><code>FlavorFungibilityPolicy</code></a>
+</td>
+<td>
+   <p>whenCanPreempt determines whether a workload should try the next flavor
+before preempting in current flavor. The possible values are:</p>
+<ul>
+<li><code>MayStopSearch</code>: stop the search for candidate flavors if workload fits or requires
+preemption to fit.</li>
+<li><code>TryNextFlavor</code> (default): try next flavor if workload requires preemption
+to fit in current flavor.</li>
+</ul>
+</td>
+</tr>
+<tr><td><code>preference</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-FlavorFungibilityPreference"><code>FlavorFungibilityPreference</code></a>
+</td>
+<td>
+   <p>preference guides the choosing of the flavor for admission in case all candidate flavors
+require either preemption, borrowing, or both. The possible values are:</p>
+<ul>
+<li><code>BorrowingOverPreemption</code> (default): prefer to use borrowing rather than preemption
+when such a choice is possible. More technically it minimizes the borrowing distance
+in the cohort tree, and solves tie-breaks by preferring better preemption mode
+(reclaim over preemption within ClusterQueue).</li>
+<li><code>PreemptionOverBorrowing</code>: prefer to use preemption rather than borrowing
+when such a choice is possible.  More technically it optimizes the preemption mode
+(reclaim over preemption within ClusterQueue), and solves tie-breaks by minimizing
+the borrowing distance in the cohort tree.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `FlavorFungibilityPolicy`     {#kueue-x-k8s-io-v1beta2-FlavorFungibilityPolicy}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [FlavorFungibility](#kueue-x-k8s-io-v1beta2-FlavorFungibility)
+
+
+
+
+
+## `FlavorFungibilityPreference`     {#kueue-x-k8s-io-v1beta2-FlavorFungibilityPreference}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [FlavorFungibility](#kueue-x-k8s-io-v1beta2-FlavorFungibility)
+
+
+
+
+
+## `FlavorQuotas`     {#kueue-x-k8s-io-v1beta2-FlavorQuotas}
+    
+
+**Appears in:**
+
+- [ResourceGroup](#kueue-x-k8s-io-v1beta2-ResourceGroup)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<a href="#kueue-x-k8s-io-v1beta2-ResourceFlavorReference"><code>ResourceFlavorReference</code></a>
+</td>
+<td>
+   <p>name of this flavor. The name should match the .metadata.name of a
+ResourceFlavor. If a matching ResourceFlavor does not exist, the
+ClusterQueue will have an Active condition set to False.</p>
+</td>
+</tr>
+<tr><td><code>resources</code> <B>[Required]</B><br/>
+<a href="#kueue-x-k8s-io-v1beta2-ResourceQuota"><code>[]ResourceQuota</code></a>
+</td>
+<td>
+   <p>resources is the list of quotas for this flavor per resource.
+There could be up to 64 resources.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `FlavorUsage`     {#kueue-x-k8s-io-v1beta2-FlavorUsage}
+    
+
+**Appears in:**
+
+- [ClusterQueueStatus](#kueue-x-k8s-io-v1beta2-ClusterQueueStatus)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<a href="#kueue-x-k8s-io-v1beta2-ResourceFlavorReference"><code>ResourceFlavorReference</code></a>
+</td>
+<td>
+   <p>name of the flavor.</p>
+</td>
+</tr>
+<tr><td><code>resources</code> <B>[Required]</B><br/>
+<a href="#kueue-x-k8s-io-v1beta2-ResourceUsage"><code>[]ResourceUsage</code></a>
+</td>
+<td>
+   <p>resources lists the quota usage for the resources in this flavor.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `KubeConfig`     {#kueue-x-k8s-io-v1beta2-KubeConfig}
+    
+
+**Appears in:**
+
+- [ClusterSource](#kueue-x-k8s-io-v1beta2-ClusterSource)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>location</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>location of the KubeConfig.</p>
+<p>If LocationType is Secret then Location is the name of the secret inside the namespace in
+which the kueue controller manager is running. The config should be stored in the &quot;kubeconfig&quot; key.</p>
+</td>
+</tr>
+<tr><td><code>locationType</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-LocationType"><code>LocationType</code></a>
+</td>
+<td>
+   <p>locationType of the KubeConfig.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `LocalQueueAdmissionFairSharingStatus`     {#kueue-x-k8s-io-v1beta2-LocalQueueAdmissionFairSharingStatus}
+    
+
+**Appears in:**
+
+- [LocalQueueFairSharingStatus](#kueue-x-k8s-io-v1beta2-LocalQueueFairSharingStatus)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>consumedResources</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcelist-v1-core"><code>k8s.io/api/core/v1.ResourceList</code></a>
+</td>
+<td>
+   <p>consumedResources represents the aggregated usage of resources over time,
+with decaying function applied.
+The value is populated if usage consumption functionality is enabled in Kueue config.</p>
+</td>
+</tr>
+<tr><td><code>lastUpdate</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta"><code>k8s.io/apimachinery/pkg/apis/meta/v1.Time</code></a>
+</td>
+<td>
+   <p>lastUpdate is the time when share and consumed resources were updated.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `LocalQueueFairSharingStatus`     {#kueue-x-k8s-io-v1beta2-LocalQueueFairSharingStatus}
+    
+
+**Appears in:**
+
+- [LocalQueueStatus](#kueue-x-k8s-io-v1beta2-LocalQueueStatus)
+
+
+<p>LocalQueueFairSharingStatus contains the information about the current status of Fair Sharing.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>weightedShare</code> <B>[Required]</B><br/>
+<code>int64</code>
+</td>
+<td>
+   <p>weightedShare represents the maximum of the ratios of usage
+above nominal quota to the lendable resources in the
+Cohort, among all the resources provided by the Node, and
+divided by the weight.  If zero, it means that the usage of
+the Node is below the nominal quota.  If the Node has a
+weight of zero and is borrowing, this will return
+9223372036854775807, the maximum possible share value.</p>
+</td>
+</tr>
+<tr><td><code>admissionFairSharingStatus</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-LocalQueueAdmissionFairSharingStatus"><code>LocalQueueAdmissionFairSharingStatus</code></a>
+</td>
+<td>
+   <p>admissionFairSharingStatus represents information relevant to the Admission Fair Sharing</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `LocalQueueFlavorUsage`     {#kueue-x-k8s-io-v1beta2-LocalQueueFlavorUsage}
+    
+
+**Appears in:**
+
+- [LocalQueueStatus](#kueue-x-k8s-io-v1beta2-LocalQueueStatus)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<a href="#kueue-x-k8s-io-v1beta2-ResourceFlavorReference"><code>ResourceFlavorReference</code></a>
+</td>
+<td>
+   <p>name of the flavor.</p>
+</td>
+</tr>
+<tr><td><code>resources</code> <B>[Required]</B><br/>
+<a href="#kueue-x-k8s-io-v1beta2-LocalQueueResourceUsage"><code>[]LocalQueueResourceUsage</code></a>
+</td>
+<td>
+   <p>resources lists the quota usage for the resources in this flavor.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `LocalQueueName`     {#kueue-x-k8s-io-v1beta2-LocalQueueName}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [WorkloadSpec](#kueue-x-k8s-io-v1beta2-WorkloadSpec)
+
+
+<p>LocalQueueName is the name of the LocalQueue.
+It must be a DNS (RFC 1123) and has the maximum length of 253 characters.</p>
+
+
+
+
+## `LocalQueueResourceUsage`     {#kueue-x-k8s-io-v1beta2-LocalQueueResourceUsage}
+    
+
+**Appears in:**
+
+- [LocalQueueFlavorUsage](#kueue-x-k8s-io-v1beta2-LocalQueueFlavorUsage)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcename-v1-core"><code>k8s.io/api/core/v1.ResourceName</code></a>
+</td>
+<td>
+   <p>name of the resource.</p>
+</td>
+</tr>
+<tr><td><code>total</code><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity"><code>k8s.io/apimachinery/pkg/api/resource.Quantity</code></a>
+</td>
+<td>
+   <p>total is the total quantity of used quota.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `LocalQueueSpec`     {#kueue-x-k8s-io-v1beta2-LocalQueueSpec}
+    
+
+**Appears in:**
+
+- [LocalQueue](#kueue-x-k8s-io-v1beta2-LocalQueue)
+
+
+<p>LocalQueueSpec defines the desired state of LocalQueue</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>clusterQueue</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-ClusterQueueReference"><code>ClusterQueueReference</code></a>
+</td>
+<td>
+   <p>clusterQueue is a reference to a clusterQueue that backs this localQueue.</p>
+</td>
+</tr>
+<tr><td><code>stopPolicy</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-StopPolicy"><code>StopPolicy</code></a>
+</td>
+<td>
+   <p>stopPolicy - if set to a value different from None, the LocalQueue is considered Inactive,
+no new reservation being made.</p>
+<p>Depending on its value, its associated workloads will:</p>
+<ul>
+<li>None - Workloads are admitted</li>
+<li>HoldAndDrain - Admitted workloads are evicted and Reserving workloads will cancel the reservation.</li>
+<li>Hold - Admitted workloads will run to completion and Reserving workloads will cancel the reservation.</li>
+</ul>
+</td>
+</tr>
+<tr><td><code>fairSharing</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-FairSharing"><code>FairSharing</code></a>
+</td>
+<td>
+   <p>fairSharing defines the properties of the LocalQueue when
+participating in AdmissionFairSharing.  The values are only relevant
+if AdmissionFairSharing is enabled in the Kueue configuration.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `LocalQueueStatus`     {#kueue-x-k8s-io-v1beta2-LocalQueueStatus}
+    
+
+**Appears in:**
+
+- [LocalQueue](#kueue-x-k8s-io-v1beta2-LocalQueue)
+
+
+<p>LocalQueueStatus defines the observed state of LocalQueue</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>conditions</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta"><code>[]k8s.io/apimachinery/pkg/apis/meta/v1.Condition</code></a>
+</td>
+<td>
+   <p>conditions hold the latest available observations of the LocalQueue
+current state.
+conditions are limited to 16 items.</p>
+</td>
+</tr>
+<tr><td><code>pendingWorkloads</code><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>pendingWorkloads is the number of Workloads in the LocalQueue not yet admitted to a ClusterQueue</p>
+</td>
+</tr>
+<tr><td><code>reservingWorkloads</code><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>reservingWorkloads is the number of workloads in this LocalQueue
+reserving quota in a ClusterQueue and that haven't finished yet.</p>
+</td>
+</tr>
+<tr><td><code>admittedWorkloads</code><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>admittedWorkloads is the number of workloads in this LocalQueue
+admitted to a ClusterQueue and that haven't finished yet.</p>
+</td>
+</tr>
+<tr><td><code>flavorsReservation</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-LocalQueueFlavorUsage"><code>[]LocalQueueFlavorUsage</code></a>
+</td>
+<td>
+   <p>flavorsReservation are the reserved quotas, by flavor currently in use by the
+workloads assigned to this LocalQueue.</p>
+</td>
+</tr>
+<tr><td><code>flavorsUsage</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-LocalQueueFlavorUsage"><code>[]LocalQueueFlavorUsage</code></a>
+</td>
+<td>
+   <p>flavorsUsage are the used quotas, by flavor currently in use by the
+workloads assigned to this LocalQueue.</p>
+</td>
+</tr>
+<tr><td><code>fairSharing</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-LocalQueueFairSharingStatus"><code>LocalQueueFairSharingStatus</code></a>
+</td>
+<td>
+   <p>fairSharing contains the information about the current status of fair sharing.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `LocationType`     {#kueue-x-k8s-io-v1beta2-LocationType}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [KubeConfig](#kueue-x-k8s-io-v1beta2-KubeConfig)
+
+
+
+
+
+## `MultiKueueClusterSpec`     {#kueue-x-k8s-io-v1beta2-MultiKueueClusterSpec}
+    
+
+**Appears in:**
+
+- [MultiKueueCluster](#kueue-x-k8s-io-v1beta2-MultiKueueCluster)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>clusterSource</code> <B>[Required]</B><br/>
+<a href="#kueue-x-k8s-io-v1beta2-ClusterSource"><code>ClusterSource</code></a>
+</td>
+<td>
+   <p>clusterSource is the source to connect to the cluster.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `MultiKueueClusterStatus`     {#kueue-x-k8s-io-v1beta2-MultiKueueClusterStatus}
+    
+
+**Appears in:**
+
+- [MultiKueueCluster](#kueue-x-k8s-io-v1beta2-MultiKueueCluster)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>conditions</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta"><code>[]k8s.io/apimachinery/pkg/apis/meta/v1.Condition</code></a>
+</td>
+<td>
+   <p>conditions hold the latest available observations of the MultiKueueCluster
+current state.
+conditions are limited to 16 elements.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `MultiKueueConfigQuotaManagementMode`     {#kueue-x-k8s-io-v1beta2-MultiKueueConfigQuotaManagementMode}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [MultiKueueConfigSpec](#kueue-x-k8s-io-v1beta2-MultiKueueConfigSpec)
+
+
+<p>MultiKueueConfigQuotaManagementMode specifies the automation mode.
+Supported modes:</p>
+<ul>
+<li><code>Manual</code>: Quota automation is manual.</li>
+<li><code>Automated</code>: Quota automation is enabled (provided that the MultiKueueManagerQuotaAutomation feature gate is enabled).</li>
+</ul>
+
+
+
+
+## `MultiKueueConfigSpec`     {#kueue-x-k8s-io-v1beta2-MultiKueueConfigSpec}
+    
+
+**Appears in:**
+
+- [MultiKueueConfig](#kueue-x-k8s-io-v1beta2-MultiKueueConfig)
+
+
+<p>MultiKueueConfigSpec defines the desired state of MultiKueueConfig</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>clusters,omitempty,omitzero</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   <p>clusters is a list of MultiKueueClusters names where the workloads from the ClusterQueue should be distributed.
+The order of the list is significant: the Incremental dispatcher nominates clusters
+following this order, so the most preferred clusters should be listed first.</p>
+</td>
+</tr>
+<tr><td><code>quotaManagement</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-MultiKueueConfigQuotaManagementMode"><code>MultiKueueConfigQuotaManagementMode</code></a>
+</td>
+<td>
+   <p>quotaManagement specifies the management of ClusterQueue quotas
+in the manager cluster.
+Supported modes:</p>
+<ul>
+<li><code>Manual</code>: Quota automation is manual.</li>
+<li><code>Automated</code>: Quota automation is enabled (provided that the MultiKueueManagerQuotaAutomation feature gate is enabled).
+If unspecified, defaults to <code>Manual</code>.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `Parameter`     {#kueue-x-k8s-io-v1beta2-Parameter}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [ProvisioningRequestConfigSpec](#kueue-x-k8s-io-v1beta2-ProvisioningRequestConfigSpec)
+
+
+<p>Parameter is limited to 255 characters.</p>
+
+
+
+
+## `PodSet`     {#kueue-x-k8s-io-v1beta2-PodSet}
+    
+
+**Appears in:**
+
+- [WorkloadSpec](#kueue-x-k8s-io-v1beta2-WorkloadSpec)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>name</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-PodSetReference"><code>PodSetReference</code></a>
+</td>
+<td>
+   <p>name is the PodSet name.</p>
+</td>
+</tr>
+<tr><td><code>template</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podtemplatespec-v1-core"><code>k8s.io/api/core/v1.PodTemplateSpec</code></a>
+</td>
+<td>
+   <p>template is the Pod template.</p>
+<p>The only allowed fields in template.metadata are labels and annotations.</p>
+<p>If requests are omitted for a container or initContainer,
+they default to the limits if they are explicitly specified for the
+container or initContainer.</p>
+<p>During admission, the rules in nodeSelector and
+nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution that match
+the keys in the nodeLabels from the ResourceFlavors considered for this
+Workload are used to filter the ResourceFlavors that can be assigned to
+this podSet.</p>
+</td>
+</tr>
+<tr><td><code>count</code><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>count is the number of pods for the spec.</p>
+</td>
+</tr>
+<tr><td><code>minCount</code><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>minCount is the minimum number of pods for the spec acceptable
+if the workload supports partial admission.</p>
+<p>If not provided, partial admission for the current PodSet is not
+enabled.</p>
+<p>Only one podSet within the workload can use this.</p>
+<p>This is an alpha field and requires enabling PartialAdmission feature gate.</p>
+</td>
+</tr>
+<tr><td><code>topologyRequest</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-PodSetTopologyRequest"><code>PodSetTopologyRequest</code></a>
+</td>
+<td>
+   <p>topologyRequest defines the topology request for the PodSet.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `PodSetAssignment`     {#kueue-x-k8s-io-v1beta2-PodSetAssignment}
+    
+
+**Appears in:**
+
+- [Admission](#kueue-x-k8s-io-v1beta2-Admission)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>name</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-PodSetReference"><code>PodSetReference</code></a>
+</td>
+<td>
+   <p>name is the name of the podSet. It should match one of the names in .spec.podSets.</p>
+</td>
+</tr>
+<tr><td><code>flavors</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-ResourceFlavorReference"><code>map[ResourceName]ResourceFlavorReference</code></a>
+</td>
+<td>
+   <p>flavors are the flavors assigned to the workload for each resource.</p>
+</td>
+</tr>
+<tr><td><code>resourceUsage</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcelist-v1-core"><code>k8s.io/api/core/v1.ResourceList</code></a>
+</td>
+<td>
+   <p>resourceUsage keeps track of the total resources all the pods in the podset need to run.</p>
+<p>Beside what is provided in podSet's specs, this calculation takes into account
+the LimitRange defaults and RuntimeClass overheads at the moment of admission.
+This field will not change in case of quota reclaim.</p>
+</td>
+</tr>
+<tr><td><code>count</code><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>count is the number of pods taken into account at admission time.
+This field will not change in case of quota reclaim.
+Value could be missing for Workloads created before this field was added,
+in that case spec.podSets[*].count value will be used.</p>
+</td>
+</tr>
+<tr><td><code>topologyAssignment</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-TopologyAssignment"><code>TopologyAssignment</code></a>
+</td>
+<td>
+   <p>topologyAssignment indicates the topology assignment divided into
+topology domains corresponding to the lowest level of the topology.
+The assignment specifies the number of Pods to be scheduled per topology
+domain and specifies the node selectors for each topology domain, in the
+following way:</p>
+<ul>
+<li><code>levels</code> specifies the node selector keys (same for all domains).
+<ul>
+<li>If the TopologySpec.Levels field contains &quot;kubernetes.io/hostname&quot; label,
+topologyAssignment will contain data only for this label,
+and omit higher levels in the topology.</li>
+</ul>
+</li>
+<li><code>slices</code> specifies the node selector values and pod counts for all domains
+(which may be partitioned into separate slices).
+<ul>
+<li>The node selector values are arranged first by topology level, only then by domain.
+(This allows &quot;optimizing&quot; similar values; see below).</li>
+</ul>
+</li>
+<li>The format of <code>slices</code> supports the following variations
+(aimed to optimize the total bytesize for very large number of domains; see examples below):
+<ul>
+<li>When all node selector values (at a given topology level, in a given slice)
+share a common prefix and/or suffix, these may be stored
+in dedicated <code>prefix</code>/<code>suffix</code> fields.
+If so, the array of <code>roots</code> will only store the remaining parts of these strings.</li>
+<li>When all node selector values (at a given topology level, in a given slice)
+are identical, this may be represented by <code>universal</code> value.</li>
+<li>When all pod counts (in a given slice) are identical,
+this may be represented by <code>universal</code> pod count.</li>
+</ul>
+</li>
+</ul>
+<p>Example 1:</p>
+<p>The following represents an assignment in which:</p>
+<ul>
+<li>4 Pods are to be scheduled on nodes matching the node selector:
+<ul>
+<li>cloud.provider.com/topology-block: block-1</li>
+<li>cloud.provider.com/topology-rack: rack-1</li>
+</ul>
+</li>
+<li>2 Pods are to be scheduled on nodes matching the node selector:
+<ul>
+<li>cloud.provider.com/topology-block: block-1</li>
+<li>cloud.provider.com/topology-rack: rack-2</li>
+</ul>
+</li>
+</ul>
+<p>topologyAssignment:
+levels:</p>
+<ul>
+<li>cloud.provider.com/topology-block</li>
+<li>cloud.provider.com/topology-rack
+slices:</li>
+<li>domainCount: 2
+valuesPerLevel:
+<ul>
+<li>individual:
+roots: [block-1, block-1]</li>
+<li>individual:
+roots: [rack-1, rack-2]
+podCounts:
+individual: [4, 2]</li>
+</ul>
+</li>
+</ul>
+<p>Example 2:</p>
+<p>The following is equivalent to Example 1 - but using extracted prefix and universalValue.</p>
+<p>topologyAssignment:
+levels:</p>
+<ul>
+<li>cloud.provider.com/topology-block</li>
+<li>cloud.provider.com/topology-rack
+slices:</li>
+<li>domainCount: 2
+valuesPerLevel:
+<ul>
+<li>universal: block-1</li>
+<li>individual:
+prefix: rack-
+roots: [1, 2]
+podCounts:
+individual: [4, 2]</li>
+</ul>
+</li>
+</ul>
+<p>Example 3:</p>
+<p>Now suppose that:</p>
+<ul>
+<li>the Topology object defines kubernetes.io/hostname as the lowest level
+(and hence, in the topologyAssignment, we omit all other levels
+since the hostname label suffices to explicitly identify a proper node),</li>
+<li>we assign 1 Pod per each node,</li>
+<li>the node naming scheme is <code>block-{blockId}-rack-{rackId}-node-{nodeId}</code>.
+Then, using the &quot;extraction of commons&quot;, the assignment from Examples 1-2 would look as follows:</li>
+</ul>
+<p>topologyAssignment:
+levels:</p>
+<ul>
+<li>kubernetes.io/hostname
+slices:</li>
+<li>domainCount: 6
+valuesPerLevel:
+<ul>
+<li>individual:
+prefix: block-1-rack-
+roots: [1-node-1, 1-node-2, 1-node-3, 1-node-4, 2-node-1, 2-node-2]
+podCounts:
+universal: 1</li>
+</ul>
+</li>
+</ul>
+<p>Example 4:</p>
+<p>By using multiple slices, we can afford even longer common prefixes.
+The assignment from Example 3 can be alternatively represented as follows:</p>
+<p>topologyAssignment:
+levels:</p>
+<ul>
+<li>kubernetes.io/hostname
+slices:</li>
+<li>domainCount: 4
+valuesPerLevel:
+<ul>
+<li>individual:
+prefix: block-1-rack-1-node-
+roots: [1, 2, 3, 4]
+podCounts:
+universal: 1</li>
+</ul>
+</li>
+<li>domainCount: 2
+valuesPerLevel:
+<ul>
+<li>individual:
+prefix: block-1-rack-2-node-
+roots: [1, 2]
+podCounts:
+universal: 1</li>
+</ul>
+</li>
+</ul>
+</td>
+</tr>
+<tr><td><code>delayedTopologyRequest</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-DelayedTopologyRequestState"><code>DelayedTopologyRequestState</code></a>
+</td>
+<td>
+   <p>delayedTopologyRequest indicates the topology assignment is delayed.
+Topology assignment might be delayed in case there is ProvisioningRequest
+AdmissionCheck used.
+Kueue schedules the second pass of scheduling for each workload with at
+least one PodSet which has delayedTopologyRequest=true and without
+topologyAssignment.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `PodSetReference`     {#kueue-x-k8s-io-v1beta2-PodSetReference}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [PodSet](#kueue-x-k8s-io-v1beta2-PodSet)
+
+- [PodSetAssignment](#kueue-x-k8s-io-v1beta2-PodSetAssignment)
+
+- [PodSetRequest](#kueue-x-k8s-io-v1beta2-PodSetRequest)
+
+- [PodSetUpdate](#kueue-x-k8s-io-v1beta2-PodSetUpdate)
+
+- [ReclaimablePod](#kueue-x-k8s-io-v1beta2-ReclaimablePod)
+
+
+<p>PodSetReference is the name of a PodSet.</p>
+
+
+
+
+## `PodSetRequest`     {#kueue-x-k8s-io-v1beta2-PodSetRequest}
+    
+
+**Appears in:**
+
+- [WorkloadStatus](#kueue-x-k8s-io-v1beta2-WorkloadStatus)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<a href="#kueue-x-k8s-io-v1beta2-PodSetReference"><code>PodSetReference</code></a>
+</td>
+<td>
+   <p>name is the name of the podSet. It should match one of the names in .spec.podSets.</p>
+</td>
+</tr>
+<tr><td><code>resources</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcelist-v1-core"><code>k8s.io/api/core/v1.ResourceList</code></a>
+</td>
+<td>
+   <p>resources is the total resources all the pods in the podset need to run.</p>
+<p>Beside what is provided in podSet's specs, this value also takes into account
+the LimitRange defaults and RuntimeClass overheads at the moment of consideration
+and the application of resource.excludeResourcePrefixes and resource.transformations.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `PodSetTopologyRequest`     {#kueue-x-k8s-io-v1beta2-PodSetTopologyRequest}
+    
+
+**Appears in:**
+
+- [PodSet](#kueue-x-k8s-io-v1beta2-PodSet)
+
+
+<p>PodSetTopologyRequest defines the topology request for a PodSet.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>required</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>required indicates the topology level required by the PodSet, as
+indicated by the <code>kueue.x-k8s.io/podset-required-topology</code> PodSet
+annotation.
+This is limited to 63 characters.</p>
+</td>
+</tr>
+<tr><td><code>preferred</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>preferred indicates the topology level preferred by the PodSet, as
+indicated by the <code>kueue.x-k8s.io/podset-preferred-topology</code> PodSet
+annotation.
+This is limited to 63 characters.</p>
+</td>
+</tr>
+<tr><td><code>unconstrained</code><br/>
+<code>bool</code>
+</td>
+<td>
+   <p>unconstrained indicates that Kueue has the freedom to schedule the PodSet within
+the entire available capacity, without constraints on the compactness of the placement.
+This is indicated by the <code>kueue.x-k8s.io/podset-unconstrained-topology</code> PodSet annotation.</p>
+</td>
+</tr>
+<tr><td><code>podIndexLabel</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>podIndexLabel indicates the name of the label indexing the pods.
+For example, in the context of</p>
+<ul>
+<li>kubernetes job this is: kubernetes.io/job-completion-index</li>
+<li>JobSet: kubernetes.io/job-completion-index (inherited from Job)</li>
+<li>Kubeflow: training.kubeflow.org/replica-index
+This is limited to 317 characters.</li>
+</ul>
+</td>
+</tr>
+<tr><td><code>subGroupIndexLabel</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>subGroupIndexLabel indicates the name of the label indexing the instances of replicated Jobs (groups)
+within a PodSet. For example, in the context of JobSet this is jobset.sigs.k8s.io/job-index.
+This is limited to 317 characters.</p>
+</td>
+</tr>
+<tr><td><code>subGroupCount</code><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>subGroupCount indicates the count of replicated Jobs (groups) within a PodSet.
+For example, in the context of JobSet this value is read from jobset.sigs.k8s.io/replicatedjob-replicas.</p>
+</td>
+</tr>
+<tr><td><code>podSetGroupName</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>podSetGroupName indicates the name of the group of PodSets to which this PodSet belongs to.
+PodSets with the same <code>PodSetGroupName</code> should be assigned the same ResourceFlavor</p>
+</td>
+</tr>
+<tr><td><code>podSetSliceRequiredTopology</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>podSetSliceRequiredTopology indicates the topology level required by the PodSet slice, as
+indicated by the <code>kueue.x-k8s.io/podset-slice-required-topology</code> annotation.</p>
+<p>This is limited to 63</p>
+</td>
+</tr>
+<tr><td><code>podSetSliceSize</code><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>podSetSliceSize indicates the size of a subgroup of pods in a PodSet for which
+Kueue finds a requested topology domain on a level defined
+in <code>kueue.x-k8s.io/podset-slice-required-topology</code> annotation.</p>
+</td>
+</tr>
+<tr><td><code>podsetSliceRequiredTopologyConstraints</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-PodsetSliceRequiredTopologyConstraint"><code>[]PodsetSliceRequiredTopologyConstraint</code></a>
+</td>
+<td>
+   <p>podsetSliceRequiredTopologyConstraints defines all layers of slice
+topology constraints. Each entry specifies a topology level and slice
+size, from the outermost (coarsest) to the innermost (finest) layer.
+At most 3 layers are supported.
+This field is mutually exclusive with podSetSliceRequiredTopology and
+podSetSliceSize.</p>
+<p>This annotation is alpha-level for the TASMultiLayerTopology feature gate.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `PodSetUpdate`     {#kueue-x-k8s-io-v1beta2-PodSetUpdate}
+    
+
+**Appears in:**
+
+- [AdmissionCheckState](#kueue-x-k8s-io-v1beta2-AdmissionCheckState)
+
+
+<p>PodSetUpdate contains a list of pod set modifications suggested by AdmissionChecks.
+The modifications should be additive only - modifications of already existing keys
+or having the same key provided by multiple AdmissionChecks is not allowed and will
+result in failure during workload admission.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<a href="#kueue-x-k8s-io-v1beta2-PodSetReference"><code>PodSetReference</code></a>
+</td>
+<td>
+   <p>name of the PodSet to modify. Should match to one of the Workload's PodSets.</p>
+</td>
+</tr>
+<tr><td><code>labels</code><br/>
+<code>map[string]string</code>
+</td>
+<td>
+   <p>labels of the PodSet to modify.</p>
+</td>
+</tr>
+<tr><td><code>annotations</code><br/>
+<code>map[string]string</code>
+</td>
+<td>
+   <p>annotations of the PodSet to modify.</p>
+</td>
+</tr>
+<tr><td><code>nodeSelector</code><br/>
+<code>map[string]string</code>
+</td>
+<td>
+   <p>nodeSelector of the PodSet to modify.</p>
+</td>
+</tr>
+<tr><td><code>tolerations</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#toleration-v1-core"><code>[]k8s.io/api/core/v1.Toleration</code></a>
+</td>
+<td>
+   <p>tolerations of the PodSet to modify.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `PodsetSliceRequiredTopologyConstraint`     {#kueue-x-k8s-io-v1beta2-PodsetSliceRequiredTopologyConstraint}
+    
+
+**Appears in:**
+
+- [PodSetTopologyRequest](#kueue-x-k8s-io-v1beta2-PodSetTopologyRequest)
+
+
+<p>PodsetSliceRequiredTopologyConstraint defines a single slice topology constraint layer.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>topology</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>topology indicates the topology level required for this slice layer.</p>
+</td>
+</tr>
+<tr><td><code>size</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>size indicates the number of pods in each group at this slice layer.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `PreemptionGate`     {#kueue-x-k8s-io-v1beta2-PreemptionGate}
+    
+
+**Appears in:**
+
+- [WorkloadSpec](#kueue-x-k8s-io-v1beta2-WorkloadSpec)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>name identifies the preemption gate.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `PreemptionGatePosition`     {#kueue-x-k8s-io-v1beta2-PreemptionGatePosition}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [PreemptionGateState](#kueue-x-k8s-io-v1beta2-PreemptionGateState)
+
+
+
+
+
+## `PreemptionGateState`     {#kueue-x-k8s-io-v1beta2-PreemptionGateState}
+    
+
+**Appears in:**
+
+- [WorkloadStatus](#kueue-x-k8s-io-v1beta2-WorkloadStatus)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>name identifies the preemption gate.</p>
+</td>
+</tr>
+<tr><td><code>position</code> <B>[Required]</B><br/>
+<a href="#kueue-x-k8s-io-v1beta2-PreemptionGatePosition"><code>PreemptionGatePosition</code></a>
+</td>
+<td>
+   <p>position of the preemption gate. One of</p>
+</td>
+</tr>
+<tr><td><code>lastTransitionTime,omitempty,omitzero</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta"><code>k8s.io/apimachinery/pkg/apis/meta/v1.Time</code></a>
+</td>
+<td>
+   <p>lastTransitionTime is the last time the gate transitioned from one status to another.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `PreemptionPolicy`     {#kueue-x-k8s-io-v1beta2-PreemptionPolicy}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [ClusterQueuePreemption](#kueue-x-k8s-io-v1beta2-ClusterQueuePreemption)
+
+
+
+
+
+## `PriorityClassGroup`     {#kueue-x-k8s-io-v1beta2-PriorityClassGroup}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [PriorityClassRef](#kueue-x-k8s-io-v1beta2-PriorityClassRef)
+
+
+<p>PriorityClassGroup indicates the API group of the PriorityClass object.</p>
+
+
+
+
+## `PriorityClassKind`     {#kueue-x-k8s-io-v1beta2-PriorityClassKind}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [PriorityClassRef](#kueue-x-k8s-io-v1beta2-PriorityClassRef)
+
+
+<p>PriorityClassKind is the kind of the PriorityClass object.</p>
+
+
+
+
+## `PriorityClassRef`     {#kueue-x-k8s-io-v1beta2-PriorityClassRef}
+    
+
+**Appears in:**
+
+- [WorkloadSpec](#kueue-x-k8s-io-v1beta2-WorkloadSpec)
+
+
+<p>PriorityClassRef references a PriorityClass in a specific API group.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>group</code> <B>[Required]</B><br/>
+<a href="#kueue-x-k8s-io-v1beta2-PriorityClassGroup"><code>PriorityClassGroup</code></a>
+</td>
+<td>
+   <p>group is the API group of the PriorityClass object.
+Use &quot;kueue.x-k8s.io&quot; for WorkloadPriorityClass.
+Use &quot;scheduling.k8s.io&quot; for Pod PriorityClass.</p>
+</td>
+</tr>
+<tr><td><code>kind</code> <B>[Required]</B><br/>
+<a href="#kueue-x-k8s-io-v1beta2-PriorityClassKind"><code>PriorityClassKind</code></a>
+</td>
+<td>
+   <p>kind is the kind of the PriorityClass object.</p>
+</td>
+</tr>
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>name is the name of the PriorityClass the Workload is associated with.
+If specified, indicates the workload's priority.
+&quot;system-node-critical&quot; and &quot;system-cluster-critical&quot; are two special
+keywords which indicate the highest priorities with the former being
+the highest priority. Any other name must be defined by creating a
+PriorityClass object with that name. If not specified, the workload
+priority will be default or zero if there is no default.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ProvisioningRequestConfigPodSetMergePolicy`     {#kueue-x-k8s-io-v1beta2-ProvisioningRequestConfigPodSetMergePolicy}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [ProvisioningRequestConfigSpec](#kueue-x-k8s-io-v1beta2-ProvisioningRequestConfigSpec)
+
+
+
+
+
+## `ProvisioningRequestConfigSpec`     {#kueue-x-k8s-io-v1beta2-ProvisioningRequestConfigSpec}
+    
+
+**Appears in:**
+
+- [ProvisioningRequestConfig](#kueue-x-k8s-io-v1beta2-ProvisioningRequestConfig)
+
+
+<p>ProvisioningRequestConfigSpec defines the desired state of ProvisioningRequestConfig</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>provisioningClassName</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>provisioningClassName describes the different modes of provisioning the resources.
+Check autoscaling.x-k8s.io ProvisioningRequestSpec.ProvisioningClassName for details.</p>
+</td>
+</tr>
+<tr><td><code>parameters</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-Parameter"><code>map[string]Parameter</code></a>
+</td>
+<td>
+   <p>parameters contains all other parameters classes may require.</p>
+</td>
+</tr>
+<tr><td><code>managedResources</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcename-v1-core"><code>[]k8s.io/api/core/v1.ResourceName</code></a>
+</td>
+<td>
+   <p>managedResources contains the list of resources managed by the autoscaling.</p>
+<p>If empty, all resources are considered managed.</p>
+<p>If not empty, the ProvisioningRequest will contain only the podsets that are
+requesting at least one of them.</p>
+<p>If none of the workloads podsets is requesting at least a managed resource,
+the workload is considered ready.</p>
+</td>
+</tr>
+<tr><td><code>retryStrategy</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-ProvisioningRequestRetryStrategy"><code>ProvisioningRequestRetryStrategy</code></a>
+</td>
+<td>
+   <p>retryStrategy defines strategy for retrying ProvisioningRequest.
+If null, then the default configuration is applied with the following parameter values:
+backoffLimitCount:  3
+backoffBaseSeconds: 60 - 1 min
+backoffMaxSeconds:  1800 - 30 mins</p>
+<p>To switch off retry mechanism
+set retryStrategy.backoffLimitCount to 0.</p>
+</td>
+</tr>
+<tr><td><code>podSetUpdates</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-ProvisioningRequestPodSetUpdates"><code>ProvisioningRequestPodSetUpdates</code></a>
+</td>
+<td>
+   <p>podSetUpdates specifies the update of the workload's PodSetUpdates which
+are used to target the provisioned nodes.</p>
+</td>
+</tr>
+<tr><td><code>podSetMergePolicy</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-ProvisioningRequestConfigPodSetMergePolicy"><code>ProvisioningRequestConfigPodSetMergePolicy</code></a>
+</td>
+<td>
+   <p>podSetMergePolicy specifies the policy for merging PodSets before being passed
+to the cluster autoscaler.</p>
+<p>The possible policies are:</p>
+<ul>
+<li><code>IdenticalPodTemplates</code>: Merges only identical PodTemplates.</li>
+<li><code>IdenticalWorkloadSchedulingRequirements</code>: Merges PodTemplates with identical fields that are considered when defining the workload scheduling requirements.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ProvisioningRequestPodSetUpdates`     {#kueue-x-k8s-io-v1beta2-ProvisioningRequestPodSetUpdates}
+    
+
+**Appears in:**
+
+- [ProvisioningRequestConfigSpec](#kueue-x-k8s-io-v1beta2-ProvisioningRequestConfigSpec)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>nodeSelector</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-ProvisioningRequestPodSetUpdatesNodeSelector"><code>[]ProvisioningRequestPodSetUpdatesNodeSelector</code></a>
+</td>
+<td>
+   <p>nodeSelector specifies the list of updates for the NodeSelector.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ProvisioningRequestPodSetUpdatesNodeSelector`     {#kueue-x-k8s-io-v1beta2-ProvisioningRequestPodSetUpdatesNodeSelector}
+    
+
+**Appears in:**
+
+- [ProvisioningRequestPodSetUpdates](#kueue-x-k8s-io-v1beta2-ProvisioningRequestPodSetUpdates)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>key</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>key specifies the key for the NodeSelector.</p>
+</td>
+</tr>
+<tr><td><code>valueFromProvisioningClassDetail</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>valueFromProvisioningClassDetail specifies the key of the
+ProvisioningRequest.status.provisioningClassDetails from which the value
+is used for the update.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ProvisioningRequestRetryStrategy`     {#kueue-x-k8s-io-v1beta2-ProvisioningRequestRetryStrategy}
+    
+
+**Appears in:**
+
+- [ProvisioningRequestConfigSpec](#kueue-x-k8s-io-v1beta2-ProvisioningRequestConfigSpec)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>backoffLimitCount</code><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>backoffLimitCount defines the maximum number of re-queuing retries.
+Once the number is reached, the workload is deactivated (<code>.spec.activate</code>=<code>false</code>).</p>
+<p>Every backoff duration is about &quot;b*2^(n-1)+Rand&quot; where:</p>
+<ul>
+<li>&quot;b&quot; represents the base set by &quot;BackoffBaseSeconds&quot; parameter,</li>
+<li>&quot;n&quot; represents the &quot;workloadStatus.requeueState.count&quot;,</li>
+<li>&quot;Rand&quot; represents the random jitter.
+During this time, the workload is taken as an inadmissible and
+other workloads will have a chance to be admitted.
+By default, the consecutive requeue delays are around: (60s, 120s, 240s, ...).</li>
+</ul>
+<p>Defaults to 3.</p>
+</td>
+</tr>
+<tr><td><code>backoffBaseSeconds</code><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>backoffBaseSeconds defines the base for the exponential backoff for
+re-queuing an evicted workload.</p>
+<p>Defaults to 60.</p>
+</td>
+</tr>
+<tr><td><code>backoffMaxSeconds</code><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>backoffMaxSeconds defines the maximum backoff time to re-queue an evicted workload.</p>
+<p>Defaults to 1800.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `QueueingStrategy`     {#kueue-x-k8s-io-v1beta2-QueueingStrategy}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [ClusterQueueSpec](#kueue-x-k8s-io-v1beta2-ClusterQueueSpec)
+
+
+
+
+
+## `ReclaimablePod`     {#kueue-x-k8s-io-v1beta2-ReclaimablePod}
+    
+
+**Appears in:**
+
+- [WorkloadStatus](#kueue-x-k8s-io-v1beta2-WorkloadStatus)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<a href="#kueue-x-k8s-io-v1beta2-PodSetReference"><code>PodSetReference</code></a>
+</td>
+<td>
+   <p>name is the PodSet name.</p>
+</td>
+</tr>
+<tr><td><code>count</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>count is the number of pods for which the requested resources are no longer needed.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `RequeueState`     {#kueue-x-k8s-io-v1beta2-RequeueState}
+    
+
+**Appears in:**
+
+- [WorkloadStatus](#kueue-x-k8s-io-v1beta2-WorkloadStatus)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>count</code><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>count records the number of times a workload has been re-queued
+When a deactivated (<code>.spec.activate</code>=<code>false</code>) workload is reactivated (<code>.spec.activate</code>=<code>true</code>),
+this count would be reset to null.</p>
+</td>
+</tr>
+<tr><td><code>requeueAt</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta"><code>k8s.io/apimachinery/pkg/apis/meta/v1.Time</code></a>
+</td>
+<td>
+   <p>requeueAt records the time when a workload will be re-queued.
+When a deactivated (<code>.spec.activate</code>=<code>false</code>) workload is reactivated (<code>.spec.activate</code>=<code>true</code>),
+this time would be reset to null.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ResourceFlavorReference`     {#kueue-x-k8s-io-v1beta2-ResourceFlavorReference}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [AdmissionCheckStrategyRule](#kueue-x-k8s-io-v1beta2-AdmissionCheckStrategyRule)
+
+- [ConcurrentAdmissionConstraints](#kueue-x-k8s-io-v1beta2-ConcurrentAdmissionConstraints)
+
+- [FlavorQuotas](#kueue-x-k8s-io-v1beta2-FlavorQuotas)
+
+- [FlavorUsage](#kueue-x-k8s-io-v1beta2-FlavorUsage)
+
+- [LocalQueueFlavorUsage](#kueue-x-k8s-io-v1beta2-LocalQueueFlavorUsage)
+
+- [PodSetAssignment](#kueue-x-k8s-io-v1beta2-PodSetAssignment)
+
+
+<p>ResourceFlavorReference is the name of the ResourceFlavor.</p>
+
+
+
+
+## `ResourceFlavorSpec`     {#kueue-x-k8s-io-v1beta2-ResourceFlavorSpec}
+    
+
+**Appears in:**
+
+- [ResourceFlavor](#kueue-x-k8s-io-v1beta2-ResourceFlavor)
+
+
+<p>ResourceFlavorSpec defines the desired state of the ResourceFlavor</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>nodeLabels</code><br/>
+<code>map[string]string</code>
+</td>
+<td>
+   <p>nodeLabels are labels that associate the ResourceFlavor with Nodes that
+have the same labels.
+When a Workload is admitted, its podsets can only get assigned
+ResourceFlavors whose nodeLabels match the nodeSelector and nodeAffinity
+fields.
+Once a ResourceFlavor is assigned to a podSet, the ResourceFlavor's
+nodeLabels should be injected into the pods of the Workload by the
+controller that integrates with the Workload object.</p>
+<p>nodeLabels can be up to 8 elements.</p>
+</td>
+</tr>
+<tr><td><code>nodeTaints</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#taint-v1-core"><code>[]k8s.io/api/core/v1.Taint</code></a>
+</td>
+<td>
+   <p>nodeTaints are taints that the nodes associated with this ResourceFlavor
+have.
+Workloads' podsets must have tolerations for these nodeTaints in order to
+get assigned this ResourceFlavor during admission.
+When this ResourceFlavor has also set the matching tolerations (in .spec.tolerations),
+then the nodeTaints are not considered during admission.
+Only the 'NoSchedule' and 'NoExecute' taint effects are evaluated,
+while 'PreferNoSchedule' is ignored.</p>
+<p>An example of a nodeTaint is
+cloud.provider.com/preemptible=&quot;true&quot;:NoSchedule</p>
+<p>nodeTaints can be up to 8 elements.</p>
+</td>
+</tr>
+<tr><td><code>tolerations</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#toleration-v1-core"><code>[]k8s.io/api/core/v1.Toleration</code></a>
+</td>
+<td>
+   <p>tolerations are extra tolerations that will be added to the pods admitted in
+the quota associated with this resource flavor.</p>
+<p>An example of a toleration is
+cloud.provider.com/preemptible=&quot;true&quot;:NoSchedule</p>
+<p>tolerations can be up to 8 elements.</p>
+</td>
+</tr>
+<tr><td><code>topologyName</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-TopologyReference"><code>TopologyReference</code></a>
+</td>
+<td>
+   <p>topologyName indicates topology for the TAS ResourceFlavor.
+When specified, it enables scraping of the topology information from the
+nodes matching to the Resource Flavor node labels.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ResourceGroup`     {#kueue-x-k8s-io-v1beta2-ResourceGroup}
+    
+
+**Appears in:**
+
+- [ClusterQueueSpec](#kueue-x-k8s-io-v1beta2-ClusterQueueSpec)
+
+- [CohortSpec](#kueue-x-k8s-io-v1beta2-CohortSpec)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>coveredResources</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcename-v1-core"><code>[]k8s.io/api/core/v1.ResourceName</code></a>
+</td>
+<td>
+   <p>coveredResources is the list of resources covered by the flavors in this
+group.
+Examples: cpu, memory, vendor.com/gpu.
+The list cannot be empty and it can contain up to 64 resources. With a total
+of up to 256 covered resources across all resource groups in the ClusterQueue.</p>
+</td>
+</tr>
+<tr><td><code>flavors</code> <B>[Required]</B><br/>
+<a href="#kueue-x-k8s-io-v1beta2-FlavorQuotas"><code>[]FlavorQuotas</code></a>
+</td>
+<td>
+   <p>flavors is the list of flavors that provide the resources of this group.
+Typically, different flavors represent different hardware models
+(e.g., gpu models, cpu architectures) or pricing models (on-demand vs spot
+cpus).
+Each flavor MUST list all the resources listed for this group in the same
+order as the .resources field.
+The list cannot be empty and it can contain up to 64 flavors, with a max of
+256 total flavors across all resource groups in the ClusterQueue.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ResourceQuota`     {#kueue-x-k8s-io-v1beta2-ResourceQuota}
+    
+
+**Appears in:**
+
+- [FlavorQuotas](#kueue-x-k8s-io-v1beta2-FlavorQuotas)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcename-v1-core"><code>k8s.io/api/core/v1.ResourceName</code></a>
+</td>
+<td>
+   <p>name of this resource.</p>
+</td>
+</tr>
+<tr><td><code>nominalQuota</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity"><code>k8s.io/apimachinery/pkg/api/resource.Quantity</code></a>
+</td>
+<td>
+   <p>nominalQuota is the quantity of this resource that is available for
+Workloads admitted by this ClusterQueue at a point in time.
+The nominalQuota must be non-negative.
+nominalQuota should represent the resources in the cluster available for
+running jobs (after discounting resources consumed by system components
+and pods not managed by kueue). In an autoscaled cluster, nominalQuota
+should account for resources that can be provided by a component such as
+Kubernetes cluster-autoscaler.</p>
+<p>If the ClusterQueue belongs to a cohort, the sum of the quotas for each
+(flavor, resource) combination defines the maximum quantity that can be
+allocated by a ClusterQueue in the cohort.</p>
+</td>
+</tr>
+<tr><td><code>borrowingLimit</code><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity"><code>k8s.io/apimachinery/pkg/api/resource.Quantity</code></a>
+</td>
+<td>
+   <p>borrowingLimit is the maximum amount of quota for the [flavor, resource]
+combination that this ClusterQueue is allowed to borrow from the unused
+quota of other ClusterQueues in the same cohort.
+In total, at a given time, Workloads in a ClusterQueue can consume a
+quantity of quota equal to nominalQuota+borrowingLimit, assuming the other
+ClusterQueues in the cohort have enough unused quota.
+If null, it means that there is no borrowing limit.
+If not null, it must be non-negative.
+borrowingLimit must be null if spec.cohortName is empty.</p>
+</td>
+</tr>
+<tr><td><code>lendingLimit</code><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity"><code>k8s.io/apimachinery/pkg/api/resource.Quantity</code></a>
+</td>
+<td>
+   <p>lendingLimit is the maximum amount of unused quota for the [flavor, resource]
+combination that this ClusterQueue can lend to other ClusterQueues in the same cohort.
+In total, at a given time, ClusterQueue reserves for its exclusive use
+a quantity of quota equals to nominalQuota - lendingLimit.
+If null, it means that there is no lending limit, meaning that
+all the nominalQuota can be borrowed by other clusterQueues in the cohort.
+If not null, it must be non-negative.
+lendingLimit must be null if spec.cohortName is empty.
+This field is in beta stage and is enabled by default.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ResourceUsage`     {#kueue-x-k8s-io-v1beta2-ResourceUsage}
+    
+
+**Appears in:**
+
+- [FlavorUsage](#kueue-x-k8s-io-v1beta2-FlavorUsage)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcename-v1-core"><code>k8s.io/api/core/v1.ResourceName</code></a>
+</td>
+<td>
+   <p>name of the resource</p>
+</td>
+</tr>
+<tr><td><code>total</code><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity"><code>k8s.io/apimachinery/pkg/api/resource.Quantity</code></a>
+</td>
+<td>
+   <p>total is the total quantity of used quota, including the amount borrowed
+from the cohort.</p>
+</td>
+</tr>
+<tr><td><code>borrowed</code><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity"><code>k8s.io/apimachinery/pkg/api/resource.Quantity</code></a>
+</td>
+<td>
+   <p>borrowed is quantity of quota that is borrowed from the cohort. In other
+words, it's the used quota that is over the nominalQuota.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `SchedulingStats`     {#kueue-x-k8s-io-v1beta2-SchedulingStats}
+    
+
+**Appears in:**
+
+- [WorkloadStatus](#kueue-x-k8s-io-v1beta2-WorkloadStatus)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>evictions</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-WorkloadSchedulingStatsEviction"><code>[]WorkloadSchedulingStatsEviction</code></a>
+</td>
+<td>
+   <p>evictions tracks eviction statistics by reason and underlyingCause.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `StopPolicy`     {#kueue-x-k8s-io-v1beta2-StopPolicy}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [ClusterQueueSpec](#kueue-x-k8s-io-v1beta2-ClusterQueueSpec)
+
+- [LocalQueueSpec](#kueue-x-k8s-io-v1beta2-LocalQueueSpec)
+
+
+
+
+
+## `TopologyAssignment`     {#kueue-x-k8s-io-v1beta2-TopologyAssignment}
+    
+
+**Appears in:**
+
+- [PodSetAssignment](#kueue-x-k8s-io-v1beta2-PodSetAssignment)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>levels</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   <p>levels is an ordered list of keys denoting the levels of the assigned
+topology (i.e. node label keys), from the highest to the lowest level of
+the topology.</p>
+</td>
+</tr>
+<tr><td><code>slices</code> <B>[Required]</B><br/>
+<a href="#kueue-x-k8s-io-v1beta2-TopologyAssignmentSlice"><code>[]TopologyAssignmentSlice</code></a>
+</td>
+<td>
+   <p>slices represent topology assignments for subsets of pods of a workload.
+The full assignment is obtained as a union of all slices.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `TopologyAssignmentSlice`     {#kueue-x-k8s-io-v1beta2-TopologyAssignmentSlice}
+    
+
+**Appears in:**
+
+- [TopologyAssignment](#kueue-x-k8s-io-v1beta2-TopologyAssignment)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>domainCount</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>domainCount is the number of domains covered by this slice.</p>
+</td>
+</tr>
+<tr><td><code>valuesPerLevel</code> <B>[Required]</B><br/>
+<a href="#kueue-x-k8s-io-v1beta2-TopologyAssignmentSliceLevelValues"><code>[]TopologyAssignmentSliceLevelValues</code></a>
+</td>
+<td>
+   <p>valuesPerLevel has one entry for each of the Levels specified in the TopologyAssignment.
+The entry corresponding to a particular level specifies the placement of pods at that level.</p>
+</td>
+</tr>
+<tr><td><code>podCounts</code> <B>[Required]</B><br/>
+<a href="#kueue-x-k8s-io-v1beta2-TopologyAssignmentSlicePodCounts"><code>TopologyAssignmentSlicePodCounts</code></a>
+</td>
+<td>
+   <p>podCounts specifies the number of pods allocated per each domain.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `TopologyAssignmentSliceLevelIndividualValues`     {#kueue-x-k8s-io-v1beta2-TopologyAssignmentSliceLevelIndividualValues}
+    
+
+**Appears in:**
+
+- [TopologyAssignmentSliceLevelValues](#kueue-x-k8s-io-v1beta2-TopologyAssignmentSliceLevelValues)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>prefix</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>prefix specifies a common prefix for all values in this slice assignment.
+It must be either nil pointer or a non-empty string.</p>
+</td>
+</tr>
+<tr><td><code>suffix</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>suffix specifies a common suffix for all values in this slice assignment.
+It must be either nil pointer or a non-empty string.</p>
+</td>
+</tr>
+<tr><td><code>roots</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   <p>roots specifies the values in this assignment (excluding prefix and suffix, if non-empty).
+Its length must be equal to the &quot;domainCount&quot; field of the TopologyAssignmentSlice.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `TopologyAssignmentSliceLevelValues`     {#kueue-x-k8s-io-v1beta2-TopologyAssignmentSliceLevelValues}
+    
+
+**Appears in:**
+
+- [TopologyAssignmentSlice](#kueue-x-k8s-io-v1beta2-TopologyAssignmentSlice)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>universal</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>universal - if set - specifies a single topology placement value (at a particular topology level)
+that applies to all pods in the current TopologyAssignmentSlice.
+Exactly one of universal, individual must be set.</p>
+</td>
+</tr>
+<tr><td><code>individual</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-TopologyAssignmentSliceLevelIndividualValues"><code>TopologyAssignmentSliceLevelIndividualValues</code></a>
+</td>
+<td>
+   <p>individual - if set - specifies multiple topology placement values (at a particular topology level)
+that apply to the pods in the current TopologyAssignmentSlice.
+Exactly one of universal, individual must be set.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `TopologyAssignmentSlicePodCounts`     {#kueue-x-k8s-io-v1beta2-TopologyAssignmentSlicePodCounts}
+    
+
+**Appears in:**
+
+- [TopologyAssignmentSlice](#kueue-x-k8s-io-v1beta2-TopologyAssignmentSlice)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>universal</code><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>universal - if set - specifies the number of pods allocated in every domain in this slice.
+Exactly one of universal, individual must be set.</p>
+</td>
+</tr>
+<tr><td><code>individual</code><br/>
+<code>[]int32</code>
+</td>
+<td>
+   <p>individual - if set - specifies the number of pods allocated in each domain in this slice.
+If set, its length must be equal to the &quot;domainCount&quot; field of the TopologyAssignmentSlice.
+Exactly one of universal, individual must be set.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `TopologyLevel`     {#kueue-x-k8s-io-v1beta2-TopologyLevel}
+    
+
+**Appears in:**
+
+- [TopologySpec](#kueue-x-k8s-io-v1beta2-TopologySpec)
+
+
+<p>TopologyLevel defines the desired state of TopologyLevel</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>nodeLabel</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>nodeLabel indicates the name of the node label for a specific topology
+level.</p>
+<p>Examples:</p>
+<ul>
+<li>cloud.provider.com/topology-block</li>
+<li>cloud.provider.com/topology-rack</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `TopologyReference`     {#kueue-x-k8s-io-v1beta2-TopologyReference}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [ResourceFlavorSpec](#kueue-x-k8s-io-v1beta2-ResourceFlavorSpec)
+
+
+
+<p>TopologyReference is the name of the Topology.</p>
+
+
+
+
+## `TopologySpec`     {#kueue-x-k8s-io-v1beta2-TopologySpec}
+    
+
+**Appears in:**
+
+- [Topology](#kueue-x-k8s-io-v1beta2-Topology)
+
+
+<p>TopologySpec defines the desired state of Topology</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>levels</code> <B>[Required]</B><br/>
+<a href="#kueue-x-k8s-io-v1beta2-TopologyLevel"><code>[]TopologyLevel</code></a>
+</td>
+<td>
+   <p>levels define the levels of topology.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `UnhealthyNode`     {#kueue-x-k8s-io-v1beta2-UnhealthyNode}
+    
+
+**Appears in:**
+
+- [WorkloadStatus](#kueue-x-k8s-io-v1beta2-WorkloadStatus)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>name is the name of the unhealthy node.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `WorkloadSchedulingStatsEviction`     {#kueue-x-k8s-io-v1beta2-WorkloadSchedulingStatsEviction}
+    
+
+**Appears in:**
+
+- [SchedulingStats](#kueue-x-k8s-io-v1beta2-SchedulingStats)
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>reason</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>reason specifies the programmatic identifier for the eviction cause.</p>
+</td>
+</tr>
+<tr><td><code>underlyingCause</code> <B>[Required]</B><br/>
+<a href="#kueue-x-k8s-io-v1beta2-EvictionUnderlyingCause"><code>EvictionUnderlyingCause</code></a>
+</td>
+<td>
+   <p>underlyingCause specifies a finer-grained explanation that complements the eviction reason.
+This may be an empty string.</p>
+</td>
+</tr>
+<tr><td><code>count</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>count tracks the number of evictions for this reason and detailed reason.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `WorkloadSpec`     {#kueue-x-k8s-io-v1beta2-WorkloadSpec}
+    
+
+**Appears in:**
+
+- [Workload](#kueue-x-k8s-io-v1beta2-Workload)
+
+
+<p>WorkloadSpec defines the desired state of Workload</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>podSets</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-PodSet"><code>[]PodSet</code></a>
+</td>
+<td>
+   <p>podSets is a list of sets of homogeneous pods, each described by a Pod spec
+and a count.
+There must be at least one element and at most 18.
+podSets cannot be changed.</p>
+</td>
+</tr>
+<tr><td><code>queueName</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-LocalQueueName"><code>LocalQueueName</code></a>
+</td>
+<td>
+   <p>queueName is the name of the LocalQueue the Workload is associated with.
+queueName cannot be changed while .status.admission is not null.</p>
+</td>
+</tr>
+<tr><td><code>priorityClassRef</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-PriorityClassRef"><code>PriorityClassRef</code></a>
+</td>
+<td>
+   <p>priorityClassRef references a PriorityClass object that defines the workload's priority.</p>
+</td>
+</tr>
+<tr><td><code>priority</code><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>priority determines the order of access to the resources managed by the
+ClusterQueue where the workload is queued.
+The priority value is populated from the referenced PriorityClass (via priorityClassRef).
+The higher the value, the higher the priority.
+If priorityClassRef is specified, priority must not be null.</p>
+</td>
+</tr>
+<tr><td><code>active</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   <p>active determines if a workload can be admitted into a queue.
+Changing active from true to false will evict any running workloads.
+Possible values are:</p>
+<ul>
+<li>false: indicates that a workload should never be admitted and evicts running workloads</li>
+<li>true: indicates that a workload can be evaluated for admission into it's respective queue.</li>
+</ul>
+<p>Defaults to true</p>
+</td>
+</tr>
+<tr><td><code>maximumExecutionTimeSeconds</code><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>maximumExecutionTimeSeconds if provided, determines the maximum time, in seconds,
+the workload can be admitted before it's automatically deactivated.</p>
+<p>If unspecified, no execution time limit is enforced on the Workload.</p>
+</td>
+</tr>
+<tr><td><code>preemptionGates</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-PreemptionGate"><code>[]PreemptionGate</code></a>
+</td>
+<td>
+   <p>preemptionGates is a list of gates governing whether the workload
+can trigger preemptions.
+The gates are closed by default.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `WorkloadStatus`     {#kueue-x-k8s-io-v1beta2-WorkloadStatus}
+    
+
+**Appears in:**
+
+- [Workload](#kueue-x-k8s-io-v1beta2-Workload)
+
+
+<p>WorkloadStatus defines the observed state of Workload</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>conditions</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta"><code>[]k8s.io/apimachinery/pkg/apis/meta/v1.Condition</code></a>
+</td>
+<td>
+   <p>conditions hold the latest available observations of the Workload
+current state.</p>
+<p>The type of the condition could be:</p>
+<ul>
+<li>Admitted: the Workload was admitted through a ClusterQueue.</li>
+<li>Finished: the associated workload finished running (failed or succeeded).</li>
+<li>PodsReady: at least <code>.spec.podSets[*].count</code> Pods are ready or have
+succeeded.
+conditions are limited to 16 items.</li>
+</ul>
+</td>
+</tr>
+<tr><td><code>admission</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-Admission"><code>Admission</code></a>
+</td>
+<td>
+   <p>admission holds the parameters of the admission of the workload by a
+ClusterQueue. admission can be set back to null, but its fields cannot be
+changed once set.</p>
+</td>
+</tr>
+<tr><td><code>requeueState</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-RequeueState"><code>RequeueState</code></a>
+</td>
+<td>
+   <p>requeueState holds the re-queue state
+when a workload meets Eviction with PodsReadyTimeout reason.</p>
+</td>
+</tr>
+<tr><td><code>reclaimablePods</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-ReclaimablePod"><code>[]ReclaimablePod</code></a>
+</td>
+<td>
+   <p>reclaimablePods keeps track of the number pods within a podset for which
+the resource reservation is no longer needed.</p>
+</td>
+</tr>
+<tr><td><code>admissionChecks</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-AdmissionCheckState"><code>[]AdmissionCheckState</code></a>
+</td>
+<td>
+   <p>admissionChecks list all the admission checks required by the workload and the current status</p>
+</td>
+</tr>
+<tr><td><code>resourceRequests</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-PodSetRequest"><code>[]PodSetRequest</code></a>
+</td>
+<td>
+   <p>resourceRequests provides a detailed view of the resources that were
+requested by a non-admitted workload when it was considered for admission.
+If admission is non-null, resourceRequests will be empty because
+admission.resourceUsage contains the detailed information.</p>
+</td>
+</tr>
+<tr><td><code>accumulatedPastExecutionTimeSeconds</code><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>accumulatedPastExecutionTimeSeconds holds the total time, in seconds, the workload spent
+in Admitted state, in the previous <code>Admit</code> - <code>Evict</code> cycles.</p>
+</td>
+</tr>
+<tr><td><code>schedulingStats</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-SchedulingStats"><code>SchedulingStats</code></a>
+</td>
+<td>
+   <p>schedulingStats tracks scheduling statistics</p>
+</td>
+</tr>
+<tr><td><code>nominatedClusterNames</code><br/>
+<code>[]string</code>
+</td>
+<td>
+   <p>nominatedClusterNames specifies the list of cluster names that have been nominated for scheduling.
+This field is mutually exclusive with the <code>.status.clusterName</code> field, and is reset when
+<code>status.clusterName</code> is set.
+This field is optional.</p>
+</td>
+</tr>
+<tr><td><code>clusterName</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>clusterName is the name of the cluster where the workload is currently assigned.</p>
+<p>With ElasticJobs, this field may also indicate the cluster where the original (old) workload
+was assigned, providing placement context for new scaled-up workloads. This supports
+affinity or propagation policies across workload slices.</p>
+<p>This field is reset after the Workload is evicted.</p>
+</td>
+</tr>
+<tr><td><code>unhealthyNodes</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-UnhealthyNode"><code>[]UnhealthyNode</code></a>
+</td>
+<td>
+   <p>unhealthyNodes holds the failed nodes running at least one pod of this workload
+when Topology-Aware Scheduling is used. This field should not be set by the users.
+It indicates Kueue's scheduler is searching for replacements of the failed nodes.
+Requires enabling the TASFailedNodeReplacement feature gate.</p>
+</td>
+</tr>
+<tr><td><code>preemptionGates</code><br/>
+<a href="#kueue-x-k8s-io-v1beta2-PreemptionGateState"><code>[]PreemptionGateState</code></a>
+</td>
+<td>
+   <p>preemptionGates is a list of states of gates governing whether the workload
+can trigger preemptions.</p>
+</td>
+</tr>
+</tbody>
+</table>
+  

--- a/site/content/zh-CN/docs/tasks/dev/develop-acc.md
+++ b/site/content/zh-CN/docs/tasks/dev/develop-acc.md
@@ -21,7 +21,7 @@ ACC 可以内置在 Kueue 中或运行在不同的 Kubernetes 控制器管理器
 
 监控集群中的准入检查，并维护与其关联（通过 `spec.controllerName`）的准入检查的 `Active` 状态。
 
-可选地，它可以监视自定义[参数](/docs/reference/kueue.v1beta1/#kueue-x-k8s-io-v1beta1-AdmissionCheckParametersReference)对象。
+可选地，它可以监视自定义[参数](/zh-cn/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-AdmissionCheckParametersReference)对象。
 
 [资源调配准入检查控制器](/docs/admission-check-controllers/provisioning/)在
 `pkg/controller/admissionchecks/provisioning/admissioncheck_reconciler.go` 中实现了此功能。
@@ -37,11 +37,11 @@ ACC 可以内置在 Kueue 中或运行在不同的 Kubernetes 控制器管理器
 ### 参数对象类型
 
 可选地，你可以定义一个集群级别的对象类型来保存特定于你的实现的准入检查参数。
-用户可以在 [spec.parameters](/zh-CN/docs/reference/kueue.v1beta1/#kueue-x-k8s-io-v1beta1-AdmissionCheckParametersReference)
+用户可以在 [spec.parameters](/zh-CN/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-AdmissionCheckParametersReference)
 中的准入检查定义里引用此类对象类型的实例。
 
 例如，[资源调配准入检查控制器](/zh-CN/docs/admission-check-controllers/provisioning/)为此使用了
-[ProvisioningRequestConfig](/zh-CN/docs/reference/kueue.v1beta1/#kueue-x-k8s-io-v1beta1-ProvisioningRequestConfig)。
+[ProvisioningRequestConfig](/zh-CN/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-ProvisioningRequestConfig)。
 
 ## 工具代码
 

--- a/site/content/zh-CN/docs/tasks/dev/setup_dev_monitoring.md
+++ b/site/content/zh-CN/docs/tasks/dev/setup_dev_monitoring.md
@@ -156,7 +156,7 @@ Verify the optional metrics are available:
 kueue_cluster_queue_nominal_quota
 ```
 
-See [Prometheus Metrics](/docs/reference/metrics#optional-metrics) for the full list of optional metrics.
+See [Prometheus Metrics](/zh-cn/docs/reference/metrics#optional-metrics) for the full list of optional metrics.
 
 ## What's next
 

--- a/site/content/zh-CN/docs/tasks/manage/observability/common_grafana_queries.md
+++ b/site/content/zh-CN/docs/tasks/manage/observability/common_grafana_queries.md
@@ -153,7 +153,7 @@ sum by (cluster_queue, reason) (
 )
 ```
 
-请参阅 [Prometheus 指标](/docs/reference/metrics)获取完整的 `reason` 标签值列表。
+请参阅 [Prometheus 指标](/zh-cn/docs/reference/metrics)获取完整的 `reason` 标签值列表。
 
 ## 集群队列状态
 

--- a/site/content/zh-CN/docs/tasks/manage/observability/configure_custom_metric_labels.md
+++ b/site/content/zh-CN/docs/tasks/manage/observability/configure_custom_metric_labels.md
@@ -96,6 +96,6 @@ metrics:
 
 ## 下一步
 
-- 查看 [Prometheus 指标](/docs/reference/metrics)，获取 Kueue 指标的完整列表。
+- 查看 [Prometheus 指标](/zh-cn/docs/reference/metrics)，获取 Kueue 指标的完整列表。
 - 查看[常用 Grafana 查询](/docs/tasks/manage/observability/common_grafana_queries)，
   获取用于在 Grafana 中监控 Kueue 的 PromQL 查询。

--- a/site/content/zh-CN/docs/tasks/manage/observability/setup_prometheus.md
+++ b/site/content/zh-CN/docs/tasks/manage/observability/setup_prometheus.md
@@ -102,7 +102,7 @@ data:
 kubectl rollout restart deployment/kueue-controller-manager -n kueue-system
 ```
 
-参阅 [Prometheus 指标](/docs/reference/metrics#optional-metrics)获取可选指标的完整列表。
+参阅 [Prometheus 指标](/zh-cn/docs/reference/metrics#optional-metrics)获取可选指标的完整列表。
 
 ## 接下来是什么
 

--- a/site/content/zh-CN/docs/tasks/manage/setup_concurrent_admission.md
+++ b/site/content/zh-CN/docs/tasks/manage/setup_concurrent_admission.md
@@ -180,4 +180,4 @@ Parent Workload 是作业集成观察准入状态的对象。Variant Workload �
 ## 接下来 {#whats-next}
 
 - 阅读[并发准入概念](/docs/concepts/concurrent_admission)。
-- 阅读 [`ConcurrentAdmissionPolicy` API 参考](/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-ConcurrentAdmissionPolicy)。
+- 阅读 [`ConcurrentAdmissionPolicy` API 参考](/zh-cn/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-ConcurrentAdmissionPolicy)。

--- a/site/content/zh-CN/docs/tasks/run/using_hami.md
+++ b/site/content/zh-CN/docs/tasks/run/using_hami.md
@@ -66,7 +66,7 @@ Kueue 将计算 `nvidia.com/total-gpumem: 2048`（1024 × 2）。
 配置你的 ClusterQueue 以跟踪 vGPU 实例计数和总资源：
 
 ```yaml
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: vgpu-cluster-queue

--- a/site/content/zh-CN/docs/tasks/troubleshooting/troubleshooting_delete_clusterqueue.md
+++ b/site/content/zh-CN/docs/tasks/troubleshooting/troubleshooting_delete_clusterqueue.md
@@ -37,7 +37,7 @@ Kueue 使用名为 `kueue.x-k8s.io/resource-in-use` 的
 ### 使用 `kueuectl` {#using-kueuectl}
 
 {{% alert title="注意" color="primary" %}}
-如果你没有安装 `kueuectl`，请按照[安装指南](/docs/reference/kubectl-kueue/installation/)进行操作。
+如果你没有安装 `kueuectl`，请按照[安装指南](/zh-cn/docs/reference/kubectl-kueue/installation/)进行操作。
 {{% /alert %}}
 
 ```shell

--- a/site/content/zh-CN/docs/tasks/troubleshooting/troubleshooting_pods.md
+++ b/site/content/zh-CN/docs/tasks/troubleshooting/troubleshooting_pods.md
@@ -23,11 +23,11 @@ Pod 可能没有 `kueue.x-k8s.io/managed` 标签的原因如下：
 
 1. [Pod 集成被禁用](/docs/tasks/run/plain_pods/#before-you-begin)。
 2. Pod 所属的命名空间不满足
-   [`managedJobsNamespaceSelector`](/docs/reference/kueue-config.v1beta1/#Configuration)
+   [`managedJobsNamespaceSelector`](/zh-cn/docs/reference/kueue-config.v1beta2/#Configuration)
    的要求。
 3. Pod 由 Kueue 管理的 Job 或等效 CRD 拥有。
 4. Pod 没有 `kueue.x-k8s.io/queue-name` 标签，并且
-   [`manageJobsWithoutQueueName`](/docs/reference/kueue-config.v1beta1/#Configuration)
+   [`manageJobsWithoutQueueName`](/zh-cn/docs/reference/kueue-config.v1beta2/#Configuration)
    设置为 `false`。
 
 {{% alert title="注意" color="primary" %}}


### PR DESCRIPTION
Cherry pick of #14624 on release-0.18.

#14624: Fix the API reference links to use v1beta2 instead of v1beta1.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind documentation


```release-note
NONE
```