### PR TITLE
test(pod): Add unit tests for IndexPodGroupName

### DIFF
--- a/pkg/controller/jobs/pod/indexer_test.go
+++ b/pkg/controller/jobs/pod/indexer_test.go
@@ -25,15 +25,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
-	"sigs.k8s.io/kueue/pkg/features"
 	testingjobspod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
 )
 
 func TestIndexPodGroupName(t *testing.T) {
 	cases := map[string]struct {
-		enableWorkloadIdentifierAnnotations bool
-		object                              client.Object
-		wantKeys                            []string
+		object   client.Object
+		wantKeys []string
 	}{
 		"non-pod object": {
 			object: &corev1.Node{
@@ -41,54 +39,22 @@ func TestIndexPodGroupName(t *testing.T) {
 					Labels: map[string]string{
 						podconstants.GroupNameLabel: "group-1",
 					},
-					Annotations: map[string]string{
-						podconstants.GroupNameAnnotation: "group-1",
-					},
 				},
 			},
 		},
 		"pod without group name": {
 			object: testingjobspod.MakePod("pod", "ns").Obj(),
 		},
-		"pod with group name label": {
+		"pod with group name": {
 			object: testingjobspod.MakePod("pod", "ns").
 				GroupNameLabel("group-1").
 				Obj(),
 			wantKeys: []string{"group-1"},
 		},
-		"pod with group name annotation and WorkloadIdentifierAnnotations enabled": {
-			enableWorkloadIdentifierAnnotations: true,
-			object: testingjobspod.MakePod("pod", "ns").
-				Annotation(podconstants.GroupNameAnnotation, "group-2").
-				Obj(),
-			wantKeys: []string{"group-2"},
-		},
-		"pod with group name annotation and WorkloadIdentifierAnnotations disabled": {
-			object: testingjobspod.MakePod("pod", "ns").
-				Annotation(podconstants.GroupNameAnnotation, "group-2").
-				Obj(),
-			wantKeys: nil,
-		},
-		"pod with both label and annotation and WorkloadIdentifierAnnotations enabled prefers annotation": {
-			enableWorkloadIdentifierAnnotations: true,
-			object: testingjobspod.MakePod("pod", "ns").
-				GroupNameLabel("group-from-label").
-				Annotation(podconstants.GroupNameAnnotation, "group-from-annotation").
-				Obj(),
-			wantKeys: []string{"group-from-annotation"},
-		},
-		"pod with both label and annotation and WorkloadIdentifierAnnotations disabled uses label": {
-			object: testingjobspod.MakePod("pod", "ns").
-				GroupNameLabel("group-from-label").
-				Annotation(podconstants.GroupNameAnnotation, "group-from-annotation").
-				Obj(),
-			wantKeys: []string{"group-from-label"},
-		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.WorkloadIdentifierAnnotations, tc.enableWorkloadIdentifierAnnotations)
 			got := IndexPodGroupName(tc.object)
 			if diff := cmp.Diff(tc.wantKeys, got); diff != "" {
 				t.Errorf("Unexpected keys (-want,+got):\n%s", diff)

--- a/pkg/controller/jobs/pod/indexer_test.go
+++ b/pkg/controller/jobs/pod/indexer_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
+	"sigs.k8s.io/kueue/pkg/features"
+	testingjobspod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
+)
+
+func TestIndexPodGroupName(t *testing.T) {
+	cases := map[string]struct {
+		enableWorkloadIdentifierAnnotations bool
+		object                              client.Object
+		wantKeys                            []string
+	}{
+		"non-pod object": {
+			object: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						podconstants.GroupNameLabel: "group-1",
+					},
+					Annotations: map[string]string{
+						podconstants.GroupNameAnnotation: "group-1",
+					},
+				},
+			},
+		},
+		"pod without group name": {
+			object: testingjobspod.MakePod("pod", "ns").Obj(),
+		},
+		"pod with group name label": {
+			object: testingjobspod.MakePod("pod", "ns").
+				GroupNameLabel("group-1").
+				Obj(),
+			wantKeys: []string{"group-1"},
+		},
+		"pod with group name annotation and WorkloadIdentifierAnnotations enabled": {
+			enableWorkloadIdentifierAnnotations: true,
+			object: testingjobspod.MakePod("pod", "ns").
+				Annotation(podconstants.GroupNameAnnotation, "group-2").
+				Obj(),
+			wantKeys: []string{"group-2"},
+		},
+		"pod with group name annotation and WorkloadIdentifierAnnotations disabled": {
+			object: testingjobspod.MakePod("pod", "ns").
+				Annotation(podconstants.GroupNameAnnotation, "group-2").
+				Obj(),
+			wantKeys: nil,
+		},
+		"pod with both label and annotation and WorkloadIdentifierAnnotations enabled prefers annotation": {
+			enableWorkloadIdentifierAnnotations: true,
+			object: testingjobspod.MakePod("pod", "ns").
+				GroupNameLabel("group-from-label").
+				Annotation(podconstants.GroupNameAnnotation, "group-from-annotation").
+				Obj(),
+			wantKeys: []string{"group-from-annotation"},
+		},
+		"pod with both label and annotation and WorkloadIdentifierAnnotations disabled uses label": {
+			object: testingjobspod.MakePod("pod", "ns").
+				GroupNameLabel("group-from-label").
+				Annotation(podconstants.GroupNameAnnotation, "group-from-annotation").
+				Obj(),
+			wantKeys: []string{"group-from-label"},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.WorkloadIdentifierAnnotations, tc.enableWorkloadIdentifierAnnotations)
+			got := IndexPodGroupName(tc.object)
+			if diff := cmp.Diff(tc.wantKeys, got); diff != "" {
+				t.Errorf("Unexpected keys (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/controller/jobs/pod/indexer_test.go
+++ b/pkg/controller/jobs/pod/indexer_test.go
@@ -34,13 +34,7 @@ func TestIndexPodGroupName(t *testing.T) {
 		wantKeys []string
 	}{
 		"non-pod object": {
-			object: &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						podconstants.GroupNameLabel: "group-1",
-					},
-				},
-			},
+			object: node.MakeNode("node").Label(podconstants.GroupNameLabel, "group-1").Obj(),
 		},
 		"pod without group name": {
 			object: testingjobspod.MakePod("pod", "ns").Obj(),

--- a/pkg/controller/jobs/pod/indexer_test.go
+++ b/pkg/controller/jobs/pod/indexer_test.go
@@ -20,12 +20,11 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
-	testingjobspod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
+	testingnode "sigs.k8s.io/kueue/pkg/util/testingjobs/node"
+	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
 )
 
 func TestIndexPodGroupName(t *testing.T) {
@@ -34,13 +33,13 @@ func TestIndexPodGroupName(t *testing.T) {
 		wantKeys []string
 	}{
 		"non-pod object": {
-			object: node.MakeNode("node").Label(podconstants.GroupNameLabel, "group-1").Obj(),
+			object: testingnode.MakeNode("node").Label(podconstants.GroupNameLabel, "group-1").Obj(),
 		},
 		"pod without group name": {
-			object: testingjobspod.MakePod("pod", "ns").Obj(),
+			object: testingpod.MakePod("pod", "ns").Obj(),
 		},
 		"pod with group name": {
-			object: testingjobspod.MakePod("pod", "ns").
+			object: testingpod.MakePod("pod", "ns").
 				GroupNameLabel("group-1").
 				Obj(),
 			wantKeys: []string{"group-1"},

--- a/pkg/util/pod/pod_test.go
+++ b/pkg/util/pod/pod_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/component-base/metrics/testutil"
 	testingclock "k8s.io/utils/clock/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -414,8 +415,8 @@ func TestRecordPodSchedulingGateRemovalSecondsReplicaRole(t *testing.T) {
 func TestGetPodGroupName(t *testing.T) {
 	cases := map[string]struct {
 		featureGates map[featuregate.Feature]bool
-		pod                                 *corev1.Pod
-		want                                string
+		pod          *corev1.Pod
+		want         string
 	}{
 		"pod without group name": {
 			pod: testingpod.MakePod("pod", "ns").Obj(),
@@ -427,20 +428,21 @@ func TestGetPodGroupName(t *testing.T) {
 			want: "group-1",
 		},
 		"pod with group name annotation and WorkloadIdentifierAnnotations enabled": {
-			enableWorkloadIdentifierAnnotations: true,
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
 			pod: testingpod.MakePod("pod", "ns").
 				Annotation(podconstants.GroupNameAnnotation, "group-2").
 				Obj(),
 			want: "group-2",
 		},
 		"pod with group name annotation and WorkloadIdentifierAnnotations disabled": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pod: testingpod.MakePod("pod", "ns").
 				Annotation(podconstants.GroupNameAnnotation, "group-2").
 				Obj(),
 			want: "",
 		},
 		"pod with both label and annotation and WorkloadIdentifierAnnotations enabled prefers annotation": {
-			enableWorkloadIdentifierAnnotations: true,
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
 			pod: testingpod.MakePod("pod", "ns").
 				GroupNameLabel("group-from-label").
 				Annotation(podconstants.GroupNameAnnotation, "group-from-annotation").
@@ -448,6 +450,7 @@ func TestGetPodGroupName(t *testing.T) {
 			want: "group-from-annotation",
 		},
 		"pod with both label and annotation and WorkloadIdentifierAnnotations disabled uses label": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pod: testingpod.MakePod("pod", "ns").
 				GroupNameLabel("group-from-label").
 				Annotation(podconstants.GroupNameAnnotation, "group-from-annotation").
@@ -458,12 +461,11 @@ func TestGetPodGroupName(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.WorkloadIdentifierAnnotations, tc.enableWorkloadIdentifierAnnotations)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			got := GetPodGroupName(tc.pod)
-			if got != tc.want {
-				t.Errorf("Unexpected group name: want=%v, got=%v", tc.want, got)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Unexpected group name (-want,+got):\n%s", diff)
 			}
 		})
 	}
 }
-

--- a/pkg/util/pod/pod_test.go
+++ b/pkg/util/pod/pod_test.go
@@ -30,6 +30,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
@@ -408,3 +410,60 @@ func TestRecordPodSchedulingGateRemovalSecondsReplicaRole(t *testing.T) {
 		})
 	}
 }
+
+func TestGetPodGroupName(t *testing.T) {
+	cases := map[string]struct {
+		enableWorkloadIdentifierAnnotations bool
+		pod                                 *corev1.Pod
+		want                                string
+	}{
+		"pod without group name": {
+			pod: testingpod.MakePod("pod", "ns").Obj(),
+		},
+		"pod with group name label": {
+			pod: testingpod.MakePod("pod", "ns").
+				GroupNameLabel("group-1").
+				Obj(),
+			want: "group-1",
+		},
+		"pod with group name annotation and WorkloadIdentifierAnnotations enabled": {
+			enableWorkloadIdentifierAnnotations: true,
+			pod: testingpod.MakePod("pod", "ns").
+				Annotation(podconstants.GroupNameAnnotation, "group-2").
+				Obj(),
+			want: "group-2",
+		},
+		"pod with group name annotation and WorkloadIdentifierAnnotations disabled": {
+			pod: testingpod.MakePod("pod", "ns").
+				Annotation(podconstants.GroupNameAnnotation, "group-2").
+				Obj(),
+			want: "",
+		},
+		"pod with both label and annotation and WorkloadIdentifierAnnotations enabled prefers annotation": {
+			enableWorkloadIdentifierAnnotations: true,
+			pod: testingpod.MakePod("pod", "ns").
+				GroupNameLabel("group-from-label").
+				Annotation(podconstants.GroupNameAnnotation, "group-from-annotation").
+				Obj(),
+			want: "group-from-annotation",
+		},
+		"pod with both label and annotation and WorkloadIdentifierAnnotations disabled uses label": {
+			pod: testingpod.MakePod("pod", "ns").
+				GroupNameLabel("group-from-label").
+				Annotation(podconstants.GroupNameAnnotation, "group-from-annotation").
+				Obj(),
+			want: "group-from-label",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.WorkloadIdentifierAnnotations, tc.enableWorkloadIdentifierAnnotations)
+			got := GetPodGroupName(tc.pod)
+			if got != tc.want {
+				t.Errorf("Unexpected group name: want=%v, got=%v", tc.want, got)
+			}
+		})
+	}
+}
+

