### PR TITLE
Propagate wlName to reconcileWorkload in StatefulSet reconciler

### DIFF
--- a/pkg/controller/jobs/statefulset/statefulset_pod_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_pod_reconciler.go
@@ -119,7 +119,7 @@ func (r *PodReconciler) setDefault(ctx context.Context, pod *corev1.Pod) (bool, 
 	}
 
 	queueName := jobframework.QueueNameForObject(sts)
-	wlName, err := findWorkloadName(ctx, r.client, sts)
+	wlName, _, err := findWorkload(ctx, r.client, sts)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler.go
@@ -117,7 +117,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	})
 
 	eg.Go(func() error {
-		return r.reconcileWorkload(ctx, sts)
+		return r.reconcileWorkload(ctx, sts, wlName)
 	})
 
 	return ctrl.Result{}, eg.Wait()
@@ -190,7 +190,7 @@ func findWorkloadName(ctx context.Context, c client.Client, sts *appsv1.Stateful
 	return wlName, nil
 }
 
-func (r *Reconciler) reconcileWorkload(ctx context.Context, sts *appsv1.StatefulSet) error {
+func (r *Reconciler) reconcileWorkload(ctx context.Context, sts *appsv1.StatefulSet, wlName string) error {
 	if sts == nil {
 		return nil
 	}
@@ -199,11 +199,7 @@ func (r *Reconciler) reconcileWorkload(ctx context.Context, sts *appsv1.Stateful
 	queueName := jobframework.QueueNameForObject(sts)
 
 	wl := &kueue.Workload{}
-	wlName, err := findWorkloadName(ctx, r.client, sts)
-	if err != nil {
-		return err
-	}
-	err = r.client.Get(ctx, client.ObjectKey{Namespace: sts.Namespace, Name: wlName}, wl)
+	err := r.client.Get(ctx, client.ObjectKey{Namespace: sts.Namespace, Name: wlName}, wl)
 
 	if apierrors.IsNotFound(err) {
 		_, isMultiKueueRemote := sts.Labels[kueue.MultiKueueOriginLabel]

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler.go
@@ -89,7 +89,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	wlName, err := findWorkloadName(ctx, r.client, sts)
+	wlName, wl, err := findWorkload(ctx, r.client, sts)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -117,7 +117,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	})
 
 	eg.Go(func() error {
-		return r.reconcileWorkload(ctx, sts, wlName)
+		return r.reconcileWorkload(ctx, sts, wl)
 	})
 
 	return ctrl.Result{}, eg.Wait()
@@ -168,48 +168,40 @@ func (r *Reconciler) syncQueueLabel(ctx context.Context, sts *appsv1.StatefulSet
 	})
 }
 
-// findWorkloadName returns the workload name for the given StatefulSet,
+// findWorkload returns the workload name and object for the given StatefulSet,
 // falling back to the legacy name (without UID) if no workload exists under the new name.
+// If no workload exists under either name, it returns the default workload name and a nil workload.
 // TODO(#9497, v0.20): Remove legacy fallback.
