### PR TITLE
Automated cherry pick of #14678: Fix PodIntegrationValidateGroupOwner and ValidateRayAndSparkJobUpdates FG versions

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -958,11 +958,11 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 
 	PodIntegrationValidateGroupOwner: {
-		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("0.18"), Default: true, PreRelease: featuregate.Beta},
 	},
 
 	ValidateRayAndSparkJobUpdates: {
-		{Version: version.MustParse("0.20"), Default: true, PreRelease: featuregate.Beta}, // GA in 0.21
+		{Version: version.MustParse("0.18"), Default: true, PreRelease: featuregate.Beta}, // GA in 0.21
 	},
 }
 

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -330,7 +330,7 @@
   - default: true
     lockToDefault: false
     preRelease: Beta
-    version: "0.19"
+    version: "0.18"
 - name: PriorityBoost
   versionedSpecs:
   - default: false
@@ -602,7 +602,7 @@
   - default: true
     lockToDefault: false
     preRelease: Beta
-    version: "0.20"
+    version: "0.18"
 - name: VectorizedResourceRequests
   versionedSpecs:
   - default: true

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -330,7 +330,7 @@
   - default: true
     lockToDefault: false
     preRelease: Beta
-    version: "0.19"
+    version: "0.18"
 - name: PriorityBoost
   versionedSpecs:
   - default: false
@@ -602,7 +602,7 @@
   - default: true
     lockToDefault: false
     preRelease: Beta
-    version: "0.20"
+    version: "0.18"
 - name: VectorizedResourceRequests
   versionedSpecs:
   - default: true


### PR DESCRIPTION
Cherry pick of #14678 on release-0.19.

#14678: Fix PodIntegrationValidateGroupOwner and ValidateRayAndSparkJobUpdates FG versions

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```