### PR TITLE
Automated cherry pick of #14305: Consolidate elastic job ungater reconciliation tests

### DIFF
--- a/pkg/controller/elasticjobs/elastic_job_ungater_test.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater_test.go
@@ -98,6 +98,7 @@ func TestReconcile(t *testing.T) {
 		// skipDefaultPodSetLabels prevents default PodSet labeling so tests can verify that unlabeled Pods remain gated.
 		skipDefaultPodSetLabels bool
 		expectUIDs              []types.UID
+		reconcileKey            client.ObjectKey
 		wantPods                []corev1.Pod
 		wantErr                 error
 	}{
@@ -940,6 +941,76 @@ func TestReconcile(t *testing.T) {
 					Obj(),
 			},
 		},
+		"redirects from finished origin slice to active replacement": {
+			// Reproduces the scale-rollover stall: an enqueued reconcile (e.g. a
+			// requeue after a pod-patch conflict lost the race to the TAS ungater)
+			// can re-run against the origin slice after it finished as part of the
+			// scale-up. Reconcile must redirect to the chain's current active slice
+			// and ungate, not bail on the finished slice and wait for a resync.
+			workloads: []kueue.Workload{
+				// Origin slice: admitted at parallelism 1, then finished when the
+				// scale-up replacement took over.
+				*utiltestingapi.MakeWorkload("wl", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					ControllerReference(rayClusterGVK, "ray", "ray-uid").
+					Creation(now.Add(-time.Minute)).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("cq").
+							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "flavor", "1").
+								Obj()).
+							Obj(), now.Add(-time.Minute),
+					).
+					AdmittedAt(true, now.Add(-time.Minute)).
+					Finished().
+					Obj(),
+				// Active slice: the scale-up replacement, admitted at parallelism 2,
+				// still pointing back at the origin name via the slice annotation.
+				*utiltestingapi.MakeWorkload("wl-2", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					ControllerReference(rayClusterGVK, "ray", "ray-uid").
+					Creation(now).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("cq").
+							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "flavor", "2").
+								Obj()).
+							Obj(), now,
+					).
+					AdmittedAt(true, now).
+					Obj(),
+			},
+			// Origin granted 1, replacement granted 2; ungating both requires the replacement's admission.
+			pods: []corev1.Pod{
+				*testingpod.MakePod("pod-0", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+				*testingpod.MakePod("pod-1", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+			},
+			// Reconcile keyed on the FINISHED origin slice, as a conflict-requeue would.
+			reconcileKey: client.ObjectKey{Name: "wl", Namespace: "ns"},
+			wantPods: []corev1.Pod{
+				*testingpod.MakePod("pod-0", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Obj(),
+				*testingpod.MakePod("pod-1", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Obj(),
+			},
+		},
 	}
 
 	for name, tc := range testCases {
@@ -1009,6 +1080,9 @@ func TestReconcile(t *testing.T) {
 				active = &tc.workloads[0]
 			}
 			key := types.NamespacedName{Namespace: active.Namespace, Name: active.Name}
+			if tc.reconcileKey != (client.ObjectKey{}) {
+				key = tc.reconcileKey
+			}
 			sliceKey := types.NamespacedName{Namespace: active.Namespace, Name: workloadslicing.SliceName(active)}
 			if len(tc.expectUIDs) > 0 {
 				ungater.expectationsStore.ExpectUIDs(log, sliceKey, tc.expectUIDs)
@@ -1029,98 +1103,6 @@ func TestReconcile(t *testing.T) {
 				t.Errorf("Pods after reconcile (-want,+got):\n%s", diff)
 			}
 		})
-	}
-}
-
-// TestReconcileRedirectsFromFinishedSlice reproduces the scale-rollover stall:
-// an enqueued reconcile (e.g. a requeue after a pod-patch conflict lost the race
-// to the TAS ungater) can re-run against the origin slice after it finished as
-// part of the scale-up. Reconcile must redirect to the chain's current active
-// slice and ungate, not bail on the finished slice and wait for a resync.
-func TestReconcileRedirectsFromFinishedSlice(t *testing.T) {
-	features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, true)
-	now := time.Now().Truncate(time.Second)
-	ctx, _ := utiltesting.ContextWithLog(t)
-
-	// Origin slice: admitted at parallelism 1, then finished when the scale-up
-	// replacement took over.
-	origin := utiltestingapi.MakeWorkload("wl", "ns").
-		Finalizers(kueue.ResourceInUseFinalizerName).
-		Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
-		ControllerReference(rayClusterGVK, "ray", "ray-uid").
-		Creation(now.Add(-time.Minute)).
-		PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-		ReserveQuotaAt(
-			utiltestingapi.MakeAdmission("cq").
-				PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
-					Assignment(corev1.ResourceCPU, "flavor", "1").Obj()).
-				Obj(), now.Add(-time.Minute),
-		).
-		AdmittedAt(true, now.Add(-time.Minute)).
-		Finished().
-		Obj()
-	// Active slice: the scale-up replacement, admitted at parallelism 2, still
-	// pointing back at the origin name via the slice annotation.
-	active := utiltestingapi.MakeWorkload("wl-2", "ns").
-		Finalizers(kueue.ResourceInUseFinalizerName).
-		Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
-		Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
-		ControllerReference(rayClusterGVK, "ray", "ray-uid").
-		Creation(now).
-		PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).
-		ReserveQuotaAt(
-			utiltestingapi.MakeAdmission("cq").
-				PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
-					Assignment(corev1.ResourceCPU, "flavor", "2").Obj()).
-				Obj(), now,
-		).
-		AdmittedAt(true, now).
-		Obj()
-
-	gatedPod := testingpod.MakePod("pod-0", "ns").
-		Annotation(kueue.WorkloadAnnotation, "wl").
-		Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
-		Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
-		Gate(kueue.ElasticJobSchedulingGate).
-		Obj()
-
-	clientBuilder := utiltesting.NewClientBuilder().
-		WithIndex(&corev1.Pod{}, coreindexer.WorkloadSliceNameKey, coreindexer.IndexPodWorkloadSliceName).
-		WithIndex(&kueue.Workload{}, coreindexer.OwnerReferenceIndexKey(rayClusterGVK), coreindexer.WorkloadOwnerIndexFunc(rayClusterGVK)).
-		WithInterceptorFuncs(interceptor.Funcs{
-			Patch: func(ctx context.Context, clnt client.WithWatch, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
-				return clnt.Update(ctx, obj)
-			},
-		}).
-		WithObjects(gatedPod).
-		WithStatusSubresource(origin, active)
-	kClient := clientBuilder.Build()
-	for _, wl := range []*kueue.Workload{origin, active} {
-		if err := kClient.Create(ctx, wl); err != nil {
-			t.Fatalf("Could not create workload %s: %v", wl.Name, err)
-		}
-	}
-
-	ungater := &elasticJobUngater{
-		client:            kClient,
-		expectationsStore: expectations.NewStore(ControllerName),
-	}
-
-	// Reconcile keyed on the FINISHED origin slice, as a conflict-requeue would.
-	if _, err := ungater.Reconcile(ctx, reconcile.Request{
-		NamespacedName: types.NamespacedName{Namespace: "ns", Name: "wl"},
-	}); err != nil {
-		t.Fatalf("Reconcile returned error: %v", err)
-	}
-
-	var got corev1.Pod
-	if err := kClient.Get(ctx, client.ObjectKeyFromObject(gatedPod), &got); err != nil {
-		t.Fatalf("Could not get pod after reconcile: %v", err)
-	}
-	for _, g := range got.Spec.SchedulingGates {
-		if g.Name == kueue.ElasticJobSchedulingGate {
-			t.Fatalf("pod still has elastic scheduling gate; expected ungate via redirect to active slice %q", active.Name)
-		}
 	}
 }
 


### PR DESCRIPTION
Cherry pick of #14305 on release-0.18.

#14305: Consolidate elastic job ungater reconciliation tests

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```