### PR TITLE
pod: pick a stable representative pod for group job identity

### DIFF
--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -742,7 +742,7 @@ func (p *Pod) Load(ctx context.Context, c client.Client, key *types.NamespacedNa
 func groupRepresentativePod(pods []corev1.Pod) corev1.Pod {
 	return slices.MinFunc(pods, func(a, b corev1.Pod) int {
 		return cmputil.LazyOr(
-			func() int { return a.CreationTimestamp.Time.Compare(b.CreationTimestamp.Time) },
+			func() int { return a.CreationTimestamp.Compare(b.CreationTimestamp.Time) },
 			func() int { return cmp.Compare(a.Name, b.Name) },
 		)
 	})

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -724,13 +724,28 @@ func (p *Pod) Load(ctx context.Context, c client.Client, key *types.NamespacedNa
 
 	if len(p.list.Items) > 0 {
 		p.isFound = true
-		p.pod = p.list.Items[0]
+		p.pod = groupRepresentativePod(p.list.Items)
 		key.Name = p.pod.Name
 	}
 
 	// If none of the pods in group are found,
 	// the respective workload should be finalized
 	return !p.isFound, nil
+}
+
+// groupRepresentativePod picks a deterministic pod to back Object() for a group,
+// instead of relying on List's unspecified ordering. Object().GetUID() is used
+// elsewhere as the job's identity, so an arbitrary Items[0] can report a different
+// UID on every read of the very same, unchanged group. The oldest pod (ties broken
+// by name) is stable across repeated reads and is never displaced by pods joining
+// the group later.
+func groupRepresentativePod(pods []corev1.Pod) corev1.Pod {
+	return slices.MinFunc(pods, func(a, b corev1.Pod) int {
+		return cmputil.LazyOr(
+			func() int { return a.CreationTimestamp.Time.Compare(b.CreationTimestamp.Time) },
+			func() int { return cmp.Compare(a.Name, b.Name) },
+		)
+	})
 }
 
 // fastAdmission determines if the pod is configured for fast admission based on specific annotations.

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -7605,3 +7605,54 @@ func TestStop(t *testing.T) {
 		})
 	}
 }
+
+func TestGroupRepresentativePod(t *testing.T) {
+	base := time.Now().Truncate(time.Second)
+
+	pod := func(name, uid string, createdAt time.Time) corev1.Pod {
+		return *testingpod.MakePod(name, metav1.NamespaceDefault).
+			UID(uid).
+			CreationTimestamp(createdAt).
+			Obj()
+	}
+
+	cases := map[string]struct {
+		pods     []corev1.Pod
+		wantName string
+	}{
+		"single pod": {
+			pods:     []corev1.Pod{pod("pod-a", "uid-a", base)},
+			wantName: "pod-a",
+		},
+		"picks the oldest pod regardless of list order": {
+			pods: []corev1.Pod{
+				pod("pod-b", "uid-b", base.Add(time.Second)),
+				pod("pod-a", "uid-a", base),
+			},
+			wantName: "pod-a",
+		},
+		"ties on creation timestamp break by name": {
+			pods: []corev1.Pod{
+				pod("pod-b", "uid-b", base),
+				pod("pod-a", "uid-a", base),
+			},
+			wantName: "pod-a",
+		},
+		"a younger pod joining the group never displaces the existing representative": {
+			pods: []corev1.Pod{
+				pod("pod-a", "uid-a", base),
+				pod("pod-new", "uid-new", base.Add(time.Minute)),
+			},
+			wantName: "pod-a",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := groupRepresentativePod(tc.pods)
+			if got.Name != tc.wantName {
+				t.Errorf("groupRepresentativePod() = %q, want %q", got.Name, tc.wantName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area integrations

#### What this PR does / why we need it:

`(*Pod).Object()` backs a job's identity for the framework: callers read `Object().GetUID()` to tell the same job persisting across a reload from one deleted and recreated under the same name. For a pod group, `Load` sourced that pod from `p.list.Items[0]` — the first entry of an unsorted `client.List` result. Two reads of the identical, unchanged group could land on different pods, and losing any member (a `Stop`, for instance, deletes every pod in the group) could shuffle which pod answers `Object()` next.

`Load` now picks a deterministic representative: the oldest pod by creation timestamp, name breaking ties. A new member never outranks an existing older pod, so the representative holds steady across membership growth and stays predictable for any caller that relies on it as the group's job identity.

No caller in this codebase currently exercises the UID comparison on a pod group (`Pod.EquivalentToWorkload` routes groups around it, and group workloads never get `JobUIDLabel` set), so this closes the gap before a future caller trips over it rather than fixing an observed failure.

#### Which issue(s) this PR fixes:
Fixes #14533

#### Special notes for your reviewer:

Assisted by Claude code. The reasoning and code were reviewed before submission.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pod groups now consistently use the oldest pod as their representative.
  * When pods share the same creation time, selection is determined by pod name.
  * Representative selection remains stable when newer pods are added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->