### PR TITLE
MultiKueue: Prevent worker Job TTL cleanup in MultiKueue

### DIFF
--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -91,11 +91,13 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 		Spec:       *localJob.Spec.DeepCopy(),
 	}
 
-	// The manager cluster is the source of truth for Job lifecycle. Propagating
-	// the TTL to the worker can delete the remote Job before its terminal status
-	// is synchronized back to the manager, causing the completed Job to be
-	// dispatched again.
-	remoteJob.Spec.TTLSecondsAfterFinished = nil
+	if features.Enabled(features.MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster) {
+		// The manager cluster is the source of truth for Job lifecycle. Propagating
+		// the TTL to the worker can delete the remote Job before its terminal status
+		// is synchronized back to the manager, causing the completed Job to be
+		// dispatched again.
+		remoteJob.Spec.TTLSecondsAfterFinished = nil
+	}
 	// drop the selector
 	remoteJob.Spec.Selector = nil
 	// drop the templates cleanup labels

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -91,7 +91,11 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 		Spec:       *localJob.Spec.DeepCopy(),
 	}
 
-	// cleanup
+	// The manager cluster is the source of truth for Job lifecycle. Propagating
+	// the TTL to the worker can delete the remote Job before its terminal status
+	// is synchronized back to the manager, causing the completed Job to be
+	// dispatched again.
+	remoteJob.Spec.TTLSecondsAfterFinished = nil
 	// drop the selector
 	remoteJob.Spec.Selector = nil
 	// drop the templates cleanup labels

