### PR TITLE
Prevent mixed LocalQueue status after ClusterQueue recreate

### DIFF
--- a/pkg/cache/scheduler/cache.go
+++ b/pkg/cache/scheduler/cache.go
@@ -29,6 +29,7 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -53,6 +54,7 @@ var (
 	ErrCohortNotFound = errors.New("cohort not found")
 	ErrCohortHasCycle = errors.New("cohort has a cycle")
 	ErrCqNotFound     = errors.New("cluster queue not found")
+	ErrCqUIDMismatch  = errors.New("cluster queue UID does not match cached object")
 	errQNotFound      = errors.New("queue not found")
 )
 
@@ -190,6 +192,7 @@ func New(client client.Client, options ...Option) *Cache {
 func (c *Cache) newClusterQueue(log logr.Logger, cq *kueue.ClusterQueue) (*clusterQueue, error) {
 	cqImpl := &clusterQueue{
 		Name:                kueue.ClusterQueueReference(cq.Name),
+		UID:                 cq.UID,
 		Workloads:           make(map[workload.Reference]*workload.Info),
 		WorkloadsNotReady:   sets.New[workload.Reference](),
 		NamespaceSelector:   labels.Nothing(),
@@ -516,6 +519,9 @@ func (c *Cache) UpdateClusterQueue(log logr.Logger, cq *kueue.ClusterQueue) erro
 	cqImpl := c.hm.ClusterQueue(kueue.ClusterQueueReference(cq.Name))
 	if cqImpl == nil {
 		return ErrCqNotFound
+	}
+	if cqImpl.UID != "" && cq.UID != "" && cqImpl.UID != cq.UID {
+		return fmt.Errorf("%w: cached %q, observed %q", ErrCqUIDMismatch, cqImpl.UID, cq.UID)
 	}
 	oldParent := cqImpl.Parent()
 	c.hm.UpdateClusterQueueEdge(kueue.ClusterQueueReference(cq.Name), cq.Spec.CohortName)
@@ -1032,6 +1038,7 @@ func (c *Cache) getUsage(frq resources.FlavorResourceQuantities, cq *clusterQueu
 }
 
 type LocalQueueUsageStats struct {
+	ClusterQueueUID    types.UID
 	ReservedResources  []kueue.LocalQueueFlavorUsage
 	ReservingWorkloads int
 	AdmittedResources  []kueue.LocalQueueFlavorUsage
@@ -1052,6 +1059,7 @@ func (c *Cache) LocalQueueUsage(qObj *kueue.LocalQueue) (*LocalQueueUsageStats, 
 	}
 
 	return &LocalQueueUsageStats{
+		ClusterQueueUID:    cqImpl.UID,
 		ReservedResources:  c.filterLocalQueueUsage(qImpl.totalReserved, cqImpl.ResourceGroups),
 		ReservingWorkloads: qImpl.reservingWorkloads,
 		AdmittedResources:  c.filterLocalQueueUsage(qImpl.admittedUsage, cqImpl.ResourceGroups),

--- a/pkg/cache/scheduler/cache.go
+++ b/pkg/cache/scheduler/cache.go
@@ -456,7 +456,7 @@ func (c *Cache) ClusterQueueEmpty(name kueue.ClusterQueueReference) bool {
 	return len(cq.Workloads) == 0
 }
 
-func (c *Cache) AddClusterQueue(ctx context.Context, cq *kueue.ClusterQueue) error {
+func (c *Cache) AddClusterQueue(ctx context.Context, cq *kueue.ClusterQueue) (err error) {
 	c.Lock()
 	defer c.Unlock()
 
@@ -468,6 +468,13 @@ func (c *Cache) AddClusterQueue(ctx context.Context, cq *kueue.ClusterQueue) err
 	if err != nil {
 		return err
 	}
+
+	// Do not expose a partially rebuilt queue if listing its contents fails.
+	defer func() {
+		if err != nil {
+			c.deleteClusterQueueWithoutLock(cq)
+		}
+	}()
 
 	// On controller restart, an add ClusterQueue event may come after
 	// add queue and workload, so here we explicitly list and add existing queues
@@ -609,6 +616,10 @@ func (c *Cache) ResyncCohortGaugeMetrics(log logr.Logger, cohortName kueue.Cohor
 func (c *Cache) DeleteClusterQueue(cq *kueue.ClusterQueue) {
 	c.Lock()
 	defer c.Unlock()
+	c.deleteClusterQueueWithoutLock(cq)
+}
+
+func (c *Cache) deleteClusterQueueWithoutLock(cq *kueue.ClusterQueue) {
 	cqName := kueue.ClusterQueueReference(cq.Name)
 	curCq := c.hm.ClusterQueue(cqName)
 	if curCq == nil {

--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -1942,6 +1943,7 @@ func TestLocalQueueUsage(t *testing.T) {
 				Obj(),
 		).
 		Obj()
+	cq.UID = "foo-uid"
 	localQueue := *utiltestingapi.MakeLocalQueue("test", "ns1").
 		ClusterQueue("foo").Obj()
 	cases := map[string]struct {
@@ -2144,7 +2146,35 @@ func TestLocalQueueUsage(t *testing.T) {
 			if diff := cmp.Diff(tc.wantUsage, gotUsage.ReservedResources); diff != "" {
 				t.Errorf("Unexpected used resources for the queue (-want,+got):\n%s", diff)
 			}
+			var wantUID types.UID
+			if tc.cq != nil {
+				wantUID = tc.cq.UID
+			}
+			if gotUsage.ClusterQueueUID != wantUID {
+				t.Errorf("ClusterQueueUID = %q, want %q", gotUsage.ClusterQueueUID, wantUID)
+			}
 		})
+	}
+}
+
+func TestUpdateClusterQueueUIDMismatch(t *testing.T) {
+	ctx, log := utiltesting.ContextWithLog(t)
+	oldCQ := utiltestingapi.MakeClusterQueue("cq").Obj()
+	oldCQ.UID = "old"
+	cache := New(utiltesting.NewFakeClient())
+	if err := cache.AddClusterQueue(ctx, oldCQ); err != nil {
+		t.Fatalf("Adding ClusterQueue: %v", err)
+	}
+
+	same := oldCQ.DeepCopy()
+	if err := cache.UpdateClusterQueue(log, same); err != nil {
+		t.Fatalf("UpdateClusterQueue() same UID: %v", err)
+	}
+
+	newCQ := oldCQ.DeepCopy()
+	newCQ.UID = "new"
+	if err := cache.UpdateClusterQueue(log, newCQ); !errors.Is(err, ErrCqUIDMismatch) {
+		t.Fatalf("UpdateClusterQueue() error = %v, want %v", err, ErrCqUIDMismatch)
 	}
 }
 

--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -1924,7 +1924,7 @@ func TestClusterQueueUsage(t *testing.T) {
 
 func TestLocalQueueUsage(t *testing.T) {
 	now := time.Now().Truncate(time.Second)
-	cq := *utiltestingapi.MakeClusterQueue("foo").
+	cq := *utiltestingapi.MakeClusterQueue("foo").UID("foo-uid").
 		ResourceGroup(
 			*utiltestingapi.MakeFlavorQuotas("default").
 				Resource(corev1.ResourceCPU, "10", "10").Obj(),
@@ -1943,14 +1943,14 @@ func TestLocalQueueUsage(t *testing.T) {
 				Obj(),
 		).
 		Obj()
-	cq.UID = "foo-uid"
 	localQueue := *utiltestingapi.MakeLocalQueue("test", "ns1").
 		ClusterQueue("foo").Obj()
 	cases := map[string]struct {
-		cq             *kueue.ClusterQueue
-		wls            []kueue.Workload
-		wantUsage      []kueue.LocalQueueFlavorUsage
-		inAdmissibleWl sets.Set[string]
+		cq                  *kueue.ClusterQueue
+		wls                 []kueue.Workload
+		wantUsage           []kueue.LocalQueueFlavorUsage
+		wantClusterQueueUID types.UID
+		inAdmissibleWl      sets.Set[string]
 	}{
 		"clusterQueue is missing": {
 			wls: []kueue.Workload{
@@ -1961,7 +1961,8 @@ func TestLocalQueueUsage(t *testing.T) {
 			inAdmissibleWl: sets.New("one"),
 		},
 		"workloads is nothing": {
-			cq: &cq,
+			cq:                  &cq,
+			wantClusterQueueUID: "foo-uid",
 			wantUsage: []kueue.LocalQueueFlavorUsage{
 				{
 					Name: "default",
@@ -2001,7 +2002,8 @@ func TestLocalQueueUsage(t *testing.T) {
 			},
 		},
 		"all workloads are admitted": {
-			cq: &cq,
+			cq:                  &cq,
+			wantClusterQueueUID: "foo-uid",
 			wls: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("one", "ns1").
 					Queue("test").
@@ -2065,7 +2067,8 @@ func TestLocalQueueUsage(t *testing.T) {
 			},
 		},
 		"some workloads are inadmissible": {
-			cq: &cq,
+			cq:                  &cq,
+			wantClusterQueueUID: "foo-uid",
 			wls: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("one", "ns1").
 					Queue("test").
@@ -2146,35 +2149,37 @@ func TestLocalQueueUsage(t *testing.T) {
 			if diff := cmp.Diff(tc.wantUsage, gotUsage.ReservedResources); diff != "" {
 				t.Errorf("Unexpected used resources for the queue (-want,+got):\n%s", diff)
 			}
-			var wantUID types.UID
-			if tc.cq != nil {
-				wantUID = tc.cq.UID
-			}
-			if gotUsage.ClusterQueueUID != wantUID {
-				t.Errorf("ClusterQueueUID = %q, want %q", gotUsage.ClusterQueueUID, wantUID)
+			if gotUsage.ClusterQueueUID != tc.wantClusterQueueUID {
+				t.Errorf("ClusterQueueUID = %q, want %q", gotUsage.ClusterQueueUID, tc.wantClusterQueueUID)
 			}
 		})
 	}
 }
 
 func TestUpdateClusterQueueUIDMismatch(t *testing.T) {
-	ctx, log := utiltesting.ContextWithLog(t)
-	oldCQ := utiltestingapi.MakeClusterQueue("cq").Obj()
-	oldCQ.UID = "old"
-	cache := New(utiltesting.NewFakeClient())
-	if err := cache.AddClusterQueue(ctx, oldCQ); err != nil {
-		t.Fatalf("Adding ClusterQueue: %v", err)
+	cases := map[string]struct {
+		clusterQueue *kueue.ClusterQueue
+		wantError    error
+	}{
+		"same UID": {
+			clusterQueue: utiltestingapi.MakeClusterQueue("cq").UID("old").Obj(),
+		},
+		"different UID": {
+			clusterQueue: utiltestingapi.MakeClusterQueue("cq").UID("new").Obj(),
+			wantError:    ErrCqUIDMismatch,
+		},
 	}
-
-	same := oldCQ.DeepCopy()
-	if err := cache.UpdateClusterQueue(log, same); err != nil {
-		t.Fatalf("UpdateClusterQueue() same UID: %v", err)
-	}
-
-	newCQ := oldCQ.DeepCopy()
-	newCQ.UID = "new"
-	if err := cache.UpdateClusterQueue(log, newCQ); !errors.Is(err, ErrCqUIDMismatch) {
-		t.Fatalf("UpdateClusterQueue() error = %v, want %v", err, ErrCqUIDMismatch)
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, log := utiltesting.ContextWithLog(t)
+			cache := New(utiltesting.NewFakeClient())
+			if err := cache.AddClusterQueue(ctx, utiltestingapi.MakeClusterQueue("cq").UID("old").Obj()); err != nil {
+				t.Fatalf("Adding ClusterQueue: %v", err)
+			}
+			if err := cache.UpdateClusterQueue(log, tc.clusterQueue); !errors.Is(err, tc.wantError) {
+				t.Errorf("UpdateClusterQueue() error = %v, want %v", err, tc.wantError)
+			}
+		})
 	}
 }
 

--- a/pkg/cache/scheduler/clusterqueue.go
+++ b/pkg/cache/scheduler/clusterqueue.go
@@ -29,6 +29,7 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 
@@ -58,6 +59,7 @@ var (
 // holds admitted workloads.
 type clusterQueue struct {
 	Name              kueue.ClusterQueueReference
+	UID               types.UID
 	ResourceGroups    []resourcegroups.ResourceGroup
 	Workloads         map[workload.Reference]*workload.Info
 	WorkloadsNotReady sets.Set[workload.Reference]

--- a/pkg/controller/core/clusterqueue_controller.go
+++ b/pkg/controller/core/clusterqueue_controller.go
@@ -18,9 +18,11 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"iter"
 	"math"
 	"slices"
+	"sync"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -72,6 +74,14 @@ type ClusterQueueReconciler struct {
 	clock                 clock.Clock
 	roleTracker           *roletracker.RoleTracker
 	customLabels          *metrics.CustomLabels
+
+	cacheUpdateMu       sync.Mutex
+	pendingReplacements map[string]clusterQueueReplacement
+}
+
+type clusterQueueReplacement struct {
+	old *kueue.ClusterQueue
+	uid types.UID
 }
 
 var _ reconcile.Reconciler = (*ClusterQueueReconciler)(nil)
@@ -163,6 +173,10 @@ func (r *ClusterQueueReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if err := r.client.Get(ctx, req.NamespacedName, &cqObj); err != nil {
 		// we'll ignore not-found errors, since there is nothing to do.
 		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if err := r.recoverClusterQueue(ctx, &cqObj); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	log := ctrl.LoggerFrom(ctx)
@@ -331,6 +345,10 @@ func (r *ClusterQueueReconciler) NotifyAdmissionCheckUpdate(oldAc, newAc *kueue.
 // ClusterQueue associated with the event.
 
 func (r *ClusterQueueReconciler) Create(e event.TypedCreateEvent[*kueue.ClusterQueue]) bool {
+	r.cacheUpdateMu.Lock()
+	defer r.cacheUpdateMu.Unlock()
+
+	delete(r.pendingReplacements, e.Object.Name)
 	defer r.notifyWatchers(nil, e.Object)
 
 	log := r.logger().WithValues("clusterQueue", klog.KObj(e.Object))
@@ -357,6 +375,10 @@ func (r *ClusterQueueReconciler) Create(e event.TypedCreateEvent[*kueue.ClusterQ
 }
 
 func (r *ClusterQueueReconciler) Delete(e event.TypedDeleteEvent[*kueue.ClusterQueue]) bool {
+	r.cacheUpdateMu.Lock()
+	defer r.cacheUpdateMu.Unlock()
+
+	delete(r.pendingReplacements, e.Object.Name)
 	defer r.notifyWatchers(e.Object, nil)
 
 	log := r.logger()
@@ -375,8 +397,28 @@ func (r *ClusterQueueReconciler) Delete(e event.TypedDeleteEvent[*kueue.ClusterQ
 }
 
 func (r *ClusterQueueReconciler) Update(e event.TypedUpdateEvent[*kueue.ClusterQueue]) bool {
+	r.cacheUpdateMu.Lock()
+	defer r.cacheUpdateMu.Unlock()
+
 	log := r.logger().WithValues("clusterQueue", klog.KObj(e.ObjectNew))
 	log.V(2).Info("ClusterQueue update event")
+
+	if e.ObjectOld.UID != "" && e.ObjectNew.UID != "" && e.ObjectOld.UID != e.ObjectNew.UID {
+		if r.pendingReplacements == nil {
+			r.pendingReplacements = make(map[string]clusterQueueReplacement)
+		}
+		// A relist can report recreation as Update, without a Delete/Add pair.
+		// Reconcile performs the rebuild so transient failures are retried.
+		replacement, pending := r.pendingReplacements[e.ObjectNew.Name]
+		if !pending {
+			replacement.old = e.ObjectOld
+		}
+		replacement.uid = e.ObjectNew.UID
+		r.pendingReplacements[e.ObjectNew.Name] = replacement
+	}
+	if _, pending := r.pendingReplacements[e.ObjectNew.Name]; pending {
+		return true
+	}
 
 	if !e.ObjectNew.DeletionTimestamp.IsZero() {
 		return true
@@ -413,6 +455,47 @@ func (r *ClusterQueueReconciler) Update(e event.TypedUpdateEvent[*kueue.ClusterQ
 		r.resyncClusterQueueGaugeMetrics(e.ObjectNew)
 	}
 	return true
+}
+
+func (r *ClusterQueueReconciler) recoverClusterQueue(ctx context.Context, cq *kueue.ClusterQueue) error {
+	r.cacheUpdateMu.Lock()
+	defer r.cacheUpdateMu.Unlock()
+
+	replacement, pending := r.pendingReplacements[cq.Name]
+	if !pending {
+		return nil
+	}
+	if replacement.uid != cq.UID {
+		return fmt.Errorf("ClusterQueue %q changed while recovering its cache", cq.Name)
+	}
+	log := ctrl.LoggerFrom(ctx)
+	// Disable scheduling first. Rebuild the scheduler cache last so it becomes
+	// visible only once its queues and reserved workloads are restored.
+	r.qManager.DeleteClusterQueue(log, replacement.old)
+	r.cache.ClearCohortMetrics(log, replacement.old.Spec.CohortName)
+	r.cache.DeleteClusterQueue(replacement.old)
+	metrics.ClearClusterQueueResourceMetrics(cq.Name)
+	if features.Enabled(features.CustomMetricLabels) {
+		r.customLabels.CQStore(kueue.ClusterQueueReference(cq.Name), cq.Labels, cq.Annotations)
+	}
+	if err := r.qManager.AddClusterQueue(ctx, cq); err != nil {
+		r.qManager.DeleteClusterQueue(log, cq)
+		return fmt.Errorf("rebuilding ClusterQueue in queue manager: %w", err)
+	}
+	if err := r.cache.AddClusterQueue(ctx, cq); err != nil {
+		r.cache.DeleteClusterQueue(cq)
+		r.qManager.DeleteClusterQueue(log, cq)
+		return fmt.Errorf("rebuilding ClusterQueue in scheduler cache: %w", err)
+	}
+	r.qManager.Lock()
+	r.qManager.Broadcast()
+	r.qManager.Unlock()
+	delete(r.pendingReplacements, cq.Name)
+	if r.reportResourceMetrics {
+		r.cache.RecordClusterQueueResourceMetrics(log, kueue.ClusterQueueReference(cq.Name))
+	}
+	r.notifyWatchers(replacement.old, cq)
+	return nil
 }
 
 func (r *ClusterQueueReconciler) Generic(e event.TypedGenericEvent[*kueue.ClusterQueue]) bool {

--- a/pkg/controller/core/clusterqueue_recreation_test.go
+++ b/pkg/controller/core/clusterqueue_recreation_test.go
@@ -1,0 +1,183 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
+	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	utilindexer "sigs.k8s.io/kueue/pkg/controller/core/indexer"
+	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+)
+
+var errRebuildList = errors.New("rebuild list failed")
+
+type rebuildListClient struct {
+	client.Client
+	failAt int
+	calls  int
+}
+
+func (c *rebuildListClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if c.failAt > 0 {
+		c.calls++
+		if c.calls == c.failAt {
+			c.failAt = 0
+			return errRebuildList
+		}
+	}
+	return c.Client.List(ctx, list, opts...)
+}
+
+func TestClusterQueueRecreationRecoversAfterRelist(t *testing.T) {
+	cases := map[string]struct {
+		failAt      int
+		consecutive bool
+	}{
+		"consecutive update-only recreations": {consecutive: true},
+		"update-only recreation":              {},
+		"retry queue manager listing":         {failAt: 1},
+		"retry scheduler LocalQueue listing":  {failAt: 2},
+		"retry scheduler Workload listing":    {failAt: 3},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, log := utiltesting.ContextWithLog(t)
+			now := time.Now().Truncate(time.Second)
+			oldCQ := utiltestingapi.MakeClusterQueue("cq").UID("old").
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "10").Obj()).
+				Active(metav1.ConditionTrue).Obj()
+			newCQ := utiltestingapi.MakeClusterQueue("cq").UID("new").
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "10").Obj()).
+				Active(metav1.ConditionTrue).Obj()
+			lq := utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj()
+			reserved := utiltestingapi.MakeWorkload("reserved", "ns").Queue("lq").Request(corev1.ResourceCPU, "4").
+				SimpleReserveQuota("cq", "default", now).AdmittedAt(true, now).Obj()
+			pending := utiltestingapi.MakeWorkload("pending", "ns").Queue("lq").Request(corev1.ResourceCPU, "1").Obj()
+			cl := &rebuildListClient{Client: utiltesting.NewClientBuilder().WithObjects(newCQ, lq, reserved, pending).
+				WithIndex(&corev1.LimitRange{}, utilindexer.LimitRangeHasContainerOrPodType, utilindexer.IndexLimitRangeHasContainerOrPodType).
+				WithStatusSubresource(&kueue.ClusterQueue{}, &kueue.LocalQueue{}).Build()}
+			cache := schdcache.New(cl)
+			cache.AddOrUpdateResourceFlavor(log, utiltestingapi.MakeResourceFlavor("default").Obj())
+			manager := qcache.NewManagerForUnitTests(cl, cache, qcache.WithPreemptionExpectations(preemptexpectations.New()))
+			if err := cache.AddClusterQueue(ctx, oldCQ); err != nil {
+				t.Fatal(err)
+			}
+			if err := manager.AddClusterQueue(ctx, oldCQ); err != nil {
+				t.Fatal(err)
+			}
+			if err := manager.AddLocalQueue(ctx, lq); err != nil {
+				t.Fatal(err)
+			}
+			if err := manager.AddOrUpdateWorkload(log, pending); err != nil {
+				t.Fatal(err)
+			}
+			// This reservation is deliberately absent from the API. Rebuilding must
+			// restore live usage rather than relabel the old cache's accumulated usage.
+			stale := utiltestingapi.MakeWorkload("stale", "ns").Queue("lq").Request(corev1.ResourceCPU, "2").
+				SimpleReserveQuota("cq", "default", now).AdmittedAt(true, now).Obj()
+			if !cache.AddOrUpdateWorkload(log, stale) {
+				t.Fatal("adding stale reservation")
+			}
+			watcher := &recoveryWatcher{}
+			r := NewClusterQueueReconciler(cl, manager, cache, WithWatchers(watcher))
+			if !r.Update(event.TypedUpdateEvent[*kueue.ClusterQueue]{ObjectOld: oldCQ, ObjectNew: newCQ}) {
+				t.Fatal("recreation did not enqueue reconciliation")
+			}
+			if tc.consecutive {
+				intermediate := utiltestingapi.MakeClusterQueue("cq").UID("intermediate").Obj()
+				// Re-deliver A -> B -> C before the queued reconciliation runs.
+				r.Update(event.TypedUpdateEvent[*kueue.ClusterQueue]{ObjectOld: oldCQ, ObjectNew: intermediate})
+				r.Update(event.TypedUpdateEvent[*kueue.ClusterQueue]{ObjectOld: intermediate, ObjectNew: newCQ})
+			}
+			cl.failAt = tc.failAt
+			req := reconcile.Request{NamespacedName: client.ObjectKey{Name: "cq"}}
+			if tc.failAt > 0 {
+				if _, err := r.Reconcile(ctx, req); !errors.Is(err, errRebuildList) {
+					t.Fatalf("first reconcile error = %v", err)
+				}
+				if stats, err := cache.LocalQueueUsage(lq); err != nil || stats.ClusterQueueUID != "" || len(stats.ReservedResources) != 0 {
+					t.Fatalf("partial scheduler cache survived failed rebuild: %+v, %v", stats, err)
+				}
+			}
+			// Retry without another informer event, then verify idempotence.
+			for range 2 {
+				if _, err := r.Reconcile(ctx, req); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if watcher.oldUID != "old" || watcher.newUID != "new" {
+				t.Fatalf("recovery notification = %q -> %q, want old -> new", watcher.oldUID, watcher.newUID)
+			}
+			stats, err := cache.LocalQueueUsage(lq)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if stats.ClusterQueueUID != "new" {
+				t.Fatalf("cached UID = %q, want new", stats.ClusterQueueUID)
+			}
+			wantUsage := []kueue.LocalQueueFlavorUsage{{Name: "default", Resources: []kueue.LocalQueueResourceUsage{{Name: corev1.ResourceCPU, Total: resource.MustParse("4")}}}}
+			if diff := cmp.Diff(wantUsage, stats.ReservedResources); diff != "" {
+				t.Fatalf("reserved usage (-want/+got): %s", diff)
+			}
+			if diff := cmp.Diff(wantUsage, stats.AdmittedResources); diff != "" {
+				t.Fatalf("admitted usage (-want/+got): %s", diff)
+			}
+			queued := manager.PendingWorkloadsInfo("cq")
+			if len(queued) != 1 || queued[0].Obj.Name != "pending" {
+				t.Fatalf("unexpected pending workloads: %v", queued)
+			}
+			lqr := NewLocalQueueReconciler(cl, manager, cache)
+			result, err := lqr.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKey{Name: "lq", Namespace: "ns"}})
+			if err != nil || result != (reconcile.Result{}) {
+				t.Fatalf("LocalQueue reconciliation did not converge: %v, %v", result, err)
+			}
+			got := &kueue.LocalQueue{}
+			if err := cl.Get(ctx, client.ObjectKey{Name: "lq", Namespace: "ns"}, got); err != nil {
+				t.Fatal(err)
+			}
+			if got.Status.ReservingWorkloads != 1 || got.Status.AdmittedWorkloads != 1 {
+				t.Fatalf("unexpected workload counts: %+v", got.Status)
+			}
+			if diff := cmp.Diff(wantUsage, got.Status.FlavorsUsage); diff != "" {
+				t.Fatalf("published usage (-want/+got): %s", diff)
+			}
+		})
+	}
+}
+
+type recoveryWatcher struct{ oldUID, newUID string }
+
+func (w *recoveryWatcher) NotifyClusterQueueUpdate(oldCQ, newCQ *kueue.ClusterQueue) {
+	w.oldUID = string(oldCQ.UID)
+	w.newUID = string(newCQ.UID)
+}

--- a/pkg/controller/core/localqueue_controller.go
+++ b/pkg/controller/core/localqueue_controller.go
@@ -203,6 +203,14 @@ func (r *LocalQueueReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+	stats, usageErr := r.cache.LocalQueueUsage(&queueObj)
+	// Same-name recreate can leave the cache holding the previous UID and
+	// usage. Do not publish Ready from the new object with that leftover usage.
+	if usageErr == nil && stats.ClusterQueueUID != "" && stats.ClusterQueueUID != cq.UID {
+		log.V(2).Info("ClusterQueue cache UID does not match API object; waiting before updating LocalQueue status",
+			"clusterQueue", cq.Name, "apiUID", cq.UID, "cacheUID", stats.ClusterQueueUID)
+		return ctrl.Result{RequeueAfter: constants.UpdatesBatchPeriod}, nil
+	}
 	if meta.IsStatusConditionTrue(cq.Status.Conditions, kueue.ClusterQueueActive) {
 		if err := r.UpdateStatusIfChanged(ctx, &queueObj, metav1.ConditionTrue, "Ready", "Can submit new workloads to localQueue"); err != nil {
 			return ctrl.Result{}, client.IgnoreNotFound(err)

--- a/pkg/controller/core/localqueue_controller.go
+++ b/pkg/controller/core/localqueue_controller.go
@@ -591,9 +591,8 @@ func (h *qCQHandler) Update(ctx context.Context, e event.UpdateEvent, wq workque
 	if !ok {
 		return
 	}
-	// Iff .status.conditions of the clusterQueue is updated,
-	// this handler sends all queues related to the clusterQueue to workqueue.
-	if equality.Semantic.DeepEqual(oldCq.Status.Conditions, newCq.Status.Conditions) {
+	// Reconcile related queues when readiness or the ClusterQueue identity changes.
+	if oldCq.UID == newCq.UID && equality.Semantic.DeepEqual(oldCq.Status.Conditions, newCq.Status.Conditions) {
 		return
 	}
 	h.addLocalQueueToWorkQueue(ctx, newCq, wq)

--- a/pkg/controller/core/localqueue_controller_test.go
+++ b/pkg/controller/core/localqueue_controller_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testingclock "k8s.io/utils/clock/testing"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -37,6 +38,7 @@ import (
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	queueafs "sigs.k8s.io/kueue/pkg/cache/queue/afs"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/features"
 	kueuemetrics "sigs.k8s.io/kueue/pkg/metrics"
 	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
@@ -57,6 +59,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 	clock := testingclock.NewFakeClock(time.Now().Truncate(time.Second))
 	cases := map[string]struct {
 		clusterQueue             *kueue.ClusterQueue
+		cacheClusterQueue        *kueue.ClusterQueue
 		deleteClusterQueue       bool
 		localQueue               *kueue.LocalQueue
 		wantLocalQueue           *kueue.LocalQueue
@@ -168,6 +171,41 @@ func TestLocalQueueReconcile(t *testing.T) {
 				).
 				Obj(),
 			wantError: nil,
+		},
+		"cluster queue recreated with a new UID while the cache still holds the old one": {
+			clusterQueue: func() *kueue.ClusterQueue {
+				cq := utiltestingapi.MakeClusterQueue("test-cluster-queue").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("rf").Resource(corev1.ResourceCPU, "10").Obj()).
+					Active(metav1.ConditionTrue).
+					Obj()
+				cq.UID = "new"
+				return cq
+			}(),
+			cacheClusterQueue: func() *kueue.ClusterQueue {
+				cq := utiltestingapi.MakeClusterQueue("test-cluster-queue").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("rf").Resource(corev1.ResourceCPU, "10").Obj()).
+					Active(metav1.ConditionTrue).
+					Obj()
+				cq.UID = "old"
+				return cq
+			}(),
+			localQueue: utiltestingapi.MakeLocalQueue("test-queue", "default").
+				ClusterQueue("test-cluster-queue").
+				Generation(1).
+				Obj(),
+			runningWls: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl", "default").
+					Queue("test-queue").
+					Request(corev1.ResourceCPU, "4").
+					SimpleReserveQuota("test-cluster-queue", "rf", now).
+					AdmittedAt(true, now).
+					Obj(),
+			},
+			wantLocalQueue: utiltestingapi.MakeLocalQueue("test-queue", "default").
+				ClusterQueue("test-cluster-queue").
+				Generation(1).
+				Obj(),
+			wantRequeueAfter: ptr.To(constants.UpdatesBatchPeriod),
 		},
 		"local queue decaying usage decays if there is no running workloads": {
 			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
@@ -915,7 +953,11 @@ func TestLocalQueueReconcile(t *testing.T) {
 
 			ctxWithLogger, log := utiltesting.ContextWithLog(t)
 			cqCache := schdcache.New(cl)
-			if err := cqCache.AddClusterQueue(ctxWithLogger, tc.clusterQueue); err != nil {
+			cqForCache := tc.clusterQueue
+			if tc.cacheClusterQueue != nil {
+				cqForCache = tc.cacheClusterQueue
+			}
+			if err := cqCache.AddClusterQueue(ctxWithLogger, cqForCache); err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}
 			_ = cqCache.AddLocalQueue(tc.localQueue)
@@ -923,7 +965,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 				cqCache.AddOrUpdateWorkload(log, &wl)
 			}
 			qManager := qcache.NewManagerForUnitTests(cl, cqCache)
-			if err := qManager.AddClusterQueue(ctxWithLogger, tc.clusterQueue); err != nil {
+			if err := qManager.AddClusterQueue(ctxWithLogger, cqForCache); err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}
 			_ = qManager.AddLocalQueue(ctxWithLogger, tc.localQueue)

--- a/pkg/controller/core/localqueue_controller_test.go
+++ b/pkg/controller/core/localqueue_controller_test.go
@@ -173,22 +173,16 @@ func TestLocalQueueReconcile(t *testing.T) {
 			wantError: nil,
 		},
 		"cluster queue recreated with a new UID while the cache still holds the old one": {
-			clusterQueue: func() *kueue.ClusterQueue {
-				cq := utiltestingapi.MakeClusterQueue("test-cluster-queue").
-					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("rf").Resource(corev1.ResourceCPU, "10").Obj()).
-					Active(metav1.ConditionTrue).
-					Obj()
-				cq.UID = "new"
-				return cq
-			}(),
-			cacheClusterQueue: func() *kueue.ClusterQueue {
-				cq := utiltestingapi.MakeClusterQueue("test-cluster-queue").
-					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("rf").Resource(corev1.ResourceCPU, "10").Obj()).
-					Active(metav1.ConditionTrue).
-					Obj()
-				cq.UID = "old"
-				return cq
-			}(),
+			clusterQueue: utiltestingapi.MakeClusterQueue("test-cluster-queue").
+				UID("new").
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("rf").Resource(corev1.ResourceCPU, "10").Obj()).
+				Active(metav1.ConditionTrue).
+				Obj(),
+			cacheClusterQueue: utiltestingapi.MakeClusterQueue("test-cluster-queue").
+				UID("old").
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("rf").Resource(corev1.ResourceCPU, "10").Obj()).
+				Active(metav1.ConditionTrue).
+				Obj(),
 			localQueue: utiltestingapi.MakeLocalQueue("test-queue", "default").
 				ClusterQueue("test-cluster-queue").
 				Generation(1).
@@ -574,7 +568,9 @@ func TestLocalQueueReconcile(t *testing.T) {
 				AdmittedWorkloads(1).
 				FairSharingStatus(
 					&kueue.LocalQueueFairSharingStatus{
-						AdmissionFairSharingStatus: &kueue.LocalQueueAdmissionFairSharingStatus{},
+						AdmissionFairSharingStatus: &kueue.LocalQueueAdmissionFairSharingStatus{
+							ConsumedResources: corev1.ResourceList{},
+						},
 					}).
 				Obj(),
 			runningWls: []kueue.Workload{
@@ -1015,7 +1011,6 @@ func TestLocalQueueReconcile(t *testing.T) {
 			}
 
 			cmpOpts := cmp.Options{
-				cmpopts.EquateEmpty(),
 				util.IgnoreConditionTimestamps,
 				util.IgnoreObjectMetaResourceVersion,
 				cmpopts.IgnoreFields(kueue.LocalQueueAdmissionFairSharingStatus{}, "LastUpdate"),

--- a/test/integration/singlecluster/controller/core/clusterqueue_recreation_test.go
+++ b/test/integration/singlecluster/controller/core/clusterqueue_recreation_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"context"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
+	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	"sigs.k8s.io/kueue/pkg/controller/core"
+	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
+	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/pkg/webhooks"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+type recreationManagerSetup struct{ client client.Client }
+
+func (s *recreationManagerSetup) setup(ctx context.Context, mgr manager.Manager) {
+	gomega.Expect(indexer.Setup(ctx, mgr.GetFieldIndexer())).To(gomega.Succeed())
+	failedWebhook, err := webhooks.Setup(mgr, nil)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "webhook", failedWebhook)
+	s.client = mgr.GetClient()
+}
+
+type recoveryHeadReader struct {
+	manager *qcache.Manager
+	cancel  context.CancelFunc
+	done    chan struct{}
+	heads   chan []qcache.Head
+}
+
+func (r *recoveryHeadReader) run(ctx context.Context) {
+	defer close(r.done)
+	r.heads <- r.manager.Heads(ctx)
+}
+
+func (r *recoveryHeadReader) stop() {
+	r.cancel()
+	r.manager.Lock()
+	r.manager.Broadcast()
+	r.manager.Unlock()
+	<-r.done
+}
+
+var _ = ginkgo.Describe("ClusterQueue relist recovery", ginkgo.Label("controller:clusterqueue", "area:core"), func() {
+	ginkgo.It("recovers a recreated ClusterQueue after update-only relist delivery", func() {
+		setup := &recreationManagerSetup{}
+		fwk.StartManager(ctx, cfg, setup.setup)
+		ginkgo.DeferCleanup(fwk.StopManager, ctx)
+		ns := util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "relist-recovery-")
+		ginkgo.DeferCleanup(util.DeleteNamespace, ctx, k8sClient, ns)
+		name := ns.Name
+		rf := utiltestingapi.MakeResourceFlavor(name).Obj()
+		util.MustCreate(ctx, k8sClient, rf)
+		ginkgo.DeferCleanup(k8sClient.Delete, ctx, rf)
+		oldCQ := utiltestingapi.MakeClusterQueue(name).
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas(name).Resource(corev1.ResourceCPU, "10").Obj()).Obj()
+		util.MustCreate(ctx, k8sClient, oldCQ)
+		lq := utiltestingapi.MakeLocalQueue("lq", ns.Name).ClusterQueue(name).Obj()
+		util.MustCreate(ctx, k8sClient, lq)
+		pending := utiltestingapi.MakeWorkload("pending", ns.Name).Queue("lq").Request(corev1.ResourceCPU, "1").Obj()
+		util.MustCreate(ctx, k8sClient, pending)
+		gomega.Eventually(readRecoveryClusterQueueUID, util.Timeout, util.Interval).WithArguments(ctx, setup.client, name).Should(gomega.Equal(oldCQ.UID))
+		gomega.Eventually(setup.client.Get, util.Timeout, util.Interval).WithArguments(ctx, client.ObjectKeyFromObject(lq), &kueue.LocalQueue{}).Should(gomega.Succeed())
+		cache := schdcache.New(setup.client)
+		cache.AddOrUpdateResourceFlavor(ctrl.LoggerFrom(ctx), rf)
+		queues := util.NewManagerForIntegrationTests(ctx, setup.client, cache, qcache.WithPreemptionExpectations(preemptexpectations.New()))
+		gomega.Expect(cache.AddClusterQueue(ctx, oldCQ)).To(gomega.Succeed())
+		gomega.Expect(queues.AddClusterQueue(ctx, oldCQ)).To(gomega.Succeed())
+		gomega.Expect(queues.AddLocalQueue(ctx, lq)).To(gomega.Succeed())
+		gomega.Expect(queues.AddOrUpdateWorkload(ctrl.LoggerFrom(ctx), pending)).To(gomega.Succeed())
+		r := core.NewClusterQueueReconciler(setup.client, queues, cache)
+
+		ginkgo.By("recreating the API object without delivering Delete/Add to the caches")
+		oldCQ.Finalizers = nil
+		gomega.Expect(k8sClient.Update(ctx, oldCQ)).To(gomega.Succeed())
+		gomega.Expect(k8sClient.Delete(ctx, oldCQ)).To(gomega.Succeed())
+		gomega.Eventually(k8sClient.Get, util.Timeout, util.Interval).
+			WithArguments(ctx, client.ObjectKeyFromObject(oldCQ), &kueue.ClusterQueue{}).
+			Should(gomega.WithTransform(apierrors.IsNotFound, gomega.BeTrue()))
+		newCQ := utiltestingapi.MakeClusterQueue(name).
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas(name).Resource(corev1.ResourceCPU, "10").Obj()).Obj()
+		util.MustCreate(ctx, k8sClient, newCQ)
+		ginkgo.DeferCleanup(deleteRecoveryClusterQueue, ctx, k8sClient, newCQ)
+		gomega.Expect(newCQ.UID).NotTo(gomega.Equal(oldCQ.UID))
+		gomega.Eventually(readRecoveryClusterQueueUID, util.Timeout, util.Interval).WithArguments(ctx, setup.client, name).Should(gomega.Equal(newCQ.UID))
+		cache.TerminateClusterQueue(kueue.ClusterQueueReference(name))
+		readerCtx, cancel := context.WithCancel(ctx)
+		reader := &recoveryHeadReader{manager: queues, cancel: cancel, done: make(chan struct{}), heads: make(chan []qcache.Head, 1)}
+		go reader.run(readerCtx)
+		ginkgo.DeferCleanup(reader.stop)
+		gomega.Expect(r.Update(event.TypedUpdateEvent[*kueue.ClusterQueue]{ObjectOld: oldCQ, ObjectNew: newCQ})).To(gomega.BeTrue())
+		_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKey{Name: name}})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		usage, err := cache.LocalQueueUsage(lq)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(usage.ClusterQueueUID).To(gomega.Equal(newCQ.UID))
+		gomega.Eventually(reader.heads, util.Timeout, util.Interval).Should(gomega.Receive(gomega.HaveLen(1)))
+		lqr := core.NewLocalQueueReconciler(setup.client, queues, cache)
+		result, err := lqr.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(lq)})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(result).To(gomega.Equal(reconcile.Result{}))
+	})
+})
+
+func readRecoveryClusterQueueUID(ctx context.Context, cl client.Client, name string) (types.UID, error) {
+	cq := &kueue.ClusterQueue{}
+	err := cl.Get(ctx, client.ObjectKey{Name: name}, cq)
+	return cq.UID, err
+}
+
+func deleteRecoveryClusterQueue(ctx context.Context, cl client.Client, cq *kueue.ClusterQueue) error {
+	current := &kueue.ClusterQueue{}
+	if err := cl.Get(ctx, client.ObjectKeyFromObject(cq), current); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	current.Finalizers = nil
+	if err := cl.Update(ctx, current); err != nil {
+		return err
+	}
+	return client.IgnoreNotFound(cl.Delete(ctx, current))
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it?

When a ClusterQueue is deleted and recreated under the same name, LocalQueue status can combine readiness from the new API object with usage from the previous cache entry. A relist can deliver this recreation as an Update without a Delete/Add pair, leaving the old cache entry in place indefinitely.

This change tracks the ClusterQueue UID in scheduler-cache usage and delays LocalQueue status publication while the API and cache identities disagree. A UID-changing update schedules a reconcile-driven replacement of the queue-manager and scheduler-cache entries. The rebuild restores pending queues and current reserved workloads, retries transient failures, and wakes scheduling when both caches are ready. Consecutive recreations retain the original cleanup identity while targeting the latest UID.

Related to #13873. This complements #14131, which handles ClusterQueue deletion ordering.

#### Useful notes for your reviewer

Recovery follows the existing Delete/Add initialization paths. Failed content loading is rolled back before partial scheduler-cache usage becomes visible, while existing cyclic-cohort handling is preserved. The normal same-UID update path remains in place.

Unit regressions cover update-only delivery, stale usage removal, pending workload restoration, consecutive recreations, and retries after each of the three list stages fails. A focused API-server integration test recreates the object, delivers only Update to the caches, and verifies scheduling and LocalQueue reconciliation resume.

Validation passed: `go test -race ./pkg/cache/scheduler ./pkg/cache/queue ./pkg/controller/core`; the focused recovery integration test with race detection and Kubernetes 1.36.2 envtest; lint for the affected packages. The full integration and end-to-end suites were not run locally.

AI tools were used to assist with implementation and review. The final diff was manually reviewed and validated.

#### Release note

```release-note
LocalQueue: Fixed mixed-generation status and stalled cache recovery when a same-name ClusterQueue recreation is delivered as an update after a relist.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## AI summary

- Track `ClusterQueue` UIDs in the scheduler cache.
- Prevent stale `LocalQueue` status after same-name `ClusterQueue` recreation.
- Recover recreated `ClusterQueue` objects after update-only relist delivery.
- Add unit and integration tests for recovery and status convergence.

### Suggested release note

**Detailed:** LocalQueues: Fixed a bug where deleting and recreating a `ClusterQueue` with the same name could publish stale `LocalQueue` status. Kueue now delays status publication until the replacement `ClusterQueue` is ready.

**Concise:** LocalQueues: Fixed stale status after same-name `ClusterQueue` recreation.

**Balanced:** LocalQueues: Fixed a bug that caused stale `LocalQueue` status when a `ClusterQueue` was deleted and recreated with the same name. Kueue now waits for the replacement to be ready before publishing status.

**Rationale:** `LocalQueues` is the narrowest affected user-facing scope. The change is a bug fix with no required user action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->