### PR TITLE
test(e2e): add MultiKueue MutatingAdmissionPolicy suite for K8s 1.36

### DIFF
--- a/hack/make/test.mk
+++ b/hack/make/test.mk
@@ -406,6 +406,9 @@ test-e2e-dra: setup-e2e-env run-test-e2e-dra-$(E2E_KIND_VERSION:kindest/node:v%=
 .PHONY: test-e2e-multikueue-dra
 test-e2e-multikueue-dra: setup-e2e-env run-test-e2e-multikueue-dra-$(E2E_KIND_VERSION:kindest/node:v%=%) ## Run the MultiKueue Dynamic Resource Allocation (DRA) e2e test suite.
 
+.PHONY: test-e2e-multikueue-map
+test-e2e-multikueue-map: setup-e2e-env run-test-multikueue-e2e-map-$(E2E_KIND_VERSION:kindest/node:v%=%) ## Run the MultiKueue MutatingAdmissionPolicy e2e test suite.
+
 run-test-e2e-baseline-%: K8S_VERSION = $(@:run-test-e2e-baseline-%=%)
 run-test-e2e-baseline-%:
 	@echo Running baseline e2e for k8s ${K8S_VERSION}
@@ -636,6 +639,19 @@ run-test-e2e-multikueue-sequential-%:
 		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
 		CLUSTERPROFILE_VERSION=$(CLUSTERPROFILE_VERSION) \
 		CLUSTERPROFILE_PLUGIN_IMAGE_VERSION=$(CLUSTERPROFILE_PLUGIN_IMAGE_VERSION) \
+		E2E_USE_HELM=$(E2E_USE_HELM) \
+		./hack/testing/e2e-multikueue-test.sh
+
+run-test-multikueue-e2e-map-%: K8S_VERSION = $(@:run-test-multikueue-e2e-map-%=%)
+run-test-multikueue-e2e-map-%:
+	@echo Running MAP multikueue e2e for k8s ${K8S_VERSION}
+	E2E_KIND_VERSION="kindest/node:v$(K8S_VERSION)" KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) \
+		ARTIFACTS="$(ARTIFACTS)/$@" IMAGE_TAG=$(IMAGE_TAG) GINKGO_ARGS="$(E2E_GINKGO_ARGS)" \
+		E2E_MODE=$(E2E_MODE) \
+		E2E_SKIP_REINSTALL=$(E2E_SKIP_REINSTALL) \
+		E2E_TARGET_FOLDER="multikueue/map" \
+		E2E_CONFIG_FOLDER="multikueue/map" \
+		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
 		E2E_USE_HELM=$(E2E_USE_HELM) \
 		./hack/testing/e2e-multikueue-test.sh
 

--- a/hack/make/test.mk
+++ b/hack/make/test.mk
@@ -407,7 +407,9 @@ test-e2e-dra: setup-e2e-env run-test-e2e-dra-$(E2E_KIND_VERSION:kindest/node:v%=
 test-e2e-multikueue-dra: setup-e2e-env run-test-e2e-multikueue-dra-$(E2E_KIND_VERSION:kindest/node:v%=%) ## Run the MultiKueue Dynamic Resource Allocation (DRA) e2e test suite.
 
 .PHONY: test-e2e-multikueue-map
-test-e2e-multikueue-map: setup-e2e-env run-test-multikueue-e2e-map-$(E2E_KIND_VERSION:kindest/node:v%=%) ## Run the MultiKueue MutatingAdmissionPolicy e2e test suite.
+test-e2e-multikueue-map: E2E_MAP_K8S_VERSION ?= 1.36.1
+test-e2e-multikueue-map: setup-e2e-env
+	@$(MAKE) run-test-multikueue-e2e-map-$(E2E_MAP_K8S_VERSION) ## Run the MultiKueue MutatingAdmissionPolicy e2e test suite (Kubernetes 1.36+).
 
 run-test-e2e-baseline-%: K8S_VERSION = $(@:run-test-e2e-baseline-%=%)
 run-test-e2e-baseline-%:
@@ -645,6 +647,10 @@ run-test-e2e-multikueue-sequential-%:
 run-test-multikueue-e2e-map-%: K8S_VERSION = $(@:run-test-multikueue-e2e-map-%=%)
 run-test-multikueue-e2e-map-%:
 	@echo Running MAP multikueue e2e for k8s ${K8S_VERSION}
+	@if [ "$$(echo $(K8S_VERSION) | cut -d. -f1,2)" != "1.36" ]; then \
+		echo "Error: MutatingAdmissionPolicy MultiKueue e2e tests require Kubernetes 1.36+ (got $(K8S_VERSION))"; \
+		exit 1; \
+	fi
 	E2E_KIND_VERSION="kindest/node:v$(K8S_VERSION)" KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) \
 		ARTIFACTS="$(ARTIFACTS)/$@" IMAGE_TAG=$(IMAGE_TAG) GINKGO_ARGS="$(E2E_GINKGO_ARGS)" \
 		E2E_MODE=$(E2E_MODE) \