-func findWorkloadName(ctx context.Context, c client.Client, sts *appsv1.StatefulSet) (string, error) {
+func findWorkload(ctx context.Context, c client.Client, sts *appsv1.StatefulSet) (string, *kueue.Workload, error) {
 	wlName := GetWorkloadName(GetOwnerUID(sts), sts.Name)
 	wl := &kueue.Workload{}
 	err := c.Get(ctx, client.ObjectKey{Namespace: sts.Namespace, Name: wlName}, wl)
 	if client.IgnoreNotFound(err) != nil {
-		return wlName, err
+		return wlName, nil, err
 	}
-	if apierrors.IsNotFound(err) {
-		legacyName := GetWorkloadName("", sts.Name)
-		if err := c.Get(ctx, client.ObjectKey{Namespace: sts.Namespace, Name: legacyName}, wl); err == nil {
-			ctrl.LoggerFrom(ctx).V(3).Info("Using legacy workload name", "legacyName", legacyName, "newName", wlName)
-			return legacyName, nil
-		} else if !apierrors.IsNotFound(err) {
-			return wlName, err
-		}
+	if err == nil {
+		return wlName, wl, nil
 	}
-	return wlName, nil
+	legacyName := GetWorkloadName("", sts.Name)
+	if err := c.Get(ctx, client.ObjectKey{Namespace: sts.Namespace, Name: legacyName}, wl); err == nil {
+		ctrl.LoggerFrom(ctx).V(3).Info("Using legacy workload name", "legacyName", legacyName, "newName", wlName)
+		return legacyName, wl, nil
+	} else if !apierrors.IsNotFound(err) {
+		return wlName, nil, err
+	}
+	return wlName, nil, nil
 }
 
-func (r *Reconciler) reconcileWorkload(ctx context.Context, sts *appsv1.StatefulSet, wlName string) error {
-	if sts == nil {
-		return nil
-	}
-
+func (r *Reconciler) reconcileWorkload(ctx context.Context, sts *appsv1.StatefulSet, wl *kueue.Workload) error {
 	replicas := ptr.Deref(sts.Spec.Replicas, 1)
 	queueName := jobframework.QueueNameForObject(sts)
 
-	wl := &kueue.Workload{}
-	err := r.client.Get(ctx, client.ObjectKey{Namespace: sts.Namespace, Name: wlName}, wl)
-
-	if apierrors.IsNotFound(err) {
+	if wl == nil {
 		_, isMultiKueueRemote := sts.Labels[kueue.MultiKueueOriginLabel]
 		if replicas > 0 && (queueName != "" || r.manageJobsWithoutQueueName) && !isMultiKueueRemote {
 			return r.createPrebuiltWorkload(ctx, sts)
 		}
 		return nil
-	}
-	if err != nil {
-		return err
 	}
 
 	hasOwnerReference, err := controllerutil.HasOwnerReference(wl.OwnerReferences, sts, r.client.Scheme())

--- a/pkg/controller/jobs/statefulset/statefulset_webhook.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook.go
@@ -29,7 +29,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
@@ -219,15 +218,10 @@ func (wh *Webhook) ValidateUpdate(ctx context.Context, oldSTSObj, newSTSObj *app
 				// Block if workload is still being deleted (exists without OnHold).
 				// If the workload is on hold, it is intentionally kept alive during
 				// scale-to-zero and will be re-admitted on scale-up.
-				wlName, err := findWorkloadName(ctx, wh.client, oldSTSObj)
+				_, wl, err := findWorkload(ctx, wh.client, (*appsv1.StatefulSet)(oldStatefulSet))
 				if err != nil {
 					return nil, err
-				}
-				var wl kueue.Workload
-				err = wh.client.Get(ctx, client.ObjectKey{Namespace: oldSTSObj.GetNamespace(), Name: wlName}, &wl)
-				if client.IgnoreNotFound(err) != nil {
-					return nil, err
-				} else if err == nil && !workload.IsOnHold(&wl) {
+				} else if wl != nil && !workload.IsOnHold(wl) {
 					allErrs = append(allErrs, field.Forbidden(replicasPath, "workload from previous scale-down is still being deleted"))
 				}
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
In the StatefulSet reconciler, `findWorkloadName` was executed twice per reconciliation cycle: once in `Reconcile` (to list pods matching the group name) and again in `reconcileWorkload`.

This PR propagates `wlName` from `Reconcile` into `reconcileWorkload(ctx, sts, wlName)`, eliminating the duplicate lookup and avoiding redundant API server calls.

#### Which issue(s) this PR fixes:
Follow-up to review feedback on StatefulSet reconciliation. https://github.com/kubernetes-sigs/kueue/pull/14597

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved StatefulSet workload reconciliation for more consistent handling of existing workloads.
  * Preserved compatibility with legacy workload naming.
  * Maintained existing workload synchronization, validation, and lifecycle behavior.
  * Streamlined workload resolution across reconciliation, pod configuration, and update validation flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->