### PR TITLE
Automated cherry pick of #13797: scheduler: prioritize workloads pending preemption to prevent thrashing

### DIFF
--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -84,55 +84,74 @@ var (
 	realClock = clock.RealClock{}
 )
 
-// stickyWorkload is the workload at the ClusterQueue head which is
-// currently preempting workloads. It is only enabled for
-// BestEffortFIFO policy, and prevents skipped over ineligible
-// workloads from going back to the head of the queue.  A workload is
-// considered sticky until it is admitted, unschedulable, or deleted.
+// preemptorWorkload is the workload at the ClusterQueue head which is
+// currently preempting workloads. For BestEffortFIFO policy, isSticky is
+// set to true and prevents skipped over ineligible workloads from going back
+// to the head of the queue. A workload is considered a preemptor until it is
+// admitted, unschedulable, or deleted.
 // See Kueue#6929 and Kueue#7101 for motivation.
 //
-// The workloadName field is accessed concurrently and drives both the CQ heap
+// The state field is accessed concurrently and drives both the CQ heap
 // ordering and the Snapshot ordering used by the visibility server. Two
 // mechanisms keep every sort transitive (see Kueue#12740):
 //   - Writes (set/clear) happen under the ClusterQueue's rwm lock, so heap
 //     operations, which also hold the lock, never observe it changing mid-sort.
 //   - Snapshot sorts a copy of the pending workloads without holding the lock,
-//     so it captures the sticky workload once per sort via capturedMatcher()
+//     so it captures the sticky workload once per sort via capturedStickyMatcher()
 //     instead of re-reading it on every comparison.
 //
-// The field holds a single whole value (nil means no sticky workload), so an
+// The field holds a single whole value (nil means no preemptor workload), so an
 // atomic.Pointer keeps individual reads and writes memory-safe on top of the
 // ordering guarantees above.