--- a/hack/make/test.mk
+++ b/hack/make/test.mk
@@ -409,7 +409,7 @@ test-e2e-multikueue-dra: setup-e2e-env run-test-e2e-multikueue-dra-$(E2E_KIND_VE
 .PHONY: test-e2e-multikueue-map
 test-e2e-multikueue-map: E2E_MAP_K8S_VERSION ?= 1.36.1
 test-e2e-multikueue-map: setup-e2e-env
-	@$(MAKE) run-test-multikueue-e2e-map-$(E2E_MAP_K8S_VERSION) ## Run the MultiKueue MutatingAdmissionPolicy e2e test suite (Kubernetes 1.36+).
+	@$(MAKE) run-test-multikueue-e2e-map-$(E2E_MAP_K8S_VERSION) ## Run the MultiKueue MutatingAdmissionPolicy e2e test suite (Kubernetes 1.36).
 
 run-test-e2e-baseline-%: K8S_VERSION = $(@:run-test-e2e-baseline-%=%)
 run-test-e2e-baseline-%:
@@ -648,7 +648,7 @@ run-test-multikueue-e2e-map-%: K8S_VERSION = $(@:run-test-multikueue-e2e-map-%=%
 run-test-multikueue-e2e-map-%:
 	@echo Running MAP multikueue e2e for k8s ${K8S_VERSION}
 	@if [ "$$(echo $(K8S_VERSION) | cut -d. -f1,2)" != "1.36" ]; then \
-		echo "Error: MutatingAdmissionPolicy MultiKueue e2e tests require Kubernetes 1.36+ (got $(K8S_VERSION))"; \
+		echo "Error: MutatingAdmissionPolicy MultiKueue e2e tests require Kubernetes 1.36 (got $(K8S_VERSION))"; \
 		exit 1; \
 	fi
 	E2E_KIND_VERSION="kindest/node:v$(K8S_VERSION)" KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) \

--- a/hack/make/test.mk
+++ b/hack/make/test.mk
@@ -407,6 +407,7 @@ test-e2e-dra: setup-e2e-env run-test-e2e-dra-$(E2E_KIND_VERSION:kindest/node:v%=
 test-e2e-multikueue-dra: setup-e2e-env run-test-e2e-multikueue-dra-$(E2E_KIND_VERSION:kindest/node:v%=%) ## Run the MultiKueue Dynamic Resource Allocation (DRA) e2e test suite.
 
 .PHONY: test-e2e-multikueue-map
+test-e2e-multikueue-map: export JOBSET_VERSION := $(JOBSET_VERSION)
 test-e2e-multikueue-map: E2E_MAP_K8S_VERSION ?= 1.36.1
 test-e2e-multikueue-map: setup-e2e-env
 	@$(MAKE) run-test-multikueue-e2e-map-$(E2E_MAP_K8S_VERSION) ## Run the MultiKueue MutatingAdmissionPolicy e2e test suite (Kubernetes 1.36).

--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -941,7 +941,11 @@ function cluster_kueue_deploy {
             build_and_apply_kueue_manifests "$1" "${ROOT_DIR}/test/e2e/config/dra/whole-device"
         fi
     elif [ "$E2E_USE_HELM" == 'true' ]; then
-        helm_install "$1" "${ROOT_DIR}/test/e2e/config/default/values.yaml"
+        local values_file="${ROOT_DIR}/test/e2e/config/${E2E_CONFIG_FOLDER:-default}/values.yaml"
+        if [[ ! -f "$values_file" ]]; then
+            values_file="${ROOT_DIR}/test/e2e/config/default/values.yaml"
+        fi
+        helm_install "$1" "$values_file"
     else
         build_and_apply_kueue_manifests "$1" "${ROOT_DIR}/test/e2e/config/${E2E_CONFIG_FOLDER:-default}"
     fi

--- a/test/e2e/config/multikueue/map/controller_manager_config.yaml
+++ b/test/e2e/config/multikueue/map/controller_manager_config.yaml
@@ -1,0 +1,36 @@
+apiVersion: config.kueue.x-k8s.io/v1beta2
+kind: Configuration
+metrics:
+  enableClusterQueueResources: true
+leaderElection:
+  leaderElect: true
+controller:
+  groupKindConcurrency:
+    Job.batch: 5
+    Pod: 5
+    Workload.kueue.x-k8s.io: 10
+    LocalQueue.kueue.x-k8s.io: 5
+    ClusterQueue.kueue.x-k8s.io: 5
+    ResourceFlavor.kueue.x-k8s.io: 1
+fairSharing:
+  preemptionStrategies: ["LessThanOrEqualToFinalShare", "LessThanInitialShare"]
+clientConnection:
+  qps: 300
+  burst: 500
+integrations:
+  frameworks:
+  - "batch/job"
+  - "pod"
+  - "deployment"
+  - "statefulset"
+featureGates:
+  MultiKueueManagerQuotaAutomation: true
+tls:
+  minVersion: "VersionTLS12"
+  cipherSuites:
+    - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+    - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+    - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+    - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+    - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+    - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384

--- a/test/e2e/config/multikueue/map/kustomization.yaml
+++ b/test/e2e/config/multikueue/map/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../baseline
+
+components:
+- ../../../../config/components/map

--- a/test/e2e/config/multikueue/map/kustomization.yaml
+++ b/test/e2e/config/multikueue/map/kustomization.yaml
@@ -3,6 +3,4 @@ kind: Kustomization
 
 resources:
 - ../../baseline
-
-components:
-- ../../../../config/components/map
+- ../../../../../config/components/map

--- a/test/e2e/config/multikueue/map/kustomization.yaml
+++ b/test/e2e/config/multikueue/map/kustomization.yaml
@@ -4,3 +4,11 @@ kind: Kustomization
 resources:
 - ../../baseline
 - ../../../../../config/components/map
+
+configMapGenerator:
+- behavior: merge
+  files:
+  - controller_manager_config.yaml
+  name: kueue-manager-config
+  namespace: kueue-system
+

--- a/test/e2e/config/multikueue/map/values.yaml
+++ b/test/e2e/config/multikueue/map/values.yaml
@@ -1,0 +1,1 @@
+enableMutatingAdmissionPolicy: true

--- a/test/e2e/config/multikueue/map/values.yaml
+++ b/test/e2e/config/multikueue/map/values.yaml
@@ -1,1 +1,76 @@
 enableMutatingAdmissionPolicy: true
+controllerManager:
+  manager:
+    image:
+      pullPolicy: IfNotPresent
+    containerSecurityContext:
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+  replicas: 2
+  imagePullSecrets: []
+  readinessProbe:
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 3
+    successThreshold: 1
+  livenessProbe:
+    initialDelaySeconds: 15
+    periodSeconds: 20
+    timeoutSeconds: 1
+    failureThreshold: 3
+    successThreshold: 1
+  topologySpreadConstraints: []
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+kubernetesClusterDomain: cluster.local
+featureGates:
+- name: LocalQueueMetrics
+  enabled: true
+- name: ElasticJobsViaWorkloadSlices
+  enabled: true
+- name: ElasticJobsViaWorkloadSlicesWithTAS
+  enabled: true
+- name: ConcurrentAdmission
+  enabled: true
+managerConfig:
+  controllerManagerConfigYaml: |-
+    apiVersion: config.kueue.x-k8s.io/v1beta2
+    kind: Configuration
+    metrics:
+      enableClusterQueueResources: true
+    leaderElection:
+      leaderElect: true
+    controller:
+      groupKindConcurrency:
+        Job.batch: 5
+        Pod: 5
+        Workload.kueue.x-k8s.io: 10
+        LocalQueue.kueue.x-k8s.io: 5
+        ClusterQueue.kueue.x-k8s.io: 5
+        ResourceFlavor.kueue.x-k8s.io: 1
+    fairSharing: {}
+    clientConnection:
+      qps: 300
+      burst: 500
+    integrations:
+      frameworks:
+        - "batch/job"
+        - "kubeflow.org/mpijob"
+        - "ray.io/rayjob"
+        - "ray.io/raycluster"
+        - "jobset.x-k8s.io/jobset"
+        - "kubeflow.org/paddlejob"
+        - "kubeflow.org/pytorchjob"
+        - "kubeflow.org/tfjob"
+        - "kubeflow.org/xgboostjob"
+        - "kubeflow.org/jaxjob"
+        - "workload.codeflare.dev/appwrapper"
+        - "pod"
+        - "deployment"
+        - "statefulset"
+        - "leaderworkerset.x-k8s.io/leaderworkerset"

--- a/test/e2e/config/multikueue/map/values.yaml
+++ b/test/e2e/config/multikueue/map/values.yaml
@@ -1,5 +1,14 @@
 enableMutatingAdmissionPolicy: true
 controllerManager:
+  featureGates:
+  - name: LocalQueueMetrics
+    enabled: true
+  - name: ElasticJobsViaWorkloadSlices
+    enabled: true
+  - name: ElasticJobsViaWorkloadSlicesWithTAS
+    enabled: true
+  - name: ConcurrentAdmission
+    enabled: true
   manager:
     image:
       pullPolicy: IfNotPresent
@@ -28,15 +37,6 @@ controllerManager:
     enabled: false
     minAvailable: 1
 kubernetesClusterDomain: cluster.local
-featureGates:
-- name: LocalQueueMetrics
-  enabled: true
-- name: ElasticJobsViaWorkloadSlices
-  enabled: true
-- name: ElasticJobsViaWorkloadSlicesWithTAS
-  enabled: true
-- name: ConcurrentAdmission
-  enabled: true
 managerConfig:
   controllerManagerConfigYaml: |-
     apiVersion: config.kueue.x-k8s.io/v1beta2

--- a/test/e2e/config/multikueue/map/values.yaml
+++ b/test/e2e/config/multikueue/map/values.yaml
@@ -60,17 +60,7 @@ managerConfig:
     integrations:
       frameworks:
         - "batch/job"
-        - "kubeflow.org/mpijob"
-        - "ray.io/rayjob"
-        - "ray.io/raycluster"
-        - "jobset.x-k8s.io/jobset"
-        - "kubeflow.org/paddlejob"
-        - "kubeflow.org/pytorchjob"
-        - "kubeflow.org/tfjob"
-        - "kubeflow.org/xgboostjob"
-        - "kubeflow.org/jaxjob"
-        - "workload.codeflare.dev/appwrapper"
         - "pod"
         - "deployment"
         - "statefulset"
-        - "leaderworkerset.x-k8s.io/leaderworkerset"
+

--- a/test/e2e/multikueue/map/e2e_test.go
+++ b/test/e2e/multikueue/map/e2e_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package mapsuite
+package map_test
 
 import (
 	"github.com/onsi/ginkgo/v2"

--- a/test/e2e/multikueue/map/e2e_test.go
+++ b/test/e2e/multikueue/map/e2e_test.go
@@ -1,0 +1,191 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mapsuite
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
+	workloadevict "sigs.k8s.io/kueue/pkg/workload/evict"
+	workloadpatching "sigs.k8s.io/kueue/pkg/workload/patching"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var _ = ginkgo.Describe("MultiKueue MutatingAdmissionPolicy E2E", func() {
+	var (
+		managerNs *corev1.Namespace
+		worker1Ns *corev1.Namespace
+		worker2Ns *corev1.Namespace
+
+		workerCluster1   *kueue.MultiKueueCluster
+		workerCluster2   *kueue.MultiKueueCluster
+		multiKueueConfig *kueue.MultiKueueConfig
+		multiKueueAc     *kueue.AdmissionCheck
+		managerFlavor    *kueue.ResourceFlavor
+		managerCq        *kueue.ClusterQueue
+		managerLq        *kueue.LocalQueue
+	)
+
+	ginkgo.BeforeEach(func() {
+		managerNs = util.CreateNamespaceFromPrefixWithLog(ctx, k8sManagerClient, "multikueue-map-")
+		worker1Ns = util.CreateNamespaceWithLog(ctx, k8sWorker1Client, managerNs.Name)
+		worker2Ns = util.CreateNamespaceWithLog(ctx, k8sWorker2Client, managerNs.Name)
+
+		workerCluster1 = utiltestingapi.MakeMultiKueueClusterWithGeneratedName("worker1-").KubeConfig(kueue.SecretLocationType, "multikueue1").Obj()
+		util.MustCreate(ctx, k8sManagerClient, workerCluster1)
+
+		workerCluster2 = utiltestingapi.MakeMultiKueueClusterWithGeneratedName("worker2-").KubeConfig(kueue.SecretLocationType, "multikueue2").Obj()
+		util.MustCreate(ctx, k8sManagerClient, workerCluster2)
+
+		multiKueueConfig = utiltestingapi.MakeMultiKueueConfigWithGeneratedName("multikueueconfig-").Clusters(workerCluster1.Name, workerCluster2.Name).Obj()
+		util.MustCreate(ctx, k8sManagerClient, multiKueueConfig)
+
+		multiKueueAc = utiltestingapi.MakeAdmissionCheck("").
+			GeneratedName("ac1-").
+			ControllerName(kueue.MultiKueueControllerName).
+			Parameters(kueue.SchemeGroupVersion.Group, "MultiKueueConfig", multiKueueConfig.Name).
+			Obj()
+		util.CreateAdmissionChecksAndWaitForActive(ctx, k8sManagerClient, multiKueueAc)
+
+		managerFlavor = utiltestingapi.MakeResourceFlavor("").GeneratedName("flavor-").Obj()
+		util.MustCreate(ctx, k8sManagerClient, managerFlavor)
+
+		managerCq = utiltestingapi.MakeClusterQueue("").
+			GeneratedName("cq-").
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas(managerFlavor.Name).Resource(corev1.ResourceCPU, "10").Obj()).
+			AdmissionChecks(kueue.AdmissionCheckReference(multiKueueAc.Name)).
+			Obj()
+		util.MustCreate(ctx, k8sManagerClient, managerCq)
+
+		managerLq = utiltestingapi.MakeLocalQueue("lq", managerNs.Name).
+			ClusterQueue(managerCq.Name).
+			Obj()
+		util.MustCreate(ctx, k8sManagerClient, managerLq)
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sManagerClient, managerNs)).To(gomega.Succeed())
+		gomega.Expect(util.DeleteNamespace(ctx, k8sWorker1Client, worker1Ns)).To(gomega.Succeed())
+		gomega.Expect(util.DeleteNamespace(ctx, k8sWorker2Client, worker2Ns)).To(gomega.Succeed())
+
+		util.ExpectObjectToBeDeleted(ctx, k8sManagerClient, managerCq, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sManagerClient, managerFlavor, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sManagerClient, multiKueueAc, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sManagerClient, multiKueueConfig, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sManagerClient, workerCluster1, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sManagerClient, workerCluster2, true)
+	})
+
+	ginkgo.DescribeTable("MutatingAdmissionPolicy clear nominatedClusterNames test matrix",
+		func(updateWlStatus func(wl *kueue.Workload), wantCleared bool) {
+			job := testingjob.MakeJob("job-map-e2e-table", managerNs.Name).
+				ManagedBy(kueue.MultiKueueControllerName).
+				Queue(kueue.LocalQueueName(managerLq.Name)).
+				Obj()
+			util.MustCreate(ctx, k8sManagerClient, job)
+
+			wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: managerNs.Name}
+
+			ginkgo.By("setting workload reservation in the management cluster", func() {
+				admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
+					PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(managerFlavor.Name)).Obj()).
+					Obj()
+				util.SetQuotaReservation(ctx, k8sManagerClient, wlLookupKey, admission)
+			})
+
+			ginkgo.By("updating workload nomination using SSA with a custom external field manager", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					managerWl := &kueue.Workload{}
+					g.Expect(k8sManagerClient.Get(ctx, wlLookupKey, managerWl)).To(gomega.Succeed())
+
+					err := workloadpatching.PatchStatus(
+						ctx,
+						k8sManagerClient,
+						managerWl,
+						client.FieldOwner("external-dispatcher-app"),
+						func(wl *kueue.Workload) (bool, error) {
+							wl.Status.NominatedClusterNames = []string{workerCluster1.Name, workerCluster2.Name}
+							return true, nil
+						},
+						workloadpatching.WithForceApply(),
+					)
+					g.Expect(err).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				gomega.Eventually(func(g gomega.Gomega) {
+					managerWl := &kueue.Workload{}
+					g.Expect(k8sManagerClient.Get(ctx, wlLookupKey, managerWl)).To(gomega.Succeed())
+					g.Expect(managerWl.Status.NominatedClusterNames).To(gomega.ConsistOf(workerCluster1.Name, workerCluster2.Name))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("updating workload status according to test case", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					managerWl := &kueue.Workload{}
+					g.Expect(k8sManagerClient.Get(ctx, wlLookupKey, managerWl)).To(gomega.Succeed())
+					g.Expect(workloadpatching.PatchAdmissionStatus(ctx, k8sManagerClient, managerWl, util.RealClock, func(wl *kueue.Workload) (bool, error) {
+						updateWlStatus(wl)
+						return true, nil
+					})).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				gomega.Eventually(func(g gomega.Gomega) {
+					managerWl := &kueue.Workload{}
+					g.Expect(k8sManagerClient.Get(ctx, wlLookupKey, managerWl)).To(gomega.Succeed())
+					if wantCleared {
+						g.Expect(managerWl.Status.NominatedClusterNames).To(gomega.BeEmpty())
+					} else {
+						g.Expect(managerWl.Status.NominatedClusterNames).To(gomega.ConsistOf(workerCluster1.Name, workerCluster2.Name))
+					}
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		},
+		ginkgo.Entry("when clusterName is set (admission)",
+			func(wl *kueue.Workload) {
+				wl.Status.ClusterName = &workerCluster1.Name
+			},
+			true,
+		),
+		ginkgo.Entry("when Evicted condition is set to True",
+			func(wl *kueue.Workload) {
+				workloadevict.SetEvictedCondition(wl, util.RealClock.Now(), kueue.WorkloadEvictedByAdmissionCheck, "check rejected")
+			},
+			true,
+		),
+		ginkgo.Entry("when clusterName and Evicted condition are both set",
+			func(wl *kueue.Workload) {
+				wl.Status.ClusterName = &workerCluster1.Name
+				workloadevict.SetEvictedCondition(wl, util.RealClock.Now(), kueue.WorkloadEvictedByAdmissionCheck, "check rejected")
+			},
+			true,
+		),
+		ginkgo.Entry("when status update does not trigger clusterName or Evicted condition (negative test)",
+			func(wl *kueue.Workload) {
+				wl.Status.RequeueState = &kueue.RequeueState{Count: ptr.To[int32](1)}
+			},
+			false,
+		),
+	)
+})

--- a/test/e2e/multikueue/map/suite_test.go
+++ b/test/e2e/multikueue/map/suite_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mapsuite
+
+import (
+	"cmp"
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	versionutil "k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/kueue/pkg/util/kubeversion"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var (
+	managerK8SVersion  *versionutil.Version
+	managerClusterName string
+	worker1ClusterName string
+	worker2ClusterName string
+	kueueNS            = util.GetKueueNamespace()
+
+	k8sManagerClient client.Client
+	k8sWorker1Client client.Client
+	k8sWorker2Client client.Client
+	ctx              context.Context
+
+	managerCfg *rest.Config
+	worker1Cfg *rest.Config
+	worker2Cfg *rest.Config
+
+	worker1KConfig []byte
+	worker2KConfig []byte
+
+	managerRestClient *rest.RESTClient
+	worker1RestClient *rest.RESTClient
+	worker2RestClient *rest.RESTClient
+)
+
+func TestAPIs(t *testing.T) {
+	util.RunE2ESuite(t, "End To End MultiKueue MutatingAdmissionPolicy Suite")
+}
+
+var _ = ginkgo.SynchronizedBeforeSuite(
+	func() {
+		util.SetupLogger()
+
+		initClusterClients()
+		createSharedMultiKueueSecrets(context.Background())
+	},
+	func() {
+		util.SetupLogger()
+
+		initClusterClients()
+		ctx = ginkgo.GinkgoT().Context()
+
+		waitForAvailableStart := time.Now()
+		util.WaitForKueueAvailability(ctx, k8sManagerClient)
+		util.WaitForKueueAvailability(ctx, k8sWorker1Client)
+		util.WaitForKueueAvailability(ctx, k8sWorker2Client)
+
+		ginkgo.GinkgoLogr.Info(
+			"Kueue and all required operators are available in all the clusters",
+			"waitingTime", time.Since(waitForAvailableStart),
+		)
+
+		discoveryClient, err := discovery.NewDiscoveryClientForConfig(managerCfg)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		managerK8SVersion, err = kubeversion.FetchServerVersion(discoveryClient)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	},
+)
+
+var _ = ginkgo.SynchronizedAfterSuite(
+	func() {},
+	func() {
+		cleanupSharedMultiKueueSecrets(context.Background())
+	},
+)
+
+func initClusterClients() {
+	managerClusterName = cmp.Or(os.Getenv("MANAGER_KIND_CLUSTER_NAME"), "kind-manager")
+	worker1ClusterName = cmp.Or(os.Getenv("WORKER1_KIND_CLUSTER_NAME"), "kind-worker1")
+	worker2ClusterName = cmp.Or(os.Getenv("WORKER2_KIND_CLUSTER_NAME"), "kind-worker2")
+
+	var err error
+	k8sManagerClient, managerCfg, err = util.CreateClientUsingCluster("kind-" + managerClusterName)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	k8sWorker1Client, worker1Cfg, err = util.CreateClientUsingCluster("kind-" + worker1ClusterName)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	k8sWorker2Client, worker2Cfg, err = util.CreateClientUsingCluster("kind-" + worker2ClusterName)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	managerRestClient = util.CreateRestClient(managerCfg)
+	worker1RestClient = util.CreateRestClient(worker1Cfg)
+	worker2RestClient = util.CreateRestClient(worker2Cfg)
+}
+
+func createSharedMultiKueueSecrets(ctx context.Context) {
+	var err error
+	worker1KConfig, err = util.KubeconfigForMultiKueueSA(ctx, k8sWorker1Client, worker1Cfg, kueueNS, "mksa", worker1ClusterName, util.MultiKueueRulesForManager(ctx, k8sManagerClient))
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	gomega.Expect(util.MakeMultiKueueSecret(ctx, k8sManagerClient, kueueNS, "multikueue1", worker1KConfig)).NotTo(gomega.HaveOccurred())
+
+	worker2KConfig, err = util.KubeconfigForMultiKueueSA(ctx, k8sWorker2Client, worker2Cfg, kueueNS, "mksa", worker2ClusterName, util.MultiKueueRulesForManager(ctx, k8sManagerClient))
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(util.MakeMultiKueueSecret(ctx, k8sManagerClient, kueueNS, "multikueue2", worker2KConfig)).NotTo(gomega.HaveOccurred())
+}
+
+func cleanupSharedMultiKueueSecrets(ctx context.Context) {
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect(util.CleanMultiKueueSecret(ctx, k8sManagerClient, kueueNS, "multikueue1")).To(gomega.Succeed())
+		g.Expect(util.CleanMultiKueueSecret(ctx, k8sManagerClient, kueueNS, "multikueue2")).To(gomega.Succeed())
+		g.Expect(util.CleanKubeconfigForMultiKueueSA(ctx, k8sWorker1Client, kueueNS, "mksa")).To(gomega.Succeed())
+		g.Expect(util.CleanKubeconfigForMultiKueueSA(ctx, k8sWorker2Client, kueueNS, "mksa")).To(gomega.Succeed())
+	}, util.Timeout, util.Interval).Should(gomega.Succeed())
+}

--- a/test/e2e/multikueue/map/suite_test.go
+++ b/test/e2e/multikueue/map/suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package mapsuite
+package map_test
 
 import (
 	"cmp"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind testing
/area multikueue

#### What this PR does / why we need it:

Moves the `MutatingAdmissionPolicy` MultiKueue coverage from integration tests into a dedicated E2E test suite under `test/e2e/multikueue/map/`:
- Adds Kustomize overlay under `test/e2e/config/multikueue/map/` layering `config/components/map` on base deployment.
- Adds Helm values file (`test/e2e/config/multikueue/map/values.yaml`) and updates `hack/testing/e2e-common.sh` to resolve `values.yaml` from `E2E_CONFIG_FOLDER` when present.
- Adds `test-e2e-multikueue-map` target in `hack/make/test.mk`.
- Adds Ginkgo E2E test suite covering external dispatcher SSA nomination under field manager `external-dispatcher-app`, admission clearing, eviction clearing, combined clearing, and negative status updates.

#### Which issue(s) this PR fixes:

Fixes #14642

#### Special notes for your reviewer:

Follow-up requested by @tenzen-y in PR #13749. A follow-up PR in `kubernetes/test-infra` will add the dedicated presubmit Prow job for this suite.

AI tools were used to assist in code generation and PR documentation in accordance with the Kubernetes AI Tool Usage Policy.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end coverage for MultiKueue mutating admission policies.
  * Added a dedicated configuration and runner for MultiKueue MAP scenarios.
  * Verified workload nominations are retained or cleared appropriately after status updates.

* **Improvements**
  * Test deployments now use configuration-specific Helm values when available.
  * MultiKueue MAP tests default to Kubernetes 1.36.1 and validate supported versions.
  * Test environments now prepare required cluster credentials and resources automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->