--- a/pkg/controller/jobs/job/job_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter_test.go
@@ -88,6 +88,30 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 		},
+		"sync does not propagate ttl seconds after finished to remote job": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			managersJobs: []batchv1.Job{
+				*baseJobManagedByKueueBuilder.Clone().
+					TTLSecondsAfterFinished(0).
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "job1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
+			},
+
+			wantManagersJobs: []batchv1.Job{
+				*baseJobManagedByKueueBuilder.Clone().
+					TTLSecondsAfterFinished(0).
+					Obj(),
+			},
+			wantWorkerJobs: []batchv1.Job{
+				*baseJobBuilder.Clone().
+					PrebuiltWorkloadLabel("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					Obj(),
+			},
+		},
 		"sync intermediate status from remote job": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersJobs: []batchv1.Job{

--- a/pkg/controller/jobs/job/job_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter_test.go
@@ -88,8 +88,11 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 		},
-		"sync does not propagate ttl seconds after finished to remote job": {
-			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+		"sync does not propagate ttl seconds after finished to remote job when clearing is enabled": {
+			featureGates: map[featuregate.Feature]bool{
+				features.MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster: true,
+				features.WorkloadIdentifierAnnotations:                                    false,
+			},
 			managersJobs: []batchv1.Job{
 				*baseJobManagedByKueueBuilder.Clone().
 					TTLSecondsAfterFinished(0).
@@ -107,6 +110,34 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 			wantWorkerJobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
+					PrebuiltWorkloadLabel("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					Obj(),
+			},
+		},
+		"sync propagates ttl seconds after finished to remote job when clearing is disabled": {
+			featureGates: map[featuregate.Feature]bool{
+				features.MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster: false,
+				features.WorkloadIdentifierAnnotations:                                    false,
+			},
+			managersJobs: []batchv1.Job{
+				*baseJobManagedByKueueBuilder.Clone().
+					TTLSecondsAfterFinished(0).
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "job1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
+			},
+
+			wantManagersJobs: []batchv1.Job{
+				*baseJobManagedByKueueBuilder.Clone().
+					TTLSecondsAfterFinished(0).
+					Obj(),
+			},
+			wantWorkerJobs: []batchv1.Job{
+				*baseJobBuilder.Clone().
+					TTLSecondsAfterFinished(0).
 					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					Obj(),

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -649,7 +649,6 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 		{Version: version.MustParse("0.9"), Default: true, PreRelease: featuregate.Beta},
 	},
 	MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster: {
-		{Version: version.MustParse("0.18"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("0.20"), Default: true, PreRelease: featuregate.Beta},
 	},
 	TopologyAwareScheduling: {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -76,6 +76,12 @@ const (
 	// Enables MultiKueue support.
 	MultiKueue featuregate.Feature = "MultiKueue"
 
+	// owner: @kevin85421
+	// issue: https://github.com/kubernetes-sigs/kueue/issues/14779
+	//
+	// Enables clearing ttlSecondsAfterFinished when creating remote batch Jobs.
+	MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster featuregate.Feature = "MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster"
+
 	// owner: @mimowo
 	//
 	// Enable Topology Aware Scheduling allowing to optimize placement of Pods
@@ -641,6 +647,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	MultiKueue: {
 		{Version: version.MustParse("0.6"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("0.9"), Default: true, PreRelease: featuregate.Beta},
+	},
+	MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster: {
+		{Version: version.MustParse("0.18"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("0.20"), Default: true, PreRelease: featuregate.Beta},
 	},
 	TopologyAwareScheduling: {
 		{Version: version.MustParse("0.9"), Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/util/testingjobs/job/wrappers.go
+++ b/pkg/util/testingjobs/job/wrappers.go
@@ -103,6 +103,11 @@ func (j *JobWrapper) BackoffLimit(limit int32) *JobWrapper {
 	return j
 }
 
+func (j *JobWrapper) TTLSecondsAfterFinished(seconds int32) *JobWrapper {
+	j.Spec.TTLSecondsAfterFinished = new(seconds)
+	return j
+}
+
 func (j *JobWrapper) BackoffLimitPerIndex(limit int32) *JobWrapper {
 	j.Spec.BackoffLimitPerIndex = new(limit)
 	return j

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -215,6 +215,16 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.15"
+- name: MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.18"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.20"
 - name: MultiKueueClusterProfile
   versionedSpecs:
   - default: false

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -217,10 +217,6 @@
     version: "0.15"
 - name: MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster
   versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: "0.18"
   - default: true
     lockToDefault: false
     preRelease: Beta

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -215,6 +215,16 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.15"
+- name: MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.18"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.20"
 - name: MultiKueueClusterProfile
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -217,10 +217,6 @@
     version: "0.15"
 - name: MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster
   versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: "0.18"
   - default: true
     lockToDefault: false
     preRelease: Beta

--- a/test/e2e/multikueue/baseline/e2e_test.go
+++ b/test/e2e/multikueue/baseline/e2e_test.go
@@ -678,6 +678,46 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 					cmpopts.IgnoreFields(batchv1.JobCondition{}, "LastTransitionTime", "LastProbeTime", "Reason", "Message"))))
 			})
 		})
+
+		ginkgo.It("Should not propagate Job TTL and should clean up the completed manager Job", func() {
+			job := testingjob.MakeJob("job-with-ttl", managerNs.Name).
+				Queue(kueue.LocalQueueName(managerLq.Name)).
+				TTLSecondsAfterFinished(0).
+				TerminationGracePeriod(1).
+				RequestAndLimit(corev1.ResourceCPU, "100m").
+				RequestAndLimit(corev1.ResourceMemory, "100M").
+				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+				Obj()
+
+			ginkgo.By("Creating the job with immediate TTL cleanup", func() {
+				util.MustCreate(ctx, k8sManagerClient, job)
+			})
+
+			wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: managerNs.Name}
+			admittedWorkerName := util.ExpectWorkloadsToBeAdmittedAndGetWorkerName(ctx, k8sManagerClient, wlLookupKey, multiKueueAc.Name)
+			admittedWorker := kubernetesClients[admittedWorkerName]
+
+			ginkgo.By("Checking that the remote Job does not inherit the manager Job TTL", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					remoteJob := &batchv1.Job{}
+					g.Expect(admittedWorker.client.Get(ctx, client.ObjectKeyFromObject(job), remoteJob)).To(gomega.Succeed())
+					g.Expect(remoteJob.Spec.TTLSecondsAfterFinished).To(gomega.BeNil())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Finishing the remote Job", func() {
+				listOpts := util.GetListOptsFromLabel(fmt.Sprintf("batch.kubernetes.io/job-name=%s", job.Name))
+				util.WaitForActivePodsAndTerminate(ctx, admittedWorker.client, admittedWorker.restClient, admittedWorker.cfg, job.Namespace, 1, 0, listOpts)
+			})
+
+			ginkgo.By("Waiting for the completed manager Job to be deleted by the TTL controller", func() {
+				util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sManagerClient, job, false, util.MediumTimeout)
+			})
+
+			ginkgo.By("Checking that the remote Jobs are cleaned up", func() {
+				util.ExpectObjectToBeDeletedOnClusters(ctx, job, k8sWorker1Client, k8sWorker2Client)
+			})
+		})
 	})
 
 	ginkgo.When("Preemption with a multikueue admission check", func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area multikueue

#### What this PR does / why we need it:

MultiKueue currently copies `spec.ttlSecondsAfterFinished` from a manager Job to its remote worker Job. The worker TTL controller can delete a completed remote Job before MultiKueue synchronizes its terminal status back to the manager, which makes the manager treat the remote as missing and dispatch the completed Job again.

This change keeps the manager cluster authoritative for Job lifecycle cleanup by omitting `spec.ttlSecondsAfterFinished` when creating a remote Job. Existing remote Jobs are not modified. The behavior is controlled by the `MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster` feature gate. It is Beta and enabled by default in v0.20; disabling it restores the previous TTL propagation behavior. For v0.18 and v0.19 backports, the gate is Alpha and disabled by default.

With the feature gate enabled, Job completion and cleanup work as follows:

1. The manager Job retains its configured `spec.ttlSecondsAfterFinished`.
2. MultiKueue creates the remote worker Job without `spec.ttlSecondsAfterFinished`.
3. When the remote Job completes, the worker TTL controller does not delete it, allowing MultiKueue to synchronize its terminal status back to the manager Job.
4. The manager Job becomes complete and is deleted according to its own TTL policy.
5. MultiKueue cleans up the remote Job as part of the manager-side cleanup flow.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

This PR was developed with assistance from AI tooling.

Tests:
- `go test ./pkg/controller/jobs/job -count=1`
- `go test ./pkg/features -count=1`
- `go test ./test/e2e/multikueue/baseline -run '^$' -count=1`
- Focused MultiKueue baseline E2E: `Should not propagate Job TTL and should clean up the completed manager Job`

#### Does this PR introduce a user-facing change?

```release-note
MultiKueue: Fixed a bug where a Job is dispatched again due to propagated `spec.ttlSecondsAfterFinished` even after Job completion. Enable the Alpha `MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster` feature gate to enable fixing.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a feature gate controlling whether completed Job cleanup settings are cleared from worker Jobs.
  - The feature is beta and enabled by default in version 0.20.

- **Bug Fixes**
  - Preserved local automatic cleanup settings when clearing is disabled.
  - Ensured immediate-cleanup Jobs are handled consistently across manager and worker environments.

- **Tests**
  - Added regression and end-to-end coverage for both feature-gate states and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
