### PR TITLE
test(e2e): stabilize LWS restart policy test

### DIFF
--- a/test/e2e/singlecluster/extended/leaderworkerset_test.go
+++ b/test/e2e/singlecluster/extended/leaderworkerset_test.go
@@ -23,18 +23,21 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	ctrlconstants "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/leaderworkerset"
 	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
+	clientutil "sigs.k8s.io/kueue/pkg/util/client"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	leaderworkersettesting "sigs.k8s.io/kueue/pkg/util/testingjobs/leaderworkerset"
@@ -1300,6 +1303,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 
 	ginkgo.When("LeaderWorkerSet created with Restart Policy", func() {
 		ginkgo.It("should recreate pods when policy is set to RecreateGroupOnPodRestart", func() {
+			const deletionBarrierFinalizer = "kueue.x-k8s.io/e2e-deletion-barrier"
+
 			lws := leaderworkersettesting.MakeLeaderWorkerSet("lws", ns.Name).
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				Size(3).
@@ -1328,7 +1333,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 				gomega.Expect(k8sClient.Get(ctx, util.WorkloadKeyForLeaderWorkerSet(lws, "0"), createdWorkload)).To(gomega.Succeed())
 			})
 
-			var podToDelete *corev1.Pod
+			var leaderPod, podToDelete *corev1.Pod
 			originalPodUIDSet := sets.New[types.UID]()
 			ginkgo.By("Select a worker pod to delete", func() {
 				pods := &corev1.PodList{}
@@ -1339,17 +1344,57 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 
 				for i, pod := range pods.Items {
 					originalPodUIDSet.Insert(pod.UID)
-					if pod.Labels[leaderworkersetv1.WorkerIndexLabelKey] != "0" {
+					if pod.Labels[leaderworkersetv1.WorkerIndexLabelKey] == "0" {
+						leaderPod = &pods.Items[i]
+					} else {
 						podToDelete = &pods.Items[i]
 					}
 				}
+				gomega.Expect(leaderPod).NotTo(gomega.BeNil(), "Couldn't find the leader pod")
 				gomega.Expect(podToDelete).NotTo(gomega.BeNil(), "Couldn't find a worker pod to delete")
 			})
 
+			leaderPodUID := leaderPod.UID
+			leaderPodKey := client.ObjectKeyFromObject(leaderPod)
 			deletedPodUID := podToDelete.UID
 			deletedPodKey := client.ObjectKeyFromObject(podToDelete)
+			removeDeletionBarrierFinalizer := func() error {
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, deletedPodKey, pod); err != nil {
+					return client.IgnoreNotFound(err)
+				}
+				return clientutil.Patch(ctx, k8sClient, pod, func() (bool, error) {
+					return controllerutil.RemoveFinalizer(pod, deletionBarrierFinalizer), nil
+				}, clientutil.WithRetryOnConflict())
+			}
+			defer func() {
+				gomega.Eventually(removeDeletionBarrierFinalizer, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+			}()
+
+			ginkgo.By("Add a deletion barrier finalizer to the worker pod", func() {
+				gomega.Expect(clientutil.Patch(ctx, k8sClient, podToDelete, func() (bool, error) {
+					return controllerutil.AddFinalizer(podToDelete, deletionBarrierFinalizer), nil
+				}, clientutil.WithRetryOnConflict())).To(gomega.Succeed())
+			})
+
 			ginkgo.By("Delete the worker pod", func() {
 				gomega.Expect(k8sClient.Delete(ctx, podToDelete)).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Wait for LWS to start recreating the group", func() {
+				gomega.Eventually(func(g gomega.Gomega) bool {
+					pod := &corev1.Pod{}
+					err := k8sClient.Get(ctx, leaderPodKey, pod)
+					if apierrors.IsNotFound(err) {
+						return true
+					}
+					g.Expect(err).NotTo(gomega.HaveOccurred())
+					return pod.UID != leaderPodUID || pod.DeletionTimestamp != nil
+				}, util.LongTimeout, util.Interval).Should(gomega.BeTrue())
+			})
+
+			ginkgo.By("Remove the deletion barrier finalizer", func() {
+				gomega.Eventually(removeDeletionBarrierFinalizer, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("Wait for the deleted pod to be recreated with a new UID", func() {

--- a/test/e2e/singlecluster/extended/leaderworkerset_test.go
+++ b/test/e2e/singlecluster/extended/leaderworkerset_test.go
@@ -23,21 +23,18 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	ctrlconstants "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/leaderworkerset"
 	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
-	clientutil "sigs.k8s.io/kueue/pkg/util/client"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	leaderworkersettesting "sigs.k8s.io/kueue/pkg/util/testingjobs/leaderworkerset"
@@ -1303,8 +1300,6 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 
 	ginkgo.When("LeaderWorkerSet created with Restart Policy", func() {
 		ginkgo.It("should recreate pods when policy is set to RecreateGroupOnPodRestart", func() {
-			const deletionBarrierFinalizer = "kueue.x-k8s.io/e2e-deletion-barrier"
-
 			lws := leaderworkersettesting.MakeLeaderWorkerSet("lws", ns.Name).
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 				Size(3).
@@ -1333,9 +1328,9 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 				gomega.Expect(k8sClient.Get(ctx, util.WorkloadKeyForLeaderWorkerSet(lws, "0"), createdWorkload)).To(gomega.Succeed())
 			})
 
-			var leaderPod, podToDelete *corev1.Pod
+			var podToRestart *corev1.Pod
 			originalPodUIDSet := sets.New[types.UID]()
-			ginkgo.By("Select a worker pod to delete", func() {
+			ginkgo.By("Select a worker pod to restart", func() {
 				pods := &corev1.PodList{}
 				gomega.Expect(k8sClient.List(ctx, pods, client.MatchingLabels{
 					leaderworkersetv1.SetNameLabelKey: lws.Name,
@@ -1344,64 +1339,28 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 
 				for i, pod := range pods.Items {
 					originalPodUIDSet.Insert(pod.UID)
-					if pod.Labels[leaderworkersetv1.WorkerIndexLabelKey] == "0" {
-						leaderPod = &pods.Items[i]
-					} else {
-						podToDelete = &pods.Items[i]
+					if pod.Labels[leaderworkersetv1.WorkerIndexLabelKey] != "0" {
+						podToRestart = &pods.Items[i]
 					}
 				}
-				gomega.Expect(leaderPod).NotTo(gomega.BeNil(), "Couldn't find the leader pod")
-				gomega.Expect(podToDelete).NotTo(gomega.BeNil(), "Couldn't find a worker pod to delete")
+				gomega.Expect(podToRestart).NotTo(gomega.BeNil(), "Couldn't find a worker pod to restart")
 			})
 
-			leaderPodUID := leaderPod.UID
-			leaderPodKey := client.ObjectKeyFromObject(leaderPod)
-			deletedPodUID := podToDelete.UID
-			deletedPodKey := client.ObjectKeyFromObject(podToDelete)
-			removeDeletionBarrierFinalizer := func() error {
-				pod := &corev1.Pod{}
-				if err := k8sClient.Get(ctx, deletedPodKey, pod); err != nil {
-					return client.IgnoreNotFound(err)
-				}
-				return clientutil.Patch(ctx, k8sClient, pod, func() (bool, error) {
-					return controllerutil.RemoveFinalizer(pod, deletionBarrierFinalizer), nil
-				}, clientutil.WithRetryOnConflict())
-			}
-			defer func() {
-				gomega.Eventually(removeDeletionBarrierFinalizer, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
-			}()
+			restartedPodUID := podToRestart.UID
+			restartedPodKey := client.ObjectKeyFromObject(podToRestart)
 
-			ginkgo.By("Add a deletion barrier finalizer to the worker pod", func() {
-				gomega.Expect(clientutil.Patch(ctx, k8sClient, podToDelete, func() (bool, error) {
-					return controllerutil.AddFinalizer(podToDelete, deletionBarrierFinalizer), nil
-				}, clientutil.WithRetryOnConflict())).To(gomega.Succeed())
+			// Restart the container instead of deleting the pod because LWS can miss the deletion
+			// if the worker StatefulSet creates a same-name replacement first.
+			// TODO: Use pod deletion once https://github.com/kubernetes-sigs/lws/issues/998 is fixed.
+			ginkgo.By("Restart the container of the selected worker pod", func() {
+				util.RestartPodContainer(ctx, k8sClient, restClient, cfg, restartedPodKey)
 			})
 
-			ginkgo.By("Delete the worker pod", func() {
-				gomega.Expect(k8sClient.Delete(ctx, podToDelete)).Should(gomega.Succeed())
-			})
-
-			ginkgo.By("Wait for LWS to start recreating the group", func() {
-				gomega.Eventually(func(g gomega.Gomega) bool {
-					pod := &corev1.Pod{}
-					err := k8sClient.Get(ctx, leaderPodKey, pod)
-					if apierrors.IsNotFound(err) {
-						return true
-					}
-					g.Expect(err).NotTo(gomega.HaveOccurred())
-					return pod.UID != leaderPodUID || pod.DeletionTimestamp != nil
-				}, util.LongTimeout, util.Interval).Should(gomega.BeTrue())
-			})
-
-			ginkgo.By("Remove the deletion barrier finalizer", func() {
-				gomega.Eventually(removeDeletionBarrierFinalizer, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
-			})
-
-			ginkgo.By("Wait for the deleted pod to be recreated with a new UID", func() {
+			ginkgo.By("Wait for the restarted pod to be recreated with a new UID", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					pod := &corev1.Pod{}
-					g.Expect(k8sClient.Get(ctx, deletedPodKey, pod)).To(gomega.Succeed())
-					g.Expect(pod.UID).NotTo(gomega.Equal(deletedPodUID), "pod should be recreated with a new UID")
+					g.Expect(k8sClient.Get(ctx, restartedPodKey, pod)).To(gomega.Succeed())
+					g.Expect(pod.UID).NotTo(gomega.Equal(restartedPodUID), "pod should be recreated with a new UID")
 				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 

--- a/test/util/e2e.go
+++ b/test/util/e2e.go
@@ -546,9 +546,7 @@ func WaitForActivePodsAndTerminate(
 		activePods = make([]corev1.Pod, 0)
 		for _, p := range pods.Items {
 			if len(p.Status.PodIP) != 0 && p.Status.Phase == corev1.PodRunning {
-				cmd := []string{"/bin/sh", "-c", fmt.Sprintf("curl \"http://%s:8080/readyz\"", p.Status.PodIP)}
-				_, _, err := KExecute(ctx, cfg, restClient, namespace, p.Name, p.Spec.Containers[0].Name, cmd)
-				g.Expect(err).ToNot(gomega.HaveOccurred())
+				g.Expect(curlAgnHost(ctx, cfg, restClient, &p, "readyz")).To(gomega.Succeed())
 				activePods = append(activePods, p)
 			}
 		}
@@ -557,17 +555,49 @@ func WaitForActivePodsAndTerminate(
 
 	for _, p := range activePods {
 		ginkgo.GinkgoLogr.Info("Terminating pod", "pod", klog.KObj(&p))
-		cmd := []string{"/bin/sh", "-c", fmt.Sprintf("curl \"http://%s:8080/exit?code=%v&timeout=2s&wait=2s\"", p.Status.PodIP, exitCode)}
-		_, _, err := KExecute(ctx, cfg, restClient, namespace, p.Name, p.Spec.Containers[0].Name, cmd)
-		// TODO: remove the custom handling of 137 response once this is fixed in the agnhost image
-		// We add the custom handling to protect in situation when the target pods completes with the expected
-		// exit code but it terminates before it completes sending the response.
-		if err != nil {
-			gomega.ExpectWithOffset(1, err.Error()).To(gomega.ContainSubstring("137"))
-		} else {
-			gomega.ExpectWithOffset(1, err).ToNot(gomega.HaveOccurred())
-		}
+		gomega.ExpectWithOffset(1, exitAgnHost(ctx, cfg, restClient, &p, exitCode)).To(gomega.Succeed())
 	}
+}
+
+// RestartPodContainer terminates the first container of a running agnhost pod and relies on RestartPolicyAlways to restart it.
+func RestartPodContainer(
+	ctx context.Context,
+	k8sClient client.Client,
+	restClient *rest.RESTClient,
+	cfg *rest.Config,
+	key client.ObjectKey,
+) {
+	ginkgo.GinkgoHelper()
+	pod := &corev1.Pod{}
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect(k8sClient.Get(ctx, key, pod)).To(gomega.Succeed())
+		g.Expect(pod.Status.Phase).To(gomega.Equal(corev1.PodRunning))
+		g.Expect(pod.Status.PodIP).NotTo(gomega.BeEmpty())
+		g.Expect(curlAgnHost(ctx, cfg, restClient, pod, "readyz")).To(gomega.Succeed())
+	}, LongTimeout, Interval).Should(gomega.Succeed())
+	gomega.Expect(pod.Spec.RestartPolicy).To(gomega.Equal(corev1.RestartPolicyAlways),
+		"RestartPodContainer only restarts a container under the Always restart policy")
+
+	ginkgo.GinkgoLogr.Info("Restarting pod container", "pod", klog.KObj(pod), "container", pod.Spec.Containers[0].Name)
+	gomega.Expect(exitAgnHost(ctx, cfg, restClient, pod, 0)).To(gomega.Succeed())
+}
+
+func curlAgnHost(ctx context.Context, cfg *rest.Config, restClient *rest.RESTClient, pod *corev1.Pod, path string) error {
+	cmd := []string{"/bin/sh", "-c", fmt.Sprintf("curl \"http://%s:8080/%s\"", pod.Status.PodIP, path)}
+	_, _, err := KExecute(ctx, cfg, restClient, pod.Namespace, pod.Name, pod.Spec.Containers[0].Name, cmd)
+	return err
+}
+
+func exitAgnHost(ctx context.Context, cfg *rest.Config, restClient *rest.RESTClient, pod *corev1.Pod, exitCode int) error {
+	cmd := []string{"/bin/sh", "-c", fmt.Sprintf("curl \"http://%s:8080/exit?code=%v&timeout=2s&wait=2s\"", pod.Status.PodIP, exitCode)}
+	_, _, err := KExecute(ctx, cfg, restClient, pod.Namespace, pod.Name, pod.Spec.Containers[0].Name, cmd)
+	// TODO: remove the custom handling of 137 response once this is fixed in the agnhost image
+	// We add the custom handling to protect in situation when the target pods completes with the expected
+	// exit code but it terminates before it completes sending the response.
+	if err != nil && strings.Contains(err.Error(), "137") {
+		return nil
+	}
+	return err
 }
 
 func WaitForKueueAvailabilityNoRestartCountCheck(ctx context.Context, k8sClient client.Client) {


### PR DESCRIPTION
#### What type of PR is this?

/kind flake
/area integrations
/area testing

#### What this PR does / why we need it:

This PR stabilizes the LeaderWorkerSet `RecreateGroupOnPodRestart` e2e test.

After the test deletes a worker pod, its StatefulSet can create a same-name replacement before the LWS controller processes the deletion event. Then, the controller observes the replacement instead of the terminating pod and does not start group recreation, leaving the leader and the other worker with their original UIDs.

The test adds a temporary deletion-barrier finalizer to the selected worker, keeping it observable until LWS starts recreating the group. It waits for the leader to begin deletion or replacement before removing the barrier, then retains the existing assertions that all original pod UIDs are replaced and all pods become running. Finalizer updates retry on conflicts, and deferred cleanup prevents the barrier from blocking namespace teardown after a failure.

#### Which issue(s) this PR fixes:

Related issue: https://github.com/kubernetes-sigs/kueue/issues/14649

#### Special notes for your reviewer:

Here are what I verified:
- Reproduced the original failure on macOS/arm64 using Docker Desktop and a local kind cluster with Kubernetes v1.36.1 and LWS v0.9.0. With a controlled three-second LWS reconciliation delay, the deleted worker was replaced while exactly two original pod UIDs remained.
- Repeated the same controlled delay with this change: LWS started group recreation and all original UIDs disappeared.
- Ran the focused test 20 times on kind with Kubernetes v1.36.1 and matching Ginkgo v2.32.1: 20 passed, 0 failed.
- Verified the extended e2e package compiles and `git diff --check` passes.

AI disclosure: I used OpenAI Codex to help investigate the failure, develop the test change, and draft this PR description. I reviewed and validated the resulting change.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end coverage for worker container restarts without deleting the associated Pod.
  * Added validation that restarted workloads become ready and receive refreshed identities.
  * Standardized readiness checks and termination handling to make restart scenarios more reliable.
  * Improved handling of expected container termination results during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->