### PR TITLE
fix: restart controller override workload priority

### DIFF
--- a/pkg/controller/core/workloadpriorityclass_controller.go
+++ b/pkg/controller/core/workloadpriorityclass_controller.go
@@ -121,6 +121,14 @@ func (r *WorkloadPriorityClassReconciler) Create(e event.TypedCreateEvent[*kueue
 	log := r.logger().WithValues("workloadPriorityClass", klog.KObj(e.Object))
 	log.V(2).Info("WorkloadPriorityClass create event")
 
+	// Events from the informer's initial list don't indicate a change of the priority value,
+	// so reconciling them would overwrite the priorities set directly on the Workloads
+	// every time the controller starts.
+	if e.IsInInitialList {
+		log.V(3).Info("Event from the initial list, skipping reconciliation")
+		return false
+	}
+
 	// Covering the case when the WorkloadPriorityClass was re-created with a different priority,
 	// but the Workload is still referencing it.
 	return true

--- a/pkg/controller/core/workloadpriorityclass_controller_test.go
+++ b/pkg/controller/core/workloadpriorityclass_controller_test.go
@@ -37,15 +37,22 @@ import (
 
 func TestWorkloadPriorityClassPredicates(t *testing.T) {
 	cases := map[string]struct {
-		eventType string
-		oldWPC    *kueue.WorkloadPriorityClass
-		newWPC    *kueue.WorkloadPriorityClass
-		want      bool
+		eventType       string
+		oldWPC          *kueue.WorkloadPriorityClass
+		newWPC          *kueue.WorkloadPriorityClass
+		isInInitialList bool
+		want            bool
 	}{
 		"create event should trigger reconcile": {
 			eventType: "create",
 			newWPC:    utiltestingapi.MakeWorkloadPriorityClass("test").PriorityValue(100).Obj(),
 			want:      true,
+		},
+		"create event from the initial list should not trigger reconcile": {
+			eventType:       "create",
+			newWPC:          utiltestingapi.MakeWorkloadPriorityClass("test").PriorityValue(100).Obj(),
+			isInInitialList: true,
+			want:            false,
 		},
 		"delete event should not trigger reconcile": {
 			eventType: "delete",
@@ -78,7 +85,7 @@ func TestWorkloadPriorityClassPredicates(t *testing.T) {
 
 			switch tc.eventType {
 			case "create":
-				got = reconciler.Create(event.TypedCreateEvent[*kueue.WorkloadPriorityClass]{Object: tc.newWPC})
+				got = reconciler.Create(event.TypedCreateEvent[*kueue.WorkloadPriorityClass]{Object: tc.newWPC, IsInInitialList: tc.isInInitialList})
 			case "delete":
 				got = reconciler.Delete(event.TypedDeleteEvent[*kueue.WorkloadPriorityClass]{Object: tc.oldWPC})
 			case "update":


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

Restarting the kueue controller or leader election will reconcile all the workloadpriorityclass' priority. Say we have modified the .spec.priority earlier, the reconciliation of workloadpriorityclass in the workloadpriorityclass_controller.go when the kueue controller restarts would override the .spec.priority back to workloadpriorityclass' priority.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14698

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
