### PR TITLE
StatefulSet: block queue-name rename while Workload still holds quota reservation

### DIFF
--- a/pkg/controller/jobs/statefulset/statefulset_webhook.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook.go
@@ -174,7 +174,10 @@ func (wh *Webhook) ValidateUpdate(ctx context.Context, oldSTSObj, newSTSObj *app
 		// StatefulSet with replicas > 0 and no Ready Pods (e.g. crashlooping or
 		// unschedulable) can keep its reservation indefinitely. Refuse the
 		// rename while reserved so the Pods and the Workload cannot end up
-		// naming different queues.
+		// naming different queues. A rename back to the queue the reserved
+		// Workload already records is allowed: it restores consistency
+		// instead of breaking it, which matters for a cluster that already
+		// drifted (e.g. across an upgrade) before this check existed.
 		wlName, err := findWorkloadName(ctx, wh.client, oldSTSObj)
 		if err != nil {
 			return nil, err
@@ -184,7 +187,7 @@ func (wh *Webhook) ValidateUpdate(ctx context.Context, oldSTSObj, newSTSObj *app
 			if client.IgnoreNotFound(err) != nil {
 				return nil, err
 			}
-		} else if workload.HasQuotaReservation(&wl) {
+		} else if workload.HasQuotaReservation(&wl) && newQueueName != wl.Spec.QueueName {
 			allErrs = append(allErrs, apivalidation.ValidateImmutableField(newQueueName, oldQueueName, queueNameLabelPath)...)
 		}
 	}

--- a/pkg/controller/jobs/statefulset/statefulset_webhook.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook.go
@@ -178,16 +178,10 @@ func (wh *Webhook) ValidateUpdate(ctx context.Context, oldSTSObj, newSTSObj *app
 		// Workload already records is allowed: it restores consistency
 		// instead of breaking it, which matters for a cluster that already
 		// drifted (e.g. across an upgrade) before this check existed.
-		wlName, err := findWorkloadName(ctx, wh.client, oldSTSObj)
+		_, wl, err := findWorkload(ctx, wh.client, oldSTSObj)
 		if err != nil {
 			return nil, err
-		}
-		var wl kueue.Workload
-		if err := wh.client.Get(ctx, client.ObjectKey{Namespace: oldSTSObj.GetNamespace(), Name: wlName}, &wl); err != nil {
-			if client.IgnoreNotFound(err) != nil {
-				return nil, err
-			}
-		} else if workload.HasQuotaReservation(&wl) && newQueueName != wl.Spec.QueueName {
+		} else if wl != nil && workload.HasQuotaReservation(wl) && newQueueName != wl.Spec.QueueName {
 			allErrs = append(allErrs, apivalidation.ValidateImmutableField(newQueueName, oldQueueName, queueNameLabelPath)...)
 		}
 	}

--- a/pkg/controller/jobs/statefulset/statefulset_webhook.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook.go
@@ -168,6 +168,25 @@ func (wh *Webhook) ValidateUpdate(ctx context.Context, oldSTSObj, newSTSObj *app
 	isSuspended := oldStatefulSet.Status.ReadyReplicas == 0
 	if !isSuspended || newQueueName == "" {
 		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newQueueName, oldQueueName, queueNameLabelPath)...)
+	} else if newQueueName != oldQueueName {
+		// ReadyReplicas==0 does not imply the Workload's quota reservation was
+		// released: shouldReleaseReservation only fires on scale-to-zero, so a
+		// StatefulSet with replicas > 0 and no Ready Pods (e.g. crashlooping or
+		// unschedulable) can keep its reservation indefinitely. Refuse the
+		// rename while reserved so the Pods and the Workload cannot end up
+		// naming different queues.
+		wlName, err := findWorkloadName(ctx, wh.client, oldSTSObj)
+		if err != nil {
+			return nil, err
+		}
+		var wl kueue.Workload
+		if err := wh.client.Get(ctx, client.ObjectKey{Namespace: oldSTSObj.GetNamespace(), Name: wlName}, &wl); err != nil {
+			if client.IgnoreNotFound(err) != nil {
+				return nil, err
+			}
+		} else if workload.HasQuotaReservation(&wl) {
+			allErrs = append(allErrs, apivalidation.ValidateImmutableField(newQueueName, oldQueueName, queueNameLabelPath)...)
+		}
 	}
 	allErrs = append(allErrs, jobframework.ValidateUpdateForWorkloadPriorityClassName(
 		isSuspended,

--- a/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
@@ -499,6 +499,28 @@ func TestValidateUpdate(t *testing.T) {
 				Replicas(3).
 				Obj(),
 		},
+		"change in queue label allowed when it restores the queue already recorded by the reserved Workload (ReadyReplicas == 0)": {
+			objs: []runtime.Object{
+				utiltestingapi.MakeWorkload(GetWorkloadName("test-uid", "test-sts"), "test-ns").
+					Queue("test-queue").
+					Condition(metav1.Condition{
+						Type:   kueue.WorkloadQuotaReserved,
+						Status: metav1.ConditionTrue,
+						Reason: "AdmittedByTest",
+					}).
+					Obj(),
+			},
+			oldObj: testingstatefulset.MakeStatefulSet("test-sts", "test-ns").
+				UID("test-uid").
+				Queue("test-queue-new").
+				Replicas(3).
+				Obj(),
+			newObj: testingstatefulset.MakeStatefulSet("test-sts", "test-ns").
+				UID("test-uid").
+				Queue("test-queue").
+				Replicas(3).
+				Obj(),
+		},
 		"set queue label": {
 			oldObj: testingstatefulset.MakeStatefulSet("test-sts", "test-ns").
 				Obj(),

--- a/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	kueueconstants "sigs.k8s.io/kueue/pkg/constants"
@@ -455,6 +456,48 @@ func TestValidateUpdate(t *testing.T) {
 					Field: queueNameLabelPath.String(),
 				},
 			}.ToAggregate(),
+		},
+		"change in queue label blocked while the Workload still holds a quota reservation (ReadyReplicas == 0)": {
+			objs: []runtime.Object{
+				utiltestingapi.MakeWorkload(GetWorkloadName("test-uid", "test-sts"), "test-ns").
+					Condition(metav1.Condition{
+						Type:   kueue.WorkloadQuotaReserved,
+						Status: metav1.ConditionTrue,
+						Reason: "AdmittedByTest",
+					}).
+					Obj(),
+			},
+			oldObj: testingstatefulset.MakeStatefulSet("test-sts", "test-ns").
+				UID("test-uid").
+				Queue("test-queue").
+				Replicas(3).
+				Obj(),
+			newObj: testingstatefulset.MakeStatefulSet("test-sts", "test-ns").
+				UID("test-uid").
+				Queue("test-queue-new").
+				Replicas(3).
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: queueNameLabelPath.String(),
+				},
+			}.ToAggregate(),
+		},
+		"change in queue label allowed when the Workload has no quota reservation (ReadyReplicas == 0)": {
+			objs: []runtime.Object{
+				utiltestingapi.MakeWorkload(GetWorkloadName("test-uid", "test-sts"), "test-ns").Obj(),
+			},
+			oldObj: testingstatefulset.MakeStatefulSet("test-sts", "test-ns").
+				UID("test-uid").
+				Queue("test-queue").
+				Replicas(3).
+				Obj(),
+			newObj: testingstatefulset.MakeStatefulSet("test-sts", "test-ns").
+				UID("test-uid").
+				Queue("test-queue-new").
+				Replicas(3).
+				Obj(),
 		},
 		"set queue label": {
 			oldObj: testingstatefulset.MakeStatefulSet("test-sts", "test-ns").


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The StatefulSet admission webhook decided whether a StatefulSet was "quiescent" (safe to
let its `kueue.x-k8s.io/queue-name` label change) purely from `Status.ReadyReplicas == 0`.
That is not the same as "the Workload has no quota reservation": a StatefulSet can sit at
`replicas > 0` with zero Ready Pods indefinitely (crashlooping image, unschedulable Pods,
etc.) while its Workload still has `QuotaReserved=True`.

In that state the webhook accepted the queue-name rename, the reconciler then
unconditionally wrote the new queue name onto `Workload.Spec.QueueName`, and the
Workload CRD's own immutability rule (which is keyed on the `QuotaReserved` condition,
not readiness) rejected that update on every reconcile. The Pods ended up labelled with
the new queue while the Workload stayed on the old one, and the StatefulSet controller
never stopped retrying the failing update.

