### PR TITLE
Update main with the latest v0.18.6

### DIFF
--- a/CHANGELOG/CHANGELOG-0.18.md
+++ b/CHANGELOG/CHANGELOG-0.18.md
@@ -1,3 +1,43 @@
+## v0.18.6
+
+Changes since `v0.18.5`:
+
+## Actions Required Before Upgrading
+
+### (No, really, you MUST read this before you upgrade)
+
+- **Minor releases:** Review the `.0` release notes for each new minor version you cross; see: [`v0.17.0`](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.17.0), [`v0.18.0`](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.18.0).
+- **Patch releases:** Review the patch release notes leading up to this version, but *only* within this minor release line; see: [`v0.18.1`](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.18.1), [`v0.18.2`](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.18.2), [`v0.18.3`](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.18.3), [`v0.18.4`](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.18.4), [`v0.18.5`](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.18.5).
+
+## Changes by Kind
+
+### Feature
+
+- TAS: Reduced CPU time and memory allocations for snapshot creation by reusing cached topology trees when scheduling-relevant Node data is unchanged. Controlled by the `TASCacheTopologyTree` feature gate, which is Alpha and disabled by default. (#14644, @tenzen-y)
+
+### Bug or Regression
+
+- AFS: Fixed entry-penalty accounting leaks that could inflate LocalQueue fair-sharing usage when a Workload was re-admitted or exited before settlement. (#14153, @apullo777)
+- DRA: Fixed a bug where a negative extended-resource request quantity (reachable only when the `WorkloadValidateResourcesAreNonNegative` validation is disabled, or on a Workload created before that validation existed) could be merged as a negative DRA quota charge, silently offsetting a legitimate charge on the same logical resource. Negative extended-resource requests are now dropped the same way zero-valued ones already are. (#14654, @pujitha24)
+- DRA: Fixed quota undercount when two extended resource names sharing a deviceClassMappings key were requested by different containers in the same PodSet. (#14200, @pujitha24)
+- FairSharing: Collapsed the per-candidate FairSharing preemption log into one entry per ClusterQueue and serialize its DominantResourceShare values, reducing scheduler log volume at verbosity 4. (#14348, @venuchitta)
+- FairSharing: skip the FairSharing preemption tournament when the preemptor's dominant resource share is +Inf, since no candidate can be preempted, avoiding wasted per-candidate evaluation and its V(4) log volume. (#14674, @kshalot)
+- Importer: Fixed a bug where the Pod importer picked a single ResourceFlavor for the whole Pod, so Pods whose resources map to different flavors could be imported with a wrong flavor assignment. Flavors are now resolved per requested resource. (#14582, @mszadkow)
+- JobFramework: Fixed ancestor resolution to verify that each controller ownerReference's UID matches the referenced object. Previously an object whose ownerReference named a Kueue-managed ancestor with a stale or mismatched UID was treated as managed by that ancestor and was skipped by Kueue (not suspended/gated and no Workload created). (#14657, @vladikkuzn)
+- LeaderWorkerSet: Fixed a bug where Pods of a LeaderWorkerSet admitted before the queue-name write moved into the LWS webhook could stay permanently SchedulingGated after an upgrade, eventually deactivating the Workload. Kueue now sets `kueue.x-k8s.io/queue-name` on LeaderWorkerSet Pods when adopting them and reconciles it on already-adopted gated Pods. (#14603, @anguszzzz)
+- MPIJob: Fixed TAS defaulting for runLauncherAsWorker jobs with missing or additional replica-spec entries, preventing a webhook panic and preserving rank-based topology placement. (#14528, @thc1006)
+- MultiKueue: Fixed a bug where a stale `status.nominatedClusterNames` could cause Server-Side Apply field manager conflicts with external dispatchers. Kueue now clears the field through a MutatingAdmissionPolicy when a Workload is admitted or evicted. (#13749, @vic-comm)
+- MultiKueue: Fixed watch establishment to prevent timeouts from blocking indefinitely on delayed watch responses. (#14020, @Dasmat13)
+- PodGroup integration: Fixed a bug where a Pod could bypass ClusterQueue quota by setting `kueue.x-k8s.io/pod-group-name` to another Workload's name. Kueue now only adopts Workloads created by the pod-group framework (stamped with `kueue.x-k8s.io/is-group-workload`), and no longer finalizes a foreign Workload that merely shares the pod group name, which previously marked it Finished and released its quota while its pods were still running. (#14617, @vladikkuzn)
+- RayJob, RayCluster, RayService, and SparkApplication: Fixed a bug where removing the `kueue.x-k8s.io/queue-name` label from an unsuspended job was accepted, so the job stopped being managed by Kueue while its pods kept running and its resources were no longer counted against quota. Removing the label is now rejected, both from an unsuspended job and from a suspended job in a namespace with a default LocalQueue. Controlled by the `ValidateRayAndSparkJobUpdates` feature gate, which is Beta and enabled by default. (#14676, @tenzen-y)
+- Scheduling: Fix preemption thrashing/loops caused by desynchronized eviction completion times by prioritizing preemptor workloads at the head of the scheduling queue. This is guarded by the PrioritizePreemptorWorkloads Alpha feature gate, disabled by default. (#14683, @Nilsachy)
+- TAS: Fixed a bug where cross-flavor TAS usage was matched against topology domains a ResourceFlavor does not hold, adding redundant per-node work and V(3) log lines to every scheduling cycle. (#14174, @venuchitta)
+- TAS: Fixed a bug where node replacement treated sibling topology domains with a common string prefix as the same domain. (#14451, @tomsen02)
+- TAS: Fixed a bug where replacing an unhealthy node could assign a workload to a node already claimed by another workload in the same scheduling cycle, leaving its pod permanently Unschedulable until the PodsReady timeout evicted it. (#14646, @varunsyal)
+- VisibilityOnDemand: Fixed a bug where the `PositionInLocalQueue` on the ClusterQueue `pendingworkloads` was being inflated when two LocalQueues in different namespaces share the same name (for example, the auto-created `default` LocalQueue). (#14434, @pujitha24)
+- VisibilityOnDemand: Fixed a panic in the pending-workloads endpoints when prebuilt Workloads (BYOW) w/o priority are created (#14417, @thc1006)
+- WaitForPodsReady: Fixed a bug where the `kueue_ready_wait_time_seconds`, `kueue_admitted_until_ready_wait_time`, `kueue_local_queue_ready_wait_time_seconds` and `kueue_local_queue_admitted_until_ready_wait_time_seconds` metrics were emitted after failure recovery, skewing the metric towards longer wait times. (#14637, @kshalot)
+
 ## v0.18.5
 
 Changes since `v0.18.4`:

--- a/site/content/en/v0.18/docs/_index.md
+++ b/site/content/en/v0.18/docs/_index.md
@@ -2,14 +2,14 @@
 type: docs
 params:
   docs_minor: v0.18
-  version: v0.18.5
-  chart_version: 0.18.5
+  version: v0.18.6
+  chart_version: 0.18.6
 cascade:
   type: docs
   params:
     docs_minor: v0.18
-    version: v0.18.5
-    chart_version: 0.18.5
+    version: v0.18.6
+    chart_version: 0.18.6
 title: "Documentation"
 linkTitle: "Documentation"
 weight: 20

--- a/site/content/en/v0.18/docs/concepts/admission_check/provisioning_request.md
+++ b/site/content/en/v0.18/docs/concepts/admission_check/provisioning_request.md
@@ -155,7 +155,7 @@ specific) supports setting unique node label on the newly provisioned nodes.
 
 #### Reference
 
-Check the [API definition](https://github.com/kubernetes-sigs/kueue/blob/main/apis/kueue/v1beta1/provisioningrequestconfig_types.go) for more details.
+Check the [API definition](https://github.com/kubernetes-sigs/kueue/blob/main/apis/kueue/v1beta2/provisioningrequestconfig_types.go) for more details.
 
 ### Job annotations
 

--- a/site/content/en/v0.18/docs/concepts/multikueue.md
+++ b/site/content/en/v0.18/docs/concepts/multikueue.md
@@ -116,11 +116,12 @@ The MultiKueue Workload Controller synchronizes the Workload with the nominated 
 
 Known Limitation:
 {{% alert title="Warning" color="primary" %}}
-For the external controller to patch the `.status.nominatedClusterNames` field there are 2 options:
+For the external controller to patch the `.status.nominatedClusterNames` field there are 3 options:
 * Use the `kueue-admission` field manager, because the kueue-admission field manager is responsible for managing updates to the `.status.nominatedClusterNames` field.
 * [Enable `WorkloadRequestUseMergePatch` feature gate](docs/concepts/workload#workload-updates-by-kueue) that drops the `kueue-admission` field manager from the `.status.nominatedClusterNames`.
+* Deploy the `clear-nominated-cluster-names` `MutatingAdmissionPolicy` (available via the `workload-map.yaml` release artifact, `config/components/map` or Helm parameter `enableMutatingAdmissionPolicy`), which automatically clears `.status.nominatedClusterNames` when a workload is admitted or evicted.
 
-Without this, the Kueue is not able to admit the MultiKueue workloads.
+Without this, Kueue is not able to admit the MultiKueue workloads.
 {{% /alert %}}
 
 ## Supported Job Types

--- a/site/content/en/v0.18/docs/concepts/preemption.md
+++ b/site/content/en/v0.18/docs/concepts/preemption.md
@@ -20,7 +20,7 @@ and any of the following events happen:
 - The preemptee belongs to the same [cohort](/v0.18/docs/concepts/cluster_queue#cohort) as the preemptor and the preemptee's ClusterQueue has a usage above
   the [nominal quota](/v0.18/docs/concepts/cluster_queue#resources) for at least one resource that the preemptee and preemptor require.
 
-The configured settings for preemption in the [Kueue Configuration](/v0.18/docs/reference/kueue-config.v1beta1#FairSharing)
+The configured settings for preemption in the [Kueue Configuration](/v0.18/docs/reference/kueue-config.v1beta2/#config-kueue-x-k8s-io-v1beta2-FairSharing)
 and in the [ClusterQueue](/v0.18/docs/concepts/cluster_queue#preemption) can limit whether a Workload can preempt others, in addition
 to the criteria above.
 

--- a/site/content/en/v0.18/docs/getting-started/installation.md
+++ b/site/content/en/v0.18/docs/getting-started/installation.md
@@ -145,7 +145,7 @@ wget https://github.com/kubernetes-sigs/kueue/releases/download/{{< param "versi
 2. With an editor of your preference, open `manifests.yaml`.
 3. In the `kueue-manager-config` ConfigMap manifest, edit the
    `controller_manager_config.yaml` data entry. The entry represents
-   the default [KueueConfiguration](/v0.18/docs/reference/kueue-config.v1beta1).
+   the default [KueueConfiguration](/v0.18/docs/reference/kueue-config.v1beta2).
    The contents of the ConfigMap are similar to the following:
 
 ```yaml
@@ -262,7 +262,7 @@ metadata:
   namespace: kueue-system
 data:
   controller_manager_config.yaml: |
-    apiVersion: config.kueue.x-k8s.io/v1beta1
+    apiVersion: config.kueue.x-k8s.io/v1beta2
     kind: Configuration
     featureGates:
       ManagedJobsNamespaceSelectorAlwaysRespected: true
@@ -311,4 +311,4 @@ The ShortWorkloadNames features are available starting from versions 0.15.7 and 
 ## What's next
 
 - Follow the [Quick Start](/v0.18/docs/getting-started/quick-start) guide to run your first Job with Kueue.
-- Read the [API reference](/v0.18/docs/reference/kueue-config.v1beta1/#Configuration) for `Configuration`
+- Read the [API reference](/v0.18/docs/reference/kueue-config.v1beta2/#config-kueue-x-k8s-io-v1beta2-Configuration) for `Configuration`

--- a/site/content/en/v0.18/docs/tasks/run/using_hami.md
+++ b/site/content/en/v0.18/docs/tasks/run/using_hami.md
@@ -55,7 +55,7 @@ This configuration tells Kueue to multiply per-vGPU resource values by the numbe
 Configure your ClusterQueue to track both vGPU instance counts and total resources:
 
 ```yaml
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: vgpu-cluster-queue

--- a/site/content/en/v0.18/docs/tasks/troubleshooting/troubleshooting_pods.md
+++ b/site/content/en/v0.18/docs/tasks/troubleshooting/troubleshooting_pods.md
@@ -24,9 +24,9 @@ A Pod might not have the `kueue.x-k8s.io/managed` due to one of the following re
 
 1. The [Pod integration is disabled](/v0.18/docs/tasks/run/plain_pods/#before-you-begin).
 2. The Pod belongs to a namespace that don't satisfy the requirements of
-   the [`managedJobsNamespaceSelector`](/v0.18/docs/reference/kueue-config.v1beta1/#Configuration).
+   the [`managedJobsNamespaceSelector`](/v0.18/docs/reference/kueue-config.v1beta2/#config-kueue-x-k8s-io-v1beta2-Configuration).
 3. The Pod is owned by a Job or equivalent CRD that is managed by Kueue.
-4. The Pod doesn't have a `kueue.x-k8s.io/queue-name` label and [`manageJobsWithoutQueueName`](/v0.18/docs/reference/kueue-config.v1beta1/#Configuration)
+4. The Pod doesn't have a `kueue.x-k8s.io/queue-name` label and [`manageJobsWithoutQueueName`](/v0.18/docs/reference/kueue-config.v1beta2/#config-kueue-x-k8s-io-v1beta2-Configuration)
    is set to `false`.
 
 {{% alert title="Note" color="primary" %}}

--- a/site/content/zh-CN/v0.18/docs/_index.md
+++ b/site/content/zh-CN/v0.18/docs/_index.md
@@ -2,14 +2,14 @@
 type: docs
 params:
   docs_minor: v0.18
-  version: v0.18.5
-  chart_version: 0.18.5
+  version: v0.18.6
+  chart_version: 0.18.6
 cascade:
   type: docs
   params:
     docs_minor: v0.18
-    version: v0.18.5
-    chart_version: 0.18.5
+    version: v0.18.6
+    chart_version: 0.18.6
 title: "文档"
 linkTitle: "文档"
 weight: 20

--- a/site/content/zh-CN/v0.18/docs/admission-check-controllers/provisioning.md
+++ b/site/content/zh-CN/v0.18/docs/admission-check-controllers/provisioning.md
@@ -137,7 +137,7 @@ ProvisioningRequestConfig 中的此代码片段指示 Kueue 在配置后更新�
 #### 参考 {#reference}
 
 有关更多详细信息，请查看
-[API 定义](https://github.com/kubernetes-sigs/kueue/blob/main/apis/kueue/v1beta1/provisioningrequestconfig_types.go)。
+[API 定义](https://github.com/kubernetes-sigs/kueue/blob/main/apis/kueue/v1beta2/provisioningrequestconfig_types.go)。
 
 ### Job 注解 {#job-annotations}
 

--- a/site/content/zh-CN/v0.18/docs/concepts/admission_check.md
+++ b/site/content/zh-CN/v0.18/docs/concepts/admission_check.md
@@ -126,4 +126,4 @@ Kueue 确保 Workload 的 AdmissionCheckStates 列表与其 ClusterQueue 的 Adm
 ## 接下来？ {#what-next}
 
 - 阅读 `AdmissionCheck` 的 [API 参考](/zh-cn/v0.18/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-AdmissionCheck)
-- 了解更多内置的 [Provisioning Admission Check Controller](/zh-CN/v0.18/docs/admission-check-controllers/provisioning)
+- 了解更多内置的 [Provisioning Admission Check Controller](/v0.18/docs/admission-check-controllers/provisioning)

--- a/site/content/zh-CN/v0.18/docs/concepts/cohort.md
+++ b/site/content/zh-CN/v0.18/docs/concepts/cohort.md
@@ -84,7 +84,7 @@ Cohort 可以组织成树形结构。我们将属于同一棵树的 ClusterQueue
 Cohort 的组合称为 **CohortTree**。
 
 给定 CohortTree 中的 ClusterQueue 可以使用其中的资源，
-并遵循[借用和借出限制](/zh-cn/v0.18/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-ResourceQuota)。
+并遵循[借用和借出限制](/zh-CN/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-ResourceQuota)。
 这些借用和借出限制可以为 Cohort 以及 ClusterQueue 指定。
 
 这是一个简单的 CohortTree，包含三个 Cohort：

--- a/site/content/zh-CN/v0.18/docs/concepts/local_queue.md
+++ b/site/content/zh-CN/v0.18/docs/concepts/local_queue.md
@@ -38,4 +38,4 @@ kubectl get -n my-namespace queues
 ## 下一步是什么？
 
 - 通过本地队列启动[工作负载](/zh-CN/docs/concepts/workload)
-- 阅读 `LocalQueue` 的 [API 参考](/zh-cn/v0.18/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-LocalQueue)
+- 阅读 `LocalQueue` 的 [API 参考](/zh-CN/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-LocalQueue)

--- a/site/content/zh-CN/v0.18/docs/concepts/preemption.md
+++ b/site/content/zh-CN/v0.18/docs/concepts/preemption.md
@@ -18,7 +18,7 @@ description: >
 - 被抢占者与抢占者属于同一个 [ClusterQueue](/v0.18/docs/concepts/cluster_queue)，且被抢占者的优先级较低。
 - 被抢占者与抢占者属于同一个 [cohort](/v0.18/docs/concepts/cluster_queue#cohort)，且被抢占者的 ClusterQueue 至少有一种资源的使用量高于[名义配额](/v0.18/docs/concepts/cluster_queue#resources)，而该资源是被抢占者和抢占者都需要的。
 
-在 [Kueue 配置](/zh-cn/v0.18/docs/reference/kueue-config.v1beta1#FairSharing) 和 [ClusterQueue](/v0.18/docs/concepts/cluster_queue#preemption) 中配置的抢占设置，除了上述标准外，还可以限制 Workload 是否可以抢占其他 Workload。
+在 [Kueue 配置](/zh-cn/v0.18/docs/reference/kueue-config.v1beta2#FairSharing) 和 [ClusterQueue](/v0.18/docs/concepts/cluster_queue#preemption) 中配置的抢占设置，除了上述标准外，还可以限制 Workload 是否可以抢占其他 Workload。
 
 当抢占 Workload 时，Kueue 会在被抢占 Workload 的 `.status.conditions` 字段中添加类似如下的条目：
 

--- a/site/content/zh-CN/v0.18/docs/installation/_index.md
+++ b/site/content/zh-CN/v0.18/docs/installation/_index.md
@@ -140,7 +140,7 @@ wget https://github.com/kubernetes-sigs/kueue/releases/download/{{< param "versi
 2. 使用你喜欢的编辑器打开 `manifests.yaml`。
 3. 在 `kueue-manager-config` ConfigMap 清单中，编辑
    `controller_manager_config.yaml` 数据条目。该条目代表默认的
-   [KueueConfiguration](/zh-cn/v0.18/docs/reference/kueue-config.v1beta1)。
+   [KueueConfiguration](/zh-cn/v0.18/docs/reference/kueue-config.v1beta2)。
    ConfigMap 的内容类似于以下内容：
 
 ```yaml
@@ -282,4 +282,4 @@ spec:
 
 ## 接下来是什么 {#whats-next}
 
-- 阅读 [`Configuration` 的 API 参考](/zh-cn/v0.18/docs/reference/kueue-config.v1beta1/#Configuration)
+- 阅读 [`Configuration` 的 API 参考](/zh-cn/v0.18/docs/reference/kueue-config.v1beta2/#Configuration)

--- a/site/content/zh-CN/v0.18/docs/reference/kueue-config.v1beta2.md
+++ b/site/content/zh-CN/v0.18/docs/reference/kueue-config.v1beta2.md
@@ -256,18 +256,28 @@ connection.</p>
 <tbody>
     
   
-<tr><td><code>credentialsProviders</code> <B>[Required]</B><br/>
-<a href="#config-kueue-x-k8s-io-v1beta2-ClusterProfileCredentialsProvider"><code>[]ClusterProfileCredentialsProvider</code></a>
+<tr><td><code>accessProviders</code><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-ClusterProfileAccessProvider"><code>[]ClusterProfileAccessProvider</code></a>
+</td>
+<td>
+   <p>AccessProviders defines a list of providers to obtain access to worker clusters
+using the ClusterProfile API.</p>
+</td>
+</tr>
+<tr><td><code>credentialsProviders</code><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-ClusterProfileAccessProvider"><code>[]ClusterProfileAccessProvider</code></a>
 </td>
 <td>
    <p>CredentialsProviders defines a list of providers to obtain credentials of worker clusters
 using the ClusterProfile API.</p>
+<p>Deprecated: Use AccessProviders instead. AccessProviders and CredentialsProviders
+are mutually exclusive.</p>
 </td>
 </tr>
 </tbody>
 </table>
 
-## `ClusterProfileCredentialsProvider`     {#config-kueue-x-k8s-io-v1beta2-ClusterProfileCredentialsProvider}
+## `ClusterProfileAccessProvider`     {#config-kueue-x-k8s-io-v1beta2-ClusterProfileAccessProvider}
     
 
 **Appears in:**
@@ -275,7 +285,7 @@ using the ClusterProfile API.</p>
 - [ClusterProfile](#config-kueue-x-k8s-io-v1beta2-ClusterProfile)
 
 
-<p>ClusterProfileCredentialsProvider defines a credentials provider in the ClusterProfile API.</p>
+<p>ClusterProfileAccessProvider defines an access provider in the ClusterProfile API.</p>
 
 
 <table class="table">
@@ -495,8 +505,8 @@ metrics will be reported.</p>
 </td>
 <td>
    <p>CustomLabels is a list of entries whose values will be added as extra
-Prometheus labels on ClusterQueue, LocalQueue, and Cohort metrics.
-Requires the CustomMetricLabels feature gate.</p>
+Prometheus labels on supported metrics.
+A maximum of 6 labels are allowed per SourceKind (2 for Workloads), with up to 20 labels defined in total.</p>
 </td>
 </tr>
 <tr><td><code>localQueueMetrics</code><br/>
@@ -530,9 +540,10 @@ as a Prometheus metric label with a &quot;custom_&quot; prefix.</p>
 <code>string</code>
 </td>
 <td>
-   <p>Name is used as a suffix to build the Prometheus label: Kueue
-automatically prepends &quot;custom_&quot; (e.g., name: &quot;team&quot; becomes label &quot;custom_team&quot;).
-Must follow Prometheus label naming conventions: [a-zA-Z_][a-zA-Z0-9_]*.</p>
+   <p>Name is the Prometheus metric label name suffix.
+Prepended with &quot;custom_&quot; to form the full Prometheus label name
+(e.g., &quot;team&quot; becomes &quot;custom_team&quot;).
+Must contain only [a-zA-Z0-9_] characters and start with a letter.</p>
 </td>
 </tr>
 <tr><td><code>sourceLabelKey</code><br/>
@@ -552,6 +563,32 @@ If neither is specified, defaults to Name.</p>
    <p>SourceAnnotationKey is the Kubernetes annotation key to read the value from.
 Must be a valid Kubernetes qualified name.
 Mutually exclusive with SourceLabelKey.</p>
+</td>
+</tr>
+<tr><td><code>sourceKind</code><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-SourceKind"><code>SourceKind</code></a>
+</td>
+<td>
+   <p>SourceKind is the object kind from which the label value should be sourced.
+Up to 2 labels are allowed for Workloads and up to 6 for other source kinds.
+Defaults to ClusterQueue.
+The possible values are:</p>
+<ul>
+<li>Cohort</li>
+<li>LocalQueue</li>
+<li>ClusterQueue</li>
+<li>Workload</li>
+</ul>
+</td>
+</tr>
+<tr><td><code>trackedValues</code><br/>
+<code>[]string</code>
+</td>
+<td>
+   <p>TrackedValues is a list of the label's allowed values.
+When SourceKind is Workload, a closed list of 1-12 TrackedValues is required.
+Non-workload source kinds can have 0-16 TrackedValues. If the list is empty, any value is allowed.
+Label values not allowed by this field will be reported as &quot;kueue.x-k8s.io/<em>UNTRACKED_VALUE</em>&quot;.</p>
 </td>
 </tr>
 </tbody>
@@ -602,6 +639,55 @@ must be named tls.key and tls.crt, respectively.</p>
 </tbody>
 </table>
 
+## `DeviceClassCapacitySource`     {#config-kueue-x-k8s-io-v1beta2-DeviceClassCapacitySource}
+    
+
+**Appears in:**
+
+- [DeviceClassSourceConfig](#config-kueue-x-k8s-io-v1beta2-DeviceClassSourceConfig)
+
+
+<p>DeviceClassCapacitySource configures capacity-based quota tracking
+for devices that allow multiple allocations (KEP-5075).</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#qualifiedname-v1-resource"><code>k8s.io/api/resource/v1.QualifiedName</code></a>
+</td>
+<td>
+   <p>Name identifies the capacity dimension to track for quota
+(e.g., &quot;gpu.example.com/memory&quot;).
+Must be a valid DRA QualifiedName.</p>
+</td>
+</tr>
+<tr><td><code>driver</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Driver is the DRA driver name used to filter relevant ResourceSlices.
+Must match the spec.driver field on ResourceSlice objects.
+Must not exceed 63 characters.</p>
+</td>
+</tr>
+<tr><td><code>deviceSelector</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#deviceselector-v1-resource"><code>k8s.io/api/resource/v1.DeviceSelector</code></a>
+</td>
+<td>
+   <p>DeviceSelector scopes which devices are eligible for quota accounting.
+Matches devices whose capacity dimensions should be tracked against
+the quota pool.
+The selector is compiled at config load time using the upstream dracel
+compiler.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
 ## `DeviceClassCounterSource`     {#config-kueue-x-k8s-io-v1beta2-DeviceClassCounterSource}
     
 
@@ -623,8 +709,8 @@ must be named tls.key and tls.crt, respectively.</p>
 </td>
 <td>
    <p>Name is the counter name within the device's consumesCounters
-entries to track for quota. Must match a counter name published by
-the driver in ResourceSlice devices' consumesCounters field.
+entries to track for quota. Must be a DNS label and match a counter
+name published by the driver in ResourceSlice devices' consumesCounters field.
 Counter set names are per-device identifiers (e.g., gpu-0-counter-set,
 gpu-1-counter-set), so name matches across all counter sets
 for a given driver without requiring one mapping per device.
@@ -636,8 +722,8 @@ The total length must not exceed 63 characters.</p>
 </td>
 <td>
    <p>Driver is the DRA driver name used to filter relevant ResourceSlices.
-Must match the spec.driver field on ResourceSlice objects.
-The total length must not exceed 253 characters.</p>
+Must be a lowercase DNS subdomain and match the spec.driver field on ResourceSlice objects.
+The total length must not exceed 63 characters.</p>
 </td>
 </tr>
 <tr><td><code>deviceSelector</code> <B>[Required]</B><br/>
@@ -705,10 +791,10 @@ The total length of each name must not exceed 253 characters.</p>
 <td>
    <p>Sources configures resource accounting sources for this mapping.
 Each source defines how quota is tracked for this DeviceClass.
-Currently only counter sources are supported (for partitionable devices).
 Extended resource requests that resolve to a DeviceClass with sources
 configured are marked inadmissible.
-Requires the KueueDRAIntegrationPartitionableDevices feature gate.</p>
+Counter sources require KueueDRAIntegrationPartitionableDevices (enabled by default since v0.19).
+Capacity sources require KueueDRAIntegrationConsumableCapacity.</p>
 </td>
 </tr>
 </tbody>
@@ -723,7 +809,7 @@ Requires the KueueDRAIntegrationPartitionableDevices feature gate.</p>
 
 
 <p>DeviceClassSourceConfig defines a resource accounting source for a DeviceClassMapping.
-Exactly one of the source types must be set.</p>
+Exactly one of the source types must be set per entry.</p>
 
 
 <table class="table">
@@ -737,6 +823,16 @@ Exactly one of the source types must be set.</p>
 <td>
    <p>Counter configures counter-based quota for partitionable devices.
 Maps a DRA driver counter to the parent DeviceClassMapping's Kueue quota resource.</p>
+</td>
+</tr>
+<tr><td><code>capacity</code><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-DeviceClassCapacitySource"><code>DeviceClassCapacitySource</code></a>
+</td>
+<td>
+   <p>Capacity configures capacity-based quota for devices that allow
+multiple allocations (consumable capacity, KEP-5075).
+Maps a device capacity dimension to the parent DeviceClassMapping's Kueue quota resource.
+Requires the KueueDRAIntegrationConsumableCapacity feature gate.</p>
 </td>
 </tr>
 </tbody>
@@ -777,6 +873,41 @@ This strategy doesn't depend on the share usage of the workload being preempted.
 As a result, the strategy chooses to preempt workloads with the lowest priority and
 newest start time first.</li>
 </ul>
+<p>Only the following lists are supported:</p>
+<ul>
+<li>[&quot;LessThanOrEqualToFinalShare&quot;]</li>
+<li>[&quot;LessThanInitialShare&quot;]</li>
+<li>[&quot;LessThanOrEqualToFinalShare&quot;, &quot;LessThanInitialShare&quot;]</li>
+</ul>
+<p>Any other combination or ordering fails configuration validation.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `IncrementalDispatcherConfig`     {#config-kueue-x-k8s-io-v1beta2-IncrementalDispatcherConfig}
+    
+
+**Appears in:**
+
+- [MultiKueue](#config-kueue-x-k8s-io-v1beta2-MultiKueue)
+
+
+<p>IncrementalDispatcherConfig holds configuration for the MultiKueue Incremental Dispatcher.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>stepSize</code><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>StepSize defines the number of worker clusters the Incremental Dispatcher
+will query simultaneously.
+Minimum value is 1. If not set, it defaults to 3.</p>
 </td>
 </tr>
 </tbody>
@@ -1001,6 +1132,15 @@ GroupVersionKind (GVK) for MultiKueue operations.</p>
 </td>
 <td>
    <p>ClusterProfile defines configuration for using the ClusterProfile API.</p>
+</td>
+</tr>
+<tr><td><code>incrementalDispatcherConfig</code><br/>
+<a href="#config-kueue-x-k8s-io-v1beta2-IncrementalDispatcherConfig"><code>IncrementalDispatcherConfig</code></a>
+</td>
+<td>
+   <p>IncrementalDispatcherConfig contains the configuration for the incremental dispatcher.
+This field is only valid when DispatcherName is set to the incremental dispatcher.
+Note: This field is going to be ignored when the MultiKueueIncrementalDispatcherConfig feature gate is disabled.</p>
 </td>
 </tr>
 </tbody>
@@ -1276,6 +1416,18 @@ for Dynamic Resource Allocation support.</p>
 </tbody>
 </table>
 
+## `SourceKind`     {#config-kueue-x-k8s-io-v1beta2-SourceKind}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [ControllerMetricsCustomLabel](#config-kueue-x-k8s-io-v1beta2-ControllerMetricsCustomLabel)
+
+
+
+
+
 ## `TLSOptions`     {#config-kueue-x-k8s-io-v1beta2-TLSOptions}
     
 
@@ -1310,6 +1462,16 @@ The default would be to not set this value and inherit golang settings.</p>
 Note that TLS 1.3 ciphersuites are not configurable.
 Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).
 The default would be to not set this value and inherit golang settings.</p>
+</td>
+</tr>
+<tr><td><code>curvePreferences</code><br/>
+<code>[]int32</code>
+</td>
+<td>
+   <p>curvePreferences is the list of allowed TLS key exchange mechanisms (curves)
+for the server, specified as numeric IANA TLS Supported Group IDs.
+See https://pkg.go.dev/crypto/tls#CurveID for values supported by the current Go version.
+If omitted, Go defaults are used.</p>
 </td>
 </tr>
 </tbody>
@@ -1378,8 +1540,9 @@ evicted and requeued in the same cluster queue.</p>
 <code>bool</code>
 </td>
 <td>
-   <p>BlockAdmission when true, the cluster queue will block admissions for all
-subsequent jobs until the jobs reach the PodsReady=true condition.
+   <p>BlockAdmission when true, Kueue blocks admission of all workloads across
+all ClusterQueues until every previously-admitted workload reaches the
+PodsReady=true condition.
 Defaults to false.</p>
 </td>
 </tr>

--- a/site/content/zh-CN/v0.18/docs/reference/kueue.v1beta2.md
+++ b/site/content/zh-CN/v0.18/docs/reference/kueue.v1beta2.md
@@ -2036,7 +2036,9 @@ Supported modes:</p>
 <code>[]string</code>
 </td>
 <td>
-   <p>clusters is a list of MultiKueueClusters names where the workloads from the ClusterQueue should be distributed.</p>
+   <p>clusters is a list of MultiKueueClusters names where the workloads from the ClusterQueue should be distributed.
+The order of the list is significant: the Incremental dispatcher nominates clusters
+following this order, so the most preferred clusters should be listed first.</p>
 </td>
 </tr>
 <tr><td><code>quotaManagement</code><br/>
@@ -3682,7 +3684,7 @@ This may be an empty string.</p>
 <td>
    <p>podSets is a list of sets of homogeneous pods, each described by a Pod spec
 and a count.
-There must be at least one element and at most 10.
+There must be at least one element and at most 18.
 podSets cannot be changed.</p>
 </td>
 </tr>

--- a/site/content/zh-CN/v0.18/docs/tasks/dev/develop-acc.md
+++ b/site/content/zh-CN/v0.18/docs/tasks/dev/develop-acc.md
@@ -23,7 +23,7 @@ ACC 可以内置在 Kueue 中或运行在不同的 Kubernetes 控制器管理器
 
 可选地，它可以监视自定义[参数](/zh-cn/v0.18/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-AdmissionCheckParametersReference)对象。
 
-[资源调配准入检查控制器](/zh-CN/v0.18/docs/admission-check-controllers/provisioning/)在
+[资源调配准入检查控制器](/v0.18/docs/admission-check-controllers/provisioning/)在
 `pkg/controller/admissionchecks/provisioning/admissioncheck_reconciler.go` 中实现了此功能。
 
 ### 工作负载协调器
@@ -37,11 +37,11 @@ ACC 可以内置在 Kueue 中或运行在不同的 Kubernetes 控制器管理器
 ### 参数对象类型
 
 可选地，你可以定义一个集群级别的对象类型来保存特定于你的实现的准入检查参数。
-用户可以在 [spec.parameters](/zh-cn/v0.18/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-AdmissionCheckParametersReference)
+用户可以在 [spec.parameters](/zh-CN/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-AdmissionCheckParametersReference)
 中的准入检查定义里引用此类对象类型的实例。
 
 例如，[资源调配准入检查控制器](/zh-CN/docs/admission-check-controllers/provisioning/)为此使用了
-[ProvisioningRequestConfig](/zh-cn/v0.18/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-ProvisioningRequestConfig)。
+[ProvisioningRequestConfig](/zh-CN/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-ProvisioningRequestConfig)。
 
 ## 工具代码
 

--- a/site/content/zh-CN/v0.18/docs/tasks/run/using_hami.md
+++ b/site/content/zh-CN/v0.18/docs/tasks/run/using_hami.md
@@ -66,7 +66,7 @@ Kueue 将计算 `nvidia.com/total-gpumem: 2048`（1024 × 2）。
 配置你的 ClusterQueue 以跟踪 vGPU 实例计数和总资源：
 
 ```yaml
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: vgpu-cluster-queue

--- a/site/content/zh-CN/v0.18/docs/tasks/troubleshooting/troubleshooting_pods.md
+++ b/site/content/zh-CN/v0.18/docs/tasks/troubleshooting/troubleshooting_pods.md
@@ -23,11 +23,11 @@ Pod 可能没有 `kueue.x-k8s.io/managed` 标签的原因如下：
 
 1. [Pod 集成被禁用](/v0.18/docs/tasks/run/plain_pods/#before-you-begin)。
 2. Pod 所属的命名空间不满足
-   [`managedJobsNamespaceSelector`](/zh-cn/v0.18/docs/reference/kueue-config.v1beta1/#Configuration)
+   [`managedJobsNamespaceSelector`](/zh-cn/v0.18/docs/reference/kueue-config.v1beta2/#Configuration)
    的要求。
 3. Pod 由 Kueue 管理的 Job 或等效 CRD 拥有。
 4. Pod 没有 `kueue.x-k8s.io/queue-name` 标签，并且
-   [`manageJobsWithoutQueueName`](/zh-cn/v0.18/docs/reference/kueue-config.v1beta1/#Configuration)
+   [`manageJobsWithoutQueueName`](/zh-cn/v0.18/docs/reference/kueue-config.v1beta2/#Configuration)
    设置为 `false`。
 
 {{% alert title="注意" color="primary" %}}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/area release

#### What this PR does / why we need it:
Update main with the latest v0.18.6.

#### Which issue(s) this PR fixes:
Part of #14322

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TAS caching support.
  * Added configuration options for access providers, capacity-based device quotas, incremental MultiKueue dispatching, metric tracking, and TLS curve preferences.

* **Bug Fixes**
  * Addressed regressions across fair sharing, DRA, importing, job integrations, scheduling, visibility, readiness metrics, and MultiKueue.

* **Documentation**
  * Updated v0.18.6 release documentation in English and Chinese.
  * Migrated configuration examples and API references to v1beta2.
  * Clarified incremental dispatching, resource limits, admission checks, and troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->