### PR TITLE
Allow 0 value for PodSet.MinCount

### DIFF
--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -304,7 +304,7 @@ type TopologyDomainAssignment struct {
 	Count int32 `json:"count"`
 }
 
-// +kubebuilder:validation:XValidation:rule="has(self.minCount) ? self.minCount <= self.count : true", message="minCount should be positive and less or equal to count"
+// +kubebuilder:validation:XValidation:rule="has(self.minCount) ? self.minCount <= self.count : true", message="minCount should be less or equal to count"
 type PodSet struct {
 	// name is the PodSet name.
 	// +kubebuilder:default=main
@@ -341,7 +341,7 @@ type PodSet struct {
 	// This is an alpha field and requires enabling PartialAdmission feature gate.
 	//
 	// +optional
-	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Minimum=0
 	MinCount *int32 `json:"minCount,omitempty"`
 
 	// topologyRequest defines the topology request for the PodSet.

--- a/apis/kueue/v1beta2/workload_types.go
+++ b/apis/kueue/v1beta2/workload_types.go
@@ -554,7 +554,7 @@ type TopologyAssignmentSlicePodCounts struct {
 	Individual []int32 `json:"individual,omitempty"`
 }
 
-// +kubebuilder:validation:XValidation:rule="has(self.minCount) ? self.minCount <= self.count : true", message="minCount should be positive and less or equal to count"
+// +kubebuilder:validation:XValidation:rule="has(self.minCount) ? self.minCount <= self.count : true", message="minCount should be less or equal to count"
 type PodSet struct {
 	// name is the PodSet name.
 	// +kubebuilder:default=main
@@ -594,7 +594,7 @@ type PodSet struct {
 	// This is an alpha field and requires enabling PartialAdmission feature gate.
 	//
 	// +optional
-	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Minimum=0
 	MinCount *int32 `json:"minCount,omitempty"`
 
 	// topologyRequest defines the topology request for the PodSet.

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
@@ -145,7 +145,7 @@ spec:
 
                           This is an alpha field and requires enabling PartialAdmission feature gate.
                         format: int32
-                        minimum: 1
+                        minimum: 0
                         type: integer
                       name:
                         default: main
@@ -8344,7 +8344,7 @@ spec:
                       - template
                     type: object
                     x-kubernetes-validations:
-                      - message: minCount should be positive and less or equal to count
+                      - message: minCount should be less or equal to count
                         rule: 'has(self.minCount) ? self.minCount <= self.count : true'
                   maxItems: 18
                   minItems: 1
@@ -9050,7 +9050,7 @@ spec:
 
                           This is an alpha field and requires enabling PartialAdmission feature gate.
                         format: int32
-                        minimum: 1
+                        minimum: 0
                         type: integer
                       name:
                         default: main
@@ -17282,7 +17282,7 @@ spec:
                       - template
                     type: object
                     x-kubernetes-validations:
-                      - message: minCount should be positive and less or equal to count
+                      - message: minCount should be less or equal to count
                         rule: 'has(self.minCount) ? self.minCount <= self.count : true'
                   maxItems: 18
                   minItems: 1

--- a/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
@@ -113,7 +113,7 @@ spec:
 
                         This is an alpha field and requires enabling PartialAdmission feature gate.
                       format: int32
-                      minimum: 1
+                      minimum: 0
                       type: integer
                     name:
                       default: main
@@ -8795,7 +8795,7 @@ spec:
                   - template
                   type: object
                   x-kubernetes-validations:
-                  - message: minCount should be positive and less or equal to count
+                  - message: minCount should be less or equal to count
                     rule: 'has(self.minCount) ? self.minCount <= self.count : true'
                 maxItems: 18
                 minItems: 1
@@ -9549,7 +9549,7 @@ spec:
 
                         This is an alpha field and requires enabling PartialAdmission feature gate.
                       format: int32
-                      minimum: 1
+                      minimum: 0
                       type: integer
                     name:
                       default: main
@@ -18276,7 +18276,7 @@ spec:
                   - template
                   type: object
                   x-kubernetes-validations:
-                  - message: minCount should be positive and less or equal to count
+                  - message: minCount should be less or equal to count
                     rule: 'has(self.minCount) ? self.minCount <= self.count : true'
                 maxItems: 18
                 minItems: 1

--- a/keps/420-partial-admission/README.md
+++ b/keps/420-partial-admission/README.md
@@ -79,7 +79,7 @@ PartialAdmission in Kueue is enabled through a combination of a Kubernetes featu
 ### Workload API
 
 ```go
-// +kubebuilder:validation:XValidation:rule="has(self.minCount) ? self.minCount <= self.count : true", message="minCount should be positive and less or equal to count"
+// +kubebuilder:validation:XValidation:rule="has(self.minCount) ? self.minCount <= self.count : true", message="minCount should be less or equal to count"
 type PodSet struct {
   // .......
 
@@ -112,7 +112,9 @@ type PodSetAssignment struct {
 ### Validation
 
 - `.spec.podSets.minCount <= .spec.podSets.count`
-- `.spec.podSets.minCount >= 1`
+- `.spec.podSets.minCount`
+  - Until Kueue v0.19, this have to be `>=1`.
+  - Since Kueue v0.20, this have to be `>=0` for KEP-12100.
 
 ### Scheduler / Flavorassignment
 
@@ -188,6 +190,7 @@ to implement this enhancement.
 - **Workload Webhook**:
   - `test/integration/singlecluster/webhook/core/workload_test.go`:
     - `invalid podSet minCount (negative)`: verifies negative minCount values are rejected.
+    - `valid podSet minCount (zero)`: verifies minCount=0 is accepted when count is 0 or greater.
     - `invalid podSet minCount (too big)`: verifies minCount larger than count is rejected.
     - `too many variable count podSets`: verifies that workloads with multiple variable count PodSets are rejected.
 

--- a/test/integration/singlecluster/webhook/core/workload_test.go
+++ b/test/integration/singlecluster/webhook/core/workload_test.go
@@ -366,6 +366,24 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 						Obj()
 				},
 				utiltesting.BeInvalidError()),
+			ginkgo.Entry("valid podSet minCount (zero with count zero)",
+				func() *kueue.Workload {
+					return utiltestingapi.MakeWorkload(workloadName, ns.Name).
+						PodSets(
+							*utiltestingapi.MakePodSet("ps1", 0).SetMinimumCount(0).Obj(),
+						).
+						Obj()
+				},
+				gomega.Succeed()),
+			ginkgo.Entry("valid podSet minCount (zero with count greater than zero)",
+				func() *kueue.Workload {
+					return utiltestingapi.MakeWorkload(workloadName, ns.Name).
+						PodSets(
+							*utiltestingapi.MakePodSet("ps1", 3).SetMinimumCount(0).Obj(),
+						).
+						Obj()
+				},
+				gomega.Succeed()),
 			ginkgo.Entry("too many variable count podSets",
 				func() *kueue.Workload {
 					return utiltestingapi.MakeWorkload(workloadName, ns.Name).


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it:

Allow `PodSet.minCount` to be `>= 0` (OpenAPI minimum was 1). `PodSet.count` already allows 0, so `count=0` with `minCount=0` was rejected even though that combination is needed for partial scaleup of ElasticWorkloadSlices.

This is validation alignment only: CEL still requires `minCount <= count`. Scheduler and controller behavior are unchanged. Related to #12100; partial scaleup logic stays on that issue.

#### Which issue(s) this PR fixes:

Fixes #14719

#### Special notes for your reviewer:

- OpenAPI `Minimum` for `minCount` is now 0 in v1beta1 and v1beta2; CRDs and Helm charts were regenerated.
- Webhook tests cover valid `minCount=0` with `count=0` and with `count>0`.
- KEP-420 validation text updated to `minCount >= 0`.

#### Does this PR introduce a user-facing change?

```release-note
Allow Workload PodSet minCount to be 0, matching PodSet count. Previously minCount had to be at least 1, so count=0 with minCount=0 was rejected.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `minCount` may now be set to `0`, including when the pod count is zero.
  * Validation requires only that `minCount` does not exceed `count`.
  * Partial admission APIs now support PodSet placement information and counts.

* **API Changes**
  * The v1beta1 Workload API version is no longer served.

* **Tests**
  * Added integration coverage for zero-valued `minCount` configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->