### PR TITLE
fix(tas): skip implied TAS for PodSets without covered resources 

### DIFF
--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -5813,10 +5813,12 @@ func TestAssignFlavors_LeaderWorkerSetTASFlavor(t *testing.T) {
 	}
 
 	cases := map[string]struct {
-		wlPods            []kueue.PodSet
-		clusterQueue      kueue.ClusterQueue
-		wantPodSetErrors  map[kueue.PodSetReference]error
-		wantPodSetFlavors map[kueue.PodSetReference]ResourceAssignment
+		wlPods                   []kueue.PodSet
+		clusterQueue             kueue.ClusterQueue
+		excludedResourcePrefixes []string
+		wantPodSetErrors         map[kueue.PodSetReference]error
+		wantPodSetFlavors        map[kueue.PodSetReference]ResourceAssignment
+		wantAssignmentMode       *FlavorAssignmentMode
 	}{
 		"leader without a managed request infers the group's TAS flavor": {
 			wlPods: []kueue.PodSet{
@@ -5871,6 +5873,50 @@ func TestAssignFlavors_LeaderWorkerSetTASFlavor(t *testing.T) {
 			},
 			wantPodSetFlavors: map[kueue.PodSetReference]ResourceAssignment{
 				"leader": {},
+				"worker": {"example.com/gpu-a": {Name: "tas-a", Mode: Fit, TriedFlavorIdx: -1}},
+			},
+		},
+		"head without requests in TAS-only CQ without explicit TAS is admitted and skips TAS": {
+			wlPods: []kueue.PodSet{
+				*utiltestingapi.MakePodSet("head", 1).
+					Obj(),
+				*utiltestingapi.MakePodSet("worker", 1).
+					Request("example.com/gpu-a", "1").
+					Obj(),
+			},
+			clusterQueue: *utiltestingapi.MakeClusterQueue("test-clusterqueue").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("tas-a").
+						Resource("example.com/gpu-a", "4").
+						Obj(),
+				).Obj(),
+			wantAssignmentMode: new(Fit),
+			wantPodSetErrors:   map[kueue.PodSetReference]error{},
+			wantPodSetFlavors: map[kueue.PodSetReference]ResourceAssignment{
+				"head":   {},
+				"worker": {"example.com/gpu-a": {Name: "tas-a", Mode: Fit, TriedFlavorIdx: -1}},
+			},
+		},
+		"head with excluded requests in TAS-only CQ without explicit TAS is admitted and skips TAS": {
+			wlPods: []kueue.PodSet{
+				*utiltestingapi.MakePodSet("head", 1).
+					Request(corev1.ResourceCPU, "1").
+					Obj(),
+				*utiltestingapi.MakePodSet("worker", 1).
+					Request("example.com/gpu-a", "1").
+					Obj(),
+			},
+			clusterQueue: *utiltestingapi.MakeClusterQueue("test-clusterqueue").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("tas-a").
+						Resource("example.com/gpu-a", "4").
+						Obj(),
+				).Obj(),
+			excludedResourcePrefixes: []string{"cpu"},
+			wantAssignmentMode:       new(Fit),
+			wantPodSetErrors:         map[kueue.PodSetReference]error{},
+			wantPodSetFlavors: map[kueue.PodSetReference]ResourceAssignment{
+				"head":   {},
 				"worker": {"example.com/gpu-a": {Name: "tas-a", Mode: Fit, TriedFlavorIdx: -1}},
 			},
 		},
@@ -5988,7 +6034,7 @@ func TestAssignFlavors_LeaderWorkerSetTASFlavor(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx, log := utiltesting.ContextWithLog(t)
 
-			wlInfo := workload.NewInfo(&kueue.Workload{Spec: kueue.WorkloadSpec{PodSets: tc.wlPods}})
+			wlInfo := workload.NewInfo(&kueue.Workload{Spec: kueue.WorkloadSpec{PodSets: tc.wlPods}}, workload.WithExcludedResourcePrefixes(tc.excludedResourcePrefixes))
 
 			cache := schdcache.New(utiltesting.NewFakeClient())
 			if err := cache.AddClusterQueue(ctx, &tc.clusterQueue); err != nil {
@@ -6038,6 +6084,12 @@ func TestAssignFlavors_LeaderWorkerSetTASFlavor(t *testing.T) {
 
 			flvAssigner := New(wlInfo, cq, resourceFlavors, false, &testOracle{}, nil, configapi.QuotaCheckBlockUndeclared, resources.NewResourceFormatter(), 0)
 			assignment := flvAssigner.Assign(ctx, nil)
+
+			if tc.wantAssignmentMode != nil {
+				if diff := cmp.Diff(*tc.wantAssignmentMode, assignment.RepresentativeMode()); diff != "" {
+					t.Errorf("assignment mode mismatch (-want,+got):\n%s", diff)
+				}
+			}
 
 			gotErrors := map[kueue.PodSetReference]error{}
 			gotFlavors := map[kueue.PodSetReference]ResourceAssignment{}

--- a/pkg/scheduler/flavorassigner/tas_flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/tas_flavorassigner.go
@@ -218,7 +218,7 @@ func hasOverlapWithPodRequestedResources(ps *kueue.PodSet, flavorResources sets.
 
 // isTASImplied returns true if TAS is requested implicitly.
 func isTASImplied(ps *kueue.PodSet, cq *schdcache.ClusterQueueSnapshot) bool {
-	return !workload.IsExplicitlyRequestingTAS(*ps) && cq.IsTASOnly()
+	return !workload.IsExplicitlyRequestingTAS(*ps) && cq.IsTASOnly() && hasOverlapWithPodRequestedResources(ps, resourcegroups.AllCoveredResources(cq.ResourceGroups))
 }
 
 // isTASRequested checks if TAS is requested for the input PodSet, either


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/area tas

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

In a TAS-only ClusterQueue, implied TAS was previously assumed for all PodSets that did not explicitly configure a TopologyRequest, regardless of whether the PodSet requested resources covered by the ClusterQueue. When a Workload contained a PodSet requesting only unmanaged or excluded resources (e.g., a CPU-only leader/head PodSet with an accelerator-only ClusterQueue), its flavor assignment was empty, causing onlyTASFlavor() to return ErrNoTASFlavorAssigned. This error invalidated the assignment's representative mode and permanently blocked admission with NoFit. Constrain isTASImplied() to only apply when the PodSet requests at least one resource covered by the ClusterQueue's ResourceGroups.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

This PR was prepared with AI assistance. I reviewed and verified all changes.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS:  Fixed an issue where workloads containing PodSets that request no resources covered by a TAS-only ClusterQueue (e.g., CPU-only leader or head PodSets) failed admission.
```
