### PR TITLE
Fix elastic ungating when pods and the Workload have different owners

### DIFF
--- a/pkg/controller/core/indexer/indexer.go
+++ b/pkg/controller/core/indexer/indexer.go
@@ -175,6 +175,23 @@ func IndexOwnerUID(obj client.Object) []string {
 	return slices.Map(obj.GetOwnerReferences(), func(o *metav1.OwnerReference) string { return string(o.UID) })
 }
 
+// IndexWorkloadSliceName indexes workloads by the slice chain they belong to.
+// Every slice created for an elastic job carries the chain's origin name, so the
+// chain stays addressable through its surviving slices once the origin itself is
+// gone. Matches IndexPodWorkloadSliceName so pods and slices share one key.
+func IndexWorkloadSliceName(obj client.Object) []string {
+	wl, ok := obj.(*kueue.Workload)
+	if !ok {
+		return nil
+	}
+	if value, found := wl.Annotations[kueue.WorkloadSliceNameAnnotation]; found {
+		return []string{value}
+	}
+	// The first slice of a chain is its own origin and is indexed under its name,
+	// which is what later slices inherit as the chain key.
+	return []string{wl.Name}
+}
+
 // IndexPodWorkloadSliceName indexes pods by their workload slice name annotation.
 // Uses WorkloadSliceNameAnnotation if present, otherwise falls back to WorkloadAnnotation
 // for non-elastic workloads.