-type stickyWorkload struct {
-	workloadName atomic.Pointer[workload.Reference]
+type preemptorWorkloadState struct {
+	workloadName workload.Reference
+	generation   int64
+	isSticky     bool
 }
 
-func (s *stickyWorkload) matches(workload workload.Reference) bool {
-	name := s.workloadName.Load()
-	return name != nil && *name == workload
+type preemptorWorkload struct {
+	state atomic.Pointer[preemptorWorkloadState]
 }
 
-// capturedMatcher captures the current sticky workload once and returns a
+func (p *preemptorWorkload) matches(workload workload.Reference, strict bool, generation int64) bool {
+	state := p.state.Load()
+	matchesKey := state != nil && state.workloadName == workload
+	if !strict {
+		return matchesKey
+	}
+	return matchesKey && state.generation == generation
+}
+
+func (p *preemptorWorkload) stickyMatches(workload workload.Reference) bool {
+	state := p.state.Load()
+	return state != nil && state.isSticky && state.workloadName == workload
+}
+
+// capturedStickyMatcher captures the current sticky workload once and returns a
 // predicate bound to that fixed value. A sort that compares through the returned
 // predicate stays transitive even if set/clear runs concurrently, because every
 // comparison in that sort observes the same sticky workload. See Kueue#12740.
-func (s *stickyWorkload) capturedMatcher() func(workload.Reference) bool {
-	name := s.workloadName.Load()
-	if name == nil {
+func (p *preemptorWorkload) capturedStickyMatcher() func(workload.Reference) bool {
+	state := p.state.Load()
+	if state == nil || !state.isSticky {
 		return func(workload.Reference) bool { return false }
 	}
-	captured := *name
+	captured := state.workloadName
 	return func(key workload.Reference) bool {
 		return captured == key
 	}
 }
 
-func (s *stickyWorkload) clear() {
-	s.workloadName.Store(nil)
+func (p *preemptorWorkload) clear() {
+	p.state.Store(nil)
 }
 
-func (s *stickyWorkload) set(workload workload.Reference) {
-	s.workloadName.Store(&workload)
+func (p *preemptorWorkload) set(workload workload.Reference, isSticky bool, generation int64) {
+	p.state.Store(&preemptorWorkloadState{
+		workloadName: workload,
+		generation:   generation,
+		isSticky:     isSticky,
+	})
 }
 
 func logStickyWorkloadSelectionIfVerbose(log logr.Logger, wl *kueue.Workload) {
@@ -194,7 +213,7 @@ type ClusterQueue struct {
 	afsUsageLedger            *queueafs.AfsUsageLedger
 	localQueuesInClusterQueue map[utilqueue.LocalQueueReference]bool
 
-	sw *stickyWorkload
+	pw *preemptorWorkload
 
 	ConcurrentAdmissionPolicy *kueue.ConcurrentAdmissionPolicy
 	// pendingResourcesTotal is the incremental sum of TotalRequests across workloads
@@ -207,6 +226,10 @@ type ClusterQueue struct {
 
 func (c *ClusterQueue) GetName() kueue.ClusterQueueReference {
 	return c.name
+}
+
+func (c *ClusterQueue) IsPreemptor(wInfo *workload.Info) bool {
+	return c.pw.matches(workloadKey(wInfo), true, wInfo.Obj.Generation)
 }
 
 func workloadKey(i *workload.Info) workload.Reference {
@@ -269,16 +292,25 @@ func newClusterQueueImpl(ctx context.Context, client client.Client, wo workload.
 	for _, opt := range opts {
 		opt(options)
 	}
-	sw := stickyWorkload{}
-	// The heap comparator reads the sticky workload live on every comparison;
-	// this is safe because sticky writes and heap operations both hold rwm.
-	compareFunc := queueOrderingFunc(ctx, client, wo, options.fsResWeights, options.enableAdmissionFs, options.afsUsageLedger, sw.matches)
+	pw := preemptorWorkload{}
+	// lqWeights is shared by reference with the ClusterQueue struct below so
+	// weight updates are visible to the comparator. All access holds rwm.
+	lqWeights := make(map[utilqueue.LocalQueueReference]float64)
+	getLQWeight := func(lqKey utilqueue.LocalQueueReference) float64 {
+		if w, ok := lqWeights[lqKey]; ok {
+			return w
+		}
+		return 1.0
+	}
+	// The comparator reads the sticky workload and cached weights live; safe
+	// because those writes and heap operations all hold rwm.
+	compareFunc := queueOrderingFunc(ctx, client, wo, options.fsResWeights, options.enableAdmissionFs, options.afsUsageLedger, pw.stickyMatches)
 	// Derive lessFunc from compareFunc for the heap.
 	lessFunc := func(a, b *workload.Info) bool { return compareFunc(a, b) < 0 }
 	// Snapshot sorts without the lock, so it captures the sticky workload once
 	// per sort rather than reading it live. See Kueue#12740.
 	snapshotSort := buildSnapshotSort(
-		ctx, wo, &sw, client,
+		ctx, wo, &pw, client,
 		options.enableAdmissionFs, options.fsResWeights,
 		options.afsUsageLedger,
 	)
@@ -294,7 +326,7 @@ func newClusterQueueImpl(ctx context.Context, client client.Client, wo workload.
 		clock:                     clock,
 		afsUsageLedger:            options.afsUsageLedger,
 		localQueuesInClusterQueue: make(map[utilqueue.LocalQueueReference]bool),
-		sw:                        &sw,
+		pw:                        &pw,
 		pendingResourcesTotal:     make(map[corev1.ResourceName]int64),
 	}
 }
@@ -590,11 +622,11 @@ func (c *ClusterQueue) delete(log logr.Logger, key workload.Reference) {
 	}
 	c.removeFromHeap(key)
 	c.forgetInflightByKey(key)
-	if c.sw.matches(key) {
+	if c.pw.matches(key, false, 0) {
 		if logV := log.V(5); logV.Enabled() {
-			logV.Info("Clearing sticky workload due to deletion", "clusterQueue", c.name, "workload", key)
+			logV.Info("Clearing preemptor workload due to deletion", "clusterQueue", c.name, "workload", key)
 		}
-		c.sw.clear()
+		c.pw.clear()
 	}
 }
 
@@ -638,15 +670,15 @@ func (c *ClusterQueue) requeueIfNotPresent(log logr.Logger, wInfo *workload.Info
 	c.rwm.Lock()
 	defer c.rwm.Unlock()
 	key := workload.Key(wInfo.Obj)
-	// When preemptions are in-progress, keep re-attempting the same workload at
-	// the head for BestEffortFIFO queues (see documentation of stickyWorkload).
-	// The sticky workload is set under the lock so heap operations, which also
-	// hold the lock, never observe it changing mid-sort. See Kueue#12740.
-	if (reason == RequeueReasonPendingPreemption || reason == RequeueReasonPendingMigration) && c.queueingStrategy == kueue.BestEffortFIFO {
+	// When preemptions are in-progress, track the preempting workload (see documentation
+	// of preemptorWorkload). For BestEffortFIFO queues, this also makes it sticky at the head.
+	// The preemptor workload is set under the lock so heap operations, which also hold the lock,
+	// never observe it changing mid-sort. See Kueue#12740.
+	if reason == RequeueReasonPendingPreemption || reason == RequeueReasonPendingMigration {
 		if logV := log.V(5); logV.Enabled() {
-			logV.Info("Setting sticky workload", "clusterQueue", wInfo.ClusterQueue, "workload", key)
+			logV.Info("Setting preemptor workload", "clusterQueue", wInfo.ClusterQueue, "workload", key)
 		}
-		c.sw.set(key)
+		c.pw.set(key, c.queueingStrategy == kueue.BestEffortFIFO, wInfo.LastEvaluatedGeneration)
 	}
 	c.forgetInflightByKey(key)
 
@@ -876,14 +908,14 @@ func (c *ClusterQueue) Snapshot() []*workload.Info {
 
 // buildSnapshotSort returns a function that sorts workload elements for Snapshot().
 // The sort runs without holding the ClusterQueue lock, so it captures the sticky
-// workload once per sort (via stickyWorkload.capturedMatcher) to keep the comparison
+// workload once per sort (via preemptorWorkload.capturedStickyMatcher) to keep the comparison
 // transitive even if the sticky workload changes concurrently. See Kueue#12740.
 // When fair-sharing is enabled, it also pre-computes FS usage per LocalQueue from
 // deep-copied AFS state to avoid inconsistent comparisons from concurrent updates.
 func buildSnapshotSort(
 	ctx context.Context,
 	wo workload.Ordering,
-	sw *stickyWorkload,
+	pw *preemptorWorkload,
 	cl client.Client,
 	enableAdmissionFs bool,
 	fsResWeights map[corev1.ResourceName]float64,
@@ -892,7 +924,7 @@ func buildSnapshotSort(
 	log := ctrl.LoggerFrom(ctx)
 	if !enableAdmissionFs {
 		return func(elements []*workload.Info) {
-			slices.SortFunc(elements, baseCompareFunc(log, wo, sw.capturedMatcher()))
+			slices.SortFunc(elements, baseCompareFunc(log, wo, pw.capturedStickyMatcher()))
 		}
 	}
 
@@ -912,7 +944,7 @@ func buildSnapshotSort(
 	return func(elements []*workload.Info) {
 		// Capture the sticky workload once so the sort stays transitive without
 		// holding the lock. See Kueue#12740.
-		baseCmp := baseCompareFunc(log, wo, sw.capturedMatcher())
+		baseCmp := baseCompareFunc(log, wo, pw.capturedStickyMatcher())
 		usageCache := make(map[utilqueue.LocalQueueReference]float64)
 		for _, wInfo := range elements {
 			lqKey := utilqueue.KeyFromWorkload(wInfo.Obj)

--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -293,17 +293,8 @@ func newClusterQueueImpl(ctx context.Context, client client.Client, wo workload.
 		opt(options)
 	}
 	pw := preemptorWorkload{}
-	// lqWeights is shared by reference with the ClusterQueue struct below so
-	// weight updates are visible to the comparator. All access holds rwm.
-	lqWeights := make(map[utilqueue.LocalQueueReference]float64)
-	getLQWeight := func(lqKey utilqueue.LocalQueueReference) float64 {
-		if w, ok := lqWeights[lqKey]; ok {
-			return w
-		}
-		return 1.0
-	}
-	// The comparator reads the sticky workload and cached weights live; safe
-	// because those writes and heap operations all hold rwm.
+	// The heap comparator reads the sticky workload live on every comparison;
+	// this is safe because sticky writes and heap operations both hold rwm.
 	compareFunc := queueOrderingFunc(ctx, client, wo, options.fsResWeights, options.enableAdmissionFs, options.afsUsageLedger, pw.stickyMatches)
 	// Derive lessFunc from compareFunc for the heap.
 	lessFunc := func(a, b *workload.Info) bool { return compareFunc(a, b) < 0 }

--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -728,7 +728,7 @@ func TestSnapshotConsistentUnderConcurrentStickyChange(t *testing.T) {
 
 func TestClusterQueueIsPreemptor(t *testing.T) {
 	ctx, _ := utiltesting.ContextWithLog(t)
-	cq, err := newClusterQueue(ctx, nil, utiltestingapi.MakeClusterQueue("cq").Obj(), nil, defaultOrdering, nil, nil)
+	cq, err := newClusterQueue(ctx, nil, utiltestingapi.MakeClusterQueue("cq").Obj(), defaultOrdering, nil, nil)
 	if err != nil {
 		t.Fatalf("failed to create ClusterQueue: %v", err)
 	}

--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -580,8 +580,8 @@ func TestSnapshotUsesDefaultWeightForMissingLocalQueue(t *testing.T) {
 }
 
 // TestSnapshotConcurrentWithRequeueNoDataRace guards against a data race on the
-// sticky workload: Snapshot sorts a copy of the pending workloads through the
-// comparator (which reads stickyWorkload.workloadName) without holding the
+// preemptor workload: Snapshot sorts a copy of the pending workloads through the
+// comparator (which reads preemptorWorkload.state) without holding the
 // ClusterQueue lock, while RequeueIfNotPresent writes that field during a
 // BestEffortFIFO preemption requeue. Run with -race to detect regressions.
 func TestSnapshotConcurrentWithRequeueNoDataRace(t *testing.T) {
@@ -703,9 +703,9 @@ func TestSnapshotConsistentUnderConcurrentStickyChange(t *testing.T) {
 				return
 			default:
 				for _, k := range keys {
-					cq.sw.set(k)
+					cq.pw.set(k, true, 0)
 				}
-				cq.sw.clear()
+				cq.pw.clear()
 			}
 		}
 	}()
@@ -723,6 +723,43 @@ func TestSnapshotConsistentUnderConcurrentStickyChange(t *testing.T) {
 		if !isValid(got) {
 			t.Fatalf("call %d: non-transitive Snapshot ordering %v; sticky workload changed mid-sort", i+1, got)
 		}
+	}
+}
+
+func TestClusterQueueIsPreemptor(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	cq, err := newClusterQueue(ctx, nil, utiltestingapi.MakeClusterQueue("cq").Obj(), nil, defaultOrdering, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to create ClusterQueue: %v", err)
+	}
+
+	wl := utiltestingapi.MakeWorkload("wl", defaultNamespace).Obj()
+	wl.Generation = 1
+	wInfo := workload.NewInfo(wl)
+	wInfo.LastEvaluatedGeneration = 1
+
+	otherWl := utiltestingapi.MakeWorkload("other", defaultNamespace).Obj()
+	otherInfo := workload.NewInfo(otherWl)
+
+	if cq.IsPreemptor(wInfo) {
+		t.Errorf("IsPreemptor(wInfo) = true, want false before requeue")
+	}
+
+	cq.RequeueIfNotPresent(ctx, wInfo, RequeueReasonPendingPreemption, "")
+
+	if !cq.IsPreemptor(wInfo) {
+		t.Errorf("IsPreemptor(wInfo) = false, want true after RequeueReasonPendingPreemption")
+	}
+	if cq.IsPreemptor(otherInfo) {
+		t.Errorf("IsPreemptor(otherInfo) = true, want false for non-preemptor workload")
+	}
+
+	wlModified := wl.DeepCopy()
+	wlModified.Generation = 2
+	wInfoModified := workload.NewInfo(wlModified)
+
+	if cq.IsPreemptor(wInfoModified) {
+		t.Errorf("IsPreemptor(wInfoModified) = true, want false after workload generation changed")
 	}
 }
 
@@ -1347,7 +1384,7 @@ func TestBestEffortFIFORequeueIfNotPresent(t *testing.T) {
 				t.Errorf("Unexpected inadmissible status (-want,+got):\n%s", diff)
 			}
 
-			gotSticky := cq.sw.matches(workload.Key(wl))
+			gotSticky := cq.pw.stickyMatches(workload.Key(wl))
 			if diff := cmp.Diff(tc.wantSticky, gotSticky); diff != "" {
 				t.Errorf("Unexpected sticky status (-want,+got):\n%s", diff)
 			}

--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -885,9 +885,15 @@ func (m *Manager) CleanUpOnContext(ctx context.Context) {
 	m.Broadcast()
 }
 
+// Head represents the head of a queue.
+type Head struct {
+	workload.Info
+	IsPreemptor bool
+}
+
 // Heads returns the heads of the queues, along with their associated ClusterQueue.
 // It blocks if the queues empty until they have elements or the context terminates.
-func (m *Manager) Heads(ctx context.Context) []workload.Info {
+func (m *Manager) Heads(ctx context.Context) []Head {
 	m.Lock()
 	defer m.Unlock()
 	log := ctrl.LoggerFrom(ctx)
@@ -906,8 +912,8 @@ func (m *Manager) Heads(ctx context.Context) []workload.Info {
 	}
 }
 
-func (m *Manager) heads() []workload.Info {
-	workloads := m.secondPassQueue.takeAllReady()
+func (m *Manager) heads() []Head {
+	heads := m.secondPassQueue.takeAllReady()
 	for cqName, cq := range m.hm.ClusterQueues() {
 		// Cache might be nil in tests, if cache is nil, we'll skip the check.
 		if m.statusChecker != nil && !m.statusChecker.ClusterQueueActive(cqName) {
@@ -921,7 +927,10 @@ func (m *Manager) heads() []workload.Info {
 		wlKey := workload.Key(wl.Obj)
 		wlCopy := *wl
 		wlCopy.ClusterQueue = cqName
-		workloads = append(workloads, wlCopy)
+		heads = append(heads, Head{
+			Info:        wlCopy,
+			IsPreemptor: cq.IsPreemptor(wl),
+		})
 
 		qKey := m.workloadAssignedQueues[wlKey]
 		q := m.localQueues[qKey]
@@ -929,7 +938,7 @@ func (m *Manager) heads() []workload.Info {
 
 		reportLQPendingWorkloads(m, q)
 	}
-	return workloads
+	return heads
 }
 
 func (m *Manager) Broadcast() {

--- a/pkg/cache/queue/manager_test.go
+++ b/pkg/cache/queue/manager_test.go
@@ -1691,7 +1691,7 @@ func TestHeadsAsync(t *testing.T) {
 	cases := map[string]struct {
 		initialObjs []client.Object
 		op          func(context.Context, *Manager, *sync.WaitGroup)
-		wantHeads   []workload.Info
+		wantHeads   []Head
 	}{
 		"AddClusterQueue": {
 			initialObjs: []client.Object{&wl, &queues[0]},
@@ -1708,10 +1708,12 @@ func TestHeadsAsync(t *testing.T) {
 					}
 				})
 			},
-			wantHeads: []workload.Info{
+			wantHeads: []Head{
 				{
-					Obj:          &wl,
-					ClusterQueue: "fooCq",
+					Info: workload.Info{
+						Obj:          &wl,
+						ClusterQueue: "fooCq",
+					},
 				},
 			},
 		},
@@ -1727,10 +1729,12 @@ func TestHeadsAsync(t *testing.T) {
 					}
 				})
 			},
-			wantHeads: []workload.Info{
+			wantHeads: []Head{
 				{
-					Obj:          &wl,
-					ClusterQueue: "fooCq",
+					Info: workload.Info{
+						Obj:          &wl,
+						ClusterQueue: "fooCq",
+					},
 				},
 			},
 		},
@@ -1748,10 +1752,12 @@ func TestHeadsAsync(t *testing.T) {
 					}
 				})
 			},
-			wantHeads: []workload.Info{
+			wantHeads: []Head{
 				{
-					Obj:          &wl,
-					ClusterQueue: "fooCq",
+					Info: workload.Info{
+						Obj:          &wl,
+						ClusterQueue: "fooCq",
+					},
 				},
 			},
 		},
@@ -1770,10 +1776,12 @@ func TestHeadsAsync(t *testing.T) {
 					}
 				})
 			},
-			wantHeads: []workload.Info{
+			wantHeads: []Head{
 				{
-					Obj:          &wl,
-					ClusterQueue: "fooCq",
+					Info: workload.Info{
+						Obj:          &wl,
+						ClusterQueue: "fooCq",
+					},
 				},
 			},
 		},
@@ -1792,10 +1800,12 @@ func TestHeadsAsync(t *testing.T) {
 					mgr.RequeueWorkload(ctx, workload.NewInfo(&wl), RequeueReasonFailedAfterNomination, "")
 				})
 			},
-			wantHeads: []workload.Info{
+			wantHeads: []Head{
 				{
-					Obj:          &wl,
-					ClusterQueue: "fooCq",
+					Info: workload.Info{
+						Obj:          &wl,
+						ClusterQueue: "fooCq",
+					},
 				},
 			},
 		},
@@ -1820,10 +1830,12 @@ func TestHeadsAsync(t *testing.T) {
 					mgr.RequeueWorkload(ctx, workload.NewInfo(&wl), RequeueReasonFailedAfterNomination, "")
 				})
 			},
-			wantHeads: []workload.Info{
+			wantHeads: []Head{
 				{
-					Obj:          &newWl,
-					ClusterQueue: "fooCq",
+					Info: workload.Info{
+						Obj:          &newWl,
+						ClusterQueue: "fooCq",
+					},
 				},
 			},
 		},
@@ -1852,10 +1864,12 @@ func TestHeadsAsync(t *testing.T) {
 					mgr.RequeueWorkload(ctx, workload.NewInfo(&wl), RequeueReasonFailedAfterNomination, "")
 				})
 			},
-			wantHeads: []workload.Info{
+			wantHeads: []Head{
 				{
-					Obj:          &newWl,
-					ClusterQueue: "barCq",
+					Info: workload.Info{
+						Obj:          &newWl,
+						ClusterQueue: "barCq",
+					},
 				},
 			},
 		},
@@ -1907,7 +1921,7 @@ func TestHeadsCancelledNoLostWakeup(t *testing.T) {
 	const iterations = 50
 	for i := range iterations {
 		headsCtx, cancel := context.WithCancel(ctx)
-		headsDone := make(chan []workload.Info, 1)
+		headsDone := make(chan []Head, 1)
 
 		go manager.CleanUpOnContext(headsCtx)
 		go func() {
@@ -2168,8 +2182,8 @@ func TestQueueSecondPassIfNeeded(t *testing.T) {
 			fakeClock.Step(tc.passTime)
 
 			gotReady := sets.New[workload.Reference]()
-			for _, wlInfo := range manager.secondPassQueue.takeAllReady() {
-				gotReady.Insert(workload.Key(wlInfo.Obj))
+			for _, head := range manager.secondPassQueue.takeAllReady() {
+				gotReady.Insert(workload.Key(head.Obj))
 			}
 
 			if diff := cmp.Diff(tc.wantReady, gotReady); diff != "" {

--- a/pkg/cache/queue/second_pass_queue.go
+++ b/pkg/cache/queue/second_pass_queue.go
@@ -50,13 +50,13 @@ func newSecondPassQueue() *secondPassQueue {
 	}
 }
 
-func (q *secondPassQueue) takeAllReady() []workload.Info {
+func (q *secondPassQueue) takeAllReady() []Head {
 	q.Lock()
 	defer q.Unlock()
 
-	var result []workload.Info
+	var result []Head
 	for _, v := range q.queued {
-		result = append(result, *v)
+		result = append(result, Head{Info: *v})
 	}
 	q.queued = make(map[workload.Reference]*workload.Info)
 	return result

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -559,6 +559,13 @@ const (
 	// in PodSet template metadata during Workload creation and update.
 	WorkloadValidationForPodSetMetadata featuregate.Feature = "WorkloadValidationForPodSetMetadata"
 
+	// owner: @Nilsachy
+	// issue: https://github.com/kubernetes-sigs/kueue/issues/13662
+	//
+	// PrioritizePreemptorWorkloads enables prioritization of workloads waiting for preemption
+	// to complete to prevent quota stealing and thrashing during desynchronized evictions.
+	PrioritizePreemptorWorkloads featuregate.Feature = "PrioritizePreemptorWorkloads"
+
 	// owner: @ivnovakov
 	//
 	// pr: https://github.com/kubernetes-sigs/kueue/pull/13279#discussion_r3655384989
@@ -935,6 +942,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 
 	WorkloadValidationForPodSetMetadata: {
 		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Beta},
+	},
+
+	PrioritizePreemptorWorkloads: {
+		{Version: version.MustParse("0.20"), Default: false, PreRelease: featuregate.Alpha},
 	},
 
 	LWSImmutableGroupSize: {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -945,7 +945,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 
 	PrioritizePreemptorWorkloads: {
-		{Version: version.MustParse("0.20"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("0.19"), Default: false, PreRelease: featuregate.Alpha},
 	},
 
 	LWSImmutableGroupSize: {

--- a/pkg/scheduler/fair_sharing_iterator.go
+++ b/pkg/scheduler/fair_sharing_iterator.go
@@ -174,11 +174,18 @@ type entryComparer struct {
 }
 
 func (e *entryComparer) less(a, b *entry, parentCohort kueue.CohortReference) bool {
+	// 1. Prioritize workloads waiting for preemption to complete if the feature is enabled.
+	if features.Enabled(features.PrioritizePreemptorWorkloads) {
+		if a.IsPreemptor != b.IsPreemptor {
+			return a.IsPreemptor
+		}
+	}
+
 	aDrs := e.drsValues[drsKey{parentCohort: parentCohort, workloadKey: workload.Key(a.Obj)}]
 	bDrs := e.drsValues[drsKey{parentCohort: parentCohort, workloadKey: workload.Key(b.Obj)}]
 
 	if features.Enabled(features.FairSharingPrioritizeNonBorrowing) {
-		// 1: Nominal first — prefer workloads whose subtree at this
+		// 2: Nominal — prefer workloads whose subtree at this
 		// tournament level is not borrowing from the parent cohort on
 		// the workload's requested flavors. A subtree borrowing on an
 		// unrelated flavor does not penalize workloads for flavors
@@ -192,12 +199,12 @@ func (e *entryComparer) less(a, b *entry, parentCohort kueue.CohortReference) bo
 		}
 	}
 
-	// 2: DRF
+	// 3: DRF
 	if cmp := schdcache.CompareDRS(aDrs, bDrs); cmp != 0 {
 		return cmp == -1
 	}
 
-	// 3: Effective priority
+	// 4: Effective priority
 	if features.Enabled(features.PrioritySortingWithinCohort) {
 		p1 := priority.EffectivePriority(e.log, a.Obj)
 		p2 := priority.EffectivePriority(e.log, b.Obj)
@@ -206,7 +213,7 @@ func (e *entryComparer) less(a, b *entry, parentCohort kueue.CohortReference) bo
 		}
 	}
 
-	// 4: FIFO
+	// 5: FIFO
 	aComparisonTimestamp := e.workloadOrdering.GetQueueOrderTimestamp(a.Obj)
 	bComparisonTimestamp := e.workloadOrdering.GetQueueOrderTimestamp(b.Obj)
 	return aComparisonTimestamp.Before(bComparisonTimestamp)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -316,13 +316,13 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 
 	// 1. Get the heads from the queues, including their desired clusterQueue.
 	// This operation blocks while the queues are empty.
-	headWorkloads := s.queues.Heads(ctx)
+	heads := s.queues.Heads(ctx)
 	// If there are no elements, it means that the program is finishing.
-	if len(headWorkloads) == 0 {
+	if len(heads) == 0 {
 		return wait.KeepGoing
 	}
 	startTime := s.clock.Now()
-	log.V(2).Info("Obtained heads", "headCount", len(headWorkloads), "waitDuration", startTime.Sub(cycleStartTime))
+	log.V(2).Info("Obtained heads", "headCount", len(heads), "waitDuration", startTime.Sub(cycleStartTime))
 
 	// 2. Take a snapshot of the cache.
 	var snapshotOpts []schdcache.SnapshotOption
@@ -340,7 +340,7 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 
 	// 3. Calculate requirements (resource flavors, borrowing) for admitting workloads.
 	phaseStartTime = s.clock.Now()
-	entries, inadmissibleEntries := s.nominate(ctx, headWorkloads, snapshot)
+	entries, inadmissibleEntries := s.nominate(ctx, heads, snapshot)
 	log.V(2).Info("Nomination done", "entries", len(entries), "inadmissibleEntries", len(inadmissibleEntries), "duration", s.clock.Since(phaseStartTime))
 
 	// 4. Create iterator which returns ordered entries.
@@ -531,11 +531,12 @@ func (s *Scheduler) handleFailedTASReplacement(ctx context.Context, log logr.Log
 
 // reserveCapacityForUnreclaimablePreempt is called when an entry needs preemption
 // but has no candidate targets. If the ClusterQueue cannot always reclaim its
-// nominal capacity, we reserve up to the borrowing limit so that lower-priority
+// nominal capacity, or if the workload is an active preemptor waiting for evictions
+// to complete, we reserve up to the borrowing limit so that lower-priority
 // workloads in another Cohort cannot admit before us.
 func (s *Scheduler) reserveCapacityForUnreclaimablePreempt(log logr.Logger, e *entry, cq *schdcache.ClusterQueueSnapshot) {
 	log.V(2).Info("Workload requires preemption, but there are no candidate workloads allowed for preemption", "preemption", cq.Preemption)
-	if !preemption.CanAlwaysReclaim(cq) {
+	if !preemption.CanAlwaysReclaim(cq) || (features.Enabled(features.PrioritizePreemptorWorkloads) && e.IsPreemptor) {
 		cq.AddUsage(resourcesToReserve(log, e, cq))
 	}
 }
@@ -628,9 +629,9 @@ const (
 
 // entry holds requirements for a workload to be admitted by a clusterQueue.
 type entry struct {
-	// workload.Info holds the workload from the API as well as resource usage
-	// and flavors assigned.
-	workload.Info
+	// qcache.Head holds the workload from the API as well as resource usage
+	// and flavors assigned, along with queue-specific metadata.
+	qcache.Head
 	assignment           flavorassigner.Assignment
 	status               entryStatus
 	inadmissibleMsg      string
@@ -659,27 +660,27 @@ func (e *entry) readResourceToFlavorMapping() workload.PodSetResourcesToFlavors 
 // nominate returns the workloads with their requirements (resource flavors, borrowing) if
 // they were admitted by the clusterQueues in the snapshot. The second return value
 // is the list of inadmissibleEntries.
-func (s *Scheduler) nominate(ctx context.Context, workloads []workload.Info, snap *schdcache.Snapshot) ([]entry, []entry) {
+func (s *Scheduler) nominate(ctx context.Context, heads []qcache.Head, snap *schdcache.Snapshot) ([]entry, []entry) {
 	log := ctrl.LoggerFrom(ctx)
-	entries := make([]entry, 0, len(workloads))
+	entries := make([]entry, 0, len(heads))
 	var inadmissibleEntries []entry
-	for _, w := range workloads {
-		log := log.WithValues("workload", klog.KObj(w.Obj), "clusterQueue", klog.KRef("", string(w.ClusterQueue)))
-		e := entry{Info: w}
-		e.clusterQueueSnapshot = snap.ClusterQueue(w.ClusterQueue)
-		if !workload.NeedsSecondPass(w.Obj) && s.cache.IsAdded(w) {
-			log.Info("Workload skipped from admission because it's already accounted in cache, and it does not need second pass", "workload", klog.KObj(w.Obj))
+	for _, h := range heads {
+		log := log.WithValues("workload", klog.KObj(h.Obj), "clusterQueue", klog.KRef("", string(h.ClusterQueue)))
+		e := entry{Head: h}
+		e.clusterQueueSnapshot = snap.ClusterQueue(h.ClusterQueue)
+		if !workload.NeedsSecondPass(h.Obj) && s.cache.IsAdded(h.Info) {
+			log.Info("Workload skipped from admission because it's already accounted in cache, and it does not need second pass", "workload", klog.KObj(h.Obj))
 			continue
-		} else if workload.HasRetryChecks(w.Obj) || workload.HasRejectedChecks(w.Obj) {
+		} else if workload.HasRetryChecks(h.Obj) || workload.HasRejectedChecks(h.Obj) {
 			e.inadmissibleMsg = "The workload has failed admission checks"
 			e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonPendingEvaluation
-		} else if snap.InactiveClusterQueueSets.Has(w.ClusterQueue) {
-			e.inadmissibleMsg = fmt.Sprintf("ClusterQueue %s is inactive", w.ClusterQueue)
+		} else if snap.InactiveClusterQueueSets.Has(h.ClusterQueue) {
+			e.inadmissibleMsg = fmt.Sprintf("ClusterQueue %s is inactive", h.ClusterQueue)
 			e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonSuspended
 		} else if e.clusterQueueSnapshot == nil {
-			e.inadmissibleMsg = fmt.Sprintf("ClusterQueue %s not found", w.ClusterQueue)
+			e.inadmissibleMsg = fmt.Sprintf("ClusterQueue %s not found", h.ClusterQueue)
 			e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonMisconfigured
-		} else if err := workload.ValidateAdmissibility(ctx, s.client, &w, e.clusterQueueSnapshot.NamespaceSelector); err != nil {
+		} else if err := workload.ValidateAdmissibility(ctx, s.client, &h.Info, e.clusterQueueSnapshot.NamespaceSelector); err != nil {
 			e.inadmissibleMsg = err.Error()
 			if errors.Is(err, workload.ErrInternal) {
 				log.Error(err, "Failed to validate workload admissibility")
@@ -1103,14 +1104,24 @@ func makeClassicalIterator(log logr.Logger, entries []entry, workloadOrdering wo
 			return 1
 		}
 
-		// 1. Request under nominal quota.
+		// 1. Process workloads pending preemption if the feature is enabled.
+		if features.Enabled(features.PrioritizePreemptorWorkloads) {
+			if a.IsPreemptor != b.IsPreemptor {
+				if a.IsPreemptor {
+					return -1
+				}
+				return 1
+			}
+		}
+
+		// 2. Request under nominal quota.
 		aBorrows := a.assignment.Borrows()
 		bBorrows := b.assignment.Borrows()
 		if aBorrows != bBorrows {
 			return cmp.Compare(aBorrows, bBorrows)
 		}
 
-		// 2. Higher priority first if not disabled.
+		// 3. Higher priority first if not disabled.
 		if features.Enabled(features.PrioritySortingWithinCohort) {
 			p1 := priority.EffectivePriority(log, a.Obj)
 			p2 := priority.EffectivePriority(log, b.Obj)
@@ -1119,7 +1130,7 @@ func makeClassicalIterator(log logr.Logger, entries []entry, workloadOrdering wo
 			}
 		}
 
-		// 3. FIFO.
+		// 4. FIFO.
 		aComparisonTimestamp := workloadOrdering.GetQueueOrderTimestamp(a.Obj)
 		bComparisonTimestamp := workloadOrdering.GetQueueOrderTimestamp(b.Obj)
 		if aComparisonTimestamp.Before(bComparisonTimestamp) {

--- a/pkg/scheduler/scheduler_afs_test.go
+++ b/pkg/scheduler/scheduler_afs_test.go
@@ -1005,7 +1005,7 @@ func TestShouldApplyEntryPenalty(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			s := &Scheduler{admissionFairSharing: tc.afsConfig}
 			e := &entry{
-				Info: *workload.NewInfo(tc.wl),
+				Head: qcache.Head{Info: *workload.NewInfo(tc.wl)},
 				clusterQueueSnapshot: &schdcache.ClusterQueueSnapshot{
 					AdmissionScope: kueue.AdmissionScope{AdmissionMode: tc.admissionMode},
 				},

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -6777,103 +6777,119 @@ func TestEntryOrdering(t *testing.T) {
 	now := time.Now()
 	input := []entry{
 		{
-			Info: workload.Info{
-				Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
-					Name:              "old_borrowing",
-					CreationTimestamp: metav1.NewTime(now),
-				}},
-			},
-			assignment: flavorassigner.Assignment{
-				Borrowing: 1,
-			},
-		},
-		{
-			Info: workload.Info{
-				Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
-					Name:              "old",
-					CreationTimestamp: metav1.NewTime(now.Add(time.Second)),
-				}},
-			},
-		},
-		{
-			Info: workload.Info{
-				Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
-					Name:              "new",
-					CreationTimestamp: metav1.NewTime(now.Add(3 * time.Second)),
-				}},
-			},
-		},
-		{
-			Info: workload.Info{
-				Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
-					Name:              "high_pri_borrowing",
-					CreationTimestamp: metav1.NewTime(now.Add(3 * time.Second)),
-				}, Spec: kueue.WorkloadSpec{
-					Priority: new(int32(1)),
-				}},
-			},
-			assignment: flavorassigner.Assignment{
-				Borrowing: 1,
-			},
-		},
-		{
-			Info: workload.Info{
-				Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
-					Name:              "new_high_pri",
-					CreationTimestamp: metav1.NewTime(now.Add(4 * time.Second)),
-				}, Spec: kueue.WorkloadSpec{
-					Priority: new(int32(1)),
-				}},
-			},
-		},
-		{
-			Info: workload.Info{
-				Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
-					Name:              "new_borrowing",
-					CreationTimestamp: metav1.NewTime(now.Add(3 * time.Second)),
-				}},
-			},
-			assignment: flavorassigner.Assignment{
-				Borrowing: 1,
-			},
-		},
-		{
-			Info: workload.Info{
-				Obj: &kueue.Workload{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:              "evicted_borrowing",
-						CreationTimestamp: metav1.NewTime(now.Add(time.Second)),
-					},
-					Status: kueue.WorkloadStatus{
-						Conditions: []metav1.Condition{
-							{
-								Type:               kueue.WorkloadEvicted,
-								Status:             metav1.ConditionTrue,
-								LastTransitionTime: metav1.NewTime(now.Add(2 * time.Second)),
-								Reason:             kueue.WorkloadEvictedByPodsReadyTimeout,
-							},
-						},
-					},
-				},
-			},
-			assignment: flavorassigner.Assignment{
-				Borrowing: 1,
-			},
-		},
-		{
-			Info: workload.Info{
-				Obj: &kueue.Workload{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:              "recently_evicted",
+			Head: qcache.Head{
+				Info: workload.Info{
+					Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+						Name:              "old_borrowing",
 						CreationTimestamp: metav1.NewTime(now),
+					}},
+				},
+			},
+			assignment: flavorassigner.Assignment{
+				Borrowing: 1,
+			},
+		},
+		{
+			Head: qcache.Head{
+				Info: workload.Info{
+					Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+						Name:              "old",
+						CreationTimestamp: metav1.NewTime(now.Add(time.Second)),
+					}},
+				},
+			},
+		},
+		{
+			Head: qcache.Head{
+				Info: workload.Info{
+					Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+						Name:              "new",
+						CreationTimestamp: metav1.NewTime(now.Add(3 * time.Second)),
+					}},
+				},
+			},
+		},
+		{
+			Head: qcache.Head{
+				Info: workload.Info{
+					Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+						Name:              "high_pri_borrowing",
+						CreationTimestamp: metav1.NewTime(now.Add(3 * time.Second)),
+					}, Spec: kueue.WorkloadSpec{
+						Priority: new(int32(1)),
+					}},
+				},
+			},
+			assignment: flavorassigner.Assignment{
+				Borrowing: 1,
+			},
+		},
+		{
+			Head: qcache.Head{
+				Info: workload.Info{
+					Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+						Name:              "new_high_pri",
+						CreationTimestamp: metav1.NewTime(now.Add(4 * time.Second)),
+					}, Spec: kueue.WorkloadSpec{
+						Priority: new(int32(1)),
+					}},
+				},
+			},
+		},
+		{
+			Head: qcache.Head{
+				Info: workload.Info{
+					Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+						Name:              "new_borrowing",
+						CreationTimestamp: metav1.NewTime(now.Add(3 * time.Second)),
+					}},
+				},
+			},
+			assignment: flavorassigner.Assignment{
+				Borrowing: 1,
+			},
+		},
+		{
+			Head: qcache.Head{
+				Info: workload.Info{
+					Obj: &kueue.Workload{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "evicted_borrowing",
+							CreationTimestamp: metav1.NewTime(now.Add(time.Second)),
+						},
+						Status: kueue.WorkloadStatus{
+							Conditions: []metav1.Condition{
+								{
+									Type:               kueue.WorkloadEvicted,
+									Status:             metav1.ConditionTrue,
+									LastTransitionTime: metav1.NewTime(now.Add(2 * time.Second)),
+									Reason:             kueue.WorkloadEvictedByPodsReadyTimeout,
+								},
+							},
+						},
 					},
-					Status: kueue.WorkloadStatus{
-						Conditions: []metav1.Condition{
-							{
-								Type:               kueue.WorkloadEvicted,
-								Status:             metav1.ConditionTrue,
-								LastTransitionTime: metav1.NewTime(now.Add(2 * time.Second)),
-								Reason:             kueue.WorkloadEvictedByPodsReadyTimeout,
+				},
+			},
+			assignment: flavorassigner.Assignment{
+				Borrowing: 1,
+			},
+		},
+		{
+			Head: qcache.Head{
+				Info: workload.Info{
+					Obj: &kueue.Workload{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "recently_evicted",
+							CreationTimestamp: metav1.NewTime(now),
+						},
+						Status: kueue.WorkloadStatus{
+							Conditions: []metav1.Condition{
+								{
+									Type:               kueue.WorkloadEvicted,
+									Status:             metav1.ConditionTrue,
+									LastTransitionTime: metav1.NewTime(now.Add(2 * time.Second)),
+									Reason:             kueue.WorkloadEvictedByPodsReadyTimeout,
+								},
 							},
 						},
 					},
@@ -6881,13 +6897,15 @@ func TestEntryOrdering(t *testing.T) {
 			},
 		},
 		{
-			Info: workload.Info{
-				Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
-					Name:              "high_pri_borrowing_more",
-					CreationTimestamp: metav1.NewTime(now.Add(3 * time.Second)),
-				}, Spec: kueue.WorkloadSpec{
-					Priority: new(int32(1)),
-				}},
+			Head: qcache.Head{
+				Info: workload.Info{
+					Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+						Name:              "high_pri_borrowing_more",
+						CreationTimestamp: metav1.NewTime(now.Add(3 * time.Second)),
+					}, Spec: kueue.WorkloadSpec{
+						Priority: new(int32(1)),
+					}},
+				},
 			},
 			assignment: flavorassigner.Assignment{
 				Borrowing: 2,
@@ -6896,80 +6914,142 @@ func TestEntryOrdering(t *testing.T) {
 	}
 	inputForOrderingPreemptedWorkloads := []entry{
 		{
-			Info: workload.Info{
-				Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
-					Name:              "old-mid-recently-preempted-in-queue",
-					CreationTimestamp: metav1.NewTime(now),
-				}, Spec: kueue.WorkloadSpec{
-					Priority: new(int32(1)),
-				}, Status: kueue.WorkloadStatus{
-					Conditions: []metav1.Condition{
-						{
-							Type:               kueue.WorkloadPreempted,
-							Status:             metav1.ConditionTrue,
-							Reason:             kueue.InClusterQueueReason,
-							LastTransitionTime: metav1.NewTime(now.Add(5 * time.Second)),
+			Head: qcache.Head{
+				Info: workload.Info{
+					Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+						Name:              "old-mid-recently-preempted-in-queue",
+						CreationTimestamp: metav1.NewTime(now),
+					}, Spec: kueue.WorkloadSpec{
+						Priority: new(int32(1)),
+					}, Status: kueue.WorkloadStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:               kueue.WorkloadPreempted,
+								Status:             metav1.ConditionTrue,
+								Reason:             kueue.InClusterQueueReason,
+								LastTransitionTime: metav1.NewTime(now.Add(5 * time.Second)),
+							},
+						},
+					}},
+				},
+			},
+		},
+		{
+			Head: qcache.Head{
+				Info: workload.Info{
+					Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+						Name:              "old-mid-recently-reclaimed-while-borrowing",
+						CreationTimestamp: metav1.NewTime(now),
+					}, Spec: kueue.WorkloadSpec{
+						Priority: new(int32(1)),
+					}, Status: kueue.WorkloadStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:               kueue.WorkloadPreempted,
+								Status:             metav1.ConditionTrue,
+								Reason:             kueue.InCohortReclaimWhileBorrowingReason,
+								LastTransitionTime: metav1.NewTime(now.Add(6 * time.Second)),
+							},
+						},
+					}},
+				},
+			},
+		},
+		{
+			Head: qcache.Head{
+				Info: workload.Info{
+					Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+						Name:              "old-mid-more-recently-reclaimed-while-borrowing",
+						CreationTimestamp: metav1.NewTime(now),
+					}, Spec: kueue.WorkloadSpec{
+						Priority: new(int32(1)),
+					}, Status: kueue.WorkloadStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:               kueue.WorkloadPreempted,
+								Status:             metav1.ConditionTrue,
+								Reason:             kueue.InCohortReclaimWhileBorrowingReason,
+								LastTransitionTime: metav1.NewTime(now.Add(7 * time.Second)),
+							},
+						},
+					}},
+				},
+			},
+		},
+		{
+			Head: qcache.Head{
+				Info: workload.Info{
+					Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+						Name:              "old-mid-not-preempted-yet",
+						CreationTimestamp: metav1.NewTime(now.Add(time.Second)),
+					}, Spec: kueue.WorkloadSpec{
+						Priority: new(int32(1)),
+					}},
+				},
+			},
+		},
+		{
+			Head: qcache.Head{
+				Info: workload.Info{
+					Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+						Name:              "preemptor",
+						CreationTimestamp: metav1.NewTime(now.Add(7 * time.Second)),
+					}, Spec: kueue.WorkloadSpec{
+						Priority: new(int32(2)),
+					}},
+				},
+			},
+		},
+	}
+	inputForOrderingPreemptorWorkloads := []entry{
+		{
+			Head: qcache.Head{
+				Info: workload.Info{
+					Obj: &kueue.Workload{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "preemptor-borrowing",
+							CreationTimestamp: metav1.NewTime(now.Add(time.Second)),
+						},
+						Spec: kueue.WorkloadSpec{
+							Priority: new(int32(1)),
 						},
 					},
-				}},
+				},
+				IsPreemptor: true,
+			},
+			assignment: flavorassigner.Assignment{
+				Borrowing: 1,
 			},
 		},
 		{
-			Info: workload.Info{
-				Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
-					Name:              "old-mid-recently-reclaimed-while-borrowing",
-					CreationTimestamp: metav1.NewTime(now),
-				}, Spec: kueue.WorkloadSpec{
-					Priority: new(int32(1)),
-				}, Status: kueue.WorkloadStatus{
-					Conditions: []metav1.Condition{
-						{
-							Type:               kueue.WorkloadPreempted,
-							Status:             metav1.ConditionTrue,
-							Reason:             kueue.InCohortReclaimWhileBorrowingReason,
-							LastTransitionTime: metav1.NewTime(now.Add(6 * time.Second)),
+			Head: qcache.Head{
+				Info: workload.Info{
+					Obj: &kueue.Workload{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "preemptor-not-borrowing",
+							CreationTimestamp: metav1.NewTime(now.Add(2 * time.Second)),
+						},
+						Spec: kueue.WorkloadSpec{
+							Priority: new(int32(1)),
 						},
 					},
-				}},
+				},
+				IsPreemptor: true,
 			},
 		},
 		{
-			Info: workload.Info{
-				Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
-					Name:              "old-mid-more-recently-reclaimed-while-borrowing",
-					CreationTimestamp: metav1.NewTime(now),
-				}, Spec: kueue.WorkloadSpec{
-					Priority: new(int32(1)),
-				}, Status: kueue.WorkloadStatus{
-					Conditions: []metav1.Condition{
-						{
-							Type:               kueue.WorkloadPreempted,
-							Status:             metav1.ConditionTrue,
-							Reason:             kueue.InCohortReclaimWhileBorrowingReason,
-							LastTransitionTime: metav1.NewTime(now.Add(7 * time.Second)),
+			Head: qcache.Head{
+				Info: workload.Info{
+					Obj: &kueue.Workload{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "not-preemptor-not-borrowing",
+							CreationTimestamp: metav1.NewTime(now),
+						},
+						Spec: kueue.WorkloadSpec{
+							Priority: new(int32(2)),
 						},
 					},
-				}},
-			},
-		},
-		{
-			Info: workload.Info{
-				Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
-					Name:              "old-mid-not-preempted-yet",
-					CreationTimestamp: metav1.NewTime(now.Add(time.Second)),
-				}, Spec: kueue.WorkloadSpec{
-					Priority: new(int32(1)),
-				}},
-			},
-		},
-		{
-			Info: workload.Info{
-				Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
-					Name:              "preemptor",
-					CreationTimestamp: metav1.NewTime(now.Add(7 * time.Second)),
-				}, Spec: kueue.WorkloadSpec{
-					Priority: new(int32(2)),
-				}},
+				},
 			},
 		},
 	}
