### PR TITLE
Add TASCacheTopologyTree Feature Gate

### DIFF
--- a/pkg/cache/scheduler/tas_flavor.go
+++ b/pkg/cache/scheduler/tas_flavor.go
@@ -222,14 +222,25 @@ func (c *TASFlavorCache) snapshot(
 // generation is current. Otherwise, it builds a candidate and returns the
 // newest tree retained in the cache, which may have been stored by a concurrent
 // caller. The returned tree must not be mutated.
+//
+// With TASCacheTopologyTree disabled the cache is neither read nor written, so
+// every snapshot gets a tree of its own and no tree is ever shared. Note that
+// storeTree must be skipped too: it returns the newest retained tree, which a
+// concurrent caller may have stored, and that would share a tree after all.
 func (c *TASFlavorCache) cachedOrBuiltTree() (*topologyTree, bool) {
-	if tree := c.cachedTree(); tree != nil && tree.generation == c.nodesCache.currentGeneration() {
-		return tree, true
+	cacheTree := features.Enabled(features.TASCacheTopologyTree)
+	if cacheTree {
+		if tree := c.cachedTree(); tree != nil && tree.generation == c.nodesCache.currentGeneration() {
+			return tree, true
+		}
 	}
 	// snapshot already holds c.RLock. Do not use c.NodeLabels here: a recursive
 	// RLock can deadlock if a writer is waiting between the two acquisitions.
 	nodes, generation := c.nodesCache.find(c.flavor.NodeLabels, c.topology.Levels)
 	tree := newTopologyTree(c.topology.Levels, nodes, generation)
+	if !cacheTree {
+		return tree, false
+	}
 	return c.storeTree(tree), false
 }
 

--- a/pkg/cache/scheduler/tas_topology_tree_test.go
+++ b/pkg/cache/scheduler/tas_topology_tree_test.go
@@ -261,6 +261,33 @@ func TestSnapshotsSharingTreeAreIsolated(t *testing.T) {
 	}
 }
 
+func TestSnapshotsDoNotShareTreeWhenCachingDisabled(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TASCacheTopologyTree, false)
+	ctx, log := utiltesting.ContextWithLog(t)
+	tasCache := NewTASCache(nil, newDefaultSimulator(), resources.NewResourceFormatter())
+	tasCache.SyncNode(makeTreeTestNode("n1", "b1", "r1"))
+	tasCache.SyncNode(makeTreeTestNode("n2", "b1", "r2"))
+	fc := tasCache.NewTASFlavorCache(
+		topologyInformation{Levels: []string{treeTestBlockLabel, treeTestRackLabel, corev1.LabelHostname}},
+		flavorInformation{TopologyName: "default"},
+	)
+
+	first, err := fc.snapshot(ctx, log, newDefaultSimulatorSnapshot(), nil)
+	if err != nil {
+		t.Fatalf("first snapshot failed: %v", err)
+	}
+	second, err := fc.snapshot(ctx, log, newDefaultSimulatorSnapshot(), nil)
+	if err != nil {
+		t.Fatalf("second snapshot failed: %v", err)
+	}
+	if first.topologyTree == second.topologyTree {
+		t.Error("snapshots share a topology tree while TASCacheTopologyTree is disabled")
+	}
+	if fc.cachedTree() != nil {
+		t.Error("the flavor cache retained a topology tree while TASCacheTopologyTree is disabled")
+	}
+}
+
 func TestSnapshotReuseAfterBalancedPlacement(t *testing.T) {
 	features.SetFeatureGateDuringTest(t, features.TASBalancedPlacement, true)
 	ctx, log := utiltesting.ContextWithLog(t)

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -461,6 +461,16 @@ const (
 	// Enables caching of remaining capacity and clone reduction in TAS Flavor Snapshot.
 	TASCachingRemainingResources featuregate.Feature = "TASCachingRemainingResources"
 
+	// owner: @tenzen-y
+	//
+	// issue: https://github.com/kubernetes-sigs/kueue/issues/12580
+	// Enables caching the immutable TAS topology tree on the TASFlavorCache and reusing it
+	// across scheduling cycles while the nodesCache generation is unchanged. When disabled,
+	// every snapshot builds a tree of its own and none is ever shared between snapshots,
+	// which is the behavior before the tree cache was introduced. Kept as an off-switch in
+	// case a stale or shared tree is suspected in a production TAS deployment.
+	TASCacheTopologyTree featuregate.Feature = "TASCacheTopologyTree"
+
 	// owner: @kshalot
 	//
 	// issue: https://github.com/kubernetes-sigs/kueue/issues/8871
@@ -818,6 +828,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 
 	TASCachingRemainingResources: {
 		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Beta},
+	},
+
+	TASCacheTopologyTree: {
+		{Version: version.MustParse("0.20"), Default: true, PreRelease: featuregate.Beta},
 	},
 
 	SchedulerLibraryIntegration: {

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -381,6 +381,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.19"
+- name: TASCacheTopologyTree
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.20"
 - name: TASCachingRemainingResources
   versionedSpecs:
   - default: true

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -381,6 +381,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.19"
+- name: TASCacheTopologyTree
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.20"
 - name: TASCachingRemainingResources
   versionedSpecs:
   - default: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

I added TASCacheTopologyTree to safely cherry-pick https://github.com/kubernetes-sigs/kueue/pull/13819 perf improvements.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a feature gate to control reuse of topology data during scheduling.
  * Enabled by default, topology data can now be reused across scheduling cycles when node information remains unchanged.
  * When disabled, each scheduling snapshot uses a separate topology tree without retaining cached data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->