@@ -288,6 +305,11 @@ func Setup(ctx context.Context, indexer client.FieldIndexer) error {
 	if features.Enabled(features.ElasticJobsViaWorkloadSlices) || features.Enabled(features.TopologyAwareScheduling) {
 		if err := indexer.IndexField(ctx, &corev1.Pod{}, WorkloadSliceNameKey, IndexPodWorkloadSliceName); err != nil {
 			return fmt.Errorf("setting index on workloadSliceName for Pod: %w", err)
+		}
+	}
+	if features.Enabled(features.ElasticJobsViaWorkloadSlices) {
+		if err := indexer.IndexField(ctx, &kueue.Workload{}, WorkloadSliceNameKey, IndexWorkloadSliceName); err != nil {
+			return fmt.Errorf("setting index on workloadSliceName for Workload: %w", err)
 		}
 	}
 	// Index DeviceClasses by extendedResourceName for fast lookup during extended resource translation.

--- a/pkg/controller/core/indexer/indexer.go
+++ b/pkg/controller/core/indexer/indexer.go
@@ -177,9 +177,9 @@ func IndexOwnerUID(obj client.Object) []string {
 
 // IndexWorkloadSliceName indexes the workload slices of an elastic job. Scaling
 // such a job up does not resize its Workload: Kueue creates a new slice for the
-// larger size, so one job accumulates a chain of Workloads. Every
-// slice carries the name of the chain's first slice in the
-// WorkloadSliceNameAnnotation, which makes that name the chain's identity.
+// larger size, so one job accumulates a chain of Workloads. Every slice carries
+// the name of the chain's first slice in the WorkloadSliceNameAnnotation, which
+// makes that name the chain's identity.
 //
 // Indexing on it lets callers list all Workloads of a job by that first slice
 // name, including after the first slice itself has been deleted.

--- a/pkg/controller/core/indexer/indexer.go
+++ b/pkg/controller/core/indexer/indexer.go
@@ -175,9 +175,9 @@ func IndexOwnerUID(obj client.Object) []string {
 	return slices.Map(obj.GetOwnerReferences(), func(o *metav1.OwnerReference) string { return string(o.UID) })
 }
 
-// IndexWorkloadSliceName indexes the workload slices of an elastic job by their
-// chain. Scaling such a job up does not resize its Workload: Kueue creates a new
-// slice for the larger size, so one job accumulates a chain of Workloads. Every
+// IndexWorkloadSliceName indexes the workload slices of an elastic job. Scaling
+// such a job up does not resize its Workload: Kueue creates a new slice for the
+// larger size, so one job accumulates a chain of Workloads. Every
 // slice carries the name of the chain's first slice in the
 // WorkloadSliceNameAnnotation, which makes that name the chain's identity.
 //

--- a/pkg/controller/core/indexer/indexer.go
+++ b/pkg/controller/core/indexer/indexer.go
@@ -175,10 +175,14 @@ func IndexOwnerUID(obj client.Object) []string {
 	return slices.Map(obj.GetOwnerReferences(), func(o *metav1.OwnerReference) string { return string(o.UID) })
 }
 
-// IndexWorkloadSliceName indexes workloads by the slice chain they belong to.
-// Every slice created for an elastic job carries the chain's origin name, so the
-// chain stays addressable through its surviving slices once the origin itself is
-// gone. Matches IndexPodWorkloadSliceName so pods and slices share one key.
+// IndexWorkloadSliceName indexes the workload slices of an elastic job by their
+// chain. Scaling such a job up does not resize its Workload: Kueue creates a new
+// slice for the larger size, so one job accumulates a chain of Workloads. Every
+// slice carries the name of the chain's first slice in the
+// WorkloadSliceNameAnnotation, which makes that name the chain's identity.
+//
+// Indexing on it lets callers list all Workloads of a job by that first slice
+// name, including after the first slice itself has been deleted.
 func IndexWorkloadSliceName(obj client.Object) []string {
 	wl, ok := obj.(*kueue.Workload)
 	if !ok {
@@ -187,8 +191,8 @@ func IndexWorkloadSliceName(obj client.Object) []string {
 	if value, found := wl.Annotations[kueue.WorkloadSliceNameAnnotation]; found {
 		return []string{value}
 	}
-	// The first slice of a chain is its own origin and is indexed under its name,
-	// which is what later slices inherit as the chain key.
+	// The chain's first slice names itself, and is indexed before the annotation
+	// is applied.
 	return []string{wl.Name}
 }
 

--- a/pkg/controller/core/indexer/indexer.go
+++ b/pkg/controller/core/indexer/indexer.go
@@ -175,14 +175,10 @@ func IndexOwnerUID(obj client.Object) []string {
 	return slices.Map(obj.GetOwnerReferences(), func(o *metav1.OwnerReference) string { return string(o.UID) })
 }
 
-// IndexWorkloadSliceName indexes the workload slices of an elastic job. Scaling
-// such a job up does not resize its Workload: Kueue creates a new slice for the
-// larger size, so one job accumulates a chain of Workloads. Every slice carries
-// the name of the chain's first slice in the WorkloadSliceNameAnnotation, which
-// makes that name the chain's identity.
-//
-// Indexing on it lets callers list all Workloads of a job by that first slice
-// name, including after the first slice itself has been deleted.
+// IndexWorkloadSliceName indexes the workload slices of an elastic job. Every
+// slice in a chain carries the name of the chain's first slice in the
+// WorkloadSliceNameAnnotation, so indexing on it lists all Workloads of a job by
+// that name, including after the first slice itself has been deleted.
 func IndexWorkloadSliceName(obj client.Object) []string {
 	wl, ok := obj.(*kueue.Workload)
 	if !ok {

--- a/pkg/controller/elasticjobs/elastic_job_ungater.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater.go
@@ -366,7 +366,8 @@ func (r *elasticJobUngater) activeSlice(ctx context.Context, anyWl *kueue.Worklo
 }
 
 // latestActiveSliceForChain resolves the latest active workload slice of the chain
-// identified by sliceName in namespace, or nil if none qualifies for ungating.
+// identified by its first slice's name (sliceName), or nil if none qualifies for
+// ungating.
 func latestActiveSliceForChain(ctx context.Context, c client.Client, namespace, sliceName string) (*kueue.Workload, error) {
 	active, err := workloadslicing.FindLatestActiveWorkloadForSlice(ctx, c, namespace, sliceName)
 	if err != nil || active == nil || !workload.IsAdmitted(active) {

--- a/pkg/controller/elasticjobs/elastic_job_ungater.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater.go
@@ -443,10 +443,6 @@ func (h *elasticPodHandler) queueReconcileForPod(ctx context.Context, object cli
 		log := ctrl.LoggerFrom(ctx).WithValues("pod", klog.KObj(pod), "workloadSlice", sliceKey.String())
 		h.expectationsStore.ObservedUID(log, sliceKey, pod.UID)
 	}
-	// Enqueue the chain's active slice so Reconcile loads a live workload directly.
-	// The chain key indexes the slices themselves, so this resolves without the
-	// origin slice the pod names, and without assuming the job that owns the pods
-	// is the one the Workload was created for.
 	active, err := latestActiveSliceForChain(ctx, h.client, pod.Namespace, sliceName)
 	if err != nil || active == nil {
 		return

--- a/pkg/controller/elasticjobs/elastic_job_ungater.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater.go
@@ -24,9 +24,6 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	autoscaling "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
 	"k8s.io/client-go/util/workqueue"
@@ -363,29 +360,18 @@ func (r *elasticJobUngater) podsToUngate(ctx context.Context, wl *kueue.Workload
 }
 
 // activeSlice resolves the chain's active slice for the workload anyWl belongs
-// to (see latestActiveSliceForOwner), or nil if none qualifies for ungating.
+// to (see latestActiveSliceForChain), or nil if none qualifies for ungating.
 func (r *elasticJobUngater) activeSlice(ctx context.Context, anyWl *kueue.Workload) (*kueue.Workload, error) {
-	owner := metav1.GetControllerOf(anyWl)
-	if owner == nil {
-		return nil, nil
-	}
-	return latestActiveSliceForOwner(ctx, r.client, anyWl.Namespace, owner)
+	return latestActiveSliceForChain(ctx, r.client, anyWl.Namespace, workloadslicing.SliceName(anyWl))
 }
 
-func (h *elasticPodHandler) activeSliceForOwner(ctx context.Context, namespace string, owner *metav1.OwnerReference) (*kueue.Workload, error) {
-	return latestActiveSliceForOwner(ctx, h.client, namespace, owner)
-}
-
-// latestActiveSliceForOwner resolves the latest active workload slice owned by the
-// given job (owner) in namespace, or nil if none qualifies for ungating. Quota
+// latestActiveSliceForChain resolves the latest active workload slice of the chain
+// identified by sliceName in namespace, or nil if none qualifies for ungating. Quota
 // reservation alone is insufficient: AdmissionChecks may still be pending, and
 // releasing the elastic gate before then would let pods schedule ahead of
 // capacity, so full admission is required.
-func latestActiveSliceForOwner(ctx context.Context, c client.Client, namespace string, owner *metav1.OwnerReference) (*kueue.Workload, error) {
-	jobObject := &metav1.PartialObjectMetadata{
-		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: owner.Name},
-	}
-	active, err := workloadslicing.FindLatestActiveWorkload(ctx, c, jobObject, schema.FromAPIVersionAndKind(owner.APIVersion, owner.Kind))
+func latestActiveSliceForChain(ctx context.Context, c client.Client, namespace, sliceName string) (*kueue.Workload, error) {
+	active, err := workloadslicing.FindLatestActiveWorkloadForSlice(ctx, c, namespace, sliceName)
 	if err != nil || active == nil || !workload.IsAdmitted(active) {
 		return nil, err
 	}
@@ -457,16 +443,11 @@ func (h *elasticPodHandler) queueReconcileForPod(ctx context.Context, object cli
 		log := ctrl.LoggerFrom(ctx).WithValues("pod", klog.KObj(pod), "workloadSlice", sliceKey.String())
 		h.expectationsStore.ObservedUID(log, sliceKey, pod.UID)
 	}
-	// Enqueue the chain's active slice so Reconcile loads a live workload directly
-	// (a deleted origin slice no longer strands the pod). Resolve the owning job
-	// from the named slice if it still exists, otherwise from the pod's own
-	// controller owner-ref — the latter is what keeps ungating working after the
-	// origin slice the pod points at has been garbage-collected.
-	owner := h.ownerForPod(ctx, pod, sliceKey)
-	if owner == nil {
-		return
-	}
-	active, err := h.activeSliceForOwner(ctx, pod.Namespace, owner)
+	// Enqueue the chain's active slice so Reconcile loads a live workload directly.
+	// The chain key indexes the slices themselves, so this resolves without the
+	// origin slice the pod names, and without assuming the job that owns the pods
+	// is the one the Workload was created for.
+	active, err := latestActiveSliceForChain(ctx, h.client, pod.Namespace, sliceName)
 	if err != nil || active == nil {
 		return
 	}
@@ -474,23 +455,6 @@ func (h *elasticPodHandler) queueReconcileForPod(ctx context.Context, object cli
 		Namespace: active.Namespace,
 		Name:      active.Name,
 	}}, constants.UpdatesBatchPeriod)
-}
-
-// ownerForPod finds the job owning the pod's slice chain: prefer the controller
-// owner of the named slice when it still exists (pods are not always owned by the
-// job directly), and fall back to the pod's own controller owner-ref when that
-// slice has been deleted.
-func (h *elasticPodHandler) ownerForPod(ctx context.Context, pod *corev1.Pod, sliceKey types.NamespacedName) *metav1.OwnerReference {
-	slice := &kueue.Workload{}
-	switch err := h.client.Get(ctx, sliceKey, slice); {
-	case err == nil:
-		if owner := metav1.GetControllerOf(slice); owner != nil {
-			return owner
-		}
-	case !apierrors.IsNotFound(err):
-		return nil
-	}
-	return metav1.GetControllerOf(pod)
 }
 
 // podSliceName returns the slice-chain key for a pod: the WorkloadSliceName

--- a/pkg/controller/elasticjobs/elastic_job_ungater.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater.go
@@ -365,9 +365,8 @@ func (r *elasticJobUngater) activeSlice(ctx context.Context, anyWl *kueue.Worklo
 	return latestActiveSliceForChain(ctx, r.client, anyWl.Namespace, workloadslicing.SliceName(anyWl))
 }
 
-// latestActiveSliceForChain resolves the latest active workload slice of the chain
-// identified by its first slice's name (sliceName), or nil if none qualifies for
-// ungating.
+// latestActiveSliceForChain resolves the latest active slice of the chain identified
+// by its first slice's name (sliceName), or nil if none qualifies for ungating.
 func latestActiveSliceForChain(ctx context.Context, c client.Client, namespace, sliceName string) (*kueue.Workload, error) {
 	active, err := workloadslicing.FindLatestActiveWorkloadForSlice(ctx, c, namespace, sliceName)
 	if err != nil || active == nil || !workload.IsAdmitted(active) {

--- a/pkg/controller/elasticjobs/elastic_job_ungater.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater.go
@@ -359,20 +359,10 @@ func (r *elasticJobUngater) podsToUngate(ctx context.Context, wl *kueue.Workload
 	return gated, nil
 }
 
-// activeSlice resolves the chain's active slice for the workload anyWl belongs
-// to (see latestActiveSliceForChain), or nil if none qualifies for ungating.
+// activeSlice resolves the admitted slice of the chain the workload anyWl belongs
+// to, or nil if none is admitted.
 func (r *elasticJobUngater) activeSlice(ctx context.Context, anyWl *kueue.Workload) (*kueue.Workload, error) {
-	return latestActiveSliceForChain(ctx, r.client, anyWl.Namespace, workloadslicing.SliceName(anyWl))
-}
-
-// latestActiveSliceForChain resolves the latest active slice of the chain identified
-// by its first slice's name (sliceName), or nil if none qualifies for ungating.
-func latestActiveSliceForChain(ctx context.Context, c client.Client, namespace, sliceName string) (*kueue.Workload, error) {
-	active, err := workloadslicing.FindLatestActiveWorkloadForSlice(ctx, c, namespace, sliceName)
-	if err != nil || active == nil || !workload.IsAdmitted(active) {
-		return nil, err
-	}
-	return active, nil
+	return workloadslicing.FindLatestAdmittedWorkloadForSlice(ctx, r.client, anyWl.Namespace, workloadslicing.SliceName(anyWl))
 }
 
 // Workload predicates
@@ -440,7 +430,7 @@ func (h *elasticPodHandler) queueReconcileForPod(ctx context.Context, object cli
 		log := ctrl.LoggerFrom(ctx).WithValues("pod", klog.KObj(pod), "workloadSlice", sliceKey.String())
 		h.expectationsStore.ObservedUID(log, sliceKey, pod.UID)
 	}
-	active, err := latestActiveSliceForChain(ctx, h.client, pod.Namespace, sliceName)
+	active, err := workloadslicing.FindLatestAdmittedWorkloadForSlice(ctx, h.client, pod.Namespace, sliceName)
 	if err != nil || active == nil {
 		return
 	}

--- a/pkg/controller/elasticjobs/elastic_job_ungater.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater.go
@@ -366,10 +366,7 @@ func (r *elasticJobUngater) activeSlice(ctx context.Context, anyWl *kueue.Worklo
 }
 
 // latestActiveSliceForChain resolves the latest active workload slice of the chain
-// identified by sliceName in namespace, or nil if none qualifies for ungating. Quota
-// reservation alone is insufficient: AdmissionChecks may still be pending, and
-// releasing the elastic gate before then would let pods schedule ahead of
-// capacity, so full admission is required.
+// identified by sliceName in namespace, or nil if none qualifies for ungating.
 func latestActiveSliceForChain(ctx context.Context, c client.Client, namespace, sliceName string) (*kueue.Workload, error) {
 	active, err := workloadslicing.FindLatestActiveWorkloadForSlice(ctx, c, namespace, sliceName)
 	if err != nil || active == nil || !workload.IsAdmitted(active) {

--- a/pkg/controller/elasticjobs/elastic_job_ungater_test.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater_test.go
@@ -28,12 +28,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	autoscaling "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
-	"k8s.io/client-go/util/workqueue"
 	"k8s.io/component-base/metrics/testutil"
 	testingclock "k8s.io/utils/clock/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -1310,99 +1308,6 @@ func TestRecordPodSchedulingGateRemovalSeconds(t *testing.T) {
 			}
 			if diff := gocmp.Diff(tc.wantMetricsSeconds, seconds, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("Invalid PodSchedulingGateRemovalSeconds seconds (-want,+got):\n%s", diff)
-			}
-		})
-	}
-}
-
-var rayServiceGVK = schema.GroupVersionKind{Group: "ray.io", Version: "v1", Kind: "RayService"}
-
-// recordingQueue captures the requests a handler enqueues. Only AddAfter is
-// exercised by the pod handler, so the embedded interface stays nil.
-type recordingQueue struct {
-	workqueue.TypedRateLimitingInterface[reconcile.Request]
-	added []reconcile.Request
-}
-
-func (q *recordingQueue) AddAfter(item reconcile.Request, _ time.Duration) {
-	q.added = append(q.added, item)
-}
-
-// TestPodHandlerEnqueueAfterOriginDeleted covers the pod-event path of the
-// ungater once the chain's origin slice is gone: the handler must still resolve
-// the owning job so Reconcile can ungate against the live active slice.
-//
-// The owner is recovered from the pod's own controller reference, which only
-// matches the Workload's owner when the job that owns the pods is also the job
-// Kueue built the Workload for. For a RayService the Workload belongs to the
-// RayService while its pods belong to the child RayCluster, so the lookup is
-// made with the wrong kind.
-func TestPodHandlerEnqueueAfterOriginDeleted(t *testing.T) {
-	now := time.Now()
-
-	// activeSlice is the chain's live slice: admitted, elastic, and still
-	// carrying the origin name that the pods are stamped with.
-	activeSlice := func(ownerGVK schema.GroupVersionKind, ownerName string) *kueue.Workload {
-		return utiltestingapi.MakeWorkload("wl-2", "ns").
-			Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
-			Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
-			ControllerReference(ownerGVK, ownerName, ownerName+"-uid").
-			PodSets(*utiltestingapi.MakePodSet(headPodSet, 1).Request(corev1.ResourceCPU, "1").Obj()).
-			ReserveQuotaAt(
-				utiltestingapi.MakeAdmission("cq").
-					PodSets(utiltestingapi.MakePodSetAssignment(headPodSet).
-						Assignment(corev1.ResourceCPU, "flavor", "1").Obj()).
-					Obj(), now,
-			).
-			AdmittedAt(true, now).
-			Obj()
-	}
-
-	// gatedPod points at the deleted origin slice "wl" and is owned by the
-	// object that actually creates Ray pods: the RayCluster.
-	gatedPod := func(podOwnerGVK schema.GroupVersionKind, podOwnerName string) *corev1.Pod {
-		return makeElasticPodForPodSet("p1", headPodSet).
-			OwnerReference(podOwnerName, podOwnerGVK).
-			Gate(kueue.ElasticJobSchedulingGate).
-			Obj()
-	}
-
-	cases := map[string]struct {
-		workload *kueue.Workload
-		pod      *corev1.Pod
-		want     []reconcile.Request
-	}{
-		"RayCluster: pods and workload share an owner": {
-			workload: activeSlice(rayClusterGVK, "ray"),
-			pod:      gatedPod(rayClusterGVK, "ray"),
-			want:     []reconcile.Request{{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "wl-2"}}},
-		},
-		"RayService: workload is owned by the service, pods by the child cluster": {
-			workload: activeSlice(rayServiceGVK, "svc"),
-			pod:      gatedPod(rayClusterGVK, "svc-raycluster"),
-			want:     []reconcile.Request{{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "wl-2"}}},
-		},
-	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, true)
-			ctx, _ := utiltesting.ContextWithLog(t)
-
-			kClient := utiltesting.NewClientBuilder().
-				WithIndex(&corev1.Pod{}, coreindexer.WorkloadSliceNameKey, coreindexer.IndexPodWorkloadSliceName).
-				WithIndex(&kueue.Workload{}, coreindexer.OwnerReferenceIndexKey(rayClusterGVK), coreindexer.WorkloadOwnerIndexFunc(rayClusterGVK)).
-				WithIndex(&kueue.Workload{}, coreindexer.WorkloadSliceNameKey, coreindexer.IndexWorkloadSliceName).
-				WithIndex(&kueue.Workload{}, coreindexer.OwnerReferenceIndexKey(rayServiceGVK), coreindexer.WorkloadOwnerIndexFunc(rayServiceGVK)).
-				WithObjects(tc.workload, tc.pod).
-				Build()
-
-			handler := &elasticPodHandler{client: kClient, expectationsStore: expectations.NewStore(ControllerName)}
-			queue := &recordingQueue{}
-			handler.Create(ctx, event.CreateEvent{Object: tc.pod}, queue)
-
-			if diff := gocmp.Diff(tc.want, queue.added, cmpopts.EquateEmpty()); diff != "" {
-				t.Errorf("unexpected enqueued requests (-want/+got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/controller/elasticjobs/elastic_job_ungater_test.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater_test.go
@@ -28,10 +28,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	autoscaling "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/component-base/metrics/testutil"
 	testingclock "k8s.io/utils/clock/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -1299,6 +1301,98 @@ func TestRecordPodSchedulingGateRemovalSeconds(t *testing.T) {
 			}
 			if diff := gocmp.Diff(tc.wantMetricsSeconds, seconds, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("Invalid PodSchedulingGateRemovalSeconds seconds (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+var rayServiceGVK = schema.GroupVersionKind{Group: "ray.io", Version: "v1", Kind: "RayService"}
+
+// recordingQueue captures the requests a handler enqueues. Only AddAfter is
+// exercised by the pod handler, so the embedded interface stays nil.
+type recordingQueue struct {
+	workqueue.TypedRateLimitingInterface[reconcile.Request]
+	added []reconcile.Request
+}
+
+func (q *recordingQueue) AddAfter(item reconcile.Request, _ time.Duration) {
+	q.added = append(q.added, item)
+}
+
+// TestPodHandlerEnqueueAfterOriginDeleted covers the pod-event path of the
+// ungater once the chain's origin slice is gone: the handler must still resolve
+// the owning job so Reconcile can ungate against the live active slice.
+//
+// The owner is recovered from the pod's own controller reference, which only
+// matches the Workload's owner when the job that owns the pods is also the job
+// Kueue built the Workload for. For a RayService the Workload belongs to the
+// RayService while its pods belong to the child RayCluster, so the lookup is
+// made with the wrong kind.
+func TestPodHandlerEnqueueAfterOriginDeleted(t *testing.T) {
+	now := time.Now()
+
+	// activeSlice is the chain's live slice: admitted, elastic, and still
+	// carrying the origin name that the pods are stamped with.
+	activeSlice := func(ownerGVK schema.GroupVersionKind, ownerName string) *kueue.Workload {
+		return utiltestingapi.MakeWorkload("wl-2", "ns").
+			Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+			ControllerReference(ownerGVK, ownerName, ownerName+"-uid").
+			PodSets(*utiltestingapi.MakePodSet(headPodSet, 1).Request(corev1.ResourceCPU, "1").Obj()).
+			ReserveQuotaAt(
+				utiltestingapi.MakeAdmission("cq").
+					PodSets(utiltestingapi.MakePodSetAssignment(headPodSet).
+						Assignment(corev1.ResourceCPU, "flavor", "1").Obj()).
+					Obj(), now,
+			).
+			AdmittedAt(true, now).
+			Obj()
+	}
+
+	// gatedPod points at the deleted origin slice "wl" and is owned by the
+	// object that actually creates Ray pods: the RayCluster.
+	gatedPod := func(podOwnerGVK schema.GroupVersionKind, podOwnerName string) *corev1.Pod {
+		return makeElasticPodForPodSet("p1", headPodSet).
+			OwnerReference(podOwnerName, podOwnerGVK).
+			Gate(kueue.ElasticJobSchedulingGate).
+			Obj()
+	}
+
+	cases := map[string]struct {
+		workload *kueue.Workload
+		pod      *corev1.Pod
+		want     []reconcile.Request
+	}{
+		"RayCluster: pods and workload share an owner": {
+			workload: activeSlice(rayClusterGVK, "ray"),
+			pod:      gatedPod(rayClusterGVK, "ray"),
+			want:     []reconcile.Request{{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "wl-2"}}},
+		},
+		"RayService: workload is owned by the service, pods by the child cluster": {
+			workload: activeSlice(rayServiceGVK, "svc"),
+			pod:      gatedPod(rayClusterGVK, "svc-raycluster"),
+			want:     []reconcile.Request{{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "wl-2"}}},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, true)
+			ctx, _ := utiltesting.ContextWithLog(t)
+
+			kClient := utiltesting.NewClientBuilder().
+				WithIndex(&corev1.Pod{}, coreindexer.WorkloadSliceNameKey, coreindexer.IndexPodWorkloadSliceName).
+				WithIndex(&kueue.Workload{}, coreindexer.OwnerReferenceIndexKey(rayClusterGVK), coreindexer.WorkloadOwnerIndexFunc(rayClusterGVK)).
+				WithIndex(&kueue.Workload{}, coreindexer.OwnerReferenceIndexKey(rayServiceGVK), coreindexer.WorkloadOwnerIndexFunc(rayServiceGVK)).
+				WithObjects(tc.workload, tc.pod).
+				Build()
+
+			handler := &elasticPodHandler{client: kClient, expectationsStore: expectations.NewStore(ControllerName)}
+			queue := &recordingQueue{}
+			handler.Create(ctx, event.CreateEvent{Object: tc.pod}, queue)
+
+			if diff := gocmp.Diff(tc.want, queue.added, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("unexpected enqueued requests (-want/+got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/controller/elasticjobs/elastic_job_ungater_test.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater_test.go
@@ -1038,6 +1038,7 @@ func TestReconcile(t *testing.T) {
 			clientBuilder := utiltesting.NewClientBuilder().
 				WithIndex(&corev1.Pod{}, coreindexer.WorkloadSliceNameKey, coreindexer.IndexPodWorkloadSliceName).
 				WithIndex(&kueue.Workload{}, coreindexer.OwnerReferenceIndexKey(rayClusterGVK), coreindexer.WorkloadOwnerIndexFunc(rayClusterGVK)).
+				WithIndex(&kueue.Workload{}, coreindexer.WorkloadSliceNameKey, coreindexer.IndexWorkloadSliceName).
 				WithInterceptorFuncs(interceptor.Funcs{
 					Patch: func(ctx context.Context, clnt client.WithWatch, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
 						// The fake client doesn't handle MergePatch for slice fields correctly.
@@ -1254,6 +1255,14 @@ func TestRecordPodSchedulingGateRemovalSeconds(t *testing.T) {
 			); err != nil {
 				t.Fatalf("Could not setup workload owner index: %v", err)
 			}
+			if err := utiltesting.AsIndexer(clientBuilder).IndexField(
+				ctx,
+				&kueue.Workload{},
+				coreindexer.WorkloadSliceNameKey,
+				coreindexer.IndexWorkloadSliceName,
+			); err != nil {
+				t.Fatalf("Could not setup workload slice name index: %v", err)
+			}
 
 			kClient := clientBuilder.Build()
 
@@ -1383,6 +1392,7 @@ func TestPodHandlerEnqueueAfterOriginDeleted(t *testing.T) {
 			kClient := utiltesting.NewClientBuilder().
 				WithIndex(&corev1.Pod{}, coreindexer.WorkloadSliceNameKey, coreindexer.IndexPodWorkloadSliceName).
 				WithIndex(&kueue.Workload{}, coreindexer.OwnerReferenceIndexKey(rayClusterGVK), coreindexer.WorkloadOwnerIndexFunc(rayClusterGVK)).
+				WithIndex(&kueue.Workload{}, coreindexer.WorkloadSliceNameKey, coreindexer.IndexWorkloadSliceName).
 				WithIndex(&kueue.Workload{}, coreindexer.OwnerReferenceIndexKey(rayServiceGVK), coreindexer.WorkloadOwnerIndexFunc(rayServiceGVK)).
 				WithObjects(tc.workload, tc.pod).
 				Build()

--- a/pkg/workloadslicing/workloadslicing.go
+++ b/pkg/workloadslicing/workloadslicing.go
@@ -126,11 +126,6 @@ func FindNotFinishedWorkloads(ctx context.Context, clnt client.Client, jobObject
 // FindLatestActiveWorkloadForSlice returns the active slice of the chain identified
 // by its first slice's name (sliceName), which every slice and pod of an elastic job
 // carries, applying the same selection rule as FindLatestActiveWorkload.
-//
-// Resolving by that name rather than by owner keeps the lookup working when the
-// first slice itself has been deleted, and when the object owning the pods is not
-// the object the Workload was created for — a RayService owns the Workload while
-// its child RayCluster owns the pods.
 func FindLatestActiveWorkloadForSlice(ctx context.Context, clnt client.Client, namespace, sliceName string) (*kueue.Workload, error) {
 	list := &kueue.WorkloadList{}
 	if err := clnt.List(ctx, list, client.InNamespace(namespace),

--- a/pkg/workloadslicing/workloadslicing.go
+++ b/pkg/workloadslicing/workloadslicing.go
@@ -123,6 +123,41 @@ func FindNotFinishedWorkloads(ctx context.Context, clnt client.Client, jobObject
 	}), nil
 }
 
+// FindLatestActiveWorkloadForSlice returns the chain's active slice given the
+// chain key that every slice and pod of an elastic job carries, applying the same
+// selection rule as FindLatestActiveWorkload.
+//
+// Resolving by chain key rather than by owner keeps the lookup working when the
+// origin slice named by the key has been deleted, and when the object owning the
+// pods is not the object the Workload was created for — a RayService owns the
+// Workload while its child RayCluster owns the pods.
+func FindLatestActiveWorkloadForSlice(ctx context.Context, clnt client.Client, namespace, sliceName string) (*kueue.Workload, error) {
+	list := &kueue.WorkloadList{}
+	if err := clnt.List(ctx, list, client.InNamespace(namespace),
+		client.MatchingFields{indexer.WorkloadSliceNameKey: sliceName}); err != nil {
+		return nil, err
+	}
+
+	// Sort oldest-first; break same-second ties by UID for stable ordering.
+	slices.SortFunc(list.Items, func(a, b kueue.Workload) int {
+		if c := a.CreationTimestamp.Compare(b.CreationTimestamp.Time); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.UID, b.UID)
+	})
+
+	for i := range slices.Backward(list.Items) {
+		wl := &list.Items[i]
+		if workloadfinish.IsFinished(wl) {
+			continue
+		}
+		if workload.HasQuotaReservation(wl) && !workloadevict.IsEvicted(wl) {
+			return wl, nil
+		}
+	}
+	return nil, nil
+}
+
 // FindLatestActiveWorkload returns the newest non-finished, non-evicted workload
 // slice owned by the provided job object/gvk that holds a quota reservation, or
 // nil if none qualifies. This is the chain's "active" slice: its granted PodSet

--- a/pkg/workloadslicing/workloadslicing.go
+++ b/pkg/workloadslicing/workloadslicing.go
@@ -123,10 +123,10 @@ func FindNotFinishedWorkloads(ctx context.Context, clnt client.Client, jobObject
 	}), nil
 }
 
-// FindLatestActiveWorkloadForSlice returns the active slice of the chain identified
-// by its first slice's name (sliceName), which every slice and pod of an elastic job
-// carries, applying the same selection rule as FindLatestActiveWorkload.
-func FindLatestActiveWorkloadForSlice(ctx context.Context, clnt client.Client, namespace, sliceName string) (*kueue.Workload, error) {
+// FindLatestAdmittedWorkloadForSlice returns the admitted slice of the chain
+// identified by its first slice's name (sliceName), which every slice and pod of an
+// elastic job carries, or nil if none is admitted.
+func FindLatestAdmittedWorkloadForSlice(ctx context.Context, clnt client.Client, namespace, sliceName string) (*kueue.Workload, error) {
 	list := &kueue.WorkloadList{}
 	if err := clnt.List(ctx, list, client.InNamespace(namespace),
 		client.MatchingFields{indexer.WorkloadSliceNameKey: sliceName}); err != nil {
@@ -146,7 +146,10 @@ func FindLatestActiveWorkloadForSlice(ctx context.Context, clnt client.Client, n
 		if workloadfinish.IsFinished(wl) {
 			continue
 		}
-		if workload.HasQuotaReservation(wl) && !workloadevict.IsEvicted(wl) {
+		// Eviction is two writes: the condition is set before the reservation is
+		// released, so an evicted slice can still report itself admitted while its
+		// capacity is on the way out.
+		if workload.IsAdmitted(wl) && !workloadevict.IsEvicted(wl) {
 			return wl, nil
 		}
 	}

--- a/pkg/workloadslicing/workloadslicing.go
+++ b/pkg/workloadslicing/workloadslicing.go
@@ -123,14 +123,14 @@ func FindNotFinishedWorkloads(ctx context.Context, clnt client.Client, jobObject
 	}), nil
 }
 
-// FindLatestActiveWorkloadForSlice returns the chain's active slice given the
-// chain key that every slice and pod of an elastic job carries, applying the same
-// selection rule as FindLatestActiveWorkload.
+// FindLatestActiveWorkloadForSlice returns the active slice of the chain identified
+// by its first slice's name (sliceName), which every slice and pod of an elastic job
+// carries, applying the same selection rule as FindLatestActiveWorkload.
 //
-// Resolving by chain key rather than by owner keeps the lookup working when the
-// origin slice named by the key has been deleted, and when the object owning the
-// pods is not the object the Workload was created for — a RayService owns the
-// Workload while its child RayCluster owns the pods.
+// Resolving by that name rather than by owner keeps the lookup working when the
+// first slice itself has been deleted, and when the object owning the pods is not
+// the object the Workload was created for — a RayService owns the Workload while
+// its child RayCluster owns the pods.
 func FindLatestActiveWorkloadForSlice(ctx context.Context, clnt client.Client, namespace, sliceName string) (*kueue.Workload, error) {
 	list := &kueue.WorkloadList{}
 	if err := clnt.List(ctx, list, client.InNamespace(namespace),

--- a/pkg/workloadslicing/workloadslicing.go
+++ b/pkg/workloadslicing/workloadslicing.go
@@ -101,6 +101,23 @@ func SliceName(wl *kueue.Workload) string {
 	return wl.Name
 }
 
+func sortAndFilterNotFinishedWorkloads(workloads []kueue.Workload) []kueue.Workload {
+	workloads = slices.Clone(workloads)
+
+	// Sort oldest-first; break same-second ties by UID for stable ordering.
+	slices.SortFunc(workloads, func(a, b kueue.Workload) int {
+		if c := a.CreationTimestamp.Compare(b.CreationTimestamp.Time); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.UID, b.UID)
+	})
+
+	// Filter out workloads with activated "Finished" condition.
+	return slices.DeleteFunc(workloads, func(w kueue.Workload) bool {
+		return workloadfinish.IsFinished(&w)
+	})
+}
+
 // FindNotFinishedWorkloads returns a sorted list of workloads "owned by" the provided job object/gvk combination and
 // without "Finished" condition with status = "True".
 func FindNotFinishedWorkloads(ctx context.Context, clnt client.Client, jobObject client.Object, jobObjectGVK schema.GroupVersionKind) ([]kueue.Workload, error) {
@@ -109,18 +126,7 @@ func FindNotFinishedWorkloads(ctx context.Context, clnt client.Client, jobObject
 		return nil, err
 	}
 
-	// Sort oldest-first; break same-second ties by UID for stable ordering.
-	slices.SortFunc(list.Items, func(a, b kueue.Workload) int {
-		if c := a.CreationTimestamp.Compare(b.CreationTimestamp.Time); c != 0 {
-			return c
-		}
-		return cmp.Compare(a.UID, b.UID)
-	})
-
-	// Filter out workloads with activated "Finished" condition.
-	return slices.DeleteFunc(list.Items, func(w kueue.Workload) bool {
-		return workloadfinish.IsFinished(&w)
-	}), nil
+	return sortAndFilterNotFinishedWorkloads(list.Items), nil
 }
 
 // FindLatestAdmittedWorkloadForSlice returns the admitted slice of the chain
@@ -133,19 +139,9 @@ func FindLatestAdmittedWorkloadForSlice(ctx context.Context, clnt client.Client,
 		return nil, err
 	}
 
-	// Sort oldest-first; break same-second ties by UID for stable ordering.
-	slices.SortFunc(list.Items, func(a, b kueue.Workload) int {
-		if c := a.CreationTimestamp.Compare(b.CreationTimestamp.Time); c != 0 {
-			return c
-		}
-		return cmp.Compare(a.UID, b.UID)
-	})
-
-	for i := range slices.Backward(list.Items) {
-		wl := &list.Items[i]
-		if workloadfinish.IsFinished(wl) {
-			continue
-		}
+	workloads := sortAndFilterNotFinishedWorkloads(list.Items)
+	for i := range slices.Backward(workloads) {
+		wl := &workloads[i]
 		// Eviction is two writes: the condition is set before the reservation is
 		// released, so an evicted slice can still report itself admitted while its
 		// capacity is on the way out.

--- a/pkg/workloadslicing/workloadslicing_test.go
+++ b/pkg/workloadslicing/workloadslicing_test.go
@@ -173,6 +173,21 @@ func testWorkload(name, jobName string, jobUID types.UID, created time.Time) *ut
 		Request(corev1.ResourceCPU, "100m")
 }
 
+func TestSortAndFilterNotFinishedWorkloadsDoesNotModifyInput(t *testing.T) {
+	now := time.Now()
+	workloads := []kueue.Workload{
+		*testWorkload("newer", testJobObject.Name, testJobObject.UID, now).Obj(),
+		*testWorkload("finished", testJobObject.Name, testJobObject.UID, now.Add(-time.Minute)).Finished().Obj(),
+	}
+	original := append([]kueue.Workload(nil), workloads...)
+
+	sortAndFilterNotFinishedWorkloads(workloads)
+
+	if diff := cmp.Diff(original, workloads); diff != "" {
+		t.Errorf("sortAndFilterNotFinishedWorkloads modified its input (-want,+got):\n%s", diff)
+	}
+}
+
 func TestFindNotFinishedWorkloads(t *testing.T) {
 	type args struct {
 		clnt         client.Client

--- a/pkg/workloadslicing/workloadslicing_test.go
+++ b/pkg/workloadslicing/workloadslicing_test.go
@@ -173,21 +173,6 @@ func testWorkload(name, jobName string, jobUID types.UID, created time.Time) *ut
 		Request(corev1.ResourceCPU, "100m")
 }
 
-func TestSortAndFilterNotFinishedWorkloadsDoesNotModifyInput(t *testing.T) {
-	now := time.Now()
-	workloads := []kueue.Workload{
-		*testWorkload("newer", testJobObject.Name, testJobObject.UID, now).Obj(),
-		*testWorkload("finished", testJobObject.Name, testJobObject.UID, now.Add(-time.Minute)).Finished().Obj(),
-	}
-	original := append([]kueue.Workload(nil), workloads...)
-
-	sortAndFilterNotFinishedWorkloads(workloads)
-
-	if diff := cmp.Diff(original, workloads); diff != "" {
-		t.Errorf("sortAndFilterNotFinishedWorkloads modified its input (-want,+got):\n%s", diff)
-	}
-}
-
 func TestFindNotFinishedWorkloads(t *testing.T) {
 	type args struct {
 		clnt         client.Client

--- a/test/integration/singlecluster/controller/jobs/rayservice/rayservice_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayservice/rayservice_controller_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rayservice
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/constants"
+	"sigs.k8s.io/kueue/pkg/features"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
+	testingrayservice "sigs.k8s.io/kueue/pkg/util/testingjobs/rayservice"
+	"sigs.k8s.io/kueue/pkg/workload"
+	workloadfinish "sigs.k8s.io/kueue/pkg/workload/finish"
+	"sigs.k8s.io/kueue/pkg/workloadslicing"
+	"sigs.k8s.io/kueue/test/integration/framework"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var _ = ginkgo.Describe("RayService with elastic jobs via workload-slices support", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+	var (
+		ns           *corev1.Namespace
+		clusterQueue *kueue.ClusterQueue
+		localQueue   *kueue.LocalQueue
+		resourceFlavor *kueue.ResourceFlavor
+	)
+
+	ginkgo.BeforeAll(func() {
+		gomega.Expect(utilfeature.DefaultMutableFeatureGate.SetFromMap(map[string]bool{string(features.ElasticJobsViaWorkloadSlices): true})).Should(gomega.Succeed())
+		fwk.StartManager(ctx, cfg, managerAndSchedulerSetup())
+	})
+
+	ginkgo.AfterAll(func() {
+		fwk.StopManager(ctx)
+	})
+
+	ginkgo.BeforeEach(func() {
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "rayservice-elastic-")
+
+		resourceFlavor = utiltestingapi.MakeResourceFlavor("flavor").Obj()
+		util.MustCreate(ctx, k8sClient, resourceFlavor)
+
+		clusterQueue = utiltestingapi.MakeClusterQueue("cq").
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas("flavor").
+				Resource(corev1.ResourceCPU, "10").
+				Resource(corev1.ResourceMemory, "5Gi").Obj()).
+			Obj()
+		util.MustCreate(ctx, k8sClient, clusterQueue)
+
+		localQueue = utiltestingapi.MakeLocalQueue("lq", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+		util.MustCreate(ctx, k8sClient, localQueue)
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, resourceFlavor, true)
+	})
+
+	ginkgo.It("Should ungate chain pods after the origin workload slice is deleted", framework.SlowSpec, func() {
+		// Same stranded-pod scenario as the RayCluster spec, but for a RayService:
+		// Kueue owns the Workload through the RayService while KubeRay owns the pods
+		// through the child RayCluster. Once the origin slice is gone, recovering the
+		// owning job from the pod's controller reference yields the RayCluster, whose
+		// kind does not match the RayService the Workload is indexed under.
+		service := testingrayservice.MakeService("foo", ns.Name).
+			Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			Queue(localQueue.Name).
+			Request(rayv1.HeadNode, corev1.ResourceCPU, "1").
+			Request(rayv1.WorkerNode, corev1.ResourceCPU, "1").
+			EnableInTreeAutoscaling().
+			Obj()
+
+		ginkgo.By("creating and admitting the rayservice's origin workload slice")
+		util.MustCreate(ctx, k8sClient, service)
+		var originSlice *kueue.Workload
+		gomega.Eventually(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+			g.Expect(workloads.Items).Should(gomega.HaveLen(1))
+			originSlice = &workloads.Items[0]
+			g.Expect(workload.IsAdmitted(originSlice)).Should(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		originSliceName := originSlice.Name
+
+		ginkgo.By("scaling up the worker replicas to create a second (active) slice")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(service), service)).Should(gomega.Succeed())
+			service.Spec.RayClusterSpec.WorkerGroupSpecs[0].Replicas = new(int32(2))
+			g.Expect(k8sClient.Update(ctx, service)).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		var activeSlice *kueue.Workload
+		gomega.Eventually(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+			g.Expect(workloads.Items).Should(gomega.HaveLen(2))
+			activeSlice = nil
+			for i := range workloads.Items {
+				if !workloadfinish.IsFinished(&workloads.Items[i]) {
+					activeSlice = &workloads.Items[i]
+				}
+			}
+			g.Expect(activeSlice).ShouldNot(gomega.BeNil())
+			g.Expect(activeSlice.Name).ShouldNot(gomega.Equal(originSliceName))
+			g.Expect(workload.IsAdmitted(activeSlice)).Should(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("deleting the origin slice to emulate a rollout GC of the old cluster's workloads")
+		util.DeleteWorkloadSliceAndAwaitDeletion(ctx, k8sClient, types.NamespacedName{Namespace: ns.Name, Name: originSliceName})
+
+		ginkgo.By("creating a still-gated pod that points at the now-deleted origin slice, owned by the child RayCluster")
+		childCluster := &rayv1.RayCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: service.Name + "-raycluster", Namespace: ns.Name},
+			Spec:       *service.Spec.RayClusterSpec.DeepCopy(),
+		}
+		util.MustCreate(ctx, k8sClient, childCluster)
+
+		gatedPod := testingpod.MakePod("worker-0", ns.Name).
+			Annotation(kueue.WorkloadAnnotation, originSliceName).
+			Annotation(kueue.WorkloadSliceNameAnnotation, originSliceName).
+			Label(constants.PodSetLabel, string(activeSlice.Spec.PodSets[1].Name)).
+			Gate(kueue.ElasticJobSchedulingGate).
+			Obj()
+		gatedPod.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion:         rayv1.SchemeGroupVersion.String(),
+			Kind:               "RayCluster",
+			Name:               childCluster.Name,
+			UID:                childCluster.UID,
+			Controller:         new(true),
+			BlockOwnerDeletion: new(true),
+		}}
+		util.MustCreate(ctx, k8sClient, gatedPod)
+
+		ginkgo.By("the ungater removes the elastic scheduling gate despite the origin slice being gone")
+		gomega.Eventually(func(g gomega.Gomega) {
+			var got corev1.Pod
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(gatedPod), &got)).To(gomega.Succeed())
+			g.Expect(got.Spec.SchedulingGates).ShouldNot(gomega.ContainElement(
+				corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+	})
+})

--- a/test/integration/singlecluster/controller/jobs/rayservice/rayservice_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayservice/rayservice_controller_test.go
@@ -36,7 +36,6 @@ import (
 	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
 	testingrayservice "sigs.k8s.io/kueue/pkg/util/testingjobs/rayservice"
 	"sigs.k8s.io/kueue/pkg/workload"
-	workloadfinish "sigs.k8s.io/kueue/pkg/workload/finish"
 	"sigs.k8s.io/kueue/pkg/workloadslicing"
 	"sigs.k8s.io/kueue/test/integration/framework"
 	"sigs.k8s.io/kueue/test/util"
@@ -140,13 +139,9 @@ var _ = ginkgo.Describe("RayService with elastic jobs via workload-slices suppor
 			workloads := &kueue.WorkloadList{}
 			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(ns.Name))).Should(gomega.Succeed())
 			g.Expect(workloads.Items).Should(gomega.HaveLen(2))
-			activeSlice = nil
-			for i := range workloads.Items {
-				if !workloadfinish.IsFinished(&workloads.Items[i]) {
-					activeSlice = &workloads.Items[i]
-				}
-			}
-			g.Expect(activeSlice).ShouldNot(gomega.BeNil())
+			activeWorkloads := util.FindNonFinishedWorkloads(workloads.Items)
+			g.Expect(activeWorkloads).Should(gomega.HaveLen(1))
+			activeSlice = &activeWorkloads[0]
 			g.Expect(activeSlice.Name).ShouldNot(gomega.Equal(originSliceName))
 			g.Expect(workload.IsAdmitted(activeSlice)).Should(gomega.BeTrue())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())

--- a/test/integration/singlecluster/controller/jobs/rayservice/rayservice_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayservice/rayservice_controller_test.go
@@ -17,6 +17,9 @@ limitations under the License.
 package rayservice
 
 import (
+	"fmt"
+	"slices"
+
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
@@ -41,9 +44,9 @@ import (
 
 var _ = ginkgo.Describe("RayService with elastic jobs via workload-slices support", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	var (
-		ns           *corev1.Namespace
-		clusterQueue *kueue.ClusterQueue
-		localQueue   *kueue.LocalQueue
+		ns             *corev1.Namespace
+		clusterQueue   *kueue.ClusterQueue
+		localQueue     *kueue.LocalQueue
 		resourceFlavor *kueue.ResourceFlavor
 	)
 
@@ -100,11 +103,36 @@ var _ = ginkgo.Describe("RayService with elastic jobs via workload-slices suppor
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		originSliceName := originSlice.Name
 
-		ginkgo.By("scaling up the worker replicas to create a second (active) slice")
+		ginkgo.By("creating the child RayCluster owned by the RayService, as KubeRay would")
+		// The child RayCluster is owned by the RayService, mirroring the real
+		// topology: the pods' controller owner (RayCluster) differs from the
+		// slices' owner (RayService).
+		childCluster := &rayv1.RayCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: service.Name + "-raycluster", Namespace: ns.Name},
+			Spec:       *service.Spec.RayClusterSpec.DeepCopy(),
+		}
+		childCluster.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion:         rayv1.SchemeGroupVersion.String(),
+			Kind:               "RayService",
+			Name:               service.Name,
+			UID:                service.UID,
+			Controller:         new(true),
+			BlockOwnerDeletion: new(true),
+		}}
+		util.MustCreate(ctx, k8sClient, childCluster)
+
+		ginkgo.By("promoting the child cluster to active in the RayService status, as KubeRay would")
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(service), service)).Should(gomega.Succeed())
-			service.Spec.RayClusterSpec.WorkerGroupSpecs[0].Replicas = new(int32(2))
-			g.Expect(k8sClient.Update(ctx, service)).Should(gomega.Succeed())
+			service.Status.ActiveServiceStatus.RayClusterName = childCluster.Name
+			g.Expect(k8sClient.Status().Update(ctx, service)).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("scaling up the child RayCluster's worker replicas, as the Ray autoscaler would")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(childCluster), childCluster)).Should(gomega.Succeed())
+			childCluster.Spec.WorkerGroupSpecs[0].Replicas = new(int32(2))
+			g.Expect(k8sClient.Update(ctx, childCluster)).Should(gomega.Succeed())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 		var activeSlice *kueue.Workload
@@ -126,35 +154,51 @@ var _ = ginkgo.Describe("RayService with elastic jobs via workload-slices suppor
 		ginkgo.By("deleting the origin slice to emulate a rollout GC of the old cluster's workloads")
 		util.DeleteWorkloadSliceAndAwaitDeletion(ctx, k8sClient, types.NamespacedName{Namespace: ns.Name, Name: originSliceName})
 
-		ginkgo.By("creating a still-gated pod that points at the now-deleted origin slice, owned by the child RayCluster")
-		childCluster := &rayv1.RayCluster{
-			ObjectMeta: metav1.ObjectMeta{Name: service.Name + "-raycluster", Namespace: ns.Name},
-			Spec:       *service.Spec.RayClusterSpec.DeepCopy(),
+		ginkgo.By("creating still-gated pods that point at the now-deleted origin slice, owned by the child RayCluster")
+		var workerPodSet kueue.PodSetReference
+		for _, ps := range activeSlice.Spec.PodSets {
+			if ps.Name != "head" {
+				workerPodSet = ps.Name
+			}
 		}
-		util.MustCreate(ctx, k8sClient, childCluster)
+		gomega.Expect(workerPodSet).ShouldNot(gomega.BeEmpty())
 
-		gatedPod := testingpod.MakePod("worker-0", ns.Name).
-			Annotation(kueue.WorkloadAnnotation, originSliceName).
-			Annotation(kueue.WorkloadSliceNameAnnotation, originSliceName).
-			Label(constants.PodSetLabel, string(activeSlice.Spec.PodSets[1].Name)).
-			Gate(kueue.ElasticJobSchedulingGate).
-			Obj()
-		gatedPod.OwnerReferences = []metav1.OwnerReference{{
-			APIVersion:         rayv1.SchemeGroupVersion.String(),
-			Kind:               "RayCluster",
-			Name:               childCluster.Name,
-			UID:                childCluster.UID,
-			Controller:         new(true),
-			BlockOwnerDeletion: new(true),
-		}}
-		util.MustCreate(ctx, k8sClient, gatedPod)
+		// One more gated pod than the active slice's granted worker count (2), so
+		// the test also pins that ungating stays capped by the admitted quota.
+		gatedPods := make([]*corev1.Pod, 3)
+		for i := range gatedPods {
+			gatedPods[i] = testingpod.MakePod(fmt.Sprintf("worker-%d", i), ns.Name).
+				Annotation(kueue.WorkloadAnnotation, originSliceName).
+				Annotation(kueue.WorkloadSliceNameAnnotation, originSliceName).
+				Label(constants.PodSetLabel, string(workerPodSet)).
+				Gate(kueue.ElasticJobSchedulingGate).
+				Obj()
+			gatedPods[i].OwnerReferences = []metav1.OwnerReference{{
+				APIVersion:         rayv1.SchemeGroupVersion.String(),
+				Kind:               "RayCluster",
+				Name:               childCluster.Name,
+				UID:                childCluster.UID,
+				Controller:         new(true),
+				BlockOwnerDeletion: new(true),
+			}}
+			util.MustCreate(ctx, k8sClient, gatedPods[i])
+		}
 
-		ginkgo.By("the ungater removes the elastic scheduling gate despite the origin slice being gone")
-		gomega.Eventually(func(g gomega.Gomega) {
+		hasElasticGate := func(g gomega.Gomega, pod *corev1.Pod) bool {
 			var got corev1.Pod
-			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(gatedPod), &got)).To(gomega.Succeed())
-			g.Expect(got.Spec.SchedulingGates).ShouldNot(gomega.ContainElement(
-				corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}))
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), &got)).To(gomega.Succeed())
+			return slices.Contains(got.Spec.SchedulingGates, corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate})
+		}
+
+		ginkgo.By("the ungater removes the elastic scheduling gate from the two lowest-named pods despite the origin slice being gone")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(hasElasticGate(g, gatedPods[0])).Should(gomega.BeFalse())
+			g.Expect(hasElasticGate(g, gatedPods[1])).Should(gomega.BeFalse())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("the pod beyond the active slice's granted worker count stays gated")
+		gomega.Consistently(func(g gomega.Gomega) {
+			g.Expect(hasElasticGate(g, gatedPods[2])).Should(gomega.BeTrue())
+		}, util.LongConsistentDuration, util.Interval).Should(gomega.Succeed())
 	})
 })

--- a/test/integration/singlecluster/controller/jobs/rayservice/rayservice_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayservice/rayservice_controller_test.go
@@ -80,11 +80,6 @@ var _ = ginkgo.Describe("RayService with elastic jobs via workload-slices suppor
 	})
 
 	ginkgo.It("Should ungate chain pods after the origin workload slice is deleted", framework.SlowSpec, func() {
-		// Same stranded-pod scenario as the RayCluster spec, but for a RayService:
-		// Kueue owns the Workload through the RayService while KubeRay owns the pods
-		// through the child RayCluster. Once the origin slice is gone, recovering the
-		// owning job from the pod's controller reference yields the RayCluster, whose
-		// kind does not match the RayService the Workload is indexed under.
 		service := testingrayservice.MakeService("foo", ns.Name).
 			Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
 			Queue(localQueue.Name).

--- a/test/integration/singlecluster/controller/jobs/rayservice/suite_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayservice/suite_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rayservice
+
+import (
+	"context"
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	config "sigs.k8s.io/kueue/apis/config/v1beta2"
+	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
+	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	"sigs.k8s.io/kueue/pkg/constants"
+	"sigs.k8s.io/kueue/pkg/controller/core"
+	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
+	"sigs.k8s.io/kueue/pkg/controller/elasticjobs"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/rayservice"
+	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/scheduler"
+	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
+	"sigs.k8s.io/kueue/pkg/webhooks"
+	"sigs.k8s.io/kueue/test/integration/framework"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	ctx       context.Context
+	fwk       *framework.Framework
+)
+
+func TestAPIs(t *testing.T) {
+	util.RunSuite(t, "RayService Controller Suite")
+}
+
+var _ = ginkgo.BeforeSuite(func() {
+	fwk = &framework.Framework{
+		DepCRDPaths: []string{util.RayOperatorCrds},
+	}
+
+	cfg = fwk.Init()
+	ctx, k8sClient = fwk.SetupClient(cfg)
+})
+
+var _ = ginkgo.AfterSuite(func() {
+	fwk.Teardown()
+})
+
+func managerAndSchedulerSetup(opts ...jobframework.Option) framework.ManagerSetup {
+	return func(ctx context.Context, mgr manager.Manager) {
+		err := indexer.Setup(ctx, mgr.GetFieldIndexer())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		cCache := schdcache.New(mgr.GetClient())
+		preemptionExpectations := preemptexpectations.New()
+		queueOptions := []qcache.Option{qcache.WithPreemptionExpectations(preemptionExpectations)}
+		queues := util.NewManagerForIntegrationTests(ctx, mgr.GetClient(), cCache, queueOptions...)
+		opts = append(opts, jobframework.WithQueues(queues))
+
+		failedCtrl, err := core.SetupControllers(
+			mgr,
+			queues,
+			cCache,
+			&config.Configuration{},
+			core.SetupControllersOpts{PreemptionExpectations: preemptionExpectations},
+		)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
+
+		failedWebhook, err := webhooks.Setup(mgr, nil)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
+
+		err = rayservice.SetupIndexes(ctx, mgr.GetFieldIndexer())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		reconciler, err := rayservice.NewReconciler(ctx, mgr.GetClient(), mgr.GetFieldIndexer(),
+			mgr.GetEventRecorder(constants.JobControllerName), opts...)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = reconciler.SetupWithManager(mgr)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = rayservice.SetupRayServiceWebhook(mgr, opts...)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		if features.Enabled(features.ElasticJobsViaWorkloadSlices) {
+			failedCtrl, err := elasticjobs.SetupWithManager(mgr, &config.Configuration{}, nil)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
+		}
+
+		sched := scheduler.New(
+			queues,
+			cCache,
+			mgr.GetClient(),
+			mgr.GetEventRecorder(constants.AdmissionName),
+			scheduler.WithPreemptionExpectations(preemptionExpectations),
+		)
+		err = sched.Start(ctx)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area integrations

#### What this PR does / why we need it:

#### Context: workload-slice chains and their annotations

Scaling an elastic job replaces its Workload with a new slice, forming a chain
S0 → S1 → S2 → … in which only the newest admitted slice is active. Two
annotations describe the chain on the slices:

- `kueue.x-k8s.io/workload-slice-name` — the name of the chain's **first** slice, shared by every slice and every pod in the chain (the first slice itself may not carry it yet, so the new Workload index falls back to the Workload's own name);
- `kueue.x-k8s.io/workload-slice-replacement-for` — the key of the slice this one **replaced**, linking each scale-up slice to its immediate predecessor.

Pods carry the chain key too, stamped into the job's pod templates at admission:

- `kueue.x-k8s.io/workload-slice-name` — the same chain key as on the slices, pointing at the chain's **first** slice; this is what the Pod index and the ungater use;
- `kueue.x-k8s.io/workload` — the slice the pod template was stamped under at admission. Templates are not re-stamped on slice replacement, so on an elastic job this stays at the origin slice's name and dangles once that slice is deleted — which is why it cannot serve as the lookup key on its own (the ungater only falls back to it for non-elastic pods that lack `workload-slice-name`).

```mermaid
flowchart LR
    S2["S2 — active slice<br/>(Admitted)"] -- "(workload-slice-replacement-for annotation)" --> S1["S1<br/>(Finished)"]
    S1 -- "(workload-slice-replacement-for annotation)" --> S0["S0<br/>(chain key = its own name;<br/>may be deleted later)"]
    S2 -. "(workload-slice-name annotation)" .-> S0
    S1 -. "(workload-slice-name annotation)" .-> S0
    P["every Pod of the job"] -. "(workload-slice-name annotation,<br/>what the ungater uses)" .-> S0
    P -- "(workload annotation,<br/>stamped at admission,<br/>never re-stamped)" --> S0
```

Besides the annotations, the owner model also ties the chain together:

- Every slice's controller ownerReference is the **top-level job** (the object Kueue
  created the Workload for). Given the top-level job, all of its slices can therefore
  be listed through the GVK-scoped owner index.
- Pods, however, are owned by whichever object directly creates them. For Ray that is
  always a **RayCluster**, which is the top-level job only when the RayCluster itself
  is the Kueue job.

**Standalone RayCluster** — Pods and slices share the same owner:

```mermaid
flowchart TB
    RC["RayCluster<br/>(top-level job)"] == "owns" ==> P["Pods"]
    RC == "owns" ==> S["workload slices S0 … Sn"]
```

**RayService / RayJob** — Pods hang off the child RayCluster, while slices hang off the top-level job:

```mermaid
flowchart TB
    RS["RayService / RayJob<br/>(top-level job)"] == "owns" ==> RC["child RayCluster"]
    RC == "owns" ==> P["Pods"]
    RS == "owns" ==> S["workload slices S0 … Sn"]
```

How a gated pod is resolved to the chain's active slice, across versions:

#### 1. **Before #14139** — the origin slice must still exist:

<details>
<summary>diagram</summary>

```mermaid
flowchart TB
    a1["gated Pod"] --> a2["Get S0<br/>(named by the pod's<br/>workload-slice-name annotation)"]
    a2 -->|"S0 exists"| a3["S0's controller owner<br/>(the top-level job that owns the slices)"]
    a3 --> a4["Workloads by owner index:<br/>newest admitted = active slice ✅"]
    a2 -->|"S0 deleted"| a5["❌ bail — pod stays gated<br/>(any job type)"]
```

</details>

#### 2. **#14139 (current `main`)** 

On a deleted origin, fall back to the pod's own controller owner; assumes that owner is also the Workloads' owner. This works for RayCluster, but not for RayService, because the Pod is owned by a child RayCluster of the RayService, while the Workload is owned by the RayService:

<details>
<summary>diagram</summary>

```mermaid
flowchart TB
    b1["gated Pod"] --> b2["Get S0<br/>(named by the pod's<br/>workload-slice-name annotation)"]
    b2 -->|"S0 exists"| b3["S0's controller owner"]
    b2 -->|"S0 deleted"| b4["fallback: pod's own controller owner<br/>(one level up)"]
    b3 --> b5["Workloads by owner index:<br/>newest admitted = active slice ✅"]
    b4 --> b6{"pod owner == Workload owner?"}
    b6 -->|"Job, RayCluster: yes"| b5
    b6 -->|"RayService: pod → RayCluster,<br/>Workloads → RayService"| b7["❌ owner-indexed lookup matches nothing —<br/>pod stays gated"]
```

</details>

#### 3. **This PR**

no owner hop; the active slice is resolved by listing Workloads indexed on the shared chain key (`kueue.x-k8s.io/workload-slice-name`), so the lookup never depends on ownership or on the origin slice surviving:

<details>
<summary>diagram</summary>

```mermaid
flowchart TB
    c1["gated Pod (or any slice event)"] --> c2["chain key = S0's name<br/>(from the workload-slice-name annotation;<br/>S0 itself indexes under its own name)"]
    c2 --> c3["Workloads by chain-key index:<br/>newest admitted = active slice ✅"]
```

</details>

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

A deterministic manual reproduction on a live cluster (kind + KubeRay v1.7.0,
`main` build) is written up in [this comment](https://github.com/kubernetes-sigs/kueue/pull/14703#issuecomment-5368210279), with the manifest in [this gist](https://gist.github.com/kevin85421/e65122594eae21be1ea6381bad2c2d37).

AI tools were used to help prepare this change, per the
[Kubernetes AI tool usage policy](https://www.kubernetes.dev/docs/guide/pull-requests/#ai-guidance).

#### Does this PR introduce a user-facing change?

```release-note
RayService: Fixed a bug where elastic (autoscaling) RayService pods could stay stuck in `SchedulingGated` on `kueue.x-k8s.io/elastic-job` after the origin workload slice was deleted, leaving the RayCluster below its desired replica count.
```











<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved elastic workload-slice tracking by recognizing slice names and using workload names when no slice annotation is available.
  * Enhanced workload selection to consistently prioritize the latest eligible, unfinished workload.

* **Bug Fixes**
  * Improved pod and active-slice resolution when the original workload slice is removed, ensuring eligible pods are ungated correctly.

* **Tests**
  * Added integration coverage for RayService elastic workload slices, including quota-based pod admission and controller behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->