@@ -7030,6 +7110,32 @@ func TestEntryOrdering(t *testing.T) {
 				"old-mid-recently-reclaimed-while-borrowing",
 				"old-mid-more-recently-reclaimed-while-borrowing",
 				"old-mid-not-preempted-yet",
+			},
+		},
+		{
+			name:  "Some workloads are preemptors; PrioritizePreemptorWorkloads is disabled",
+			input: inputForOrderingPreemptorWorkloads,
+			featureGates: map[featuregate.Feature]bool{
+				features.PrioritySortingWithinCohort:  true,
+				features.PrioritizePreemptorWorkloads: false,
+			},
+			wantOrder: []string{
+				"not-preemptor-not-borrowing",
+				"preemptor-not-borrowing",
+				"preemptor-borrowing",
+			},
+		},
+		{
+			name:  "Some workloads are preemptors; PrioritizePreemptorWorkloads is enabled",
+			input: inputForOrderingPreemptorWorkloads,
+			featureGates: map[featuregate.Feature]bool{
+				features.PrioritySortingWithinCohort:  true,
+				features.PrioritizePreemptorWorkloads: true,
+			},
+			wantOrder: []string{
+				"preemptor-not-borrowing",
+				"preemptor-borrowing",
+				"not-preemptor-not-borrowing",
 			},
 		},
 	} {
@@ -8123,7 +8229,7 @@ func TestRequeueAndUpdate(t *testing.T) {
 				if len(wInfos) != 1 {
 					t.Fatalf("Failed getting heads in cluster queue")
 				}
-				tc.e.Info = wInfos[0]
+				tc.e.Head = wInfos[0]
 				scheduler.requeueAndUpdate(ctx, tc.e)
 
 				qDump := qManager.Dump()
@@ -8190,10 +8296,12 @@ func TestEntryMarkSkipped(t *testing.T) {
 			features.SetFeatureGateDuringTest(t, features.FlavorFungibilityPreserveScanProgress, tc.preserveProgress)
 
 			e := entry{
-				Info: workload.Info{
-					LastAssignment: &workload.AssignmentClusterQueueState{
-						LastTriedFlavorIdx: []map[corev1.ResourceName]int{
-							{corev1.ResourceCPU: 0},
+				Head: qcache.Head{
+					Info: workload.Info{
+						LastAssignment: &workload.AssignmentClusterQueueState{
+							LastTriedFlavorIdx: []map[corev1.ResourceName]int{
+								{corev1.ResourceCPU: 0},
+							},
 						},
 					},
 				},
@@ -8261,8 +8369,10 @@ func TestEntryMarkPreemptionOutcome(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			e := entry{
 				inadmissibleMsg: "fits with preemption",
-				Info: workload.Info{
-					LastAssignment: assignmentState,
+				Head: qcache.Head{
+					Info: workload.Info{
+						LastAssignment: assignmentState,
+					},
 				},
 			}
 
@@ -8293,26 +8403,31 @@ func TestEntryComparerLess(t *testing.T) {
 		b            *entry
 		drsValues    map[drsKey]schdcache.DRS
 		requestedFRs map[workload.Reference]resources.FlavorResourceQuantities
+		featureGates map[featuregate.Feature]bool
 		wantLess     bool
 	}{
 		{
 			name: "non-borrowing subtree preferred over borrowing subtree",
 			a: &entry{
-				Info: workload.Info{
-					Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
-						Name:              "nominal",
-						Namespace:         "default",
-						CreationTimestamp: metav1.NewTime(now.Add(time.Second)),
-					}},
+				Head: qcache.Head{
+					Info: workload.Info{
+						Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+							Name:              "nominal",
+							Namespace:         "default",
+							CreationTimestamp: metav1.NewTime(now.Add(time.Second)),
+						}},
+					},
 				},
 			},
 			b: &entry{
-				Info: workload.Info{
-					Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
-						Name:              "borrowing",
-						Namespace:         "default",
-						CreationTimestamp: metav1.NewTime(now),
-					}},
+				Head: qcache.Head{
+					Info: workload.Info{
+						Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+							Name:              "borrowing",
+							Namespace:         "default",
+							CreationTimestamp: metav1.NewTime(now),
+						}},
+					},
 				},
 			},
 			drsValues: map[drsKey]schdcache.DRS{
@@ -8328,21 +8443,25 @@ func TestEntryComparerLess(t *testing.T) {
 		{
 			name: "both borrowing on requested flavors falls through to FIFO",
 			a: &entry{
-				Info: workload.Info{
-					Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
-						Name:              "borrow-a",
-						Namespace:         "default",
-						CreationTimestamp: metav1.NewTime(now.Add(time.Second)),
-					}},
+				Head: qcache.Head{
+					Info: workload.Info{
+						Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+							Name:              "borrow-a",
+							Namespace:         "default",
+							CreationTimestamp: metav1.NewTime(now.Add(time.Second)),
+						}},
+					},
 				},
 			},
 			b: &entry{
-				Info: workload.Info{
-					Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
-						Name:              "borrow-b",
-						Namespace:         "default",
-						CreationTimestamp: metav1.NewTime(now),
-					}},
+				Head: qcache.Head{
+					Info: workload.Info{
+						Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+							Name:              "borrow-b",
+							Namespace:         "default",
+							CreationTimestamp: metav1.NewTime(now),
+						}},
+					},
 				},
 			},
 			drsValues: map[drsKey]schdcache.DRS{
@@ -8358,21 +8477,25 @@ func TestEntryComparerLess(t *testing.T) {
 		{
 			name: "lower DRS preferred over higher DRS",
 			a: &entry{
-				Info: workload.Info{
-					Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
-						Name:              "lower-drs",
-						Namespace:         "default",
-						CreationTimestamp: metav1.NewTime(now.Add(time.Second)),
-					}},
+				Head: qcache.Head{
+					Info: workload.Info{
+						Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+							Name:              "lower-drs",
+							Namespace:         "default",
+							CreationTimestamp: metav1.NewTime(now.Add(time.Second)),
+						}},
+					},
 				},
 			},
 			b: &entry{
-				Info: workload.Info{
-					Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
-						Name:              "higher-drs",
-						Namespace:         "default",
-						CreationTimestamp: metav1.NewTime(now),
-					}},
+				Head: qcache.Head{
+					Info: workload.Info{
+						Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+							Name:              "higher-drs",
+							Namespace:         "default",
+							CreationTimestamp: metav1.NewTime(now),
+						}},
+					},
 				},
 			},
 			drsValues: map[drsKey]schdcache.DRS{
@@ -8384,27 +8507,155 @@ func TestEntryComparerLess(t *testing.T) {
 		{
 			name: "both non-borrowing falls through to FIFO",
 			a: &entry{
-				Info: workload.Info{
-					Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
-						Name:              "older",
-						Namespace:         "default",
-						CreationTimestamp: metav1.NewTime(now),
-					}},
+				Head: qcache.Head{
+					Info: workload.Info{
+						Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+							Name:              "older",
+							Namespace:         "default",
+							CreationTimestamp: metav1.NewTime(now),
+						}},
+					},
 				},
 			},
 			b: &entry{
-				Info: workload.Info{
-					Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
-						Name:              "newer",
-						Namespace:         "default",
-						CreationTimestamp: metav1.NewTime(now.Add(time.Second)),
-					}},
+				Head: qcache.Head{
+					Info: workload.Info{
+						Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+							Name:              "newer",
+							Namespace:         "default",
+							CreationTimestamp: metav1.NewTime(now.Add(time.Second)),
+						}},
+					},
 				},
 			},
 			wantLess: true,
 		},
