### PR TITLE
Fix(flake): pull-kueue-verify-website-links-preview-release-0-19

### DIFF
--- a/hack/testing/linkchecker/verify-preview.sh
+++ b/hack/testing/linkchecker/verify-preview.sh
@@ -42,7 +42,7 @@ STATUS_CONTEXT="deploy/netlify"
 # Netlify site slug for the PR's deploy-preview URL (built below).
 NETLIFY_SITE="${NETLIFY_SITE:-kubernetes-sigs-kueue}"
 # Bounded wait for the preview build: 20 checks × 30s (~9.5 min), then fail.
-PREVIEW_WAIT_ATTEMPTS="${PREVIEW_WAIT_ATTEMPTS:-20}"
+PREVIEW_WAIT_ATTEMPTS="${PREVIEW_WAIT_ATTEMPTS:-40}"
 PREVIEW_WAIT_DELAY="${PREVIEW_WAIT_DELAY:-30}"
 
 log()   { echo "[verify-website-links-preview] $*"; }


### PR DESCRIPTION
#### What type of PR is this?

/kind flake
/area testing


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Part of #14684

#### Special notes for your reviewer:
Netlify preview builds are slow, and we are timing out waiting for them. So, I increased the time

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the preview availability check limit, allowing more time for previews to become ready before timing out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->