This PR closes the gap at the admission boundary: when the webhook's existing
`ReadyReplicas == 0` check would otherwise allow the rename, it now also looks up the
StatefulSet's Workload (reusing the `findWorkloadName` helper already used a few lines
below for the scale-up-from-zero check) and refuses the rename if that Workload still
has `QuotaReserved=True`. This aligns the webhook with the same condition the Workload
CRD itself already enforces. If the Workload doesn't exist or has no reservation, the
rename is allowed exactly as before.

The `isSuspended` value used for the (unrelated) WorkloadPriorityClassName immutability
check is left untouched, and the reconciler is not changed — the fix is scoped to the
validation boundary that let the inconsistent state occur in the first place.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

- Root cause and fix are both traceable purely in code (no live cluster needed): the
  webhook logic in `pkg/controller/jobs/statefulset/statefulset_webhook.go`, the
  unconditional write in `pkg/controller/jobs/statefulset/statefulset_reconciler.go`
  (~line 273), and the Workload CRD's own `QuotaReserved`-keyed immutability rule quoted
  in the issue. `pkg/workload.HasQuotaReservation` already checks exactly that condition,
  so the fix reuses an existing helper rather than inventing new semantics.
- Validation performed locally (no live cluster / envtest run):
  - `go build ./...`
  - `go vet ./pkg/controller/jobs/statefulset/...`
  - `golangci-lint run ./pkg/controller/jobs/statefulset/...` — 0 issues
  - `go test ./pkg/controller/jobs/statefulset/...` and `go test ./pkg/controller/jobs/...` — all pass
  - Confirmed the two new webhook unit tests are a real regression test: with only the
    `statefulset_webhook.go` change reverted (test file kept), the new
    "change in queue label blocked while the Workload still holds a quota reservation"
    case fails; with the fix restored, it passes and the whole suite is green.
  - This particular admission-lookup logic is unit-tested only elsewhere in this same
    file too (see the pre-existing "scale up from zero blocked by existing workload"
    case, which uses the identical fake-client/workload-lookup pattern), so a unit test
    matches this codebase's own precedent for this kind of check; no
    `test/integration/singlecluster/webhook/...` envtest run was added or required.
- Not run: `make verify` / `make ci-lint` (this environment lacks GNU sed, which the
  Makefile hard-requires); `golangci-lint run` was run directly on the changed package
  instead and reported 0 issues.
- Base branch: branched from and rebased on the current `upstream/main` tip
  (`8bb5b30b8`, "Remove obsolete AdmissionCheck controller aggregation (#14634)").

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
StatefulSet: Fixed a bug where the `kueue.x-k8s.io/queue-name` label could be changed while the StatefulSet's Workload still held a quota reservation, if the StatefulSet had replicas greater than zero but no Ready Pods (for example, crashlooping or unschedulable Pods). Previously this let the Pods and the Workload end up referencing different queues, with the Workload update failing on every reconcile. The webhook now rejects the rename in that case, matching the immutability rule already enforced by the Workload CRD.
```

---
AI assistance: this change was drafted with Claude Code.

Fixes #14266

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when changing a StatefulSet’s queue while no replicas are ready.
  * Prevented queue changes that conflict with an existing workload quota reservation.
  * Allowed restoring the queue recorded by the reserved workload.
  * Workloads without reservations, or missing workloads, do not block queue changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->