+		{
+			name: "a is preemptor, b not, feature enabled",
+			a: &entry{
+				Head: qcache.Head{
+					Info: workload.Info{
+						Obj: &kueue.Workload{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "preemptor-borrowing",
+								Namespace: "default",
+							},
+						},
+					},
+					IsPreemptor: true,
+				},
+			},
+			b: &entry{
+				Head: qcache.Head{
+					Info: workload.Info{
+						Obj: &kueue.Workload{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "not-preemptor-nominal",
+								Namespace: "default",
+							},
+						},
+					},
+				},
+			},
+			drsValues: map[drsKey]schdcache.DRS{
+				{parentCohort: cohort, workloadKey: "default/preemptor-borrowing"}:   schdcache.BorrowingDRS(cpuDefault),
+				{parentCohort: cohort, workloadKey: "default/not-preemptor-nominal"}: {},
+			},
+			requestedFRs: map[workload.Reference]resources.FlavorResourceQuantities{
+				"default/preemptor-borrowing":   {cpuDefault: resources.NewAmount(1)},
+				"default/not-preemptor-nominal": {cpuDefault: resources.NewAmount(1)},
+			},
+			featureGates: map[featuregate.Feature]bool{
+				features.PrioritizePreemptorWorkloads: true,
+			},
+			wantLess: true,
+		},
+		{
+			name: "a is preemptor, b not, feature disabled",
+			a: &entry{
+				Head: qcache.Head{
+					Info: workload.Info{
+						Obj: &kueue.Workload{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "preemptor-borrowing",
+								Namespace: "default",
+							},
+						},
+					},
+					IsPreemptor: true,
+				},
+			},
+			b: &entry{
+				Head: qcache.Head{
+					Info: workload.Info{
+						Obj: &kueue.Workload{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "not-preemptor-nominal",
+								Namespace: "default",
+							},
+						},
+					},
+				},
+			},
+			drsValues: map[drsKey]schdcache.DRS{
+				{parentCohort: cohort, workloadKey: "default/preemptor-borrowing"}:   schdcache.BorrowingDRS(cpuDefault),
+				{parentCohort: cohort, workloadKey: "default/not-preemptor-nominal"}: {},
+			},
+			requestedFRs: map[workload.Reference]resources.FlavorResourceQuantities{
+				"default/preemptor-borrowing":   {cpuDefault: resources.NewAmount(1)},
+				"default/not-preemptor-nominal": {cpuDefault: resources.NewAmount(1)},
+			},
+			featureGates: map[featuregate.Feature]bool{
+				features.PrioritizePreemptorWorkloads: false,
+			},
+			wantLess: false,
+		},
+		{
+			name: "both are preemptors, feature enabled",
+			a: &entry{
+				Head: qcache.Head{
+					Info: workload.Info{
+						Obj: &kueue.Workload{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "preemptor-borrowing",
+								Namespace: "default",
+							},
+						},
+					},
+					IsPreemptor: true,
+				},
+			},
+			b: &entry{
+				Head: qcache.Head{
+					Info: workload.Info{
+						Obj: &kueue.Workload{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "preemptor-nominal",
+								Namespace: "default",
+							},
+						},
+					},
+					IsPreemptor: true,
+				},
+			},
+			drsValues: map[drsKey]schdcache.DRS{
+				{parentCohort: cohort, workloadKey: "default/preemptor-borrowing"}: schdcache.BorrowingDRS(cpuDefault),
+				{parentCohort: cohort, workloadKey: "default/preemptor-nominal"}:   {},
+			},
+			requestedFRs: map[workload.Reference]resources.FlavorResourceQuantities{
+				"default/preemptor-borrowing": {cpuDefault: resources.NewAmount(1)},
+				"default/preemptor-nominal":   {cpuDefault: resources.NewAmount(1)},
+			},
+			featureGates: map[featuregate.Feature]bool{
+				features.PrioritizePreemptorWorkloads: true,
+			},
+			wantLess: false,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			if tc.featureGates != nil {
+				features.SetFeatureGatesDuringTest(t, tc.featureGates)
+			}
 			drsValues := tc.drsValues
 			if drsValues == nil {
 				drsValues = make(map[drsKey]schdcache.DRS)
@@ -8583,9 +8834,9 @@ func TestResourcesToReserve(t *testing.T) {
 				Borrowing: tc.borrowing,
 				Usage:     workload.Usage{Quota: tc.assignmentUsage},
 			}
-			e := &entry{assignment: assignment, Info: *workload.NewInfo(
+			e := &entry{assignment: assignment, Head: qcache.Head{Info: *workload.NewInfo(
 				&kueue.Workload{},
-			)}
+			)}}
 			cl := utiltesting.NewClientBuilder().
 				WithLists(&kueue.ClusterQueueList{Items: []kueue.ClusterQueue{*cq}}).
 				Build()

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -331,6 +331,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.18"
+- name: PrioritizePreemptorWorkloads
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.20"
 - name: PriorityBoost
   versionedSpecs:
   - default: false

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -336,7 +336,7 @@
   - default: false
     lockToDefault: false
     preRelease: Alpha
-    version: "0.20"
+    version: "0.19"
 - name: PriorityBoost
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -331,6 +331,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.18"
+- name: PrioritizePreemptorWorkloads
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.20"
 - name: PriorityBoost
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -336,7 +336,7 @@
   - default: false
     lockToDefault: false
     preRelease: Alpha
-    version: "0.20"
+    version: "0.19"
 - name: PriorityBoost
   versionedSpecs:
   - default: false

--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -403,6 +403,77 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing"), func()
 			util.ExpectEvictedWorkloadsTotalMetric(cqB.Name, kueue.WorkloadEvictedByPreemption, "", "", 0)
 		})
 
