### PR TITLE
Automated cherry pick of #13819: refactor: Reuse TAS topology trees across scheduler snapshots

### DIFF
--- a/pkg/cache/scheduler/snapshot.go
+++ b/pkg/cache/scheduler/snapshot.go
@@ -218,11 +218,7 @@ func (c *Cache) Snapshot(ctx context.Context, options ...SnapshotOption) (*Snaps
 			if features.Enabled(features.TASHandleOverlappingFlavors) && utiltas.IsLowestLevelHostname(cache.topology.Levels) {
 				aggregatedDomainUsagesForFlavor = aggregatedDomainUsages
 			}
-			tasSnapshots[flavor] = cache.snapshot(
-				log,
-				c.tasCache.nodesCache.find(cache.flavor.NodeLabels, cache.topology.Levels),
-				aggregatedDomainUsagesForFlavor,
-			)
+			tasSnapshots[flavor] = cache.snapshot(log, aggregatedDomainUsagesForFlavor)
 		}
 	}
 	for _, cq := range cqNames {

--- a/pkg/cache/scheduler/snapshot_test.go
+++ b/pkg/cache/scheduler/snapshot_test.go
@@ -1081,8 +1081,8 @@ func TestSnapshot(t *testing.T) {
 					// A leaf's usage is nil until first updated; skip those.
 					domainUsage := make(map[utiltas.TopologyDomainID]resources.Requests)
 					for domainID, leaf := range flavorSnapshot.leaves {
-						if leaf.tasUsage != nil {
-							domainUsage[domainID] = leaf.tasUsage
+						if leafCapacity := flavorSnapshot.leafCapacityOf(leaf); leafCapacity.tasUsage != nil {
+							domainUsage[domainID] = leafCapacity.tasUsage
 						}
 					}
 					gotTASUsage[flavor] = domainUsage

--- a/pkg/cache/scheduler/tas_balanced_placement.go
+++ b/pkg/cache/scheduler/tas_balanced_placement.go
@@ -34,11 +34,11 @@ func evaluateGreedyAssignment(s *TASFlavorSnapshot, domains []*domain, sliceCoun
 	idx := 0
 	if leaderCount > 0 {
 		sortedWithLeader = s.sortedDomainsWithLeader(domains, false)
-		for ; remainingLeaderCount > 0 && idx < len(sortedWithLeader) && sortedWithLeader[idx].leaderCount > 0; idx++ {
+		for ; remainingLeaderCount > 0 && idx < len(sortedWithLeader) && s.domainStateOf(sortedWithLeader[idx]).leaderCount > 0; idx++ {
 			selectedDomainsCount++
 			lastDomainWithLeader = sortedWithLeader[idx]
-			remainingLeaderCount -= sortedWithLeader[idx].leaderCount
-			remainingSliceCount -= sortedWithLeader[idx].sliceCountWithLeader
+			remainingLeaderCount -= s.domainStateOf(sortedWithLeader[idx]).leaderCount
+			remainingSliceCount -= s.domainStateOf(sortedWithLeader[idx]).sliceCountWithLeader
 		}
 		sortedWithoutLeader = s.sortedDomains(sortedWithLeader[idx:], false)
 	} else {
@@ -49,10 +49,10 @@ func evaluateGreedyAssignment(s *TASFlavorSnapshot, domains []*domain, sliceCoun
 		return false, 0, nil, nil
 	}
 
-	for idx = 0; remainingSliceCount > 0 && idx < len(sortedWithoutLeader) && sortedWithoutLeader[idx].sliceCount > 0; idx++ {
+	for idx = 0; remainingSliceCount > 0 && idx < len(sortedWithoutLeader) && s.domainStateOf(sortedWithoutLeader[idx]).sliceCount > 0; idx++ {
 		selectedDomainsCount++
 		lastDomain = sortedWithoutLeader[idx]
-		remainingSliceCount -= sortedWithoutLeader[idx].sliceCount
+		remainingSliceCount -= s.domainStateOf(sortedWithoutLeader[idx]).sliceCount
 	}
 	if remainingSliceCount > 0 {
 		return false, 0, nil, nil
@@ -61,13 +61,13 @@ func evaluateGreedyAssignment(s *TASFlavorSnapshot, domains []*domain, sliceCoun
 }
 
 // The balance threshold value is maximum possible minimum number of slices placed on a domain in a balanced placement solution.
-func balanceThresholdValue(sliceCount int32, selectedDomainsCount int32, lastDomainWithLeader *domain, lastDomain *domain) int32 {
+func balanceThresholdValue(s *TASFlavorSnapshot, sliceCount int32, selectedDomainsCount int32, lastDomainWithLeader *domain, lastDomain *domain) int32 {
 	threshold := sliceCount / selectedDomainsCount
 	if lastDomainWithLeader != nil {
-		threshold = min(threshold, lastDomainWithLeader.sliceCountWithLeader)
+		threshold = min(threshold, s.domainStateOf(lastDomainWithLeader).sliceCountWithLeader)
 	}
 	if lastDomain != nil {
-		threshold = min(threshold, lastDomain.sliceCount)
+		threshold = min(threshold, s.domainStateOf(lastDomain).sliceCount)
 	}
 	return threshold
 }
@@ -84,7 +84,7 @@ func selectOptimalDomainSetToFit(s *TASFlavorSnapshot, domains []*domain, sliceC
 
 	orderedDomains := slices.Clone(domains)
 	if prioritizeByEntropy {
-		slices.SortFunc(orderedDomains, compareDomainCapacityAndEntropy)
+		slices.SortFunc(orderedDomains, s.compareDomainCapacityAndEntropy)
 	} else {
 		slices.SortFunc(orderedDomains, compareDomainLevelValues)
 	}
@@ -98,6 +98,7 @@ func selectOptimalDomainSetToFit(s *TASFlavorSnapshot, domains []*domain, sliceC
 	domainPlacements[0][leaderCount] = map[int32][]*domain{sliceCount * sliceSize: {}}
 
 	for _, d := range orderedDomains {
+		dState := s.domainStateOf(d)
 		for i := optimalNumberOfDomains; i > 0; i-- {
 			for _, beforeLeader := range slices.Sorted(maps.Keys(domainPlacements[i-1])) {
 				for _, beforeState := range slices.Sorted(maps.Keys(domainPlacements[i-1][beforeLeader])) {
@@ -109,9 +110,9 @@ func selectOptimalDomainSetToFit(s *TASFlavorSnapshot, domains []*domain, sliceC
 					copy(newPlacement, beforePlacement)
 					newPlacement = append(newPlacement, d)
 					// Case 1: Pick this domain with leader
-					if beforeLeader > 0 && d.leaderCount > 0 {
-						afterLeader := beforeLeader - d.leaderCount
-						afterState := beforeState - d.podCountWithLeader
+					if beforeLeader > 0 && dState.leaderCount > 0 {
+						afterLeader := beforeLeader - dState.leaderCount
+						afterState := beforeState - dState.podCountWithLeader
 						if domainPlacements[i][afterLeader] == nil {
 							domainPlacements[i][afterLeader] = make(map[int32][]*domain)
 						}
@@ -120,8 +121,8 @@ func selectOptimalDomainSetToFit(s *TASFlavorSnapshot, domains []*domain, sliceC
 						}
 					}
 					// Case 2: Pick this domain without leader
-					if d.sliceCount > 0 {
-						afterState := beforeState - d.podCount
+					if dState.sliceCount > 0 {
+						afterState := beforeState - dState.podCount
 						if domainPlacements[i][beforeLeader] == nil {
 							domainPlacements[i][beforeLeader] = make(map[int32][]*domain)
 						}
@@ -160,22 +161,23 @@ func placeSlicesOnDomainsBalanced(s *TASFlavorSnapshot, domains []*domain, slice
 	leadersLeft := leaderCount
 	var extraSlicesToTake int32
 	for _, domain := range resultDomains {
+		domainState := s.domainStateOf(domain)
 		switch {
 		case leadersLeft > 0:
-			extraSlicesToTake = min(domain.sliceCountWithLeader-threshold, extraSlicesLeft)
-			domain.leaderCount = 1
+			extraSlicesToTake = min(domainState.sliceCountWithLeader-threshold, extraSlicesLeft)
+			domainState.leaderCount = 1
 			leadersLeft--
 		case extraSlicesLeft > 0:
-			extraSlicesToTake = min(domain.sliceCount-threshold, extraSlicesLeft)
-			domain.leaderCount = 0
+			extraSlicesToTake = min(domainState.sliceCount-threshold, extraSlicesLeft)
+			domainState.leaderCount = 0
 		default:
-			domain.leaderCount = 0
+			domainState.leaderCount = 0
 			extraSlicesToTake = 0
 		}
-		domain.podCount = (threshold + extraSlicesToTake) * sliceSize
-		domain.sliceCount = (threshold + extraSlicesToTake)
-		domain.sliceCountWithLeader = domain.sliceCount
-		domain.podCountWithLeader = domain.podCount - domain.leaderCount
+		domainState.podCount = (threshold + extraSlicesToTake) * sliceSize
+		domainState.sliceCount = (threshold + extraSlicesToTake)
+		domainState.sliceCountWithLeader = domainState.sliceCount
+		domainState.podCountWithLeader = domainState.podCount - domainState.leaderCount
 		extraSlicesLeft -= extraSlicesToTake
 	}
 	if extraSlicesLeft > 0 || leadersLeft > 0 {
@@ -184,14 +186,14 @@ func placeSlicesOnDomainsBalanced(s *TASFlavorSnapshot, domains []*domain, slice
 	return resultDomains, ""
 }
 
-func calculateDomainsEntropy(domains []*domain) float64 {
+func (s *TASFlavorSnapshot) calculateDomainsEntropy(domains []*domain) float64 {
 	if len(domains) == 0 {
 		return 0.0
 	}
 
 	var total int32
 	for _, d := range domains {
-		total += d.podCount
+		total += s.domainStateOf(d).podCount
 	}
 
 	if total == 0 {
@@ -201,23 +203,23 @@ func calculateDomainsEntropy(domains []*domain) float64 {
 	var entropy float64
 	totalF := float64(total)
 	for _, d := range domains {
-		if d.podCount > 0 {
-			pI := float64(d.podCount) / totalF
+		if state := s.domainStateOf(d).podCount; state > 0 {
+			pI := float64(state) / totalF
 			entropy += -pI * math.Log2(pI)
 		}
 	}
 	return entropy
 }
 
-func compareDomainCapacityAndEntropy(a, b *domain) int {
-	if r := b.leaderCount - a.leaderCount; r != 0 {
+func (s *TASFlavorSnapshot) compareDomainCapacityAndEntropy(a, b *domain) int {
+	if r := s.domainStateOf(b).leaderCount - s.domainStateOf(a).leaderCount; r != 0 {
 		return int(r)
 	}
-	if r := b.sliceCountWithLeader - a.sliceCountWithLeader; r != 0 {
+	if r := s.domainStateOf(b).sliceCountWithLeader - s.domainStateOf(a).sliceCountWithLeader; r != 0 {
 		return int(r)
 	}
-	aEntropy := calculateDomainsEntropy(a.children)
-	bEntropy := calculateDomainsEntropy(b.children)
+	aEntropy := s.calculateDomainsEntropy(a.children)
+	bEntropy := s.calculateDomainsEntropy(b.children)
 	if bEntropy > aEntropy {
 		return 1
 	}
@@ -251,16 +253,16 @@ func findBestDomainsForBalancedPlacement(s *TASFlavorSnapshot, params *topologyA
 	var currFitDomain []*domain
 
 	for _, requestedLevelSiblingDomains := range requestedLevelDomainsToConsider {
-		candidateDomains := cloneDomains(requestedLevelSiblingDomains)
+		candidateDomains := s.cloneDomains(requestedLevelSiblingDomains)
 		lowerLevelDomains := getLowerLevelDomains(s, candidateDomains, params.requestedLevelIdx, params.sliceLevelIdx)
 		fits, selectedDomainsCount, lastDomainWithLeader, lastDomain := evaluateGreedyAssignment(s, lowerLevelDomains, sliceCount, params.leaderCount)
 		if !fits {
 			continue
 		}
-		threshold := balanceThresholdValue(sliceCount, selectedDomainsCount, lastDomainWithLeader, lastDomain)
+		threshold := balanceThresholdValue(s, sliceCount, selectedDomainsCount, lastDomainWithLeader, lastDomain)
 		thresholdWithLeaderReservation := threshold
 		if params.leaderCount > 0 && lastDomain != nil {
-			thresholdWithLeaderReservation = min(threshold, lastDomain.sliceCountWithLeader)
+			thresholdWithLeaderReservation = min(threshold, s.domainStateOf(lastDomain).sliceCountWithLeader)
 		}
 		if threshold >= bestThreshold {
 			s.pruneDomainsBelowThreshold(candidateDomains, threshold, params.sliceSize, params.sliceLevelIdx, params.requestedLevelIdx, params.leaderCount > 0)
@@ -271,7 +273,7 @@ func findBestDomainsForBalancedPlacement(s *TASFlavorSnapshot, params *topologyA
 					continue
 				}
 				threshold = thresholdWithLeaderReservation
-				candidateDomains = cloneDomains(requestedLevelSiblingDomains)
+				candidateDomains = s.cloneDomains(requestedLevelSiblingDomains)
 				s.pruneDomainsBelowThreshold(candidateDomains, threshold, params.sliceSize, params.sliceLevelIdx, params.requestedLevelIdx, params.leaderCount > 0)
 				fitsAfterPruning, requestedLevelDomainCount, _, _ = evaluateGreedyAssignment(s, candidateDomains, sliceCount, params.leaderCount)
 			}
@@ -319,63 +321,67 @@ func getLowerLevelDomains(s *TASFlavorSnapshot, domains []*domain, levelIdx, sli
 	return domains
 }
 
-func clearState(d *domain) {
-	d.podCount = int32(0)
-	d.sliceCount = int32(0)
-	d.podCountWithLeader = int32(0)
-	d.sliceCountWithLeader = int32(0)
-	d.leaderCount = int32(0)
+func (s *TASFlavorSnapshot) clearState(d *domain) {
+	st := s.domainStateOf(d)
+	*st = domainState{affinityScore: st.affinityScore}
 	for _, child := range d.children {
-		clearState(child)
+		s.clearState(child)
 	}
 }
 
-func clearLeaderCapacity(d *domain) {
-	d.podCountWithLeader = int32(0)
-	d.sliceCountWithLeader = int32(0)
-	d.leaderCount = int32(0)
+func (s *TASFlavorSnapshot) clearLeaderCapacity(d *domain) {
+	domainState := s.domainStateOf(d)
+	domainState.podCountWithLeader = 0
+	domainState.sliceCountWithLeader = 0
+	domainState.leaderCount = 0
 	for _, child := range d.children {
-		clearLeaderCapacity(child)
+		s.clearLeaderCapacity(child)
 	}
 }
 
-func cloneDomains(domains []*domain) []*domain {
+// cloneDomains deep-copies the given domain subtrees, giving every copied
+// domain its own per-snapshot state slot initialized from the original's
+// current state. This lets the balanced-placement algorithm speculatively
+// mutate (e.g. prune) the copies without corrupting the state of the shared
+// domains, which other candidate sets and the fallback path still need.
+func (s *TASFlavorSnapshot) cloneDomains(domains []*domain) []*domain {
 	result := make([]*domain, len(domains))
 	for i, d := range domains {
-		result[i] = cloneDomain(d, nil)
+		result[i] = s.cloneDomain(d, nil)
 	}
 	return result
 }
 
-func cloneDomain(d *domain, parent *domain) *domain {
-	clone := *d
+func (s *TASFlavorSnapshot) cloneDomain(d *domain, parent *domain) *domain {
+	clone := s.shallowCloneWithState(d)
 	clone.parent = parent
 	clone.children = make([]*domain, len(d.children))
 	for i, child := range d.children {
-		clone.children[i] = cloneDomain(child, &clone)
+		clone.children[i] = s.cloneDomain(child, clone)
 	}
-	return &clone
+	return clone
 }
 
-func pruneDomainNodeBelowThreshold(d *domain, threshold int32, leaderRequired bool) {
-	if d.sliceCount < threshold {
-		clearState(d)
+func (s *TASFlavorSnapshot) pruneDomainNodeBelowThreshold(d *domain, threshold int32, leaderRequired bool) {
+	domainState := s.domainStateOf(d)
+	if domainState.sliceCount < threshold {
+		s.clearState(d)
 		return
 	}
 	// The domain can still be used for workers, but not as the leader host at this threshold.
-	if leaderRequired && d.leaderCount > 0 && d.sliceCountWithLeader < threshold {
-		clearLeaderCapacity(d)
+	if leaderRequired && domainState.leaderCount > 0 && domainState.sliceCountWithLeader < threshold {
+		s.clearLeaderCapacity(d)
 	}
 }
 
 func (s *TASFlavorSnapshot) pruneDomainsBelowThreshold(domains []*domain, threshold int32, sliceSize int32, sliceLevelIdx int, level int, leaderRequired bool) {
 	for _, d := range domains {
 		for _, c := range d.children {
-			pruneDomainNodeBelowThreshold(c, threshold, leaderRequired)
+			s.pruneDomainNodeBelowThreshold(c, threshold, leaderRequired)
 		}
 	}
 	for _, d := range domains {
 		s.fillInCountsHelper(d, sliceSize, sliceLevelIdx, level, nil, leaderRequired)
-		pruneDomainNodeBelowThreshold(d, threshold, leaderRequired)
+		s.pruneDomainNodeBelowThreshold(d, threshold, leaderRequired)
 	}
 }

--- a/pkg/cache/scheduler/tas_balanced_placement_test.go
+++ b/pkg/cache/scheduler/tas_balanced_placement_test.go
@@ -32,44 +32,86 @@ func domainIDs(domains []*domain) []string {
 	return utilslices.Map(domains, func(d **domain) string { return string((*d).id) })
 }
 
+func addDomainWithState(s *TASFlavorSnapshot, d *domain, st domainState) *domain {
+	d.idx = len(s.domainStates)
+	s.domainStates = append(s.domainStates, st)
+	return d
+}
+
 func TestSelectOptimalDomainSetToFit(t *testing.T) {
-	d1 := &domain{id: "d1", levelValues: []string{"d1"}, podCount: 9, sliceCount: 9, leaderCount: 1, podCountWithLeader: 8, sliceCountWithLeader: 8}
-	d2 := &domain{id: "d2", levelValues: []string{"d2"}, podCount: 6, sliceCount: 6, leaderCount: 0, podCountWithLeader: 6, sliceCountWithLeader: 6}
-	d3 := &domain{id: "d3", levelValues: []string{"d3"}, podCount: 4, sliceCount: 4, leaderCount: 1, podCountWithLeader: 3, sliceCountWithLeader: 3}
-	d4 := &domain{id: "d4", levelValues: []string{"d4"}, podCount: 2, sliceCount: 2, leaderCount: 0, podCountWithLeader: 2, sliceCountWithLeader: 2}
+	d1 := testDomainSpec{
+		domain: domain{id: "d1", levelValues: []string{"d1"}},
+		state: domainState{
+			podCount:             9,
+			sliceCount:           9,
+			leaderCount:          1,
+			podCountWithLeader:   8,
+			sliceCountWithLeader: 8,
+		},
+	}
+	d2 := testDomainSpec{
+		domain: domain{id: "d2", levelValues: []string{"d2"}},
+		state: domainState{
+			podCount:             6,
+			sliceCount:           6,
+			leaderCount:          0,
+			podCountWithLeader:   6,
+			sliceCountWithLeader: 6,
+		},
+	}
+	d3 := testDomainSpec{
+		domain: domain{id: "d3", levelValues: []string{"d3"}},
+		state: domainState{
+			podCount:             4,
+			sliceCount:           4,
+			leaderCount:          1,
+			podCountWithLeader:   3,
+			sliceCountWithLeader: 3,
+		},
+	}
+	d4 := testDomainSpec{
+		domain: domain{id: "d4", levelValues: []string{"d4"}},
+		state: domainState{
+			podCount:             2,
+			sliceCount:           2,
+			leaderCount:          0,
+			podCountWithLeader:   2,
+			sliceCountWithLeader: 2,
+		},
+	}
 
 	testCases := map[string]struct {
-		domains     []*domain
+		domains     []testDomainSpec
 		workerCount int32
 		leaderCount int32
 		want        []string
 	}{
 		"no fit": {
-			domains:     []*domain{d1, d2, d3, d4},
+			domains:     []testDomainSpec{d1, d2, d3, d4},
 			workerCount: 22,
 			leaderCount: 0,
 			want:        []string{},
 		},
 		"simple fit one domain": {
-			domains:     []*domain{d1, d2, d3, d4},
+			domains:     []testDomainSpec{d1, d2, d3, d4},
 			workerCount: 5,
 			leaderCount: 1,
 			want:        []string{"d1"},
 		},
 		"perfect fit with two domains": {
-			domains:     []*domain{d1, d2, d3, d4},
+			domains:     []testDomainSpec{d1, d2, d3, d4},
 			workerCount: 9,
 			leaderCount: 1,
 			want:        []string{"d2", "d3"},
 		},
 		"perfect fit with two domains 2": {
-			domains:     []*domain{d1, d2, d3, d4},
+			domains:     []testDomainSpec{d1, d2, d3, d4},
 			workerCount: 10,
 			leaderCount: 1,
 			want:        []string{"d1", "d4"},
 		},
 		"best fit, single domain": {
-			domains:     []*domain{d1, d2, d3, d4},
+			domains:     []testDomainSpec{d1, d2, d3, d4},
 			workerCount: 5,
 			leaderCount: 0,
 			want:        []string{"d2"},
@@ -79,8 +121,9 @@ func TestSelectOptimalDomainSetToFit(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			_, log := utiltesting.ContextWithLog(t)
-			s := newTASFlavorSnapshot(log, "dummy", []string{}, nil)
-			got := selectOptimalDomainSetToFit(s, tc.domains, tc.workerCount, tc.leaderCount, 1, true)
+			s := newTASFlavorSnapshot(log, "dummy", newTopologyTree([]string{}, nil, 0), nil)
+			domains := addDomainsWithState(s, tc.domains)
+			got := selectOptimalDomainSetToFit(s, domains, tc.workerCount, tc.leaderCount, 1, true)
 			gotIDs := make([]string, len(got))
 			for i, d := range got {
 				gotIDs[i] = string(d.id)
@@ -107,12 +150,13 @@ func TestSelectOptimalDomainSetToFitStableTieBreak(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			_, log := utiltesting.ContextWithLog(t)
-			s := newTASFlavorSnapshot(log, "dummy", []string{}, nil)
+			s := newTASFlavorSnapshot(log, "dummy", newTopologyTree([]string{}, nil, 0), nil)
+			equalState := domainState{podCount: 3, sliceCount: 3, podCountWithLeader: 3, sliceCountWithLeader: 3}
 			domains := []*domain{
-				{id: "leaf-a", levelValues: []string{"block-b", "host-a"}, podCount: 3, sliceCount: 3, podCountWithLeader: 3, sliceCountWithLeader: 3},
-				{id: "leaf-m", levelValues: []string{"block-b", "host-m"}, podCount: 3, sliceCount: 3, podCountWithLeader: 3, sliceCountWithLeader: 3},
-				{id: "leaf-z", levelValues: []string{"block-a", "host-z"}, podCount: 3, sliceCount: 3, podCountWithLeader: 3, sliceCountWithLeader: 3},
-				{id: "leaf-zz", levelValues: []string{"block-a", "host-zz"}, podCount: 3, sliceCount: 3, podCountWithLeader: 3, sliceCountWithLeader: 3},
+				addDomainWithState(s, &domain{id: "leaf-a", levelValues: []string{"block-b", "host-a"}}, equalState),
+				addDomainWithState(s, &domain{id: "leaf-m", levelValues: []string{"block-b", "host-m"}}, equalState),
+				addDomainWithState(s, &domain{id: "leaf-z", levelValues: []string{"block-a", "host-z"}}, equalState),
+				addDomainWithState(s, &domain{id: "leaf-zz", levelValues: []string{"block-a", "host-zz"}}, equalState),
 			}
 
 			got := selectOptimalDomainSetToFit(s, domains, 1, 0, 1, tc.prioritizeByEntropy)
@@ -126,23 +170,43 @@ func TestSelectOptimalDomainSetToFitStableTieBreak(t *testing.T) {
 
 func TestCompareDomainCapacityAndEntropy(t *testing.T) {
 	testCases := map[string]struct {
-		domains []*domain
+		domains func(s *TASFlavorSnapshot) []*domain
 		want    []string
 	}{
 		"tie-breaking on level values when capacity and entropy are equal": {
-			domains: []*domain{
-				{id: "leaf-a", levelValues: []string{"block-b", "host-a"}, leaderCount: 1, sliceCountWithLeader: 5, children: []*domain{{podCount: 2}, {podCount: 2}}},
-				{id: "leaf-m", levelValues: []string{"block-b", "host-m"}, leaderCount: 1, sliceCountWithLeader: 5, children: []*domain{{podCount: 2}, {podCount: 2}}},
-				{id: "leaf-z", levelValues: []string{"block-a", "host-z"}, leaderCount: 1, sliceCountWithLeader: 5, children: []*domain{{podCount: 2}, {podCount: 2}}},
+			domains: func(s *TASFlavorSnapshot) []*domain {
+				leaderCount := domainState{leaderCount: 1, sliceCountWithLeader: 5}
+				childState := domainState{podCount: 2}
+				return []*domain{
+					addDomainWithState(s, &domain{id: "leaf-a", levelValues: []string{"block-b", "host-a"}, children: []*domain{
+						addDomainWithState(s, &domain{}, childState), addDomainWithState(s, &domain{}, childState),
+					}}, leaderCount),
+					addDomainWithState(s, &domain{id: "leaf-m", levelValues: []string{"block-b", "host-m"}, children: []*domain{
+						addDomainWithState(s, &domain{}, childState), addDomainWithState(s, &domain{}, childState),
+					}}, leaderCount),
+					addDomainWithState(s, &domain{id: "leaf-z", levelValues: []string{"block-a", "host-z"}, children: []*domain{
+						addDomainWithState(s, &domain{}, childState), addDomainWithState(s, &domain{}, childState),
+					}}, leaderCount),
+				}
 			},
 			want: []string{"leaf-z", "leaf-a", "leaf-m"},
 		},
 		"capacity overrides entropy, and higher entropy overrides level values": {
-			domains: []*domain{
-				{id: "lower-leader", levelValues: []string{"a"}, leaderCount: 0, sliceCountWithLeader: 100, children: []*domain{{podCount: 50}, {podCount: 50}}},
-				{id: "lower-capacity", levelValues: []string{"b"}, leaderCount: 1, sliceCountWithLeader: 4, children: []*domain{{podCount: 2}, {podCount: 2}}},
-				{id: "low-entropy", levelValues: []string{"c"}, leaderCount: 1, sliceCountWithLeader: 5, children: []*domain{{podCount: 4}, {podCount: 0}}},
-				{id: "high-entropy", levelValues: []string{"d"}, leaderCount: 1, sliceCountWithLeader: 5, children: []*domain{{podCount: 2}, {podCount: 2}}},
+			domains: func(s *TASFlavorSnapshot) []*domain {
+				return []*domain{
+					addDomainWithState(s, &domain{id: "lower-leader", levelValues: []string{"a"}, children: []*domain{
+						addDomainWithState(s, &domain{}, domainState{podCount: 50}), addDomainWithState(s, &domain{}, domainState{podCount: 50}),
+					}}, domainState{leaderCount: 0, sliceCountWithLeader: 100}),
+					addDomainWithState(s, &domain{id: "lower-capacity", levelValues: []string{"b"}, children: []*domain{
+						addDomainWithState(s, &domain{}, domainState{podCount: 2}), addDomainWithState(s, &domain{}, domainState{podCount: 2}),
+					}}, domainState{leaderCount: 1, sliceCountWithLeader: 4}),
+					addDomainWithState(s, &domain{id: "low-entropy", levelValues: []string{"c"}, children: []*domain{
+						addDomainWithState(s, &domain{}, domainState{podCount: 4}), addDomainWithState(s, &domain{}, domainState{podCount: 0}),
+					}}, domainState{leaderCount: 1, sliceCountWithLeader: 5}),
+					addDomainWithState(s, &domain{id: "high-entropy", levelValues: []string{"d"}, children: []*domain{
+						addDomainWithState(s, &domain{}, domainState{podCount: 2}), addDomainWithState(s, &domain{}, domainState{podCount: 2}),
+					}}, domainState{leaderCount: 1, sliceCountWithLeader: 5}),
+				}
 			},
 			want: []string{"high-entropy", "low-entropy", "lower-capacity", "lower-leader"},
 		},
@@ -150,9 +214,12 @@ func TestCompareDomainCapacityAndEntropy(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			slices.SortFunc(tc.domains, compareDomainCapacityAndEntropy)
+			_, log := utiltesting.ContextWithLog(t)
+			s := newTASFlavorSnapshot(log, "dummy", newTopologyTree([]string{}, nil, 0), nil)
+			got := tc.domains(s)
+			slices.SortFunc(got, s.compareDomainCapacityAndEntropy)
 
-			if diff := cmp.Diff(tc.want, domainIDs(tc.domains)); diff != "" {
+			if diff := cmp.Diff(tc.want, domainIDs(got)); diff != "" {
 				t.Errorf("unexpected domain order (-want,+got): %s", diff)
 			}
 		})
@@ -160,85 +227,124 @@ func TestCompareDomainCapacityAndEntropy(t *testing.T) {
 }
 
 func TestPlaceSlicesOnDomainsBalanced(t *testing.T) {
-	d1 := &domain{id: "d1", levelValues: []string{"d1"}, podCount: 18, sliceCount: 18, podCountWithLeader: 18, leaderCount: 0, sliceCountWithLeader: 18}
-	d2 := &domain{id: "d2", levelValues: []string{"d2"}, podCount: 18, sliceCount: 18, podCountWithLeader: 18, leaderCount: 0, sliceCountWithLeader: 18}
-	d3 := &domain{id: "d3", levelValues: []string{"d3"}, podCount: 18, sliceCount: 18, podCountWithLeader: 18, leaderCount: 0, sliceCountWithLeader: 18}
-	d4 := &domain{id: "d4", levelValues: []string{"d4"}, podCount: 10, sliceCount: 10, podCountWithLeader: 10, leaderCount: 0, sliceCountWithLeader: 10}
-	d5 := &domain{id: "d5", levelValues: []string{"d5"}, podCount: 2, sliceCount: 2, podCountWithLeader: 2, leaderCount: 0, sliceCountWithLeader: 2}
+	d1 := testDomainSpec{
+		domain: domain{id: "d1", levelValues: []string{"d1"}},
+		state: domainState{
+			podCount:             18,
+			sliceCount:           18,
+			podCountWithLeader:   18,
+			leaderCount:          0,
+			sliceCountWithLeader: 18,
+		},
+	}
+	d2 := testDomainSpec{
+		domain: domain{id: "d2", levelValues: []string{"d2"}},
+		state: domainState{
+			podCount:             18,
+			sliceCount:           18,
+			podCountWithLeader:   18,
+			leaderCount:          0,
+			sliceCountWithLeader: 18,
+		},
+	}
+	d3 := testDomainSpec{
+		domain: domain{id: "d3", levelValues: []string{"d3"}},
+		state: domainState{
+			podCount:             18,
+			sliceCount:           18,
+			podCountWithLeader:   18,
+			leaderCount:          0,
+			sliceCountWithLeader: 18,
+		},
+	}
+	d4 := testDomainSpec{
+		domain: domain{id: "d4", levelValues: []string{"d4"}},
+		state: domainState{
+			podCount:             10,
+			sliceCount:           10,
+			podCountWithLeader:   10,
+			leaderCount:          0,
+			sliceCountWithLeader: 10,
+		},
+	}
+	d5 := testDomainSpec{
+		domain: domain{id: "d5", levelValues: []string{"d5"}},
+		state: domainState{
+			podCount:             2,
+			sliceCount:           2,
+			podCountWithLeader:   2,
+			leaderCount:          0,
+			sliceCountWithLeader: 2,
+		},
+	}
 
 	testCases := map[string]struct {
-		domains     []*domain
+		domains     []testDomainSpec
 		sliceCount  int32
 		leaderCount int32
 		sliceSize   int32
 		threshold   int32
-		want        []*domain
+		want        map[string]domainState
 	}{
 		"simple balanced placement on two domains": {
-			domains:     []*domain{d1, d2, d3},
+			domains:     []testDomainSpec{d1, d2, d3},
 			sliceCount:  20,
 			leaderCount: 0,
 			sliceSize:   1,
 			threshold:   10,
-			want: []*domain{
-				{id: "d1", sliceCount: 10, podCount: 10, podCountWithLeader: 10, sliceCountWithLeader: 10, leaderCount: 0},
-				{id: "d2", sliceCount: 10, podCount: 10, podCountWithLeader: 10, sliceCountWithLeader: 10, leaderCount: 0},
+			want: map[string]domainState{
+				"d1": {sliceCount: 10, podCount: 10, podCountWithLeader: 10, sliceCountWithLeader: 10, leaderCount: 0},
+				"d2": {sliceCount: 10, podCount: 10, podCountWithLeader: 10, sliceCountWithLeader: 10, leaderCount: 0},
 			},
 		},
 		"simple placement on three domains": {
-			domains:     []*domain{d1, d2, d3},
+			domains:     []testDomainSpec{d1, d2, d3},
 			sliceCount:  40,
 			leaderCount: 0,
 			sliceSize:   1,
 			threshold:   13,
-			want: []*domain{
-				{id: "d1", sliceCount: 14, podCount: 14, podCountWithLeader: 14, sliceCountWithLeader: 14, leaderCount: 0},
-				{id: "d2", sliceCount: 13, podCount: 13, podCountWithLeader: 13, sliceCountWithLeader: 13, leaderCount: 0},
-				{id: "d3", sliceCount: 13, podCount: 13, podCountWithLeader: 13, sliceCountWithLeader: 13, leaderCount: 0},
+			want: map[string]domainState{
+				"d1": {sliceCount: 14, podCount: 14, podCountWithLeader: 14, sliceCountWithLeader: 14, leaderCount: 0},
+				"d2": {sliceCount: 13, podCount: 13, podCountWithLeader: 13, sliceCountWithLeader: 13, leaderCount: 0},
+				"d3": {sliceCount: 13, podCount: 13, podCountWithLeader: 13, sliceCountWithLeader: 13, leaderCount: 0},
 			},
 		},
 		"find smallest domain that fits": {
-			domains:     []*domain{d1, d2, d3, d4, d5},
+			domains:     []testDomainSpec{d1, d2, d3, d4, d5},
 			sliceCount:  2,
 			leaderCount: 0,
 			sliceSize:   1,
 			threshold:   2,
-			want: []*domain{
-				{id: "d5", sliceCount: 2, podCount: 2, podCountWithLeader: 2, sliceCountWithLeader: 2, leaderCount: 0},
+			want: map[string]domainState{
+				"d5": {sliceCount: 2, podCount: 2, podCountWithLeader: 2, sliceCountWithLeader: 2, leaderCount: 0},
 			},
 		},
 		"correctly select domains": {
-			domains:     []*domain{d1, d2, d3, d4, d5},
+			domains:     []testDomainSpec{d1, d2, d3, d4, d5},
 			sliceCount:  25,
 			leaderCount: 0,
 			sliceSize:   1,
 			threshold:   10,
-			want: []*domain{
-				{id: "d1", sliceCount: 15, podCount: 15, podCountWithLeader: 15, sliceCountWithLeader: 15, leaderCount: 0},
-				{id: "d4", sliceCount: 10, podCount: 10, podCountWithLeader: 10, sliceCountWithLeader: 10, leaderCount: 0},
+			want: map[string]domainState{
+				"d1": {sliceCount: 15, podCount: 15, podCountWithLeader: 15, sliceCountWithLeader: 15, leaderCount: 0},
+				"d4": {sliceCount: 10, podCount: 10, podCountWithLeader: 10, sliceCountWithLeader: 10, leaderCount: 0},
 			},
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			domains := make([]*domain, len(tc.domains))
 			_, log := utiltesting.ContextWithLog(t)
-			s := newTASFlavorSnapshot(log, "dummy", []string{}, nil)
-			for i, d := range tc.domains {
-				clone := *d
-				domains[i] = &clone
-			}
+			s := newTASFlavorSnapshot(log, "dummy", newTopologyTree([]string{}, nil, 0), nil)
+			domains := addDomainsWithState(s, tc.domains)
 
 			got, _ := placeSlicesOnDomainsBalanced(s, domains, tc.sliceCount, tc.leaderCount, tc.sliceSize, tc.threshold)
 
-			if diff := cmp.Diff(
-				tc.want,
-				got,
-				cmp.AllowUnexported(domain{}),
-				cmpopts.IgnoreFields(domain{}, "parent", "children", "levelValues"),
-				cmpopts.SortSlices(func(a, b *domain) bool { return a.id < b.id }),
-			); diff != "" {
+			gotStates := make(map[string]domainState, len(got))
+			for _, d := range got {
+				gotStates[string(d.id)] = *s.domainStateOf(d)
+			}
+			if diff := cmp.Diff(tc.want, gotStates, cmp.AllowUnexported(domainState{})); diff != "" {
 				t.Errorf("Unexpected domains (-want,+got):\n%s", diff)
 			}
 		})
@@ -247,10 +353,11 @@ func TestPlaceSlicesOnDomainsBalanced(t *testing.T) {
 
 func TestPlaceSlicesOnDomainsBalancedStableTieBreak(t *testing.T) {
 	_, log := utiltesting.ContextWithLog(t)
-	s := newTASFlavorSnapshot(log, "dummy", []string{}, nil)
+	s := newTASFlavorSnapshot(log, "dummy", newTopologyTree([]string{}, nil, 0), nil)
+	equalState := domainState{podCount: 3, sliceCount: 3, podCountWithLeader: 3, sliceCountWithLeader: 3}
 	domains := []*domain{
-		{id: "leaf-a", levelValues: []string{"block-b", "host-a"}, podCount: 3, sliceCount: 3, podCountWithLeader: 3, sliceCountWithLeader: 3},
-		{id: "leaf-z", levelValues: []string{"block-a", "host-z"}, podCount: 3, sliceCount: 3, podCountWithLeader: 3, sliceCountWithLeader: 3},
+		addDomainWithState(s, &domain{id: "leaf-a", levelValues: []string{"block-b", "host-a"}}, equalState),
+		addDomainWithState(s, &domain{id: "leaf-z", levelValues: []string{"block-a", "host-z"}}, equalState),
 	}
 
 	got, reason := placeSlicesOnDomainsBalanced(s, domains, 1, 0, 1, 1)
@@ -264,12 +371,13 @@ func TestPlaceSlicesOnDomainsBalancedStableTieBreak(t *testing.T) {
 }
 
 func TestPruneDomainsBelowThreshold(t *testing.T) {
-	domainState := func(d *domain) [5]int32 {
-		return [5]int32{d.podCount, d.sliceCount, d.podCountWithLeader, d.sliceCountWithLeader, d.leaderCount}
+	domainStateValues := func(s *TASFlavorSnapshot, d *domain) [5]int32 {
+		st := s.domainStateOf(d)
+		return [5]int32{st.podCount, st.sliceCount, st.podCountWithLeader, st.sliceCountWithLeader, st.leaderCount}
 	}
 
 	testCases := map[string]struct {
-		domains        func() ([]*domain, map[string]*domain)
+		domains        func(s *TASFlavorSnapshot) ([]*domain, map[string]*domain)
 		threshold      int32
 		sliceSize      int32
 		sliceLevelIdx  int
@@ -278,14 +386,51 @@ func TestPruneDomainsBelowThreshold(t *testing.T) {
 		want           map[string][5]int32
 	}{
 		"keeps worker only domain": {
-			domains: func() ([]*domain, map[string]*domain) {
-				leaderLeaf := &domain{id: "leader-leaf", podCount: 6, sliceCount: 6, leaderCount: 1, podCountWithLeader: 5, sliceCountWithLeader: 5}
-				leaderDomain := &domain{id: "leader-domain", podCount: 6, sliceCount: 6, leaderCount: 1, podCountWithLeader: 5, sliceCountWithLeader: 5, children: []*domain{leaderLeaf}}
+			domains: func(s *TASFlavorSnapshot) ([]*domain, map[string]*domain) {
+				leaderLeaf := addDomainWithState(s, &domain{
+					id: "leader-leaf",
+				}, domainState{
+					podCount:             6,
+					sliceCount:           6,
+					leaderCount:          1,
+					podCountWithLeader:   5,
+					sliceCountWithLeader: 5,
+				})
+				leaderDomain := addDomainWithState(s, &domain{
+					id:       "leader-domain",
+					children: []*domain{leaderLeaf},
+				}, domainState{
+					podCount:             6,
+					sliceCount:           6,
+					leaderCount:          1,
+					podCountWithLeader:   5,
+					sliceCountWithLeader: 5,
+				})
 				leaderLeaf.parent = leaderDomain
-				workerOnlyLeaf := &domain{id: "worker-only-leaf", podCount: 5, sliceCount: 5, leaderCount: 1, podCountWithLeader: 4, sliceCountWithLeader: 4}
-				workerOnlyDomain := &domain{id: "worker-only-domain", podCount: 5, sliceCount: 5, leaderCount: 1, podCountWithLeader: 4, sliceCountWithLeader: 4, children: []*domain{workerOnlyLeaf}}
+				workerOnlyLeaf := addDomainWithState(s, &domain{
+					id: "worker-only-leaf",
+				}, domainState{
+					podCount:             5,
+					sliceCount:           5,
+					leaderCount:          1,
+					podCountWithLeader:   4,
+					sliceCountWithLeader: 4,
+				})
+				workerOnlyDomain := addDomainWithState(s, &domain{
+					id:       "worker-only-domain",
+					children: []*domain{workerOnlyLeaf},
+				}, domainState{
+					podCount:             5,
+					sliceCount:           5,
+					leaderCount:          1,
+					podCountWithLeader:   4,
+					sliceCountWithLeader: 4,
+				})
 				workerOnlyLeaf.parent = workerOnlyDomain
-				parentDomain := &domain{id: "parent-domain", children: []*domain{leaderDomain, workerOnlyDomain}}
+				parentDomain := addDomainWithState(s, &domain{
+					id:       "parent-domain",
+					children: []*domain{leaderDomain, workerOnlyDomain},
+				}, domainState{})
 				leaderDomain.parent = parentDomain
 				workerOnlyDomain.parent = parentDomain
 				return []*domain{parentDomain}, map[string]*domain{
@@ -311,20 +456,50 @@ func TestPruneDomainsBelowThreshold(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			domains, domainsByName := tc.domains()
 			_, log := utiltesting.ContextWithLog(t)
-			s := newTASFlavorSnapshot(log, "dummy", []string{}, nil)
+			s := newTASFlavorSnapshot(log, "dummy", newTopologyTree([]string{}, nil, 0), nil)
+			domains, domainsByName := tc.domains(s)
 
 			s.pruneDomainsBelowThreshold(domains, tc.threshold, tc.sliceSize, tc.sliceLevelIdx, tc.level, tc.leaderRequired)
 
 			got := make(map[string][5]int32, len(tc.want))
 			for name := range tc.want {
-				got[name] = domainState(domainsByName[name])
+				got[name] = domainStateValues(s, domainsByName[name])
 			}
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("Unexpected domain state (-want,+got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestPruneDomainsBelowThresholdPreservesAffinityScore(t *testing.T) {
+	_, log := utiltesting.ContextWithLog(t)
+	s := newTASFlavorSnapshot(log, "dummy", newTopologyTree([]string{}, nil, 0), nil)
+	prunedLeaf := addDomainWithState(s, &domain{id: "pruned-leaf"}, domainState{
+		sliceCount:    1,
+		affinityScore: 100,
+	})
+	keptLeaf := addDomainWithState(s, &domain{id: "kept-leaf"}, domainState{
+		podCount:           4,
+		sliceCount:         4,
+		podCountWithLeader: 4,
+		affinityScore:      10,
+	})
+	parent := addDomainWithState(s, &domain{
+		id:       "parent",
+		children: []*domain{prunedLeaf, keptLeaf},
+	}, domainState{})
+	prunedLeaf.parent = parent
+	keptLeaf.parent = parent
+
+	s.pruneDomainsBelowThreshold([]*domain{parent}, 2, 1, 1, 0, false)
+
+	if got, want := s.domainStateOf(prunedLeaf).affinityScore, int64(100); got != want {
+		t.Errorf("Unexpected pruned leaf affinity score: got %d, want %d", got, want)
+	}
+	if got, want := s.domainStateOf(parent).affinityScore, int64(110); got != want {
+		t.Errorf("Unexpected parent affinity score: got %d, want %d", got, want)
 	}
 }
 
@@ -389,18 +564,19 @@ func TestFindBestDomainsForBalancedPlacement(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			_, log := utiltesting.ContextWithLog(t)
-			s := newTASFlavorSnapshot(log, "dummy", []string{"block", "rack"}, nil)
+			s := newTASFlavorSnapshot(log, "dummy", newTopologyTree([]string{"block", "rack"}, nil, 0), nil)
 			domainsByID := make(map[string]*domain, len(tc.domains))
 			for _, spec := range tc.domains {
-				d := &domain{
-					id:                   utiltas.TopologyDomainID(spec.id),
-					levelValues:          spec.levelValues,
+				d := addDomainWithState(s, &domain{
+					id:          utiltas.TopologyDomainID(spec.id),
+					levelValues: spec.levelValues,
+				}, domainState{
 					podCount:             spec.podCount,
 					sliceCount:           spec.sliceCount,
 					podCountWithLeader:   spec.podCountWithLeader,
 					sliceCountWithLeader: spec.sliceCountWithLeader,
 					leaderCount:          spec.leaderCount,
-				}
+				})
 				if len(spec.parentID) == 0 {
 					s.domainsPerLevel[0][d.id] = d
 				} else {

--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -8385,11 +8385,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				if features.Enabled(features.TASHandleOverlappingFlavors) && tas.IsLowestLevelHostname(tasFlavorCache.topology.Levels) {
 					aggregatedDomainUsage = tc.aggregatedDomainUsages
 				}
-				snapshot := tasFlavorCache.snapshot(
-					log,
-					tasCache.nodesCache.find(tasFlavorCache.flavor.NodeLabels, tasFlavorCache.topology.Levels),
-					aggregatedDomainUsage,
-				)
+				snapshot := tasFlavorCache.snapshot(log, aggregatedDomainUsage)
 				flavorTASRequests := make([]TASPodSetRequests, 0, len(tc.podSets))
 				wantResult := make(TASAssignmentsResult)
 				for _, ps := range tc.podSets {
@@ -8895,11 +8891,8 @@ func TestFindTopologyAssignmentsMultiLayerReplacement(t *testing.T) {
 			if features.Enabled(features.TASHandleOverlappingFlavors) && tas.IsLowestLevelHostname(tasFlavorCache.topology.Levels) {
 				aggregatedDomainUsages = tc.aggregatedDomainUsages
 			}
-			snapshot := tasFlavorCache.snapshot(
-				log,
-				tasCache.nodesCache.find(tasFlavorCache.flavor.NodeLabels, tasFlavorCache.topology.Levels),
-				aggregatedDomainUsages,
-			)
+			snapshot := tasFlavorCache.snapshot(log, aggregatedDomainUsages)
+
 			result := snapshot.FindTopologyAssignmentsForFlavor(log, flavorTASRequests, WithWorkload(wl))
 
 			psResult, ok := result[podSetName]

--- a/pkg/cache/scheduler/tas_flavor.go
+++ b/pkg/cache/scheduler/tas_flavor.go
@@ -89,6 +89,19 @@ type TASFlavorCache struct {
 	// nonTasUsageCache maintains the usage coming from non-TAS pods,
 	// e.g. static Pods or DaemonSet pods.
 	nonTasUsageCache *nonTasUsageCache
+
+	// nodesCache provides the nodes matching the flavor, and the generation
+	// used to decide whether the cached topology tree can still be reused.
+	nodesCache *nodesCache
+
+	// treeLock guards tree. It is separate from the embedded RWMutex because
+	// snapshot() holds only the read lock, but must store the tree it built.
+	treeLock sync.Mutex
+
+	// tree caches the static topology structure derived from the node set at
+	// tree.generation. It is shared read-only by the snapshots of the flavor
+	// and reused across scheduling cycles until the node set changes.
+	tree *topologyTree
 }
 
 func (t *tasCache) NewTASFlavorCache(topologyInfo topologyInformation,
@@ -100,6 +113,7 @@ func (t *tasCache) NewTASFlavorCache(topologyInfo topologyInformation,
 		usage:            make(map[utiltas.TopologyDomainID]resources.Requests),
 		wlUsage:          make(map[workload.Reference][]workload.TopologyDomainRequests),
 		nonTasUsageCache: t.nonTasUsageCache,
+		nodesCache:       t.nodesCache,
 	}
 }
 
@@ -116,27 +130,25 @@ func (c *TASFlavorCache) TopologyLevels() []string {
 }
 
 func (c *TASFlavorCache) snapshot(
-	log logr.Logger, nodes []*corev1.Node, aggregatedDomainUsages map[utiltas.TopologyDomainID]resources.Requests,
+	log logr.Logger, aggregatedDomainUsages map[utiltas.TopologyDomainID]resources.Requests,
 ) *TASFlavorSnapshot {
 	c.RLock()
 	defer c.RUnlock()
 
+	tree, treeReused := c.cachedOrBuiltTree()
+
 	infoKV := []any{
 		"nodeLabels", c.flavor.NodeLabels,
 		"levels", c.topology.Levels,
-		"nodeCount", len(nodes),
+		"nodeCount", len(tree.nodes),
+		"treeReused", treeReused,
 	}
 	if features.Enabled(features.TASHandleOverlappingFlavors) {
 		infoKV = append(infoKV, "crossFlavorAggregation", aggregatedDomainUsages != nil)
 	}
 	log.V(3).Info("Constructing TAS snapshot", infoKV...)
 
-	snapshot := newTASFlavorSnapshot(log, c.flavor.TopologyName, c.topology.Levels, c.flavor.Tolerations)
-	nodeToDomain := make(map[string]utiltas.TopologyDomainID)
-	for _, node := range nodes {
-		nodeToDomain[node.Name] = snapshot.addNode(node)
-	}
-	snapshot.initialize()
+	snapshot := newTASFlavorSnapshot(log, c.flavor.TopologyName, tree, c.flavor.Tolerations)
 
 	tasDomainUsages := c.usage
 	if features.Enabled(features.TASHandleOverlappingFlavors) && aggregatedDomainUsages != nil {
@@ -144,11 +156,43 @@ func (c *TASFlavorCache) snapshot(
 	}
 	snapshot.addTASUsageForHeldDomains(tasDomainUsages)
 	c.nonTasUsageCache.forEachNodeUsage(func(nodeName string, usage resources.Requests) {
-		if domainID, ok := nodeToDomain[nodeName]; ok {
+		if domainID, ok := tree.nodeToDomain[nodeName]; ok {
 			snapshot.addNonTASUsage(domainID, usage)
 		}
 	})
 	return snapshot
+}
+
+// cachedOrBuiltTree returns the cached topology tree when its nodesCache
+// generation is current. Otherwise, it builds a candidate and returns the
+// newest tree retained in the cache, which may have been stored by a concurrent
+// caller. The returned tree must not be mutated.
+func (c *TASFlavorCache) cachedOrBuiltTree() (*topologyTree, bool) {
+	if tree := c.cachedTree(); tree != nil && tree.generation == c.nodesCache.currentGeneration() {
+		return tree, true
+	}
+	// snapshot already holds c.RLock. Do not use c.NodeLabels here: a recursive
+	// RLock can deadlock if a writer is waiting between the two acquisitions.
+	nodes, generation := c.nodesCache.find(c.flavor.NodeLabels, c.topology.Levels)
+	tree := newTopologyTree(c.topology.Levels, nodes, generation)
+	return c.storeTree(tree), false
+}
+
+func (c *TASFlavorCache) cachedTree() *topologyTree {
+	c.treeLock.Lock()
+	defer c.treeLock.Unlock()
+	return c.tree
+}
+
+func (c *TASFlavorCache) storeTree(tree *topologyTree) *topologyTree {
+	c.treeLock.Lock()
+	defer c.treeLock.Unlock()
+	// Concurrent snapshot callers may race to store a rebuilt tree; keep the
+	// newest one so the cache cannot regress to an older generation.
+	if c.tree == nil || tree.generation > c.tree.generation {
+		c.tree = tree
+	}
+	return c.tree
 }
 
 func (c *TASFlavorCache) addUsage(log logr.Logger, key workload.Reference, topologyRequests []workload.TopologyDomainRequests) {

--- a/pkg/cache/scheduler/tas_flavor.go
+++ b/pkg/cache/scheduler/tas_flavor.go
@@ -167,14 +167,25 @@ func (c *TASFlavorCache) snapshot(
 // generation is current. Otherwise, it builds a candidate and returns the
 // newest tree retained in the cache, which may have been stored by a concurrent
 // caller. The returned tree must not be mutated.
+//
+// With TASCacheTopologyTree disabled the cache is neither read nor written, so
+// every snapshot gets a tree of its own and no tree is ever shared. Note that
+// storeTree must be skipped too: it returns the newest retained tree, which a
+// concurrent caller may have stored, and that would share a tree after all.
 func (c *TASFlavorCache) cachedOrBuiltTree() (*topologyTree, bool) {
-	if tree := c.cachedTree(); tree != nil && tree.generation == c.nodesCache.currentGeneration() {
-		return tree, true
+	cacheTree := features.Enabled(features.TASCacheTopologyTree)
+	if cacheTree {
+		if tree := c.cachedTree(); tree != nil && tree.generation == c.nodesCache.currentGeneration() {
+			return tree, true
+		}
 	}
 	// snapshot already holds c.RLock. Do not use c.NodeLabels here: a recursive
 	// RLock can deadlock if a writer is waiting between the two acquisitions.
 	nodes, generation := c.nodesCache.find(c.flavor.NodeLabels, c.topology.Levels)
 	tree := newTopologyTree(c.topology.Levels, nodes, generation)
+	if !cacheTree {
+		return tree, false
+	}
 	return c.storeTree(tree), false
 }
 

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -1576,7 +1576,17 @@ func (s *TASFlavorSnapshot) updateCountsToMinimumGeneric(domains []*domain, coun
 					true,
 				)
 			} else {
-				d, completed = s.consumeWithLeadersGeneric(dom, domains[i:], &remainingPrimary, &remainingLeaderCount, unconstrained, &s.domainStateOf(dom).podCountWithLeader, &s.domainStateOf(dom).podCount, 1, false)
+				d, completed = s.consumeWithLeadersGeneric(
+					dom,
+					domains[i:],
+					&remainingPrimary,
+					&remainingLeaderCount,
+					unconstrained,
+					&s.domainStateOf(dom).podCountWithLeader,
+					&s.domainStateOf(dom).podCount,
+					1,
+					false,
+				)
 			}
 			result = append(result, d)
 			if completed {
@@ -1919,15 +1929,6 @@ func (s *TASFlavorSnapshot) fillLeafCounts(leaf *leafDomain, requirements *topol
 	}
 
 	leafDomainState.podCountWithLeader = requirements.requests.CountIn(remainingCapacity.Get())
-}
-
-func belongsToRequiredDomain(leaf *leafDomain, requiredReplacementDomain utiltas.TopologyDomainID) bool {
-	if requiredReplacementDomain == "" {
-		return true
-	}
-	// Uses levelValues instead of leaf.id since for topologies with hostname as lowest level it points directly to the hostname
-	// TODO(#5322): Use util function that compare two DomainIDs
-	return strings.HasPrefix(string(utiltas.DomainID(leaf.levelValues)), string(requiredReplacementDomain))
 }
 
 func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, sliceLevelIdx int, level int, sliceSizeAtLevel map[int]int32, leaderRequired bool) {

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -48,19 +48,10 @@ var (
 	errCodeAssumptionsViolated = errors.New("code assumptions violated")
 )
 
-// domain holds the static information about placement of a topology
-// domain in the hierarchy of topology domains.
-type domain struct {
-	// id is the globally unique id of the domain
-	id utiltas.TopologyDomainID
-
-	// parent points to domain which is a parent in topology structure
-	parent *domain
-
-	// children points to domains which are children in topology structure
-	children []*domain
-
-	// podCount is a temporary podCount of the topology domains during the
+// domainState is the per-snapshot mutable state of a domain during the
+// assignment algorithm, addressed by domain.idx.
+type domainState struct {
+	// state is a temporary state of the topology domains during the
 	// assignment algorithm.
 	//
 	// In the first phase of the algorithm (traversal to the top the topology to
@@ -85,18 +76,14 @@ type domain struct {
 	sliceCountWithLeader int32
 	leaderCount          int32
 
-	// levelValues stores the mapping from domain ID back to the
-	// ordered list of values
-	levelValues []string
-
 	// affinityScore is the sum of weights of all preferred affinity terms that match the node.
 	// For non-leaf domains, it is the sum of affinity scores of all children.
 	affinityScore int64
 }
 
-// leafDomain extends the domain with information for the lowest-level domain.
-type leafDomain struct {
-	domain
+// leafCapacity is the per-snapshot mutable state of a leaf domain, addressed by
+// leafDomain.leafIdx.
+type leafCapacity struct {
 	// freeCapacity represents the total node capacity minus the non-TAS usage,
 	// coming from Pods which are not managed by workloads admitted by TAS
 	// (typically static Pods, DaemonSets, or Deployments).
@@ -109,13 +96,7 @@ type leafDomain struct {
 	// It is lazily calculated using LazyRequests and updated incrementally during TAS usage changes, avoiding repeated
 	// map cloning and resource subtraction during capacity checks (e.g. preemption).
 	cachedRemainingCapacity resources.LazyRequests
-
-	// node at the leaf, if the lowest level is a node
-	node *corev1.Node
 }
-
-type domainByID map[utiltas.TopologyDomainID]*domain
-type leafDomainByID map[utiltas.TopologyDomainID]*leafDomain
 
 type TASFlavorSnapshot struct {
 	log logr.Logger
@@ -124,24 +105,20 @@ type TASFlavorSnapshot struct {
 	// ResourceFlavor spec.topologyName field.
 	topologyName kueue.TopologyReference
 
-	// levelKeys denotes the ordered list of topology keys set as label keys
-	// on the Topology object
-	levelKeys []string
+	// topologyTree is the static topology structure, shared with the other
+	// snapshots of the flavor. It must not be mutated.
+	*topologyTree
 
-	// leaves maps domainID to domains that are at the lowest level of topology structure
-	leaves leafDomainByID
+	// domainStates holds the per-snapshot mutable state for domains, indexed by
+	// domain.idx.
+	domainStates []domainState
 
-	// roots maps domainID to domains that are at the highest level of topology structure
-	roots domainByID
-
-	// domainsPerLevel stores the static tree information
-	domainsPerLevel []domainByID
+	// leafCapacities holds the per-snapshot mutable capacity data for leaves,
+	// indexed by leafDomain.leafIdx.
+	leafCapacities []leafCapacity
 
 	// tolerations represents the list of tolerations defined for the resource flavor
 	tolerations []corev1.Toleration
-
-	// isLowestLevelNode indicates if kubernetes.io/hostname is the lowest topology level
-	isLowestLevelNode bool
 
 	// matchingLeavesCache caches the set of qualified leaves for a PodSet
 	// of a Workload to avoid recalculating selectors/taints during preemption simulations or
@@ -149,7 +126,28 @@ type TASFlavorSnapshot struct {
 	matchingLeavesCache map[podSetMatchKey]*matchingLeavesCacheEntry
 }
 
-// podSetMatchKey uniquely identifies a PodSet within a Workload for caching purposes.
+// domainStateOf returns the snapshot's mutable state of the given shared domain.
+func (s *TASFlavorSnapshot) domainStateOf(d *domain) *domainState {
+	return &s.domainStates[d.idx]
+}
+
+// leafCapacityOf returns the snapshot's mutable capacity data of the given shared leaf.
+func (s *TASFlavorSnapshot) leafCapacityOf(l *leafDomain) *leafCapacity {
+	return &s.leafCapacities[l.leafIdx]
+}
+
+// shallowCloneWithState returns a shallow copy of d with independent state
+// initialized from d's current state.
+//
+// WARNING: This may reallocate s.domainStates. Callers must not retain pointers
+// returned by domainStateOf across this call.
+func (s *TASFlavorSnapshot) shallowCloneWithState(d *domain) *domain {
+	clone := *d
+	clone.idx = len(s.domainStates)
+	s.domainStates = append(s.domainStates, s.domainStates[d.idx])
+	return &clone
+}
+
 type podSetMatchKey struct {
 	workloadUID types.UID
 	podSetName  kueue.PodSetReference
@@ -183,121 +181,35 @@ const (
 	exclusionAffinity
 )
 
-func newTASFlavorSnapshot(log logr.Logger, topologyName kueue.TopologyReference,
-	levels []string, tolerations []corev1.Toleration) *TASFlavorSnapshot {
-	domainsPerLevel := make([]domainByID, len(levels))
-	for level := range levels {
-		domainsPerLevel[level] = make(domainByID)
-	}
-
+// newTASFlavorSnapshot creates a snapshot backed by the shared topology tree,
+// with fresh per-snapshot state: the leaves start at their static capacity
+// with no usage, and the assignment-algorithm scratch state is zeroed.
+func newTASFlavorSnapshot(
+	log logr.Logger,
+	topologyName kueue.TopologyReference,
+	tree *topologyTree,
+	tolerations []corev1.Toleration,
+) *TASFlavorSnapshot {
 	snapshot := &TASFlavorSnapshot{
-		log:               log,
-		topologyName:      topologyName,
-		levelKeys:         slices.Clone(levels),
-		leaves:            make(leafDomainByID),
-		tolerations:       slices.Clone(tolerations),
-		roots:             make(domainByID),
-		domainsPerLevel:   domainsPerLevel,
-		isLowestLevelNode: len(levels) > 0 && levels[len(levels)-1] == corev1.LabelHostname,
+		log:            log,
+		topologyName:   topologyName,
+		topologyTree:   tree,
+		domainStates:   make([]domainState, tree.domainCount),
+		leafCapacities: make([]leafCapacity, len(tree.leaves)),
+		tolerations:    slices.Clone(tolerations),
+	}
+	for _, leaf := range tree.leaves {
+		snapshot.leafCapacities[leaf.leafIdx].freeCapacity = leaf.capacity.Clone()
 	}
 	return snapshot
 }
 
-func (s *TASFlavorSnapshot) addNode(node *corev1.Node) utiltas.TopologyDomainID {
-	var levelValues []string
-	var domainID utiltas.TopologyDomainID
-	var leafFound bool
-
-	if s.isLowestLevelNode {
-		// When the lowest level is kubernetes.io/hostname, directly extract hostname.
-		hostname := node.Labels[corev1.LabelHostname]
-		domainID = utiltas.TopologyDomainID(hostname)
-		_, leafFound = s.leaves[domainID]
-		// Only compute levelValues when we actually need to create a new leafDomain.
-		if !leafFound {
-			levelValues = utiltas.LevelValues(s.levelKeys, node.Labels)
-		}
-	} else {
-		// Compute full level values and domain ID.
-		levelValues = utiltas.LevelValues(s.levelKeys, node.Labels)
-		domainID = utiltas.DomainID(levelValues)
-		_, leafFound = s.leaves[domainID]
-	}
-	if !leafFound {
-		leafDomain := leafDomain{
-			domain: domain{
-				id:          domainID,
-				levelValues: levelValues,
-			},
-		}
-		if s.isLowestLevelNode {
-			leafDomain.node = node
-		}
-		s.leaves[domainID] = &leafDomain
-	}
-	capacity := resources.NewRequestsFromResourceList(node.Status.Allocatable)
-	s.addCapacity(domainID, capacity)
-	return domainID
-}
-
-func (s *TASFlavorSnapshot) lowestLevel() string {
-	return s.levelKeys[len(s.levelKeys)-1]
-}
-
-func (s *TASFlavorSnapshot) highestLevel() string {
-	return s.levelKeys[0]
-}
-
-// initialize prepares the topology tree structure. This structure holds
-// for a given the list of topology domains with additional static and dynamic
-// information. This function initializes the static information which
-// represents the edges to the parent and child domains. This structure is
-// reused for multiple workloads during a single scheduling cycle.
-func (s *TASFlavorSnapshot) initialize() {
-	for _, leafDomain := range s.leaves {
-		domain := &leafDomain.domain
-		s.domainsPerLevel[len(domain.levelValues)-1][domain.id] = domain
-		s.initializeHelper(domain)
-	}
-}
-
-// initializeHelper is a recursive helper for initialize() method
-func (s *TASFlavorSnapshot) initializeHelper(dom *domain) {
-	if len(dom.levelValues) == 1 {
-		s.roots[dom.id] = dom
-		return
-	}
-	parentValues := dom.levelValues[:len(dom.levelValues)-1]
-	parentID := utiltas.DomainID(parentValues)
-	parent, parentFound := s.domainsPerLevel[len(parentValues)-1][parentID]
-	if !parentFound {
-		// create parent
-		parent = &domain{
-			id:          parentID,
-			levelValues: parentValues,
-		}
-		s.domainsPerLevel[len(parentValues)-1][parentID] = parent
-		s.initializeHelper(parent)
-	}
-	// connect parent and child
-	dom.parent = parent
-	parent.children = append(parent.children, dom)
-}
-
-func (s *TASFlavorSnapshot) addCapacity(domainID utiltas.TopologyDomainID, capacity resources.Requests) {
-	if s.leaves[domainID].freeCapacity == nil {
-		s.leaves[domainID].freeCapacity = resources.NewRequests()
-	}
-	s.leaves[domainID].freeCapacity.Add(capacity)
-	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
-}
-
 func (s *TASFlavorSnapshot) addNonTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests) {
-	// The usage for non-TAS pods is only accounted for "TAS" nodes  - with at
-	// least one TAS pod, and so the addCapacity function to initialize
-	// freeCapacity is already called.
-	s.leaves[domainID].freeCapacity.Sub(usage)
-	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
+	// domainID comes from topologyTree.nodeToDomain, while leaves is populated
+	// from the same node set by newTopologyTree, so the corresponding leaf exists.
+	leafCapacity := s.leafCapacityOf(s.leaves[domainID])
+	leafCapacity.freeCapacity.Sub(usage)
+	leafCapacity.cachedRemainingCapacity = resources.LazyRequests{}
 }
 
 func (s *TASFlavorSnapshot) updateTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests, op usageOp, count int32) {
@@ -311,11 +223,12 @@ func (s *TASFlavorSnapshot) updateTASUsage(domainID utiltas.TopologyDomainID, us
 }
 
 func (s *TASFlavorSnapshot) getRemainingCapacity(leaf *leafDomain) resources.Requests {
-	if leaf.cachedRemainingCapacity.IsEmpty() {
-		leaf.cachedRemainingCapacity = resources.NewLazyRequests(leaf.freeCapacity)
-		leaf.cachedRemainingCapacity.Sub(leaf.tasUsage)
+	leafCapacity := s.leafCapacityOf(leaf)
+	if leafCapacity.cachedRemainingCapacity.IsEmpty() {
+		leafCapacity.cachedRemainingCapacity = resources.NewLazyRequests(leafCapacity.freeCapacity)
+		leafCapacity.cachedRemainingCapacity.Sub(leafCapacity.tasUsage)
 	}
-	return leaf.cachedRemainingCapacity.Get()
+	return leafCapacity.cachedRemainingCapacity.Get()
 }
 
 // hasDomain reports whether the domain has a leaf in the snapshot, i.e. whether
@@ -351,11 +264,12 @@ func (s *TASFlavorSnapshot) addTASUsage(domainID utiltas.TopologyDomainID, usage
 		s.log.V(3).Info("skip accounting for TAS usage in domain", "domain", domainID, "usage", usage)
 		return
 	}
-	if s.leaves[domainID].tasUsage == nil {
-		s.leaves[domainID].tasUsage = resources.NewRequests()
+	leafCapacity := s.leafCapacityOf(s.leaves[domainID])
+	if leafCapacity.tasUsage == nil {
+		leafCapacity.tasUsage = resources.NewRequests()
 	}
-	s.leaves[domainID].tasUsage.Add(usage)
-	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
+	leafCapacity.tasUsage.Add(usage)
+	leafCapacity.cachedRemainingCapacity = resources.LazyRequests{}
 }
 
 func (s *TASFlavorSnapshot) removeTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests) {
@@ -366,11 +280,12 @@ func (s *TASFlavorSnapshot) removeTASUsage(domainID utiltas.TopologyDomainID, us
 		s.log.V(3).Info("skip removing TAS usage in domain", "domain", domainID, "usage", usage)
 		return
 	}
-	if s.leaves[domainID].tasUsage == nil {
-		s.leaves[domainID].tasUsage = resources.NewRequests()
+	leafCapacity := s.leafCapacityOf(s.leaves[domainID])
+	if leafCapacity.tasUsage == nil {
+		leafCapacity.tasUsage = resources.NewRequests()
 	}
-	s.leaves[domainID].tasUsage.Sub(usage)
-	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
+	leafCapacity.tasUsage.Sub(usage)
+	leafCapacity.cachedRemainingCapacity = resources.LazyRequests{}
 }
 
 type domainCapacityDetails struct {
@@ -395,9 +310,10 @@ func (s *TASFlavorSnapshot) SerializeFreeCapacityPerDomain() (string, error) {
 	details := make(map[utiltas.TopologyDomainID]domainCapacityDetails, len(s.leaves))
 
 	for domainID, leaf := range s.leaves {
+		leafCapacity := s.leafCapacityOf(leaf)
 		details[domainID] = domainCapacityDetails{
-			FreeCapacity: s.resourceDetails(leaf.freeCapacity),
-			TasUsage:     s.resourceDetails(leaf.tasUsage),
+			FreeCapacity: s.resourceDetails(leafCapacity.freeCapacity),
+			TasUsage:     s.resourceDetails(leafCapacity.tasUsage),
 		}
 	}
 
@@ -1108,12 +1024,14 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 				// The pre-populated sliceCount was computed for the
 				// outermost slice level and is not valid here.
 				for _, d := range sortedLowerDomains {
-					d.sliceCount = d.podCount / sliceSizeOnLevel
-					d.sliceCountWithLeader = d.podCountWithLeader / sliceSizeOnLevel
+					dState := s.domainStateOf(d)
+					dState.sliceCount = dState.podCount / sliceSizeOnLevel
+					dState.sliceCountWithLeader = dState.podCountWithLeader / sliceSizeOnLevel
 				}
 			}
 
-			addCurrFitDomain := s.updateCountsToMinimumGeneric(sortedLowerDomains, domain.podCount, domain.leaderCount, sliceSizeOnLevel, state.unconstrained, sliceSizeOnLevel > 1)
+			domainState := s.domainStateOf(domain)
+			addCurrFitDomain := s.updateCountsToMinimumGeneric(sortedLowerDomains, domainState.podCount, domainState.leaderCount, sliceSizeOnLevel, state.unconstrained, sliceSizeOnLevel > 1)
 			newCurrFitDomain = append(newCurrFitDomain, addCurrFitDomain...)
 		}
 		currFitDomain = newCurrFitDomain
@@ -1126,14 +1044,14 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 		var workerFitDomains []*domain
 		for _, domain := range currFitDomain {
 			// select domains with leaders
-			if domain.leaderCount > 0 {
-				copiedDomain := *domain
-				copiedDomain.podCount = copiedDomain.leaderCount
-				leaderFitDomains = append(leaderFitDomains, &copiedDomain)
+			if leaderCount := s.domainStateOf(domain).leaderCount; leaderCount > 0 {
+				copiedDomain := s.shallowCloneWithState(domain)
+				s.domainStateOf(copiedDomain).podCount = leaderCount
+				leaderFitDomains = append(leaderFitDomains, copiedDomain)
 			}
 
 			// select domains with workers
-			if domain.podCount > 0 {
+			if s.domainStateOf(domain).podCount > 0 {
 				workerFitDomains = append(workerFitDomains, domain)
 			}
 		}
@@ -1333,16 +1251,16 @@ func getSliceSizeWithSinglePodAsDefault(podSetTopologyRequest *kueue.PodSetTopol
 // When leaders are requested, domains that cannot fit them are ignored.
 // If no domain fits, it returns the first domain to preserve the caller's
 // established ordering.
-func findBestFitDomain(domains []*domain, count int32, leaderCount int32) *domain {
+func (s *TASFlavorSnapshot) findBestFitDomain(domains []*domain, count int32, leaderCount int32) *domain {
 	getState := func(d *domain) int32 {
-		return d.podCount
+		return s.domainStateOf(d).podCount
 	}
 	if leaderCount > 0 {
 		getState = func(d *domain) int32 {
-			return d.podCountWithLeader
+			return s.domainStateOf(d).podCountWithLeader
 		}
 	}
-	return findBestFitDomainBy(domains, count, getState, leaderCount)
+	return s.findBestFitDomainBy(domains, count, getState, leaderCount)
 }
 
 // findBestFitDomainForSlices returns the first domain with the smallest
@@ -1350,28 +1268,28 @@ func findBestFitDomain(domains []*domain, count int32, leaderCount int32) *domai
 // When leaders are requested, domains that cannot fit them are ignored.
 // If no domain fits, it returns the first domain to preserve the caller's
 // established ordering.
-func findBestFitDomainForSlices(domains []*domain, sliceCount int32, leaderCount int32) *domain {
+func (s *TASFlavorSnapshot) findBestFitDomainForSlices(domains []*domain, sliceCount int32, leaderCount int32) *domain {
 	getState := func(d *domain) int32 {
-		return d.sliceCount
+		return s.domainStateOf(d).sliceCount
 	}
 	if leaderCount > 0 {
 		getState = func(d *domain) int32 {
-			return d.sliceCountWithLeader
+			return s.domainStateOf(d).sliceCountWithLeader
 		}
 	}
-	return findBestFitDomainBy(domains, sliceCount, getState, leaderCount)
+	return s.findBestFitDomainBy(domains, sliceCount, getState, leaderCount)
 }
 
-type domainState func(d *domain) int32
+type domainStateGetter func(d *domain) int32
 
-func findBestFitDomainBy(domains []*domain, needed int32, state domainState, leaderCount int32) *domain {
-	candidates := topAffinityTierDomains(domains)
+func (s *TASFlavorSnapshot) findBestFitDomainBy(domains []*domain, needed int32, state domainStateGetter, leaderCount int32) *domain {
+	candidates := s.topAffinityTierDomains(domains)
 	bestDomain := candidates[0]
 	bestDomainState := int32(math.MaxInt32)
 	found := false
 
 	for _, domain := range candidates {
-		if domain.leaderCount < leaderCount {
+		if s.domainStateOf(domain).leaderCount < leaderCount {
 			continue
 		}
 		domainState := state(domain)
@@ -1406,9 +1324,9 @@ func (s *TASFlavorSnapshot) findLevelWithFitDomains(
 	topDomain := sortedDomain[0]
 
 	sliceCount := state.count / state.sliceSize
-	if useBestFitAlgorithm(state.unconstrained) && topDomain.sliceCountWithLeader >= sliceCount && topDomain.leaderCount >= state.leaderCount {
+	if useBestFitAlgorithm(state.unconstrained) && s.domainStateOf(topDomain).sliceCountWithLeader >= sliceCount && s.domainStateOf(topDomain).leaderCount >= state.leaderCount {
 		// optimize the potentially last domain
-		topDomain = findBestFitDomainForSlices(sortedDomain, sliceCount, state.leaderCount)
+		topDomain = s.findBestFitDomainForSlices(sortedDomain, sliceCount, state.leaderCount)
 	}
 	notFitReason := func(slicesFitCount, totalRequestsSlicesCount int32) string {
 		if len(state.multiLayerConstraints) > 0 {
@@ -1419,34 +1337,35 @@ func (s *TASFlavorSnapshot) findLevelWithFitDomains(
 
 	if useLeastFreeCapacityAlgorithm(state.unconstrained) {
 		for _, candidateDomain := range sortedDomain {
-			candidateCapacity := candidateDomain.sliceCount
+			candidateDomainState := s.domainStateOf(candidateDomain)
+			candidateCapacity := candidateDomainState.sliceCount
 			if state.leaderCount > 0 {
-				if candidateDomain.leaderCount < state.leaderCount {
+				if candidateDomainState.leaderCount < state.leaderCount {
 					continue
 				}
-				candidateCapacity = candidateDomain.sliceCountWithLeader
+				candidateCapacity = candidateDomainState.sliceCountWithLeader
 			}
 			if candidateCapacity >= sliceCount {
 				return searchLevelIdx, []*domain{candidateDomain}, ""
 			}
 		}
 		if state.required {
-			maxCapacityFound := sortedDomain[len(sortedDomain)-1].podCount
+			maxCapacityFound := s.domainStateOf(sortedDomain[len(sortedDomain)-1]).podCount
 			return 0, nil, notFitReason(maxCapacityFound, sliceCount)
 		}
 	}
-	if topDomain.sliceCountWithLeader < sliceCount || topDomain.leaderCount < state.leaderCount {
+	if s.domainStateOf(topDomain).sliceCountWithLeader < sliceCount || s.domainStateOf(topDomain).leaderCount < state.leaderCount {
 		if state.required {
 			// Scan remaining domains to support preferred affinity before failing
 			if features.Enabled(features.TASRespectNodeAffinityPreferred) {
 				for i := 1; i < len(sortedDomain); i++ {
 					d := sortedDomain[i]
-					if d.sliceCountWithLeader >= sliceCount && d.leaderCount >= state.leaderCount {
-						return searchLevelIdx, []*domain{findBestFitDomainForSlices(sortedDomain[i:], sliceCount, state.leaderCount)}, ""
+					if s.domainStateOf(d).sliceCountWithLeader >= sliceCount && s.domainStateOf(d).leaderCount >= state.leaderCount {
+						return searchLevelIdx, []*domain{s.findBestFitDomainForSlices(sortedDomain[i:], sliceCount, state.leaderCount)}, ""
 					}
 				}
 			}
-			return 0, nil, notFitReason(topDomain.sliceCount, sliceCount)
+			return 0, nil, notFitReason(s.domainStateOf(topDomain).sliceCount, sliceCount)
 		}
 		if searchLevelIdx > 0 && !state.unconstrained {
 			return s.findLevelWithFitDomains(searchLevelIdx-1, state)
@@ -1457,22 +1376,22 @@ func (s *TASFlavorSnapshot) findLevelWithFitDomains(
 		// Prioritize before selecting the fitting set, since later descent cannot
 		// recover a feasible leader domain omitted here. updateCountsToMinimumGeneric
 		// repeats this for each newly produced domain set during descent.
-		sortedDomain = prioritizeLeaderDomain(sortedDomain, state.count, state.leaderCount, state.sliceSize, true)
+		sortedDomain = s.prioritizeLeaderDomain(sortedDomain, state.count, state.leaderCount, state.sliceSize, true)
 
 		// Assign leaders first from a domain that preserves total worker capacity.
 		// After assigning all leaders, sort the remaining domains by worker capacity
 		// and assign the remaining workers.
 		idx := 0
-		for ; remainingLeaderCount > 0 && idx < len(sortedDomain) && sortedDomain[idx].leaderCount > 0; idx++ {
+		for ; remainingLeaderCount > 0 && idx < len(sortedDomain) && s.domainStateOf(sortedDomain[idx]).leaderCount > 0; idx++ {
 			domain := sortedDomain[idx]
-			if useBestFitAlgorithm(state.unconstrained) && sortedDomain[idx].sliceCountWithLeader >= remainingSliceCount {
+			if useBestFitAlgorithm(state.unconstrained) && s.domainStateOf(sortedDomain[idx]).sliceCountWithLeader >= remainingSliceCount {
 				// optimize the last domain
-				domain = findBestFitDomainForSlices(sortedDomain[idx:], remainingSliceCount, remainingLeaderCount)
+				domain = s.findBestFitDomainForSlices(sortedDomain[idx:], remainingSliceCount, remainingLeaderCount)
 			}
 			results = append(results, domain)
 
-			remainingLeaderCount -= domain.leaderCount
-			remainingSliceCount -= domain.sliceCountWithLeader
+			remainingLeaderCount -= s.domainStateOf(domain).leaderCount
+			remainingSliceCount -= s.domainStateOf(domain).sliceCountWithLeader
 		}
 		if remainingLeaderCount > 0 {
 			return 0, nil, notFitReason(state.leaderCount-remainingLeaderCount, sliceCount)
@@ -1483,13 +1402,13 @@ func (s *TASFlavorSnapshot) findLevelWithFitDomains(
 		sortedDomain = s.sortedDomains(sortedDomain[idx:], state.unconstrained)
 		for idx := 0; remainingSliceCount > 0 && idx < len(sortedDomain); idx++ {
 			domain := sortedDomain[idx]
-			if useBestFitAlgorithm(state.unconstrained) && sortedDomain[idx].sliceCount >= remainingSliceCount {
+			if useBestFitAlgorithm(state.unconstrained) && s.domainStateOf(sortedDomain[idx]).sliceCount >= remainingSliceCount {
 				// optimize the last domain
-				domain = findBestFitDomainForSlices(sortedDomain[idx:], remainingSliceCount, 0)
+				domain = s.findBestFitDomainForSlices(sortedDomain[idx:], remainingSliceCount, 0)
 			}
 			results = append(results, domain)
 
-			remainingSliceCount -= domain.sliceCount
+			remainingSliceCount -= s.domainStateOf(domain).sliceCount
 		}
 		if remainingSliceCount > 0 {
 			return 0, nil, notFitReason(sliceCount-remainingSliceCount, sliceCount)
@@ -1506,13 +1425,13 @@ func (s *TASFlavorSnapshot) findLevelWithFitDomains(
 // consecutive matches from the beginning and truncates the slice as soon as the score drops.
 // This prevents the capacity-focused BestFit algorithm from optimizing across affinity tiers,
 // guaranteeing that affinity scores take absolute precedence over capacity minimization.
-func topAffinityTierDomains(candidates []*domain) []*domain {
+func (s *TASFlavorSnapshot) topAffinityTierDomains(candidates []*domain) []*domain {
 	if !features.Enabled(features.TASRespectNodeAffinityPreferred) || len(candidates) == 0 {
 		return candidates
 	}
-	score := candidates[0].affinityScore
+	score := s.domainStateOf(candidates[0]).affinityScore
 	for i, c := range candidates {
-		if c.affinityScore != score {
+		if s.domainStateOf(c).affinityScore != score {
 			return candidates[:i]
 		}
 	}
@@ -1537,11 +1456,9 @@ func useLeastFreeCapacityAlgorithm(unconstrained bool) bool {
 // Parameters:
 //   - domain: the domain being consumed
 //   - remainingDomains: the slice of domains that are still eligible for best-fit optimization
-//   - withLeader: pointer to the domain field that represents capacity with a leader present
-//     (use &domain.podCountWithLeader for pods, &domain.sliceCountWithLeader for slices)
-//   - primary: pointer to the domain field that represents the primary unit being distributed
-//     (use &domain.podCount for pods, &domain.sliceCount for slices)
-//   - sliceSize: factor to set domain.podCount when finalizing or partially consuming
+//   - withLeader: pointer to the per-snapshot capacity with a leader present
+//   - primary: pointer to the per-snapshot primary unit being distributed
+//   - sliceSize: factor to set the pod count when finalizing or partially consuming
 //     (use 1 for pods, the actual sliceSize for slices)
 //   - slices: whether we're distributing slices (true) or pods (false)
 func (s *TASFlavorSnapshot) consumeWithLeadersGeneric(
@@ -1555,35 +1472,35 @@ func (s *TASFlavorSnapshot) consumeWithLeadersGeneric(
 	sliceSize int32,
 	slices bool,
 ) (*domain, bool) {
-	if useBestFitAlgorithm(unconstrained) && *withLeader >= *remainingPrimary && domain.leaderCount >= *remainingLeaderCount {
+	if useBestFitAlgorithm(unconstrained) && *withLeader >= *remainingPrimary && s.domainStateOf(domain).leaderCount >= *remainingLeaderCount {
 		// optimize the last domain
 		if slices {
-			domain = findBestFitDomainForSlices(remainingDomains, *remainingPrimary, *remainingLeaderCount)
-			withLeader = &domain.sliceCountWithLeader
-			primary = &domain.sliceCount
+			domain = s.findBestFitDomainForSlices(remainingDomains, *remainingPrimary, *remainingLeaderCount)
+			withLeader = &s.domainStateOf(domain).sliceCountWithLeader
+			primary = &s.domainStateOf(domain).sliceCount
 		} else {
-			domain = findBestFitDomain(remainingDomains, *remainingPrimary, *remainingLeaderCount)
-			withLeader = &domain.podCountWithLeader
-			primary = &domain.podCount
+			domain = s.findBestFitDomain(remainingDomains, *remainingPrimary, *remainingLeaderCount)
+			withLeader = &s.domainStateOf(domain).podCountWithLeader
+			primary = &s.domainStateOf(domain).podCount
 		}
 	}
 
-	if *withLeader >= *remainingPrimary && domain.leaderCount >= *remainingLeaderCount {
+	domainState := s.domainStateOf(domain)
+	if *withLeader >= *remainingPrimary && domainState.leaderCount >= *remainingLeaderCount {
 		*primary = *remainingPrimary
-		domain.leaderCount = *remainingLeaderCount
-		domain.podCount = *remainingPrimary * sliceSize
+		domainState.leaderCount = *remainingLeaderCount
+		domainState.podCount = *remainingPrimary * sliceSize
 		return domain, true
 	}
-
 	if *withLeader > *remainingPrimary {
 		*withLeader = *remainingPrimary
 	}
-	if domain.leaderCount > *remainingLeaderCount {
-		domain.leaderCount = *remainingLeaderCount
+	if domainState.leaderCount > *remainingLeaderCount {
+		domainState.leaderCount = *remainingLeaderCount
 	}
 	*primary = *withLeader
-	domain.podCount = *withLeader * sliceSize
-	*remainingLeaderCount -= domain.leaderCount
+	domainState.podCount = *withLeader * sliceSize
+	*remainingLeaderCount -= domainState.leaderCount
 	*remainingPrimary -= *withLeader
 	return domain, false
 }
@@ -1591,7 +1508,7 @@ func (s *TASFlavorSnapshot) consumeWithLeadersGeneric(
 // prioritizeLeaderDomain preserves the capacity summarized by fillInCountsHelper.
 // That summary subtracts the smallest eligible child leader penalty, so descent
 // must select a leader-capable domain whose penalty fits within the available slack.
-func prioritizeLeaderDomain(domains []*domain, count, leaderCount, sliceSize int32, slicesEnabled bool) []*domain {
+func (s *TASFlavorSnapshot) prioritizeLeaderDomain(domains []*domain, count, leaderCount, sliceSize int32, slicesEnabled bool) []*domain {
 	if leaderCount == 0 || len(domains) < 2 {
 		return domains
 	}
@@ -1601,21 +1518,22 @@ func prioritizeLeaderDomain(domains []*domain, count, leaderCount, sliceSize int
 	if slicesEnabled {
 		requiredCapacity /= sliceSize
 		for _, domain := range domains {
-			availableCapacity += domain.sliceCount
+			availableCapacity += s.domainStateOf(domain).sliceCount
 		}
 	} else {
 		for _, domain := range domains {
-			availableCapacity += domain.podCount
+			availableCapacity += s.domainStateOf(domain).podCount
 		}
 	}
 
 	for i, domain := range domains {
-		if domain.leaderCount < leaderCount {
+		domainState := s.domainStateOf(domain)
+		if domainState.leaderCount < leaderCount {
 			continue
 		}
-		leaderPenalty := domain.podCount - domain.podCountWithLeader
+		leaderPenalty := domainState.podCount - domainState.podCountWithLeader
 		if slicesEnabled {
-			leaderPenalty = domain.sliceCount - domain.sliceCountWithLeader
+			leaderPenalty = domainState.sliceCount - domainState.sliceCountWithLeader
 		}
 		if availableCapacity-leaderPenalty < requiredCapacity {
 			continue
@@ -1633,7 +1551,7 @@ func prioritizeLeaderDomain(domains []*domain, count, leaderCount, sliceSize int
 }
 
 func (s *TASFlavorSnapshot) updateCountsToMinimumGeneric(domains []*domain, count int32, leaderCount int32, sliceSize int32, unconstrained bool, slices bool) []*domain {
-	domains = prioritizeLeaderDomain(domains, count, leaderCount, sliceSize, slices)
+	domains = s.prioritizeLeaderDomain(domains, count, leaderCount, sliceSize, slices)
 	result := make([]*domain, 0)
 	remainingPrimary := count
 	if slices {
@@ -1646,9 +1564,19 @@ func (s *TASFlavorSnapshot) updateCountsToMinimumGeneric(domains []*domain, coun
 			var d *domain
 			var completed bool
 			if slices {
-				d, completed = s.consumeWithLeadersGeneric(dom, domains[i:], &remainingPrimary, &remainingLeaderCount, unconstrained, &dom.sliceCountWithLeader, &dom.sliceCount, sliceSize, true)
+				d, completed = s.consumeWithLeadersGeneric(
+					dom,
+					domains[i:],
+					&remainingPrimary,
+					&remainingLeaderCount,
+					unconstrained,
+					&s.domainStateOf(dom).sliceCountWithLeader,
+					&s.domainStateOf(dom).sliceCount,
+					sliceSize,
+					true,
+				)
 			} else {
-				d, completed = s.consumeWithLeadersGeneric(dom, domains[i:], &remainingPrimary, &remainingLeaderCount, unconstrained, &dom.podCountWithLeader, &dom.podCount, 1, false)
+				d, completed = s.consumeWithLeadersGeneric(dom, domains[i:], &remainingPrimary, &remainingLeaderCount, unconstrained, &s.domainStateOf(dom).podCountWithLeader, &s.domainStateOf(dom).podCount, 1, false)
 			}
 			result = append(result, d)
 			if completed {
@@ -1659,35 +1587,37 @@ func (s *TASFlavorSnapshot) updateCountsToMinimumGeneric(domains []*domain, coun
 
 		// No leaders remaining: handle tail without leaders
 		if slices {
-			if useBestFitAlgorithm(unconstrained) && dom.sliceCount >= remainingPrimary {
+			if useBestFitAlgorithm(unconstrained) && s.domainStateOf(dom).sliceCount >= remainingPrimary {
 				// optimize the last domain
-				dom = findBestFitDomainForSlices(domains[i:], remainingPrimary, 0)
+				dom = s.findBestFitDomainForSlices(domains[i:], remainingPrimary, 0)
 			}
-			dom.leaderCount = 0
-			if dom.sliceCount >= remainingPrimary {
-				dom.podCount = remainingPrimary * sliceSize
-				dom.sliceCount = remainingPrimary
+			domState := s.domainStateOf(dom)
+			domState.leaderCount = 0
+			if domState.sliceCount >= remainingPrimary {
+				domState.podCount = remainingPrimary * sliceSize
+				domState.sliceCount = remainingPrimary
 				result = append(result, dom)
 				return result
 			}
-			dom.podCount = dom.sliceCount * sliceSize
-			remainingPrimary -= dom.sliceCount
+			domState.podCount = domState.sliceCount * sliceSize
+			remainingPrimary -= domState.sliceCount
 			result = append(result, dom)
 			continue
 		}
 
 		// pods (slices=false)
-		if useBestFitAlgorithm(unconstrained) && dom.podCount >= remainingPrimary {
+		if useBestFitAlgorithm(unconstrained) && s.domainStateOf(dom).podCount >= remainingPrimary {
 			// optimize the last domain
-			dom = findBestFitDomain(domains[i:], remainingPrimary, 0)
+			dom = s.findBestFitDomain(domains[i:], remainingPrimary, 0)
 		}
-		dom.leaderCount = 0
-		if dom.podCount >= remainingPrimary {
-			dom.podCount = remainingPrimary
+		domState := s.domainStateOf(dom)
+		domState.leaderCount = 0
+		if domState.podCount >= remainingPrimary {
+			domState.podCount = remainingPrimary
 			result = append(result, dom)
 			return result
 		}
-		remainingPrimary -= dom.podCount
+		remainingPrimary -= domState.podCount
 		result = append(result, dom)
 	}
 	// Error logs are not verbosity-gated; dumping leaves scales with cluster size.
@@ -1725,13 +1655,13 @@ func (s *TASFlavorSnapshot) buildTopologyAssignmentForLevels(domains []*domain, 
 	}
 	assignment.Levels = s.levelKeys[levelIdx:]
 	for _, domain := range domains {
-		if domain.podCount == 0 {
+		if s.domainStateOf(domain).podCount == 0 {
 			// It may happen when PodSet count is 0 or when using LeastFreeCapacity algorithm.
 			continue
 		}
 		assignment.Domains = append(assignment.Domains, utiltas.TopologyDomainAssignment{
 			Values: domain.levelValues[levelIdx:],
-			Count:  domain.podCount,
+			Count:  s.domainStateOf(domain).podCount,
 		})
 	}
 	return assignment
@@ -1772,25 +1702,26 @@ func (s *TASFlavorSnapshot) sortedDomainsWithLeader(domains []*domain, unconstra
 	respectNodeAffinityPreferred := features.Enabled(features.TASRespectNodeAffinityPreferred)
 	result := slices.Clone(domains)
 	slices.SortFunc(result, func(a, b *domain) int {
-		if a.leaderCount != b.leaderCount {
-			return cmp.Compare(b.leaderCount, a.leaderCount)
+		aState, bState := s.domainStateOf(a), s.domainStateOf(b)
+		if aState.leaderCount != bState.leaderCount {
+			return cmp.Compare(bState.leaderCount, aState.leaderCount)
 		}
 
-		if respectNodeAffinityPreferred && a.affinityScore != b.affinityScore {
-			return cmp.Compare(b.affinityScore, a.affinityScore)
+		if respectNodeAffinityPreferred && aState.affinityScore != bState.affinityScore {
+			return cmp.Compare(bState.affinityScore, aState.affinityScore)
 		}
 
-		if a.sliceCountWithLeader != b.sliceCountWithLeader {
+		if aState.sliceCountWithLeader != bState.sliceCountWithLeader {
 			if isLeastFreeCapacity {
 				// Start from the domain with the least amount of free resources.
 				// Ascending order.
-				return cmp.Compare(a.sliceCountWithLeader, b.sliceCountWithLeader)
+				return cmp.Compare(aState.sliceCountWithLeader, bState.sliceCountWithLeader)
 			}
-			return cmp.Compare(b.sliceCountWithLeader, a.sliceCountWithLeader)
+			return cmp.Compare(bState.sliceCountWithLeader, aState.sliceCountWithLeader)
 		}
 
-		if a.podCountWithLeader != b.podCountWithLeader {
-			return cmp.Compare(a.podCountWithLeader, b.podCountWithLeader)
+		if aState.podCountWithLeader != bState.podCountWithLeader {
+			return cmp.Compare(aState.podCountWithLeader, bState.podCountWithLeader)
 		}
 
 		return s.compareDomainLevelValues(a, b)
@@ -1810,21 +1741,22 @@ func (s *TASFlavorSnapshot) sortedDomains(domains []*domain, unconstrained bool)
 	respectNodeAffinityPreferred := features.Enabled(features.TASRespectNodeAffinityPreferred)
 	result := slices.Clone(domains)
 	slices.SortFunc(result, func(a, b *domain) int {
-		if respectNodeAffinityPreferred && a.affinityScore != b.affinityScore {
-			return cmp.Compare(b.affinityScore, a.affinityScore)
+		aState, bState := s.domainStateOf(a), s.domainStateOf(b)
+		if respectNodeAffinityPreferred && aState.affinityScore != bState.affinityScore {
+			return cmp.Compare(bState.affinityScore, aState.affinityScore)
 		}
 
-		if a.sliceCount != b.sliceCount {
+		if aState.sliceCount != bState.sliceCount {
 			if isLeastFreeCapacity {
 				// Start from the domain with the least amount of free resources.
 				// Ascending order.
-				return cmp.Compare(a.sliceCount, b.sliceCount)
+				return cmp.Compare(aState.sliceCount, bState.sliceCount)
 			}
-			return cmp.Compare(b.sliceCount, a.sliceCount)
+			return cmp.Compare(bState.sliceCount, aState.sliceCount)
 		}
 
-		if a.podCount != b.podCount {
-			return cmp.Compare(a.podCount, b.podCount)
+		if aState.podCount != bState.podCount {
+			return cmp.Compare(aState.podCount, bState.podCount)
 		}
 
 		return s.compareDomainLevelValues(a, b)
@@ -1835,24 +1767,17 @@ func (s *TASFlavorSnapshot) sortedDomains(domains []*domain, unconstrained bool)
 // fillInCounts computes per-domain pod, slice, and leader capacities from the
 // pod requirements, then rolls those capacities up the topology tree.
 func (s *TASFlavorSnapshot) fillInCounts(requirements *topologyAssignmentPodRequirements, state *findTopologyAssignmentState) {
-	for _, domainsAtLevel := range s.domainsPerLevel {
-		for _, domain := range domainsAtLevel {
-			// cleanup the state in case some remaining values are present from computing
-			// assignments for previous PodSets.
-			domain.podCount = 0
-			domain.podCountWithLeader = 0
-			domain.sliceCount = 0
-			domain.sliceCountWithLeader = 0
-			domain.leaderCount = 0
-			domain.affinityScore = 0
-		}
-	}
+	// cleanup the state in case some remaining values are present from computing
+	// assignments for previous PodSets. Truncating to discard the state
+	// slots of domain copies made for the previous PodSet.
+	s.domainStates = s.domainStates[:s.domainCount]
+	clear(s.domainStates)
 	cachingRemainingResourcesEnabled := features.Enabled(features.TASCachingRemainingResources)
 	if features.Enabled(features.TASCacheNodeMatchResults) {
 		matchingLeaves, stats := s.getMatchingLeaves(requirements)
 		state.stats.add(stats)
 		for _, ml := range matchingLeaves {
-			ml.leaf.affinityScore += ml.affinityScore
+			s.domainStateOf(&ml.leaf.domain).affinityScore += ml.affinityScore
 			s.fillLeafCounts(ml.leaf, requirements, state, cachingRemainingResourcesEnabled)
 		}
 	} else {
@@ -1865,7 +1790,7 @@ func (s *TASFlavorSnapshot) fillInCounts(requirements *topologyAssignmentPodRequ
 					state.stats.recordExclusion(exclusionType, taint)
 					continue
 				}
-				leaf.affinityScore += affinityScore
+				s.domainStateOf(&leaf.domain).affinityScore += affinityScore
 			}
 			s.fillLeafCounts(leaf, requirements, state, cachingRemainingResourcesEnabled)
 		}
@@ -1951,15 +1876,16 @@ func (s *TASFlavorSnapshot) matchNode(leaf *leafDomain, requirements *topologyAs
 }
 
 func (s *TASFlavorSnapshot) remainingCapacityForLeaf(leaf *leafDomain, simulateEmpty, cachingRemainingResourcesEnabled bool) resources.LazyRequests {
+	leafCapacity := s.leafCapacityOf(leaf)
 	if cachingRemainingResourcesEnabled {
 		if simulateEmpty {
-			return resources.NewLazyRequests(leaf.freeCapacity)
+			return resources.NewLazyRequests(leafCapacity.freeCapacity)
 		}
 		return resources.NewLazyRequests(s.getRemainingCapacity(leaf))
 	}
-	remainingCapacity := resources.NewLazyRequests(leaf.freeCapacity)
+	remainingCapacity := resources.NewLazyRequests(leafCapacity.freeCapacity)
 	if !simulateEmpty {
-		remainingCapacity.Sub(leaf.tasUsage)
+		remainingCapacity.Sub(leafCapacity.tasUsage)
 	}
 	return remainingCapacity
 }
@@ -1977,30 +1903,41 @@ func (s *TASFlavorSnapshot) fillLeafCounts(leaf *leafDomain, requirements *topol
 		remainingCapacity.Sub(leafAssumedUsage)
 	}
 	var limitingRes corev1.ResourceName
-	leaf.podCount, limitingRes = requirements.requests.CountInWithLimitingResource(remainingCapacity.Get())
+	leafDomainState := s.domainStateOf(&leaf.domain)
+	leafDomainState.podCount, limitingRes = requirements.requests.CountInWithLimitingResource(remainingCapacity.Get())
 
 	// Track resource exclusions: if this node can't fit even one pod,
 	// identify which resource is the bottleneck.
-	if leaf.podCount == 0 && limitingRes != "" {
+	if leafDomainState.podCount == 0 && limitingRes != "" {
 		state.stats.recordResourceExclusion(limitingRes)
 	}
 
-	leaf.leaderCount = 0
+	leafDomainState.leaderCount = 0
 	if requirements.leaderRequests != nil && requirements.leaderRequests.CountIn(remainingCapacity.Get()) > 0 {
-		leaf.leaderCount = 1
+		leafDomainState.leaderCount = 1
 		remainingCapacity.Sub(requirements.leaderRequests)
 	}
 
-	leaf.podCountWithLeader = requirements.requests.CountIn(remainingCapacity.Get())
+	leafDomainState.podCountWithLeader = requirements.requests.CountIn(remainingCapacity.Get())
+}
+
+func belongsToRequiredDomain(leaf *leafDomain, requiredReplacementDomain utiltas.TopologyDomainID) bool {
+	if requiredReplacementDomain == "" {
+		return true
+	}
+	// Uses levelValues instead of leaf.id since for topologies with hostname as lowest level it points directly to the hostname
+	// TODO(#5322): Use util function that compare two DomainIDs
+	return strings.HasPrefix(string(utiltas.DomainID(leaf.levelValues)), string(requiredReplacementDomain))
 }
 
 func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, sliceLevelIdx int, level int, sliceSizeAtLevel map[int]int32, leaderRequired bool) {
+	domainState := s.domainStateOf(domain)
 	// logic for a leaf
 	if len(domain.children) == 0 {
 		if level == sliceLevelIdx {
 			// initialize the sliceCount if leaf is the request slice level
-			domain.sliceCount = domain.podCount / sliceSize
-			domain.sliceCountWithLeader = domain.podCountWithLeader / sliceSize
+			domainState.sliceCount = domainState.podCount / sliceSize
+			domainState.sliceCountWithLeader = domainState.podCountWithLeader / sliceSize
 		}
 		return
 	}
@@ -2023,40 +1960,41 @@ func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, 
 	for _, child := range domain.children {
 		s.fillInCountsHelper(child, sliceSize, sliceLevelIdx, childLevel, sliceSizeAtLevel, leaderRequired)
 
-		childPodCount := child.podCount
-		childPodCountWithLeader := child.podCountWithLeader
+		childDomainState := s.domainStateOf(child)
+		childPodCount := childDomainState.podCount
+		childPodCountWithLeader := childDomainState.podCountWithLeader
 		if hasInnerConstraint {
-			childPodCount = (child.podCount / innerSize) * innerSize
-			childPodCountWithLeader = (child.podCountWithLeader / innerSize) * innerSize
+			childPodCount = (childDomainState.podCount / innerSize) * innerSize
+			childPodCountWithLeader = (childDomainState.podCountWithLeader / innerSize) * innerSize
 		}
 
 		childrenCapacity += childPodCount
-		sliceCapacity += child.sliceCount
-		if !leaderRequired || child.leaderCount > 0 {
+		sliceCapacity += childDomainState.sliceCount
+		if !leaderRequired || childDomainState.leaderCount > 0 {
 			hasWithLeaderCapacityContributor = true
 			minPodCountWithLeaderDifference = min(childPodCount-childPodCountWithLeader, minPodCountWithLeaderDifference)
-			minSliceCountWithLeaderDifference = min(child.sliceCount-child.sliceCountWithLeader, minSliceCountWithLeaderDifference)
+			minSliceCountWithLeaderDifference = min(childDomainState.sliceCount-childDomainState.sliceCountWithLeader, minSliceCountWithLeaderDifference)
 		}
-		leaderCount = max(child.leaderCount, leaderCount)
-		affinityScore += child.affinityScore
+		leaderCount = max(childDomainState.leaderCount, leaderCount)
+		affinityScore += childDomainState.affinityScore
 	}
-	domain.podCount = childrenCapacity
+	domainState.podCount = childrenCapacity
 	sliceCountWithLeader := int32(0)
 	if hasWithLeaderCapacityContributor {
-		domain.podCountWithLeader = childrenCapacity - minPodCountWithLeaderDifference
+		domainState.podCountWithLeader = childrenCapacity - minPodCountWithLeaderDifference
 		sliceCountWithLeader = sliceCapacity - minSliceCountWithLeaderDifference
 	} else {
-		domain.podCountWithLeader = 0
+		domainState.podCountWithLeader = 0
 	}
-	domain.leaderCount = leaderCount
-	domain.affinityScore = affinityScore
+	domainState.leaderCount = leaderCount
+	domainState.affinityScore = affinityScore
 	if level == sliceLevelIdx {
 		// initialize the sliceCount for the requested slice level.
-		sliceCapacity = domain.podCount / sliceSize
-		sliceCountWithLeader = domain.podCountWithLeader / sliceSize
+		sliceCapacity = domainState.podCount / sliceSize
+		sliceCountWithLeader = domainState.podCountWithLeader / sliceSize
 	}
-	domain.sliceCount = sliceCapacity
-	domain.sliceCountWithLeader = sliceCountWithLeader
+	domainState.sliceCount = sliceCapacity
+	domainState.sliceCountWithLeader = sliceCountWithLeader
 }
 
 func (s *TASFlavorSnapshot) notFitMessage(slicesFitCount, totalRequestsSlicesCount, sliceSize int32, stats *ExclusionStats) string {
@@ -2081,13 +2019,13 @@ func (s *TASFlavorSnapshot) notFitMessage(slicesFitCount, totalRequestsSlicesCou
 	return builder.String()
 }
 
-func countSlicesInSubtree(d *domain, currentLevel, targetLevel int, sliceSize int32) int32 {
+func (s *TASFlavorSnapshot) countSlicesInSubtree(d *domain, currentLevel, targetLevel int, sliceSize int32) int32 {
 	if currentLevel == targetLevel {
-		return d.podCount / sliceSize
+		return s.domainStateOf(d).podCount / sliceSize
 	}
 	var total int32
 	for _, child := range d.children {
-		total += countSlicesInSubtree(child, currentLevel+1, targetLevel, sliceSize)
+		total += s.countSlicesInSubtree(child, currentLevel+1, targetLevel, sliceSize)
 	}
 	return total
 }
@@ -2106,8 +2044,8 @@ func (s *TASFlavorSnapshot) multiLayerNotFitMessage(
 	// domainsPerLevel is map-backed and iteration order is random.
 	var bestDomain *domain
 	for _, d := range s.domainsPerLevel[requiredLevelIdx] {
-		if bestDomain == nil || d.sliceCount > bestDomain.sliceCount ||
-			(d.sliceCount == bestDomain.sliceCount && d.id < bestDomain.id) {
+		if bestDomain == nil || s.domainStateOf(d).sliceCount > s.domainStateOf(bestDomain).sliceCount ||
+			(s.domainStateOf(d).sliceCount == s.domainStateOf(bestDomain).sliceCount && d.id < bestDomain.id) {
 			bestDomain = d
 		}
 	}
@@ -2121,7 +2059,7 @@ func (s *TASFlavorSnapshot) multiLayerNotFitMessage(
 			continue
 		}
 		neededSlices := count / c.Size
-		fitSlices := countSlicesInSubtree(bestDomain, requiredLevelIdx, targetLevelIdx, c.Size)
+		fitSlices := s.countSlicesInSubtree(bestDomain, requiredLevelIdx, targetLevelIdx, c.Size)
 		fmt.Fprintf(&builder, "; %d/%d slice(s) fit on level %s", fitSlices, neededSlices, c.Topology)
 	}
 

--- a/pkg/cache/scheduler/tas_flavor_snapshot_bench_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_bench_test.go
@@ -19,11 +19,16 @@ package scheduler
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/resources"
 	testingnode "sigs.k8s.io/kueue/pkg/util/testingjobs/node"
 	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
 )
@@ -40,6 +45,14 @@ type benchTopology struct {
 	racksPerBlock  int
 	flavors        int
 	withNonTASPods bool
+}
+
+type benchSnapshotMode struct {
+	name            string
+	heartbeatUpdate bool
+	// invalidationPeriod bumps the nodesCache generation on every cycle that is a
+	// multiple of it; 0 never invalidates.
+	invalidationPeriod int
 }
 
 func buildBenchNodes(t benchTopology) []corev1.Node {
@@ -72,6 +85,12 @@ func BenchmarkTASFlavorSnapshot(b *testing.B) {
 		{nodes: 2500, nodesPerRack: 16, racksPerBlock: 16, flavors: 15, withNonTASPods: true},
 		{nodes: 2500, nodesPerRack: 16, racksPerBlock: 16},
 	}
+	modes := []benchSnapshotMode{
+		{name: "reuse"},
+		{name: "heartbeat", heartbeatUpdate: true},
+		{name: "invalidate-every-cycle", invalidationPeriod: 1},
+		{name: "invalidate-every-2-cycles", invalidationPeriod: 2},
+	}
 
 	for _, topo := range topologies {
 		flavors := max(1, topo.flavors)
@@ -79,48 +98,161 @@ func BenchmarkTASFlavorSnapshot(b *testing.B) {
 		if topo.withNonTASPods {
 			name += "/withNonTASPods"
 		}
-		b.Run(name, func(b *testing.B) {
-			b.ReportAllocs()
-			log := logr.Discard()
+		for _, mode := range modes {
+			runBenchmarkTASFlavorSnapshot(b, topo, flavors, fmt.Sprintf("%s/mode=%s", name, mode.name), mode)
+		}
+	}
+}
 
-			nodes := buildBenchNodes(topo)
-			levels := []string{benchBlockLabel, benchRackLabel, benchHostLabel}
+func runBenchmarkTASFlavorSnapshot(b *testing.B, topo benchTopology, flavors int, name string, mode benchSnapshotMode) {
+	b.Run(name, func(b *testing.B) {
+		b.ReportAllocs()
+		log := logr.Discard()
 
-			tasCache := NewTASCache(nil)
+		nodes := buildBenchNodes(topo)
+		levels := []string{benchBlockLabel, benchRackLabel, benchHostLabel}
+
+		tasCache := NewTASCache(nil)
+		for i := range nodes {
+			tasCache.SyncNode(&nodes[i])
+		}
+
+		if topo.withNonTASPods {
 			for i := range nodes {
-				tasCache.SyncNode(&nodes[i])
+				pod := testingpod.MakePod(fmt.Sprintf("bg-%d", i), "default").
+					NodeName(nodes[i].Name).
+					Request(corev1.ResourceCPU, "1").
+					Request(corev1.ResourceMemory, "1Gi").
+					StatusPhase(corev1.PodRunning).
+					Obj()
+				tasCache.Update(pod, log)
 			}
+		}
 
-			if topo.withNonTASPods {
-				for i := range nodes {
-					pod := testingpod.MakePod(fmt.Sprintf("bg-%d", i), "default").
-						NodeName(nodes[i].Name).
-						Request(corev1.ResourceCPU, "1").
-						Request(corev1.ResourceMemory, "1Gi").
-						StatusPhase(corev1.PodRunning).
-						Obj()
-					tasCache.Update(pod, log)
-				}
-			}
+		flavorCaches := make([]*TASFlavorCache, flavors)
+		for i := range flavorCaches {
+			flavorCaches[i] = tasCache.NewTASFlavorCache(
+				topologyInformation{Levels: levels},
+				flavorInformation{TopologyName: "default"},
+			)
+		}
 
-			flavorCaches := make([]*TASFlavorCache, flavors)
-			for i := range flavorCaches {
-				flavorCaches[i] = tasCache.NewTASFlavorCache(
-					topologyInformation{Levels: levels},
-					flavorInformation{TopologyName: "default"},
-				)
-			}
+		// Build the initial tree outside the timed loop. This makes reuse a
+		// cache-hit-only benchmark and gives the update modes a tree to
+		// invalidate.
+		for _, flavorCache := range flavorCaches {
+			flavorCache.snapshot(log, nil)
+		}
 
-			flavorNodes := make([][]*corev1.Node, len(flavorCaches))
-			for i, flavorCache := range flavorCaches {
-				flavorNodes[i] = tasCache.nodesCache.find(flavorCache.flavor.NodeLabels, flavorCache.topology.Levels)
-			}
+		// Only fields dropped by copyAndStripNode differ, so syncing this must not
+		// bump the nodesCache generation.
+		heartbeatNode := (&testingnode.NodeWrapper{Node: *nodes[0].DeepCopy()}).
+			ResourceVersion("heartbeat").
+			ConditionHeartbeat(corev1.NodeReady, metav1.NewTime(time.Unix(1, 0))).
+			Obj()
+		invalidatingNodes := []*corev1.Node{
+			(&testingnode.NodeWrapper{Node: *nodes[0].DeepCopy()}).
+				StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("97")}).Obj(),
+			(&testingnode.NodeWrapper{Node: *nodes[0].DeepCopy()}).
+				StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("96")}).Obj(),
+		}
 
-			for b.Loop() {
-				for i, flavorCache := range flavorCaches {
-					_ = flavorCache.snapshot(log, flavorNodes[i], nil)
-				}
+		cycle := 0
+		for b.Loop() {
+			switch {
+			case mode.heartbeatUpdate:
+				tasCache.SyncNode(heartbeatNode)
+			case mode.invalidationPeriod > 0 && cycle%mode.invalidationPeriod == 0:
+				update := cycle / mode.invalidationPeriod
+				tasCache.SyncNode(invalidatingNodes[update%len(invalidatingNodes)])
 			}
+			for _, flavorCache := range flavorCaches {
+				flavorCache.snapshot(log, nil)
+			}
+			cycle++
+		}
+	})
+}
+
+func BenchmarkTASFlavorAssignment(b *testing.B) {
+	features.SetFeatureGateDuringTest(b, features.TASBalancedPlacement, true)
+
+	benchmarks := []struct {
+		name       string
+		topology   benchTopology
+		withLeader bool
+	}{
+		{name: "nodes=100/workersOnly", topology: benchTopology{nodes: 100, nodesPerRack: 16, racksPerBlock: 16}},
+		{name: "nodes=500/workersOnly", topology: benchTopology{nodes: 500, nodesPerRack: 16, racksPerBlock: 16}},
+		{name: "nodes=2500/workersOnly", topology: benchTopology{nodes: 2500, nodesPerRack: 16, racksPerBlock: 16}},
+		{name: "nodes=2500/withLeader", topology: benchTopology{nodes: 2500, nodesPerRack: 16, racksPerBlock: 16}, withLeader: true},
+	}
+	for _, benchmark := range benchmarks {
+		runBenchmarkTASFlavorAssignment(b, benchmark.topology, benchmark.name, benchmark.withLeader)
+	}
+}
+
+func runBenchmarkTASFlavorAssignment(b *testing.B, topo benchTopology, name string, withLeader bool) {
+	b.Run(name, func(b *testing.B) {
+		b.ReportAllocs()
+		log := logr.Discard()
+		nodes := buildBenchNodes(topo)
+		levels := []string{benchBlockLabel, benchRackLabel, benchHostLabel}
+
+		tasCache := NewTASCache(nil)
+		for i := range nodes {
+			tasCache.SyncNode(&nodes[i])
+		}
+		flavorCache := tasCache.NewTASFlavorCache(
+			topologyInformation{Levels: levels},
+			flavorInformation{TopologyName: "default"},
+		)
+		snapshot := flavorCache.snapshot(log, nil)
+
+		requests := balancedPlacementBenchRequests(topo, withLeader)
+		result := snapshot.FindTopologyAssignmentsForFlavor(log, requests)
+		if failure := result.Failure(); failure != nil {
+			b.Fatalf("balanced placement preflight failed: %s", failure.Reason)
+		}
+		if len(snapshot.domainStates) == snapshot.domainCount {
+			b.Fatal("balanced placement preflight did not clone domain state")
+		}
+
+		for b.Loop() {
+			result = snapshot.FindTopologyAssignmentsForFlavor(log, requests)
+		}
+		if failure := result.Failure(); failure != nil {
+			b.Fatalf("repeated balanced placement failed: %s", failure.Reason)
+		}
+	})
+}
+
+func balancedPlacementBenchRequests(topo benchTopology, withLeader bool) FlavorTASRequests {
+	preferredLevel := benchRackLabel
+	groupName := "benchmark-group"
+	nodesInBlock := min(topo.nodes, topo.nodesPerRack*topo.racksPerBlock)
+	requests := FlavorTASRequests{{
+		PodSet: &kueue.PodSet{
+			Name: "workers",
+			TopologyRequest: &kueue.PodSetTopologyRequest{
+				Preferred: &preferredLevel,
+			},
+		},
+		SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+			corev1.ResourceCPU: 8000,
+		}),
+		Count:           int32(nodesInBlock * 9),
+		PodSetGroupName: &groupName,
+	}}
+	if withLeader {
+		requests = append(requests, TASPodSetRequests{
+			PodSet: &kueue.PodSet{Name: "leader"},
+			SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+				corev1.ResourceCPU: 72000,
+			}),
+			Count:           1,
+			PodSetGroupName: &groupName,
 		})
 	}
+	return requests
 }

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -42,17 +42,46 @@ import (
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 
+type testDomainSpec struct {
+	domain domain
+	state  domainState
+}
+
+func addDomainsWithState(s *TASFlavorSnapshot, specs []testDomainSpec) []*domain {
+	result := make([]*domain, len(specs))
+	for i, spec := range specs {
+		d := spec.domain
+		d.idx = len(s.domainStates)
+		s.domainStates = append(s.domainStates, spec.state)
+		result[i] = &d
+	}
+	return result
+}
+
+func newFreeCapacityTestSnapshot(states map[tas.TopologyDomainID]leafCapacity) *TASFlavorSnapshot {
+	leaves := make(leafDomainByID, len(states))
+	leafCapacities := make([]leafCapacity, 0, len(states))
+	for id, state := range states {
+		leaves[id] = &leafDomain{domain: domain{id: id}, leafIdx: len(leafCapacities)}
+		leafCapacities = append(leafCapacities, state)
+	}
+	return &TASFlavorSnapshot{
+		topologyTree:   &topologyTree{leaves: leaves},
+		leafCapacities: leafCapacities,
+	}
+}
+
 func TestFreeCapacityPerDomain(t *testing.T) {
 	cases := map[string]struct {
-		// leaves is a function, so that the requests are built with the
+		// snapshot is a function, so that the requests are built with the
 		// VectorizedResourceRequests feature gate already set.
-		leaves   func() leafDomainByID
+		snapshot func() *TASFlavorSnapshot
 		expected string
 	}{
 		"domains with free capacity and TAS usage": {
-			leaves: func() leafDomainByID {
-				return leafDomainByID{
-					"domain2": &leafDomain{
+			snapshot: func() *TASFlavorSnapshot {
+				return newFreeCapacityTestSnapshot(map[tas.TopologyDomainID]leafCapacity{
+					"domain2": {
 						freeCapacity: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU:    1000,
 							corev1.ResourceMemory: 2 * 1024 * 1024 * 1024, // 2 GiB
@@ -62,7 +91,7 @@ func TestFreeCapacityPerDomain(t *testing.T) {
 							corev1.ResourceCPU:    500,
 						}),
 					},
-					"domain1": &leafDomain{
+					"domain1": {
 						freeCapacity: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceMemory: 4 * 1024 * 1024 * 1024, // 4 GiB
 							corev1.ResourceCPU:    2000,
@@ -74,32 +103,34 @@ func TestFreeCapacityPerDomain(t *testing.T) {
 							corev1.ResourceMemory: 2 * 1024 * 1024 * 1024, // 1 GiB
 						}),
 					},
-				}
+				})
 			},
 			expected: `{"domain1":{"freeCapacity":{"cpu":"2","memory":"4Gi","nvidia.com/gpu":"1"},"tasUsage":{"cpu":"500m","memory":"2Gi","nvidia.com/gpu":"1"}},"domain2":{"freeCapacity":{"cpu":"1","memory":"2Gi"},"tasUsage":{"cpu":"500m","memory":"1Gi"}}}`,
 		},
 		"domain with free capacity, but without TAS usage": {
-			leaves: func() leafDomainByID {
-				return leafDomainByID{
-					"domain1": &leafDomain{
+			snapshot: func() *TASFlavorSnapshot {
+				return newFreeCapacityTestSnapshot(map[tas.TopologyDomainID]leafCapacity{
+					"domain1": {
 						freeCapacity: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU: 1000,
 						}),
 						// tasUsage is left nil, as there is no TAS workload
 						// admitted in the domain.
 					},
-				}
+				})
 			},
 			expected: `{"domain1":{"freeCapacity":{"cpu":"1"},"tasUsage":{}}}`,
 		},
 		"domain without free capacity and without TAS usage": {
-			leaves: func() leafDomainByID {
-				return leafDomainByID{"domain1": &leafDomain{}}
+			snapshot: func() *TASFlavorSnapshot {
+				return newFreeCapacityTestSnapshot(map[tas.TopologyDomainID]leafCapacity{"domain1": {}})
 			},
 			expected: `{"domain1":{"freeCapacity":{},"tasUsage":{}}}`,
 		},
 		"snapshot without domains": {
-			leaves:   func() leafDomainByID { return leafDomainByID{} },
+			snapshot: func() *TASFlavorSnapshot {
+				return newFreeCapacityTestSnapshot(nil)
+			},
 			expected: `{}`,
 		},
 	}
@@ -109,7 +140,7 @@ func TestFreeCapacityPerDomain(t *testing.T) {
 			t.Run(fmt.Sprintf("%s, VectorizedResourceRequests=%t", name, enableVectorizedRequests), func(t *testing.T) {
 				features.SetFeatureGateDuringTest(t, features.VectorizedResourceRequests, enableVectorizedRequests)
 
-				snapshot := &TASFlavorSnapshot{leaves: tc.leaves()}
+				snapshot := tc.snapshot()
 				var wantErr error
 
 				got, gotErr := snapshot.SerializeFreeCapacityPerDomain()
@@ -125,13 +156,14 @@ func TestFreeCapacityPerDomain(t *testing.T) {
 }
 
 func TestMergeTopologyAssignments(t *testing.T) {
-	nodes := []corev1.Node{
-		*node.MakeNode("x").Label("level-1", "a").Label("level-2", "b").Obj(),
-		*node.MakeNode("y").Label("level-1", "a").Label("level-2", "c").Obj(),
-		*node.MakeNode("z").Label("level-1", "d").Label("level-2", "e").Obj(),
-		*node.MakeNode("w").Label("level-1", "d").Label("level-2", "f").Obj(),
+	nodes := []*corev1.Node{
+		node.MakeNode("x").Label("level-1", "a").Label("level-2", "b").Obj(),
+		node.MakeNode("y").Label("level-1", "a").Label("level-2", "c").Obj(),
+		node.MakeNode("z").Label("level-1", "d").Label("level-2", "e").Obj(),
+		node.MakeNode("w").Label("level-1", "d").Label("level-2", "f").Obj(),
 	}
 	levels := []string{"level-1", "level-2"}
+	tree := newTopologyTree(levels, nodes, 0)
 
 	cases := map[string]struct {
 		a    *tas.TopologyAssignment
@@ -399,11 +431,7 @@ func TestMergeTopologyAssignments(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			_, log := utiltesting.ContextWithLog(t)
-			s := newTASFlavorSnapshot(log, "dummy", levels, nil)
-			for i := range nodes {
-				s.addNode(&nodes[i])
-			}
-			s.initialize()
+			s := newTASFlavorSnapshot(log, "dummy", tree, nil)
 
 			got := s.mergeTopologyAssignments(tc.a, tc.b)
 			if diff := cmp.Diff(tc.want, *got); diff != "" {
@@ -474,7 +502,7 @@ func TestHasLevel(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			_, log := utiltesting.ContextWithLog(t)
-			s := newTASFlavorSnapshot(log, "dummy", levels, nil)
+			s := newTASFlavorSnapshot(log, "dummy", newTopologyTree(levels, nil, 0), nil)
 			got := s.HasLevel(tc.podSetTopologyRequest)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("unexpected HasLevel result (-want,+got): %s", diff)
@@ -492,87 +520,254 @@ func TestSortedDomainsWithLeader(t *testing.T) {
 	levels := []string{"block"}
 
 	testCases := map[string]struct {
-		domains                              []*domain
+		domains                              []testDomainSpec
 		unconstrained                        bool
 		enableTASPreferredSchedulingAffinity bool
 		wantOrder                            []string
 	}{
 		"affinityScore descending: higher affinity score comes first": {
 			enableTASPreferredSchedulingAffinity: true,
-			domains: []*domain{
-				{id: "low-affinity", affinityScore: 10, leaderCount: 1, sliceCountWithLeader: 5, podCountWithLeader: 10, levelValues: []string{"a"}},
-				{id: "high-affinity", affinityScore: 100, leaderCount: 1, sliceCountWithLeader: 5, podCountWithLeader: 10, levelValues: []string{"b"}},
+			domains: []testDomainSpec{
+				{
+					domain: domain{id: "low-affinity", levelValues: []string{"a"}},
+					state: domainState{
+						affinityScore:        10,
+						leaderCount:          1,
+						sliceCountWithLeader: 5,
+						podCountWithLeader:   10,
+					},
+				},
+				{
+					domain: domain{id: "high-affinity", levelValues: []string{"b"}},
+					state: domainState{
+						affinityScore:        100,
+						leaderCount:          1,
+						sliceCountWithLeader: 5,
+						podCountWithLeader:   10,
+					},
+				},
 			},
 			unconstrained: false,
 			wantOrder:     []string{"high-affinity", "low-affinity"},
 		},
 		"affinityScore ignored when feature gate is disabled": {
 			enableTASPreferredSchedulingAffinity: false,
-			domains: []*domain{
-				{id: "low-affinity", affinityScore: 10, leaderCount: 1, sliceCountWithLeader: 5, podCountWithLeader: 10, levelValues: []string{"a"}},
-				{id: "high-affinity", affinityScore: 100, leaderCount: 1, sliceCountWithLeader: 5, podCountWithLeader: 10, levelValues: []string{"b"}},
+			domains: []testDomainSpec{
+				{
+					domain: domain{id: "low-affinity", levelValues: []string{"a"}},
+					state: domainState{
+						affinityScore:        10,
+						leaderCount:          1,
+						sliceCountWithLeader: 5,
+						podCountWithLeader:   10,
+					},
+				},
+				{
+					domain: domain{id: "high-affinity", levelValues: []string{"b"}},
+					state: domainState{
+						affinityScore:        100,
+						leaderCount:          1,
+						sliceCountWithLeader: 5,
+						podCountWithLeader:   10,
+					},
+				},
 			},
 			unconstrained: false,
 			wantOrder:     []string{"low-affinity", "high-affinity"},
 		},
 		"leaderCount descending: domains that can host leader come first": {
-			domains: []*domain{
-				{id: "no-leader", leaderCount: 0, sliceCountWithLeader: 10, podCountWithLeader: 10, levelValues: []string{"a"}},
-				{id: "has-leader", leaderCount: 1, sliceCountWithLeader: 1, podCountWithLeader: 1, levelValues: []string{"b"}},
+			domains: []testDomainSpec{
+				{
+					domain: domain{id: "no-leader", levelValues: []string{"a"}},
+					state: domainState{
+						leaderCount:          0,
+						sliceCountWithLeader: 10,
+						podCountWithLeader:   10,
+					},
+				},
+				{
+					domain: domain{id: "has-leader", levelValues: []string{"b"}},
+					state: domainState{
+						leaderCount:          1,
+						sliceCountWithLeader: 1,
+						podCountWithLeader:   1,
+					},
+				},
 			},
 			unconstrained: false,
 			wantOrder:     []string{"has-leader", "no-leader"},
 		},
 		"leader capability prioritized over preferred affinity": {
 			enableTASPreferredSchedulingAffinity: true,
-			domains: []*domain{
-				{id: "preferred-no-leader", affinityScore: 100, leaderCount: 0, sliceCountWithLeader: 0, podCountWithLeader: 0, levelValues: []string{"a"}},
-				{id: "non-preferred-has-leader", affinityScore: 10, leaderCount: 1, sliceCountWithLeader: 5, podCountWithLeader: 10, levelValues: []string{"b"}},
+			domains: []testDomainSpec{
+				{
+					domain: domain{id: "preferred-no-leader", levelValues: []string{"a"}},
+					state: domainState{
+						affinityScore:        100,
+						leaderCount:          0,
+						sliceCountWithLeader: 0,
+						podCountWithLeader:   0,
+					},
+				},
+				{
+					domain: domain{id: "non-preferred-has-leader", levelValues: []string{"b"}},
+					state: domainState{
+						affinityScore:        10,
+						leaderCount:          1,
+						sliceCountWithLeader: 5,
+						podCountWithLeader:   10,
+					},
+				},
 			},
 			unconstrained: false,
 			wantOrder:     []string{"non-preferred-has-leader", "preferred-no-leader"},
 		},
 		"BestFit: sliceCountWithLeader descending": {
-			domains: []*domain{
-				{id: "a", leaderCount: 1, sliceCountWithLeader: 3, podCountWithLeader: 1, levelValues: []string{"a"}},
-				{id: "b", leaderCount: 1, sliceCountWithLeader: 1, podCountWithLeader: 1, levelValues: []string{"b"}},
-				{id: "c", leaderCount: 1, sliceCountWithLeader: 2, podCountWithLeader: 1, levelValues: []string{"c"}},
+			domains: []testDomainSpec{
+				{
+					domain: domain{id: "a", levelValues: []string{"a"}},
+					state: domainState{
+						leaderCount:          1,
+						sliceCountWithLeader: 3,
+						podCountWithLeader:   1,
+					},
+				},
+				{
+					domain: domain{id: "b", levelValues: []string{"b"}},
+					state: domainState{
+						leaderCount:          1,
+						sliceCountWithLeader: 1,
+						podCountWithLeader:   1,
+					},
+				},
+				{
+					domain: domain{id: "c", levelValues: []string{"c"}},
+					state: domainState{
+						leaderCount:          1,
+						sliceCountWithLeader: 2,
+						podCountWithLeader:   1,
+					},
+				},
 			},
 			unconstrained: false,
 			wantOrder:     []string{"a", "c", "b"},
 		},
 		"LeastFreeCapacity: sliceCountWithLeader ascending": {
-			domains: []*domain{
-				{id: "a", leaderCount: 1, sliceCountWithLeader: 3, podCountWithLeader: 1, levelValues: []string{"a"}},
-				{id: "b", leaderCount: 1, sliceCountWithLeader: 1, podCountWithLeader: 1, levelValues: []string{"b"}},
-				{id: "c", leaderCount: 1, sliceCountWithLeader: 2, podCountWithLeader: 1, levelValues: []string{"c"}},
+			domains: []testDomainSpec{
+				{
+					domain: domain{id: "a", levelValues: []string{"a"}},
+					state: domainState{
+						leaderCount:          1,
+						sliceCountWithLeader: 3,
+						podCountWithLeader:   1,
+					},
+				},
+				{
+					domain: domain{id: "b", levelValues: []string{"b"}},
+					state: domainState{
+						leaderCount:          1,
+						sliceCountWithLeader: 1,
+						podCountWithLeader:   1,
+					},
+				},
+				{
+					domain: domain{id: "c", levelValues: []string{"c"}},
+					state: domainState{
+						leaderCount:          1,
+						sliceCountWithLeader: 2,
+						podCountWithLeader:   1,
+					},
+				},
 			},
 			unconstrained: true,
 			wantOrder:     []string{"b", "c", "a"},
 		},
 		"BestFit: podCountWithLeader ascending as tiebreaker": {
-			domains: []*domain{
-				{id: "large", leaderCount: 1, sliceCountWithLeader: 5, podCountWithLeader: 100, levelValues: []string{"a"}},
-				{id: "small", leaderCount: 1, sliceCountWithLeader: 5, podCountWithLeader: 10, levelValues: []string{"b"}},
-				{id: "medium", leaderCount: 1, sliceCountWithLeader: 5, podCountWithLeader: 50, levelValues: []string{"c"}},
+			domains: []testDomainSpec{
+				{
+					domain: domain{id: "large", levelValues: []string{"a"}},
+					state: domainState{
+						leaderCount:          1,
+						sliceCountWithLeader: 5,
+						podCountWithLeader:   100,
+					},
+				},
+				{
+					domain: domain{id: "small", levelValues: []string{"b"}},
+					state: domainState{
+						leaderCount:          1,
+						sliceCountWithLeader: 5,
+						podCountWithLeader:   10,
+					},
+				},
+				{
+					domain: domain{id: "medium", levelValues: []string{"c"}},
+					state: domainState{
+						leaderCount:          1,
+						sliceCountWithLeader: 5,
+						podCountWithLeader:   50,
+					},
+				},
 			},
 			unconstrained: false,
 			wantOrder:     []string{"small", "medium", "large"},
 		},
 		"LeastFreeCapacity: podCountWithLeader ascending as tiebreaker": {
-			domains: []*domain{
-				{id: "large", leaderCount: 1, sliceCountWithLeader: 5, podCountWithLeader: 100, levelValues: []string{"a"}},
-				{id: "small", leaderCount: 1, sliceCountWithLeader: 5, podCountWithLeader: 10, levelValues: []string{"b"}},
-				{id: "medium", leaderCount: 1, sliceCountWithLeader: 5, podCountWithLeader: 50, levelValues: []string{"c"}},
+			domains: []testDomainSpec{
+				{
+					domain: domain{id: "large", levelValues: []string{"a"}},
+					state: domainState{
+						leaderCount:          1,
+						sliceCountWithLeader: 5,
+						podCountWithLeader:   100,
+					},
+				},
+				{
+					domain: domain{id: "small", levelValues: []string{"b"}},
+					state: domainState{
+						leaderCount:          1,
+						sliceCountWithLeader: 5,
+						podCountWithLeader:   10,
+					},
+				},
+				{
+					domain: domain{id: "medium", levelValues: []string{"c"}},
+					state: domainState{
+						leaderCount:          1,
+						sliceCountWithLeader: 5,
+						podCountWithLeader:   50,
+					},
+				},
 			},
 			unconstrained: true,
 			wantOrder:     []string{"small", "medium", "large"},
 		},
 		"levelValues ascending as final tiebreaker": {
-			domains: []*domain{
-				{id: "c", leaderCount: 1, sliceCountWithLeader: 5, podCountWithLeader: 10, levelValues: []string{"c"}},
-				{id: "a", leaderCount: 1, sliceCountWithLeader: 5, podCountWithLeader: 10, levelValues: []string{"a"}},
-				{id: "b", leaderCount: 1, sliceCountWithLeader: 5, podCountWithLeader: 10, levelValues: []string{"b"}},
+			domains: []testDomainSpec{
+				{
+					domain: domain{id: "c", levelValues: []string{"c"}},
+					state: domainState{
+						leaderCount:          1,
+						sliceCountWithLeader: 5,
+						podCountWithLeader:   10,
+					},
+				},
+				{
+					domain: domain{id: "a", levelValues: []string{"a"}},
+					state: domainState{
+						leaderCount:          1,
+						sliceCountWithLeader: 5,
+						podCountWithLeader:   10,
+					},
+				},
+				{
+					domain: domain{id: "b", levelValues: []string{"b"}},
+					state: domainState{
+						leaderCount:          1,
+						sliceCountWithLeader: 5,
+						podCountWithLeader:   10,
+					},
+				},
 			},
 			unconstrained: false,
 			wantOrder:     []string{"a", "b", "c"},
@@ -583,9 +778,9 @@ func TestSortedDomainsWithLeader(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			features.SetFeatureGateDuringTest(t, features.TASRespectNodeAffinityPreferred, tc.enableTASPreferredSchedulingAffinity)
 			_, log := utiltesting.ContextWithLog(t)
-			s := newTASFlavorSnapshot(log, "test", levels, nil)
+			s := newTASFlavorSnapshot(log, "test", newTopologyTree(levels, nil, 0), nil)
 
-			sorted := s.sortedDomainsWithLeader(tc.domains, tc.unconstrained)
+			sorted := s.sortedDomainsWithLeader(addDomainsWithState(s, tc.domains), tc.unconstrained)
 
 			gotOrder := make([]string, len(sorted))
 			for i, d := range sorted {
@@ -608,70 +803,188 @@ func TestSortedDomains(t *testing.T) {
 	levels := []string{"block"}
 
 	testCases := map[string]struct {
-		domains                              []*domain
+		domains                              []testDomainSpec
 		unconstrained                        bool
 		enableTASPreferredSchedulingAffinity bool
 		wantOrder                            []string
 	}{
 		"affinityScore descending: higher affinity score comes first": {
 			enableTASPreferredSchedulingAffinity: true,
-			domains: []*domain{
-				{id: "low-affinity", affinityScore: 10, sliceCount: 5, podCount: 10, levelValues: []string{"a"}},
-				{id: "high-affinity", affinityScore: 100, sliceCount: 5, podCount: 10, levelValues: []string{"b"}},
+			domains: []testDomainSpec{
+				{
+					domain: domain{id: "low-affinity", levelValues: []string{"a"}},
+					state: domainState{
+						affinityScore: 10,
+						sliceCount:    5,
+						podCount:      10,
+					},
+				},
+				{
+					domain: domain{id: "high-affinity", levelValues: []string{"b"}},
+					state: domainState{
+						affinityScore: 100,
+						sliceCount:    5,
+						podCount:      10,
+					},
+				},
 			},
 			unconstrained: false,
 			wantOrder:     []string{"high-affinity", "low-affinity"},
 		},
 		"affinityScore ignored when feature gate is disabled": {
 			enableTASPreferredSchedulingAffinity: false,
-			domains: []*domain{
-				{id: "low-affinity", affinityScore: 10, sliceCount: 5, podCount: 10, levelValues: []string{"a"}},
-				{id: "high-affinity", affinityScore: 100, sliceCount: 5, podCount: 10, levelValues: []string{"b"}},
+			domains: []testDomainSpec{
+				{
+					domain: domain{id: "low-affinity", levelValues: []string{"a"}},
+					state: domainState{
+						affinityScore: 10,
+						sliceCount:    5,
+						podCount:      10,
+					},
+				},
+				{
+					domain: domain{id: "high-affinity", levelValues: []string{"b"}},
+					state: domainState{
+						affinityScore: 100,
+						sliceCount:    5,
+						podCount:      10,
+					},
+				},
 			},
 			unconstrained: false,
 			wantOrder:     []string{"low-affinity", "high-affinity"},
 		},
 		"BestFit: sliceCount descending": {
-			domains: []*domain{
-				{id: "a", sliceCount: 3, podCount: 1, levelValues: []string{"a"}},
-				{id: "b", sliceCount: 1, podCount: 1, levelValues: []string{"b"}},
-				{id: "c", sliceCount: 2, podCount: 1, levelValues: []string{"c"}},
+			domains: []testDomainSpec{
+				{
+					domain: domain{id: "a", levelValues: []string{"a"}},
+					state: domainState{
+						sliceCount: 3,
+						podCount:   1,
+					},
+				},
+				{
+					domain: domain{id: "b", levelValues: []string{"b"}},
+					state: domainState{
+						sliceCount: 1,
+						podCount:   1,
+					},
+				},
+				{
+					domain: domain{id: "c", levelValues: []string{"c"}},
+					state: domainState{
+						sliceCount: 2,
+						podCount:   1,
+					},
+				},
 			},
 			unconstrained: false,
 			wantOrder:     []string{"a", "c", "b"},
 		},
 		"LeastFreeCapacity: sliceCount ascending": {
-			domains: []*domain{
-				{id: "a", sliceCount: 3, podCount: 1, levelValues: []string{"a"}},
-				{id: "b", sliceCount: 1, podCount: 1, levelValues: []string{"b"}},
-				{id: "c", sliceCount: 2, podCount: 1, levelValues: []string{"c"}},
+			domains: []testDomainSpec{
+				{
+					domain: domain{id: "a", levelValues: []string{"a"}},
+					state: domainState{
+						sliceCount: 3,
+						podCount:   1,
+					},
+				},
+				{
+					domain: domain{id: "b", levelValues: []string{"b"}},
+					state: domainState{
+						sliceCount: 1,
+						podCount:   1,
+					},
+				},
+				{
+					domain: domain{id: "c", levelValues: []string{"c"}},
+					state: domainState{
+						sliceCount: 2,
+						podCount:   1,
+					},
+				},
 			},
 			unconstrained: true,
 			wantOrder:     []string{"b", "c", "a"},
 		},
 		"BestFit: state ascending as tiebreaker": {
-			domains: []*domain{
-				{id: "large", sliceCount: 5, podCount: 100, levelValues: []string{"a"}},
-				{id: "small", sliceCount: 5, podCount: 10, levelValues: []string{"b"}},
-				{id: "medium", sliceCount: 5, podCount: 50, levelValues: []string{"c"}},
+			domains: []testDomainSpec{
+				{
+					domain: domain{id: "large", levelValues: []string{"a"}},
+					state: domainState{
+						sliceCount: 5,
+						podCount:   100,
+					},
+				},
+				{
+					domain: domain{id: "small", levelValues: []string{"b"}},
+					state: domainState{
+						sliceCount: 5,
+						podCount:   10,
+					},
+				},
+				{
+					domain: domain{id: "medium", levelValues: []string{"c"}},
+					state: domainState{
+						sliceCount: 5,
+						podCount:   50,
+					},
+				},
 			},
 			unconstrained: false,
 			wantOrder:     []string{"small", "medium", "large"},
 		},
 		"LeastFreeCapacity: state ascending as tiebreaker": {
-			domains: []*domain{
-				{id: "large", sliceCount: 5, podCount: 100, levelValues: []string{"a"}},
-				{id: "small", sliceCount: 5, podCount: 10, levelValues: []string{"b"}},
-				{id: "medium", sliceCount: 5, podCount: 50, levelValues: []string{"c"}},
+			domains: []testDomainSpec{
+				{
+					domain: domain{id: "large", levelValues: []string{"a"}},
+					state: domainState{
+						sliceCount: 5,
+						podCount:   100,
+					},
+				},
+				{
+					domain: domain{id: "small", levelValues: []string{"b"}},
+					state: domainState{
+						sliceCount: 5,
+						podCount:   10,
+					},
+				},
+				{
+					domain: domain{id: "medium", levelValues: []string{"c"}},
+					state: domainState{
+						sliceCount: 5,
+						podCount:   50,
+					},
+				},
 			},
 			unconstrained: true,
 			wantOrder:     []string{"small", "medium", "large"},
 		},
 		"levelValues ascending as final tiebreaker": {
-			domains: []*domain{
-				{id: "c", sliceCount: 5, podCount: 10, levelValues: []string{"c"}},
-				{id: "a", sliceCount: 5, podCount: 10, levelValues: []string{"a"}},
-				{id: "b", sliceCount: 5, podCount: 10, levelValues: []string{"b"}},
+			domains: []testDomainSpec{
+				{
+					domain: domain{id: "c", levelValues: []string{"c"}},
+					state: domainState{
+						sliceCount: 5,
+						podCount:   10,
+					},
+				},
+				{
+					domain: domain{id: "a", levelValues: []string{"a"}},
+					state: domainState{
+						sliceCount: 5,
+						podCount:   10,
+					},
+				},
+				{
+					domain: domain{id: "b", levelValues: []string{"b"}},
+					state: domainState{
+						sliceCount: 5,
+						podCount:   10,
+					},
+				},
 			},
 			unconstrained: false,
 			wantOrder:     []string{"a", "b", "c"},
@@ -682,9 +995,9 @@ func TestSortedDomains(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			features.SetFeatureGateDuringTest(t, features.TASRespectNodeAffinityPreferred, tc.enableTASPreferredSchedulingAffinity)
 			_, log := utiltesting.ContextWithLog(t)
-			s := newTASFlavorSnapshot(log, "test", levels, nil)
+			s := newTASFlavorSnapshot(log, "test", newTopologyTree(levels, nil, 0), nil)
 
-			sorted := s.sortedDomains(tc.domains, tc.unconstrained)
+			sorted := s.sortedDomains(addDomainsWithState(s, tc.domains), tc.unconstrained)
 
 			gotOrder := make([]string, len(sorted))
 			for i, d := range sorted {
@@ -746,7 +1059,7 @@ func TestCompareDomainLevelValues(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			s := newTASFlavorSnapshot(log, "test", tc.levels, nil)
+			s := newTASFlavorSnapshot(log, "test", newTopologyTree(tc.levels, nil, 0), nil)
 			got := s.compareDomainLevelValues(tc.a, tc.b)
 			if (got < 0 && tc.want >= 0) || (got > 0 && tc.want <= 0) || (got == 0 && tc.want != 0) {
 				t.Errorf("compareDomainLevelValues() = %d, want sign matching %d", got, tc.want)
@@ -1058,7 +1371,6 @@ func TestTASCachingRemainingResourcesFeatureGate(t *testing.T) {
 			features.SetFeatureGateDuringTest(t, features.TASCachingRemainingResources, enableCaching)
 
 			_, log := utiltesting.ContextWithLog(t)
-			snapshot := newTASFlavorSnapshot(log, "tas-topology", []string{"hostname"}, nil)
 			nodeObj := node.MakeNode("node-a").
 				Label("hostname", "node-a").
 				StatusAllocatable(corev1.ResourceList{
@@ -1067,7 +1379,8 @@ func TestTASCachingRemainingResourcesFeatureGate(t *testing.T) {
 				}).
 				Ready().
 				Obj()
-			domainID := snapshot.addNode(nodeObj)
+			snapshot := newTASFlavorSnapshot(log, "tas-topology", newTopologyTree([]string{"hostname"}, []*corev1.Node{nodeObj}, 0), nil)
+			domainID := snapshot.nodeToDomain[nodeObj.Name]
 
 			leaf := snapshot.leaves[domainID]
 			g.Expect(leaf).ToNot(gomega.BeNil())
@@ -1106,12 +1419,7 @@ func TestTASCachingRemainingResourcesFeatureGate(t *testing.T) {
 func newTestSnapshot(t *testing.T, levels []string, nodes ...*corev1.Node) *TASFlavorSnapshot {
 	t.Helper()
 	_, log := utiltesting.ContextWithLog(t)
-	s := newTASFlavorSnapshot(log, "dummy", levels, nil)
-	for _, n := range nodes {
-		s.addNode(n)
-	}
-	s.initialize()
-	return s
+	return newTASFlavorSnapshot(log, "dummy", newTopologyTree(levels, nodes, 0), nil)
 }
 
 func TestInitializeDomainIDCollision(t *testing.T) {
@@ -1250,20 +1558,22 @@ func TestUpdateCountsToMinimumGenericLogsLeafSummary(t *testing.T) {
 	// node. Their identifiers must not end up in the error entry, which is not
 	// gated by the verbosity level.
 	newSnapshot := func(log logr.Logger) *TASFlavorSnapshot {
-		snapshot := newTASFlavorSnapshot(log, "tas-topology", []string{corev1.LabelHostname}, nil)
+		nodes := make([]*corev1.Node, 0, 2)
 		for _, name := range []string{"node-a", "node-b"} {
-			snapshot.addNode(node.MakeNode(name).
+			nodes = append(nodes, node.MakeNode(name).
 				Label(corev1.LabelHostname, name).
 				StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("8")}).
 				Ready().
 				Obj())
 		}
-		return snapshot
+		return newTASFlavorSnapshot(log, "tas-topology", newTopologyTree([]string{corev1.LabelHostname}, nodes, 0), nil)
 	}
 	// A single domain with room for one pod cannot accommodate the ten requested
 	// ones, which violates the assumptions of the algorithm.
 	callWithViolatedAssumptions := func(snapshot *TASFlavorSnapshot) []*domain {
-		return snapshot.updateCountsToMinimumGeneric([]*domain{{id: "rack-1", podCount: 1}}, 10, 0, 1, false, false)
+		dom := &domain{id: "rack-1", idx: 0}
+		snapshot.domainStateOf(dom).podCount = 1
+		return snapshot.updateCountsToMinimumGeneric([]*domain{dom}, 10, 0, 1, false, false)
 	}
 	wantErrorFields := map[string]any{
 		"error":                "code assumptions violated",

--- a/pkg/cache/scheduler/tas_flavor_test.go
+++ b/pkg/cache/scheduler/tas_flavor_test.go
@@ -138,3 +138,27 @@ func TestTASFlavorCacheAddAndRemoveUsage(t *testing.T) {
 		})
 	}
 }
+
+func TestStoreTreeReturnsNewest(t *testing.T) {
+	cache := &TASFlavorCache{}
+	newer := &topologyTree{generation: 2}
+	if got := cache.storeTree(newer); got != newer {
+		t.Fatal("storeTree did not return the newly stored tree")
+	}
+
+	older := &topologyTree{generation: 1}
+	if got := cache.storeTree(older); got != newer {
+		t.Fatal("storeTree returned an older tree instead of the cached tree")
+	}
+	if got := cache.cachedTree(); got != newer {
+		t.Fatal("storeTree replaced the cached tree with an older tree")
+	}
+
+	equalGeneration := &topologyTree{generation: 2}
+	if got := cache.storeTree(equalGeneration); got != newer {
+		t.Fatal("storeTree did not return the cached tree for an equal generation")
+	}
+	if got := cache.cachedTree(); got != newer {
+		t.Fatal("storeTree replaced the cached tree with an equal-generation tree")
+	}
+}

--- a/pkg/cache/scheduler/tas_nodes_cache.go
+++ b/pkg/cache/scheduler/tas_nodes_cache.go
@@ -17,17 +17,29 @@ limitations under the License.
 package scheduler
 
 import (
+	"maps"
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 )
 
 type nodesCache struct {
-	lock  sync.RWMutex
+	lock sync.RWMutex
+
+	// nodes stores stripped Node views that nodesCache treats as immutable. sync
+	// replaces an entry rather than mutating it. The views share Labels, Taints,
+	// and Allocatable with the input Node, so callers must not mutate those fields
+	// after sync.
 	nodes map[string]*corev1.Node
+
+	// generation counts changes to scheduling-relevant node data. It increments
+	// when a node is added or removed, or when its labels, taints, or allocatable
+	// resources change - not on every Node update event.
+	generation int64
 }
 
 func newNodesCache() *nodesCache {
@@ -43,11 +55,16 @@ func (t *nodesCache) sync(node *corev1.Node) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
-	if schedulableAndReady {
-		t.nodes[node.Name] = copyAndStripNode(node)
-	} else {
+	if !schedulableAndReady {
 		t.deleteWithoutLock(node.Name)
+		return
 	}
+	stripped := copyAndStripNode(node)
+	if existing, found := t.nodes[node.Name]; found && strippedNodesEqual(existing, stripped) {
+		return
+	}
+	t.nodes[node.Name] = stripped
+	t.generation++
 }
 
 func (t *nodesCache) delete(nodeName string) {
@@ -57,10 +74,16 @@ func (t *nodesCache) delete(nodeName string) {
 }
 
 func (t *nodesCache) deleteWithoutLock(nodeName string) {
-	delete(t.nodes, nodeName)
+	if _, found := t.nodes[nodeName]; found {
+		delete(t.nodes, nodeName)
+		t.generation++
+	}
 }
 
-func (t *nodesCache) find(nodeLabels map[string]string, levels []string) []*corev1.Node {
+// find returns the nodes matching the flavor along with the generation at
+// which they were read, so that structures derived from the result can later
+// be revalidated against currentGeneration.
+func (t *nodesCache) find(nodeLabels map[string]string, levels []string) ([]*corev1.Node, int64) {
 	t.lock.RLock()
 	defer t.lock.RUnlock()
 	filteredNodes := make([]*corev1.Node, 0, len(t.nodes))
@@ -69,7 +92,13 @@ func (t *nodesCache) find(nodeLabels map[string]string, levels []string) []*core
 			filteredNodes = append(filteredNodes, node)
 		}
 	}
-	return filteredNodes
+	return filteredNodes, t.generation
+}
+
+func (t *nodesCache) currentGeneration() int64 {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+	return t.generation
 }
 
 // copyAndStripNode creates a minimal copy of the Node object containing only the
@@ -90,4 +119,14 @@ func copyAndStripNode(node *corev1.Node) *corev1.Node {
 			Allocatable: node.Status.Allocatable,
 		},
 	}
+}
+
+// strippedNodesEqual reports whether two stripped nodes carry semantically
+// identical scheduling-relevant information. It is used to avoid bumping the
+// nodesCache generation for Node updates that do not affect TAS scheduling,
+// such as kubelet heartbeats.
+func strippedNodesEqual(a, b *corev1.Node) bool {
+	return maps.Equal(a.Labels, b.Labels) &&
+		equality.Semantic.DeepEqual(a.Spec.Taints, b.Spec.Taints) &&
+		equality.Semantic.DeepEqual(a.Status.Allocatable, b.Status.Allocatable)
 }

--- a/pkg/cache/scheduler/tas_nodes_cache_test.go
+++ b/pkg/cache/scheduler/tas_nodes_cache_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"sigs.k8s.io/kueue/pkg/util/testingjobs/node"
 )
@@ -142,11 +144,129 @@ func TestNodesCacheFind(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			gotNodes := nc.find(tc.nodeLabels, tc.levels)
+			gotNodes, _ := nc.find(tc.nodeLabels, tc.levels)
 			if diff := cmp.Diff(tc.wantNodes, gotNodes, cmpopts.SortSlices(func(a, b *corev1.Node) bool {
 				return a.Name < b.Name
 			})); diff != "" {
 				t.Errorf("Unexpected nodes (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestNodesCacheGeneration(t *testing.T) {
+	baseNode := func() *node.NodeWrapper {
+		return node.MakeNode("gen-test").
+			Label("cloud.provider.com/zone", "us-east-1a").
+			StatusAllocatable(corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("16Gi"),
+			}).
+			Ready()
+	}
+
+	testCases := map[string]struct {
+		prime     []*corev1.Node
+		op        func(nc *nodesCache)
+		wantDelta int64
+	}{
+		"sync of a new ready node bumps": {
+			op: func(nc *nodesCache) {
+				nc.sync(baseNode().Obj())
+			},
+			wantDelta: 1,
+		},
+		"re-sync of an identical node does not bump": {
+			prime: []*corev1.Node{baseNode().Obj()},
+			op: func(nc *nodesCache) {
+				nc.sync(baseNode().Obj())
+			},
+			wantDelta: 0,
+		},
+		"heartbeat-only update does not bump": {
+			prime: []*corev1.Node{baseNode().Obj()},
+			op: func(nc *nodesCache) {
+				nc.sync(baseNode().
+					ResourceVersion("2").
+					ConditionHeartbeat(corev1.NodeReady, metav1.Now()).
+					Obj())
+			},
+			wantDelta: 0,
+		},
+		"equivalent allocatable expressed in different units does not bump": {
+			prime: []*corev1.Node{baseNode().Obj()},
+			op: func(nc *nodesCache) {
+				nc.sync(baseNode().StatusAllocatable(corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("4000m"),
+					corev1.ResourceMemory: resource.MustParse("16Gi"),
+				}).Obj())
+			},
+			wantDelta: 0,
+		},
+		"label change bumps": {
+			prime: []*corev1.Node{baseNode().Obj()},
+			op: func(nc *nodesCache) {
+				nc.sync(baseNode().Label("cloud.provider.com/zone", "us-east-1b").Obj())
+			},
+			wantDelta: 1,
+		},
+		"allocatable change bumps": {
+			prime: []*corev1.Node{baseNode().Obj()},
+			op: func(nc *nodesCache) {
+				nc.sync(baseNode().StatusAllocatable(corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("8"),
+					corev1.ResourceMemory: resource.MustParse("16Gi"),
+				}).Obj())
+			},
+			wantDelta: 1,
+		},
+		"taint change bumps": {
+			prime: []*corev1.Node{baseNode().Obj()},
+			op: func(nc *nodesCache) {
+				nc.sync(baseNode().Taints(corev1.Taint{
+					Key:    "example.com/gpu",
+					Effect: corev1.TaintEffectNoSchedule,
+				}).Obj())
+			},
+			wantDelta: 1,
+		},
+		"transition to unschedulable removes the node and bumps": {
+			prime: []*corev1.Node{baseNode().Obj()},
+			op: func(nc *nodesCache) {
+				nc.sync(baseNode().Unschedulable().Obj())
+			},
+			wantDelta: 1,
+		},
+		"sync of an absent not-ready node does not bump": {
+			op: func(nc *nodesCache) {
+				nc.sync(node.MakeNode("gen-test").Obj())
+			},
+			wantDelta: 0,
+		},
+		"delete of an existing node bumps": {
+			prime: []*corev1.Node{baseNode().Obj()},
+			op: func(nc *nodesCache) {
+				nc.delete("gen-test")
+			},
+			wantDelta: 1,
+		},
+		"delete of an absent node does not bump": {
+			op: func(nc *nodesCache) {
+				nc.delete("other")
+			},
+			wantDelta: 0,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			nc := newNodesCache()
+			for _, n := range tc.prime {
+				nc.sync(n)
+			}
+			before := nc.currentGeneration()
+			tc.op(nc)
+			if delta := nc.currentGeneration() - before; delta != tc.wantDelta {
+				t.Errorf("unexpected generation delta: got %d, want %d", delta, tc.wantDelta)
 			}
 		})
 	}

--- a/pkg/cache/scheduler/tas_topology_tree.go
+++ b/pkg/cache/scheduler/tas_topology_tree.go
@@ -1,0 +1,227 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"slices"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/kueue/pkg/resources"
+	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
+)
+
+// domain holds the static information about placement of a topology
+// domain in the hierarchy of topology domains.
+// Its per-snapshot mutable state lives in TASFlavorSnapshot.domainStates,
+// addressed by idx.
+type domain struct {
+	// id identifies the domain within its topology level
+	id utiltas.TopologyDomainID
+
+	// idx is the dense index of the domain within its topologyTree, used to
+	// address the per-snapshot state in TASFlavorSnapshot.domainStates.
+	idx int
+
+	// parent points to domain which is a parent in topology structure
+	parent *domain
+
+	// children points to domains which are children in topology structure
+	children []*domain
+
+	// levelValues stores the mapping from domain ID back to the
+	// ordered list of values
+	levelValues []string
+}
+
+// leafDomain extends the domain with static information for the lowest-level
+// domain. Its per-snapshot mutable capacity data lives in
+// TASFlavorSnapshot.leafCapacities, addressed by leafIdx.
+type leafDomain struct {
+	domain
+
+	// leafIdx is the dense index of the leaf within its topologyTree, used
+	// to address the per-snapshot capacity data in TASFlavorSnapshot.leafCapacities.
+	leafIdx int
+
+	// capacity is the static capacity of the leaf: the summed allocatable of
+	// its nodes, before subtracting any usage.
+	capacity resources.Requests
+
+	// node at the leaf, if the lowest level is a node
+	node *corev1.Node
+}
+
+type domainByID map[utiltas.TopologyDomainID]*domain
+type leafDomainByID map[utiltas.TopologyDomainID]*leafDomain
+
+// topologyTree holds the static topology structure derived from the node set
+// at a given nodesCache generation: the domain hierarchy, the per-leaf static
+// capacity and the node membership. It is built once per generation, cached
+// on the TASFlavorCache, and shared read-only by every snapshot created from it.
+// All mutable per-cycle values live on the TASFlavorSnapshot instead, so
+// concurrent snapshots never share mutable state.
+type topologyTree struct {
+	// generation is the nodesCache generation the tree was built from.
+	generation int64
+
+	// levelKeys denotes the ordered list of topology keys set as label keys
+	// on the Topology object
+	levelKeys []string
+
+	// leaves maps domainID to domains that are at the lowest level of topology structure
+	leaves leafDomainByID
+
+	// roots maps domainID to domains that are at the highest level of topology structure
+	roots domainByID
+
+	// domainCount is the number of allocated domains. Domain IDs are not unique
+	// across levels, so it counts domains rather than distinct IDs.
+	domainCount int
+
+	// domainsPerLevel stores the static tree information
+	domainsPerLevel []domainByID
+
+	// isLowestLevelNode indicates if kubernetes.io/hostname is the lowest topology level
+	isLowestLevelNode bool
+
+	// nodes lists the nodes matching the flavor which the tree was built
+	// from.
+	nodes []*corev1.Node
+
+	// nodeToDomain maps node names to their leaf domain ID, used to apply
+	// per-node non-TAS usage onto snapshots.
+	nodeToDomain map[string]utiltas.TopologyDomainID
+}
+
+// newTopologyTree builds the static topology structure from the given node
+// set, read at the given nodesCache generation.
+func newTopologyTree(levels []string, nodes []*corev1.Node, generation int64) *topologyTree {
+	domainsPerLevel := make([]domainByID, len(levels))
+	for level := range levels {
+		domainsPerLevel[level] = make(domainByID)
+	}
+
+	tree := &topologyTree{
+		generation:        generation,
+		levelKeys:         slices.Clone(levels),
+		leaves:            make(leafDomainByID),
+		roots:             make(domainByID),
+		domainsPerLevel:   domainsPerLevel,
+		isLowestLevelNode: len(levels) > 0 && levels[len(levels)-1] == corev1.LabelHostname,
+		nodes:             slices.Clip(slices.Clone(nodes)),
+		nodeToDomain:      make(map[string]utiltas.TopologyDomainID, len(nodes)),
+	}
+	for _, node := range nodes {
+		tree.nodeToDomain[node.Name] = tree.addNode(node)
+	}
+	tree.initialize()
+	return tree
+}
+
+func (t *topologyTree) addNode(node *corev1.Node) utiltas.TopologyDomainID {
+	var levelValues []string
+	var domainID utiltas.TopologyDomainID
+	var leafFound bool
+
+	if t.isLowestLevelNode {
+		// When the lowest level is kubernetes.io/hostname, directly extract hostname.
+		hostname := node.Labels[corev1.LabelHostname]
+		domainID = utiltas.TopologyDomainID(hostname)
+		_, leafFound = t.leaves[domainID]
+		// Only compute levelValues when we actually need to create a new leafDomain.
+		if !leafFound {
+			levelValues = utiltas.LevelValues(t.levelKeys, node.Labels)
+		}
+	} else {
+		// Compute full level values and domain ID.
+		levelValues = utiltas.LevelValues(t.levelKeys, node.Labels)
+		domainID = utiltas.DomainID(levelValues)
+		_, leafFound = t.leaves[domainID]
+	}
+	if !leafFound {
+		leafDomain := leafDomain{
+			domain:  domain{id: domainID, levelValues: levelValues},
+			leafIdx: len(t.leaves),
+		}
+
+		if t.isLowestLevelNode {
+			leafDomain.node = node
+		}
+		t.leaves[domainID] = &leafDomain
+	}
+	capacity := resources.NewRequestsFromResourceList(node.Status.Allocatable)
+	t.addCapacity(domainID, capacity)
+	return domainID
+}
+
+func (t *topologyTree) lowestLevel() string {
+	return t.levelKeys[len(t.levelKeys)-1]
+}
+
+func (t *topologyTree) highestLevel() string {
+	return t.levelKeys[0]
+}
+
+func (t *topologyTree) indexDomain(dom *domain) {
+	dom.idx = t.domainCount
+	t.domainCount++
+}
+
+// initialize prepares the topology tree structure. This structure holds
+// for a given the list of topology domains with additional static
+// information. This function initializes the static information which
+// represents the edges to the parent and child domains, and assigns each
+// domain its dense index used to address per-snapshot state. This structure
+// is reused by all snapshots until the node set changes.
+func (t *topologyTree) initialize() {
+	for _, leafDomain := range t.leaves {
+		domain := &leafDomain.domain
+		t.indexDomain(domain)
+		t.domainsPerLevel[len(domain.levelValues)-1][domain.id] = domain
+		t.initializeHelper(domain)
+	}
+}
+
+// initializeHelper is a recursive helper for initialize() method
+func (t *topologyTree) initializeHelper(dom *domain) {
+	if len(dom.levelValues) == 1 {
+		t.roots[dom.id] = dom
+		return
+	}
+	parentValues := dom.levelValues[:len(dom.levelValues)-1]
+	parentID := utiltas.DomainID(parentValues)
+	parent, parentFound := t.domainsPerLevel[len(parentValues)-1][parentID]
+	if !parentFound {
+		// create parent
+		parent = &domain{id: parentID, levelValues: parentValues}
+		t.indexDomain(parent)
+
+		t.domainsPerLevel[len(parentValues)-1][parentID] = parent
+		t.initializeHelper(parent)
+	}
+	// connect parent and child
+	dom.parent = parent
+	parent.children = append(parent.children, dom)
+}
+
+func (t *topologyTree) addCapacity(domainID utiltas.TopologyDomainID, capacity resources.Requests) {
+	if t.leaves[domainID].capacity == nil {
+		t.leaves[domainID].capacity = resources.NewRequests()
+	}
+	t.leaves[domainID].capacity.Add(capacity)
+}

--- a/pkg/cache/scheduler/tas_topology_tree_test.go
+++ b/pkg/cache/scheduler/tas_topology_tree_test.go
@@ -1,0 +1,439 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/resources"
+	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	testingnode "sigs.k8s.io/kueue/pkg/util/testingjobs/node"
+	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
+	"sigs.k8s.io/kueue/pkg/workload"
+)
+
+const (
+	treeTestBlockLabel = "cloud.provider.com/topology-block"
+	treeTestRackLabel  = "cloud.provider.com/topology-rack"
+)
+
+func makeTreeTestNode(name, block, rack string) *corev1.Node {
+	return testingnode.MakeNode(name).
+		Label(treeTestBlockLabel, block).
+		Label(treeTestRackLabel, rack).
+		Label(corev1.LabelHostname, name).
+		StatusAllocatable(corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("4"),
+			corev1.ResourceMemory: resource.MustParse("16Gi"),
+			corev1.ResourcePods:   resource.MustParse("110"),
+		}).
+		Ready().
+		Obj()
+}
+
+func treeTestBalancedRequests(name kueue.PodSetReference) FlavorTASRequests {
+	preferredLevel := treeTestRackLabel
+	return FlavorTASRequests{{
+		PodSet: &kueue.PodSet{
+			Name: name,
+			TopologyRequest: &kueue.PodSetTopologyRequest{
+				Preferred: &preferredLevel,
+			},
+		},
+		SinglePodRequests: resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourceCPU: 1000}),
+		Count:             6,
+	}}
+}
+
+func TestNewTopologyTreeCopiesAndRightSizesNodeSlice(t *testing.T) {
+	nodes := make([]*corev1.Node, 1, 100)
+	nodes[0] = makeTreeTestNode("n1", "b1", "r1")
+
+	tree := newTopologyTree([]string{corev1.LabelHostname}, nodes, 0)
+	if got, want := cap(tree.nodes), len(tree.nodes); got != want {
+		t.Errorf("tree.nodes capacity = %d, want %d", got, want)
+	}
+
+	nodes[0] = nil
+	if tree.nodes[0] == nil {
+		t.Error("topology tree retained the input node slice")
+	}
+}
+
+// domainKey identifies a domain in the dumps below. A leaf and root can share
+// an ID, so the level is part of the key.
+type domainKey struct {
+	Level int
+	ID    utiltas.TopologyDomainID
+}
+
+func domainKeyOf(dom *domain) domainKey {
+	return domainKey{Level: len(dom.levelValues) - 1, ID: dom.id}
+}
+
+func (k domainKey) compare(other domainKey) int {
+	if k.Level != other.Level {
+		return k.Level - other.Level
+	}
+	return strings.Compare(string(k.ID), string(other.ID))
+}
+
+// snapshotDomainDump is a comparison representation of one domain of a
+// TASFlavorSnapshot, used to verify that snapshots sharing a cached topology
+// tree behave exactly like snapshots built from scratch.
+type snapshotDomainDump struct {
+	Parent       domainKey
+	Children     []domainKey
+	LevelValues  []string
+	Root         bool
+	Leaf         bool
+	NodeName     string
+	FreeCapacity resources.Requests
+	TASUsage     resources.Requests
+}
+
+func dumpSnapshotTree(t *testing.T, s *TASFlavorSnapshot) map[domainKey]snapshotDomainDump {
+	t.Helper()
+	perLevelCount := 0
+	for _, level := range s.domainsPerLevel {
+		perLevelCount += len(level)
+	}
+	if perLevelCount != s.domainCount {
+		t.Errorf("domainsPerLevel holds %d domains, want %d", perLevelCount, s.domainCount)
+	}
+	dump := make(map[domainKey]snapshotDomainDump, perLevelCount)
+	for _, level := range s.domainsPerLevel {
+		for id, dom := range level {
+			d := snapshotDomainDump{
+				LevelValues: dom.levelValues,
+				Root:        s.roots[id] == dom,
+			}
+			if dom.parent != nil {
+				d.Parent = domainKeyOf(dom.parent)
+			}
+			for _, child := range dom.children {
+				d.Children = append(d.Children, domainKeyOf(child))
+			}
+			slices.SortFunc(d.Children, domainKey.compare)
+			if leaf, found := s.leaves[id]; found && &leaf.domain == dom {
+				d.Leaf = true
+				leafCapacity := s.leafCapacityOf(leaf)
+				if leafCapacity.freeCapacity != nil {
+					d.FreeCapacity = leafCapacity.freeCapacity.Clone()
+				}
+				if leafCapacity.tasUsage != nil {
+					d.TASUsage = leafCapacity.tasUsage.Clone()
+				}
+				if leaf.node != nil {
+					d.NodeName = leaf.node.Name
+				}
+			}
+			dump[domainKeyOf(dom)] = d
+		}
+	}
+	return dump
+}
+
+func TestSnapshotWithReusedTreeMatchesColdBuild(t *testing.T) {
+	testCases := map[string]struct {
+		levels         []string
+		tasUsageValues []string
+	}{
+		"lowest level is hostname": {
+			levels:         []string{treeTestBlockLabel, treeTestRackLabel, corev1.LabelHostname},
+			tasUsageValues: []string{"b1", "r1", "n1"},
+		},
+		"lowest level is not hostname": {
+			levels:         []string{treeTestBlockLabel, treeTestRackLabel},
+			tasUsageValues: []string{"b1", "r1"},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			_, log := utiltesting.ContextWithLog(t)
+			tasCache := NewTASCache(nil)
+			for _, n := range []*corev1.Node{
+				makeTreeTestNode("n1", "b1", "r1"),
+				makeTreeTestNode("n2", "b1", "r1"),
+				makeTreeTestNode("n3", "b1", "r2"),
+				makeTreeTestNode("n4", "b2", "r3"),
+			} {
+				tasCache.SyncNode(n)
+			}
+			tasCache.Update(testingpod.MakePod("bg-1", "default").
+				NodeName("n1").
+				Request(corev1.ResourceCPU, "500m").
+				StatusPhase(corev1.PodRunning).
+				Obj(), log)
+			fc := tasCache.NewTASFlavorCache(
+				topologyInformation{Levels: tc.levels},
+				flavorInformation{TopologyName: "default"},
+			)
+			fc.addUsage(log, "wl", []workload.TopologyDomainRequests{{
+				Values:            tc.tasUsageValues,
+				SinglePodRequests: resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourceCPU: 1000}),
+				Count:             2,
+			}})
+
+			cold := fc.snapshot(log, nil)
+			tree := fc.cachedTree()
+			if tree == nil {
+				t.Fatal("expected the cold build to store the topology tree")
+			}
+			reused := fc.snapshot(log, nil)
+			if fc.cachedTree() != tree {
+				t.Error("expected the second snapshot to reuse the cached tree, but it was rebuilt")
+			}
+			if reused.topologyTree != tree {
+				t.Error("expected the second snapshot to share the cached tree")
+			}
+			if diff := cmp.Diff(dumpSnapshotTree(t, cold), dumpSnapshotTree(t, reused), cmp.Comparer(resources.Equal)); diff != "" {
+				t.Errorf("unexpected difference between cold-built and tree-reusing snapshots (-cold,+reused):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSnapshotsSharingTreeAreIsolated(t *testing.T) {
+	_, log := utiltesting.ContextWithLog(t)
+	tasCache := NewTASCache(nil)
+	tasCache.SyncNode(makeTreeTestNode("n1", "b1", "r1"))
+	tasCache.SyncNode(makeTreeTestNode("n2", "b1", "r2"))
+	fc := tasCache.NewTASFlavorCache(
+		topologyInformation{Levels: []string{treeTestBlockLabel, treeTestRackLabel, corev1.LabelHostname}},
+		flavorInformation{TopologyName: "default"},
+	)
+
+	first := fc.snapshot(log, nil)
+	second := fc.snapshot(log, nil)
+	leafID := utiltas.TopologyDomainID("n1")
+	if first.leaves[leafID] != second.leaves[leafID] {
+		t.Fatal("expected both snapshots to share the tree's leaf domain")
+	}
+	firstDump := dumpSnapshotTree(t, first)
+
+	// Mutating one snapshot, as the scheduler does during a cycle, must not
+	// leak into snapshots of other cycles.
+	second.addTASUsage(leafID, resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourceCPU: 1000}))
+	second.addNonTASUsage(leafID, resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourceCPU: 500}))
+	third := fc.snapshot(log, nil)
+	if diff := cmp.Diff(firstDump, dumpSnapshotTree(t, third), cmp.Comparer(resources.Equal)); diff != "" {
+		t.Errorf("usage applied to one snapshot leaked into another (-first,+third):\n%s", diff)
+	}
+}
+
+func TestSnapshotReuseAfterBalancedPlacement(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TASBalancedPlacement, true)
+	_, log := utiltesting.ContextWithLog(t)
+	tasCache := NewTASCache(nil)
+	tasCache.SyncNode(makeTreeTestNode("n1", "b1", "r1"))
+	tasCache.SyncNode(makeTreeTestNode("n2", "b1", "r2"))
+	fc := tasCache.NewTASFlavorCache(
+		topologyInformation{Levels: []string{treeTestBlockLabel, treeTestRackLabel, corev1.LabelHostname}},
+		flavorInformation{TopologyName: "default"},
+	)
+	snapshot := fc.snapshot(log, nil)
+
+	requests := treeTestBalancedRequests("workers")
+	first := snapshot.FindTopologyAssignmentsForFlavor(log, requests)
+	if failure := first.Failure(); failure != nil {
+		t.Fatalf("first assignment failed: %s", failure.Reason)
+	}
+	if len(snapshot.domainStates) <= snapshot.domainCount {
+		t.Fatalf("balanced placement created %d state slots for %d base domains, want clone state", len(snapshot.domainStates), snapshot.domainCount)
+	}
+
+	second := snapshot.FindTopologyAssignmentsForFlavor(log, requests)
+	if failure := second.Failure(); failure != nil {
+		t.Fatalf("second assignment failed: %s", failure.Reason)
+	}
+	if diff := cmp.Diff(first, second); diff != "" {
+		t.Errorf("assignment changed after resetting clone state (-first,+second):\n%s", diff)
+	}
+}
+
+func TestSnapshotsSharingTreeCanAssignConcurrently(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TASBalancedPlacement, true)
+	_, log := utiltesting.ContextWithLog(t)
+	tasCache := NewTASCache(nil)
+	tasCache.SyncNode(makeTreeTestNode("n1", "b1", "r1"))
+	tasCache.SyncNode(makeTreeTestNode("n2", "b1", "r2"))
+	fc := tasCache.NewTASFlavorCache(
+		topologyInformation{Levels: []string{treeTestBlockLabel, treeTestRackLabel, corev1.LabelHostname}},
+		flavorInformation{TopologyName: "default"},
+	)
+
+	snapshots := make([]*TASFlavorSnapshot, 2)
+	for i := range snapshots {
+		snapshots[i] = fc.snapshot(log, nil)
+	}
+	if snapshots[0].topologyTree != snapshots[1].topologyTree {
+		t.Fatal("expected snapshots to share the cached topology tree")
+	}
+
+	start := make(chan struct{})
+	results := make(chan TASAssignmentsResult, len(snapshots))
+	for _, snapshot := range snapshots {
+		go func(snapshot *TASFlavorSnapshot) {
+			<-start
+			var result TASAssignmentsResult
+			for range 20 {
+				result = snapshot.FindTopologyAssignmentsForFlavor(log, treeTestBalancedRequests("workers"))
+				if result.Failure() != nil {
+					break
+				}
+			}
+			results <- result
+		}(snapshot)
+	}
+	close(start)
+
+	got := make([]TASAssignmentsResult, 0, len(snapshots))
+	for range snapshots {
+		result := <-results
+		if failure := result.Failure(); failure != nil {
+			t.Fatalf("concurrent assignment failed: %s", failure.Reason)
+		}
+		got = append(got, result)
+	}
+	if diff := cmp.Diff(got[0], got[1]); diff != "" {
+		t.Errorf("concurrent snapshots produced different assignments (-first,+second):\n%s", diff)
+	}
+}
+
+func TestTopologyTreeInvalidation(t *testing.T) {
+	tests := map[string]struct {
+		initialNodeLabels map[string]string
+		mutate            func(*tasCache, *TASFlavorCache)
+		wantTreeReused    bool
+		validate          func(*testing.T, *TASFlavorSnapshot)
+	}{
+		"heartbeat-only update": {
+			mutate: func(tasCache *tasCache, _ *TASFlavorCache) {
+				node := makeTreeTestNode("n1", "b1", "r1")
+				node.ResourceVersion = "2"
+				node.Status.Conditions[0].LastHeartbeatTime = metav1.Now()
+				tasCache.SyncNode(node)
+			},
+			wantTreeReused: true,
+		},
+		"allocatable change": {
+			mutate: func(tasCache *tasCache, _ *TASFlavorCache) {
+				node := makeTreeTestNode("n1", "b1", "r1")
+				node.Status.Allocatable[corev1.ResourceCPU] = resource.MustParse("8")
+				tasCache.SyncNode(node)
+			},
+			validate: func(t *testing.T, snapshot *TASFlavorSnapshot) {
+				n1State := snapshot.leafCapacityOf(snapshot.leaves[utiltas.TopologyDomainID("n1")])
+				if gotCapacity := n1State.freeCapacity.ResourceValue(corev1.ResourceCPU); gotCapacity != 8000 {
+					t.Errorf("snapshot has cpu capacity %d, want 8000", gotCapacity)
+				}
+			},
+		},
+		"node added": {
+			mutate: func(tasCache *tasCache, _ *TASFlavorCache) {
+				tasCache.SyncNode(makeTreeTestNode("n3", "b3", "r3"))
+			},
+			validate: func(t *testing.T, snapshot *TASFlavorSnapshot) {
+				if _, found := snapshot.domainsPerLevel[0][utiltas.DomainID([]string{"b3"})]; !found {
+					t.Error("snapshot does not contain the added node's block domain")
+				}
+			},
+		},
+		"node deletion": {
+			mutate: func(tasCache *tasCache, _ *TASFlavorCache) {
+				tasCache.DeleteNodeByName("n2")
+			},
+			validate: func(t *testing.T, snapshot *TASFlavorSnapshot) {
+				if _, found := snapshot.domainsPerLevel[0][utiltas.DomainID([]string{"b2"})]; found {
+					t.Error("snapshot still contains the deleted node's block domain")
+				}
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, log := utiltesting.ContextWithLog(t)
+			tasCache := NewTASCache(nil)
+			tasCache.SyncNode(makeTreeTestNode("n1", "b1", "r1"))
+			tasCache.SyncNode(makeTreeTestNode("n2", "b2", "r2"))
+			fc := tasCache.NewTASFlavorCache(
+				topologyInformation{Levels: []string{treeTestBlockLabel, treeTestRackLabel, corev1.LabelHostname}},
+				flavorInformation{TopologyName: "default", NodeLabels: tc.initialNodeLabels},
+			)
+
+			fc.snapshot(log, nil)
+			tree := fc.cachedTree()
+			if tree == nil {
+				t.Fatal("expected the cold build to store the topology tree")
+			}
+
+			tc.mutate(&tasCache, fc)
+			snapshot := fc.snapshot(log, nil)
+			if gotTreeReused := fc.cachedTree() == tree; gotTreeReused != tc.wantTreeReused {
+				t.Errorf("cached tree reused = %t, want %t", gotTreeReused, tc.wantTreeReused)
+			}
+			if tc.validate != nil {
+				tc.validate(t, snapshot)
+			}
+		})
+	}
+}
+
+func makeTopologyTreeWithCollidingLeafAndRootIDs() *topologyTree {
+	return newTopologyTree(
+		[]string{treeTestBlockLabel, corev1.LabelHostname},
+		[]*corev1.Node{
+			makeTreeTestNode("block-a", "block-b", "r1"),
+			makeTreeTestNode("block-b", "block-a", "r1"),
+		},
+		0,
+	)
+}
+
+func TestTopologyTreeStateIndexesWhenDomainIDsCollide(t *testing.T) {
+	_, log := utiltesting.ContextWithLog(t)
+	tree := makeTopologyTreeWithCollidingLeafAndRootIDs()
+	snapshot := newTASFlavorSnapshot(log, "default", tree, nil)
+	seen := make(map[int]*domain, tree.domainCount)
+	for _, levelDomains := range tree.domainsPerLevel {
+		for _, dom := range levelDomains {
+			if dom.idx < 0 || dom.idx >= len(snapshot.domainStates) {
+				t.Errorf("domain %q has state index %d, outside [0, %d)", dom.levelValues, dom.idx, len(snapshot.domainStates))
+				continue
+			}
+			if other, found := seen[dom.idx]; found {
+				t.Errorf("domains %q and %q share state index %d", other.levelValues, dom.levelValues, dom.idx)
+			}
+			seen[dom.idx] = dom
+		}
+	}
+	if got := len(seen); got != tree.domainCount {
+		t.Errorf("domains with state indexes = %d, want %d", got, tree.domainCount)
+	}
+}

--- a/pkg/cache/scheduler/tas_topology_tree_test.go
+++ b/pkg/cache/scheduler/tas_topology_tree_test.go
@@ -159,6 +159,7 @@ func dumpSnapshotTree(t *testing.T, s *TASFlavorSnapshot) map[domainKey]snapshot
 }
 
 func TestSnapshotWithReusedTreeMatchesColdBuild(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TASCacheTopologyTree, true)
 	testCases := map[string]struct {
 		levels         []string
 		tasUsageValues []string
@@ -219,6 +220,7 @@ func TestSnapshotWithReusedTreeMatchesColdBuild(t *testing.T) {
 }
 
 func TestSnapshotsSharingTreeAreIsolated(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TASCacheTopologyTree, true)
 	_, log := utiltesting.ContextWithLog(t)
 	tasCache := NewTASCache(nil)
 	tasCache.SyncNode(makeTreeTestNode("n1", "b1", "r1"))
@@ -243,6 +245,27 @@ func TestSnapshotsSharingTreeAreIsolated(t *testing.T) {
 	third := fc.snapshot(log, nil)
 	if diff := cmp.Diff(firstDump, dumpSnapshotTree(t, third), cmp.Comparer(resources.Equal)); diff != "" {
 		t.Errorf("usage applied to one snapshot leaked into another (-first,+third):\n%s", diff)
+	}
+}
+
+func TestSnapshotsDoNotShareTreeWhenCachingDisabled(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TASCacheTopologyTree, false)
+	_, log := utiltesting.ContextWithLog(t)
+	tasCache := NewTASCache(nil)
+	tasCache.SyncNode(makeTreeTestNode("n1", "b1", "r1"))
+	tasCache.SyncNode(makeTreeTestNode("n2", "b1", "r2"))
+	fc := tasCache.NewTASFlavorCache(
+		topologyInformation{Levels: []string{treeTestBlockLabel, treeTestRackLabel, corev1.LabelHostname}},
+		flavorInformation{TopologyName: "default"},
+	)
+
+	first := fc.snapshot(log, nil)
+	second := fc.snapshot(log, nil)
+	if first.topologyTree == second.topologyTree {
+		t.Error("snapshots share a topology tree while TASCacheTopologyTree is disabled")
+	}
+	if fc.cachedTree() != nil {
+		t.Error("the flavor cache retained a topology tree while TASCacheTopologyTree is disabled")
 	}
 }
 
@@ -277,6 +300,7 @@ func TestSnapshotReuseAfterBalancedPlacement(t *testing.T) {
 }
 
 func TestSnapshotsSharingTreeCanAssignConcurrently(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TASCacheTopologyTree, true)
 	features.SetFeatureGateDuringTest(t, features.TASBalancedPlacement, true)
 	_, log := utiltesting.ContextWithLog(t)
 	tasCache := NewTASCache(nil)
@@ -326,6 +350,7 @@ func TestSnapshotsSharingTreeCanAssignConcurrently(t *testing.T) {
 }
 
 func TestTopologyTreeInvalidation(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TASCacheTopologyTree, true)
 	tests := map[string]struct {
 		initialNodeLabels map[string]string
 		mutate            func(*tasCache, *TASFlavorCache)

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -495,6 +495,16 @@ const (
 	// Enables caching of remaining capacity and clone reduction in TAS Flavor Snapshot.
 	TASCachingRemainingResources featuregate.Feature = "TASCachingRemainingResources"
 
+	// owner: @tenzen-y
+	//
+	// issue: https://github.com/kubernetes-sigs/kueue/issues/12580
+	// Enables caching the immutable TAS topology tree on the TASFlavorCache and reusing it
+	// across scheduling cycles while the nodesCache generation is unchanged. When disabled,
+	// every snapshot builds a tree of its own and none is ever shared between snapshots,
+	// which is the behavior before the tree cache was introduced. Disabled by default, so a
+	// production TAS deployment opts in to the shared tree explicitly.
+	TASCacheTopologyTree featuregate.Feature = "TASCacheTopologyTree"
+
 	// owner: @j-skiba
 	//
 	// VectorizedResourceRequests enables slice-based indexing for resource requests in TAS snapshots,
@@ -859,6 +869,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 
 	TASCachingRemainingResources: {
 		{Version: version.MustParse("0.18"), Default: true, PreRelease: featuregate.Beta},
+	},
+
+	TASCacheTopologyTree: {
+		{Version: version.MustParse("0.18"), Default: false, PreRelease: featuregate.Alpha},
 	},
 
 	VectorizedResourceRequests: {

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -467,6 +467,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.18"
+- name: TASCacheTopologyTree
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.18"
 - name: TASCachingRemainingResources
   versionedSpecs:
   - default: true

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -467,6 +467,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.18"
+- name: TASCacheTopologyTree
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.18"
 - name: TASCachingRemainingResources
   versionedSpecs:
   - default: true


### PR DESCRIPTION
Cherry pick of #13819 on release-0.18.

#13819: refactor: Reuse TAS topology trees across scheduler snapshots

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
TAS: Reduced CPU time and memory allocations for snapshot creation by reusing cached topology trees when scheduling-relevant Node data is unchanged. Controlled by the `TASCacheTopologyTree` feature gate, which is Alpha and disabled by default.
```