--- a/pkg/util/pod/pod_test.go
+++ b/pkg/util/pod/pod_test.go
@@ -449,6 +449,14 @@ func TestGetPodGroupName(t *testing.T) {
 				Obj(),
 			want: "group-from-annotation",
 		},
+		"pod with both label and empty annotation and WorkloadIdentifierAnnotations enabled falls back to label": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+			pod: testingpod.MakePod("pod", "ns").
+				GroupNameLabel("group-from-label").
+				Annotation(podconstants.GroupNameAnnotation, "").
+				Obj(),
+			want: "group-from-label",
+		},
 		"pod with both label and annotation and WorkloadIdentifierAnnotations disabled uses label": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pod: testingpod.MakePod("pod", "ns").

--- a/pkg/util/pod/pod_test.go
+++ b/pkg/util/pod/pod_test.go
@@ -413,7 +413,7 @@ func TestRecordPodSchedulingGateRemovalSecondsReplicaRole(t *testing.T) {
 
 func TestGetPodGroupName(t *testing.T) {
 	cases := map[string]struct {
-		enableWorkloadIdentifierAnnotations bool
+		featureGates map[featuregate.Feature]bool
 		pod                                 *corev1.Pod
 		want                                string
 	}{


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area testing

#### What this PR does / why we need it:

Adds unit tests for `IndexPodGroupName` in `pkg/controller/jobs/pod/indexer_test.go`.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

This test was extracted from the StatefulSet pod defaulting consolidation PR per review feedback.

I used AI tools to assist in preparing and testing this change.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for resolving pod group names from labels and feature-gated annotations.
  * Verified precedence when both annotation and label values are present.
  * Confirmed indexing behavior for pods with and without group names, as well as non-pod objects.
  * Improved validation across multiple feature-gate configurations and expected indexing results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->