+		ginkgo.It("Should prevent other workloads from stealing quota when preemptor is waiting for multiple evictions", func() {
+			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.PrioritizePreemptorWorkloads, true)
+
+			cohort := createCohort(utiltestingapi.MakeCohort(kueue.CohortReference("thrash-cohort-" + ns.Name)).Obj())
+
+			cq1 := createQueue(utiltestingapi.MakeClusterQueue("cq-1-" + ns.Name).
+				Cohort(kueue.CohortReference(cohort.Name)).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "10").
+						Resource(corev1.ResourceMemory, "0").Obj(),
+				).
+				Preemption(kueue.ClusterQueuePreemption{
+					ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+				}).
+				Obj())
+
+			cq2 := createQueue(utiltestingapi.MakeClusterQueue("cq-2-" + ns.Name).
+				Cohort(kueue.CohortReference(cohort.Name)).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "0").
+						Resource(corev1.ResourceMemory, "10").Obj(),
+				).
+				Preemption(kueue.ClusterQueuePreemption{
+					ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+				}).
+				Obj())
+
+			createWorkloadWithCPUAndMemory := func(queue string, cpu, memory string, priority int32) *kueue.Workload {
+				wl := utiltestingapi.MakeWorkloadWithGeneratedName("wl-", ns.Name).
+					Priority(priority).
+					Queue(kueue.LocalQueueName(queue)).
+					Request(corev1.ResourceCPU, cpu).
+					Request(corev1.ResourceMemory, memory).Obj()
+				wls = append(wls, wl)
+				util.MustCreate(ctx, k8sClient, wl)
+				return wl
+			}
+
+			ginkgo.By("Creating wlA in cq-2")
+			wlA := createWorkloadWithCPUAndMemory(cq2.Name, "1", "0", 100)
+
+			ginkgo.By("Creating wlB in cq-2")
+			wlB := createWorkloadWithCPUAndMemory(cq2.Name, "1", "0", 100)
+
+			ginkgo.By("Waiting for wlA and wlB to be admitted")
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlA, wlB)
+
+			ginkgo.By("Creating preemptor-wl in cq-1")
+			preemptorWl := createWorkloadWithCPUAndMemory(cq1.Name, "10", "10", 0)
+
+			ginkgo.By("Waiting for wlA and wlB to be preempted/evicted")
+			util.ExpectWorkloadsToBePreempted(ctx, k8sClient, wlA, wlB)
+
+			ginkgo.By("Finishing eviction for wlA")
+			util.FinishEvictionForWorkloads(ctx, k8sClient, wlA)
+
+			ginkgo.By("Ensuring wlA is not re-admitted in the interim")
+			gomega.Consistently(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wlA), wlA)).To(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(wlA)).To(gomega.BeFalse())
+			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+
+			ginkgo.By("Finishing eviction for wlB")
+			util.FinishEvictionForWorkloads(ctx, k8sClient, wlB)
+
+			ginkgo.By("Waiting for preemptorWl to be re-admitted")
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, preemptorWl)
+		})
+
 		ginkgo.It("should have NaN weighted share metric", func() {
 			ginkgo.By("Creating a workload in cqA")
 			wlA1 := createWorkloadWithPriority(cqA.Name, "4", 100)

--- a/test/integration/singlecluster/scheduler/preemption_test.go
+++ b/test/integration/singlecluster/scheduler/preemption_test.go
@@ -1359,6 +1359,131 @@ var _ = ginkgo.Describe("Preemption", func() {
 		})
 	})
 
