### PR TITLE
Automated cherry pick of #14678: Fix PodIntegrationValidateGroupOwner and ValidateRayAndSparkJobUpdates FG versions

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -940,7 +940,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 
 	ValidateRayAndSparkJobUpdates: {
-		{Version: version.MustParse("0.18"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("0.18"), Default: true, PreRelease: featuregate.Beta}, // GA in 0.21
 	},
 }
 


### PR DESCRIPTION
Cherry pick of #14678 on release-0.18.

#14678: Fix PodIntegrationValidateGroupOwner and ValidateRayAndSparkJobUpdates FG versions

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```