+	ginkgo.Context("In a cohort with multiple queues", func() {
+		var (
+			alphaCQ, betaCQ, gammaCQ *kueue.ClusterQueue
+			alphaLQ, betaLQ, gammaLQ *kueue.LocalQueue
+			oneFlavor                *kueue.ResourceFlavor
+		)
+
+		ginkgo.BeforeEach(func() {
+			oneFlavor = utiltestingapi.MakeResourceFlavor("one").Obj()
+			util.MustCreate(ctx, k8sClient, oneFlavor)
+
+			alphaCQ = utiltestingapi.MakeClusterQueue("alpha-cq").
+				Cohort("all").
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("one").Resource(corev1.ResourceCPU, "2").Obj()).
+				Preemption(kueue.ClusterQueuePreemption{
+					WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+					ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					BorrowWithinCohort: &kueue.BorrowWithinCohort{
+						Policy: kueue.BorrowWithinCohortPolicyLowerPriority,
+					},
+				}).
+				Obj()
+			util.MustCreate(ctx, k8sClient, alphaCQ)
+			alphaLQ = utiltestingapi.MakeLocalQueue("alpha-lq", ns.Name).ClusterQueue("alpha-cq").Obj()
+			util.MustCreate(ctx, k8sClient, alphaLQ)
+
+			betaCQ = utiltestingapi.MakeClusterQueue("beta-cq").
+				Cohort("all").
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("one").Resource(corev1.ResourceCPU, "1").Obj()).
+				Preemption(kueue.ClusterQueuePreemption{
+					WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+					ReclaimWithinCohort: kueue.PreemptionPolicyLowerPriority,
+					BorrowWithinCohort: &kueue.BorrowWithinCohort{
+						Policy: kueue.BorrowWithinCohortPolicyLowerPriority,
+					},
+				}).
+				Obj()
+			util.MustCreate(ctx, k8sClient, betaCQ)
+			betaLQ = utiltestingapi.MakeLocalQueue("beta-lq", ns.Name).ClusterQueue("beta-cq").Obj()
+			util.MustCreate(ctx, k8sClient, betaLQ)
+
+			gammaCQ = utiltestingapi.MakeClusterQueue("gamma-cq").
+				Cohort("all").
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("one").Resource(corev1.ResourceCPU, "1").Obj()).
+				Preemption(kueue.ClusterQueuePreemption{
+					WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+					ReclaimWithinCohort: kueue.PreemptionPolicyLowerPriority,
+					BorrowWithinCohort: &kueue.BorrowWithinCohort{
+						Policy: kueue.BorrowWithinCohortPolicyLowerPriority,
+					},
+				}).
+				Obj()
+			util.MustCreate(ctx, k8sClient, gammaCQ)
+			gammaLQ = utiltestingapi.MakeLocalQueue("gamma-lq", ns.Name).ClusterQueue("gamma-cq").Obj()
+			util.MustCreate(ctx, k8sClient, gammaLQ)
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+			gomega.Expect(util.DeleteObject(ctx, k8sClient, alphaLQ)).To(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, alphaCQ, true)
+			gomega.Expect(util.DeleteObject(ctx, k8sClient, betaLQ)).To(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, betaCQ, true)
+			gomega.Expect(util.DeleteObject(ctx, k8sClient, gammaLQ)).To(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, gammaCQ, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, oneFlavor, true)
+		})
+
+		ginkgo.It("Should prevent other workloads from stealing quota when a preemptor is waiting for multiple evictions", func() {
+			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.UnadmittedWorkloadsObservability, true)
+			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.PrioritizePreemptorWorkloads, true)
+
+			ginkgo.By("Creating initial workloads in cohort to consume all quota")
+			wlA := utiltestingapi.MakeWorkload("wl-a", ns.Name).
+				Queue(kueue.LocalQueueName(alphaLQ.Name)).
+				Priority(midPriority).
+				Request(corev1.ResourceCPU, "1").
+				Obj()
+			wlB := utiltestingapi.MakeWorkload("wl-b", ns.Name).
+				Queue(kueue.LocalQueueName(betaLQ.Name)).
+				Priority(midPriority).
+				Request(corev1.ResourceCPU, "3").
+				Obj()
+			util.MustCreate(ctx, k8sClient, wlA)
+			util.MustCreate(ctx, k8sClient, wlB)
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlA, wlB)
+
+			ginkgo.By("Creating a pending workload in gamma-lq")
+			wlC := utiltestingapi.MakeWorkload("wl-c", ns.Name).
+				Queue(kueue.LocalQueueName(gammaLQ.Name)).
+				Priority(lowPriority).
+				Request(corev1.ResourceCPU, "1").
+				Obj()
+			util.MustCreate(ctx, k8sClient, wlC)
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, wlC)
+
+			ginkgo.By("Creating a high priority preemptor requesting cohort's full capacity")
+			preemptor := utiltestingapi.MakeWorkload("preemptor", ns.Name).
+				Queue(kueue.LocalQueueName(alphaLQ.Name)).
+				Priority(highPriority).
+				Request(corev1.ResourceCPU, "4").
+				Obj()
+			util.MustCreate(ctx, k8sClient, preemptor)
+
+			ginkgo.By("Verifying both wl-a and wl-b are marked for preemption")
+			util.ExpectWorkloadsToBePreempted(ctx, k8sClient, wlA, wlB)
+
+			ginkgo.By("Finishing eviction for wl-b without deleting it")
+			util.FinishEvictionForWorkloads(ctx, k8sClient, wlB)
+
+			ginkgo.By("Ensuring the pending workload wl-c is not admitted in the interim")
+			gomega.Consistently(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wlC), wlC)).To(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(wlC)).To(gomega.BeFalse())
+			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+
+			ginkgo.By("Finishing eviction for wl-a")
+			util.FinishEvictionForWorkloads(ctx, k8sClient, wlA)
+
+			ginkgo.By("Verifying preemptor is admitted")
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, preemptor)
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, wlC)
+		})
+	})
+
 	ginkgo.Context("Queue head is preemption gated", func() {
 		var (
 			cq *kueue.ClusterQueue


### PR DESCRIPTION
Cherry pick of #13797 on release-0.19.

#13797: scheduler: prioritize workloads pending preemption to prevent thrashing

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
Scheduling: Fix preemption thrashing/loops caused by desynchronized eviction completion times by prioritizing preemptor workloads at the head of the scheduling queue. This is guarded by the PrioritizePreemptorWorkloads Alpha feature gate, disabled by default.
```