### PR TITLE
Bound and make cancellable the WorkloadPriorityClass sweep

### DIFF
--- a/pkg/controller/core/workloadpriorityclass_controller.go
+++ b/pkg/controller/core/workloadpriorityclass_controller.go
@@ -18,7 +18,6 @@ package core
 
 import (
 	"context"
-	"errors"
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -36,6 +35,7 @@ import (
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
+	"sigs.k8s.io/kueue/pkg/util/parallelize"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 )
 
@@ -89,32 +89,32 @@ func (r *WorkloadPriorityClassReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, nil
 	}
 
-	var updateErrors []error
-
-	// Update each workload's priority field
-	for i := range workloads.Items {
+	// Update each workload's priority field, bounded and cancellable like the
+	// rest of the tree, rather than serially in this single reconcile.
+	err := parallelize.Until(ctx, len(workloads.Items), func(i int) error {
 		wl := &workloads.Items[i]
 		wlLog := log.WithValues("workload", klog.KObj(wl))
 
 		// Skip if priority is already up to date
 		if wl.Spec.Priority != nil && *wl.Spec.Priority == wpc.Value {
 			wlLog.V(3).Info("Workload priority already up to date")
-			continue
+			return nil
 		}
 
 		wl.Spec.Priority = new(wpc.Value)
 
 		if err := r.client.Update(ctx, wl); err != nil {
-			if !apierrors.IsNotFound(err) {
-				wlLog.Error(err, "Failed to update workload priority")
-				updateErrors = append(updateErrors, err)
+			if apierrors.IsNotFound(err) {
+				return nil
 			}
-			continue
+			wlLog.Error(err, "Failed to update workload priority")
+			return err
 		}
 
 		wlLog.V(2).Info("Updated workload priority", "newPriority", wpc.Value)
-	}
-	return ctrl.Result{}, errors.Join(updateErrors...)
+		return nil
+	})
+	return ctrl.Result{}, err
 }
 
 func (r *WorkloadPriorityClassReconciler) Create(e event.TypedCreateEvent[*kueue.WorkloadPriorityClass]) bool {

--- a/pkg/controller/core/workloadpriorityclass_controller_test.go
+++ b/pkg/controller/core/workloadpriorityclass_controller_test.go
@@ -101,11 +101,12 @@ func TestWorkloadPriorityClassPredicates(t *testing.T) {
 
 func TestWorkloadPriorityClassReconcile(t *testing.T) {
 	cases := map[string]struct {
-		wpc           *kueue.WorkloadPriorityClass
-		workloads     []kueue.Workload
-		wantWorkloads []kueue.Workload
-		wantError     bool
-		clientFuncs   *interceptor.Funcs
+		wpc             *kueue.WorkloadPriorityClass
+		workloads       []kueue.Workload
+		wantWorkloads   []kueue.Workload
+		wantError       bool
+		wantSingleError bool
+		clientFuncs     *interceptor.Funcs
 	}{
 		"reconcile updates workload priority when WPC priority changes": {
 			wpc: utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(1000).Obj(),
@@ -239,6 +240,48 @@ func TestWorkloadPriorityClassReconcile(t *testing.T) {
 					Obj(),
 			},
 		},
+		"reconcile keeps a single error when all updates fail": {
+			// Pins the second half of the fix: the sweep now goes through
+			// parallelize.Until, which keeps a single error rather than
+			// accumulating one per failed Workload the way the old
+			// errors.Join(updateErrors...) loop did.
+			wpc: utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(1000).Obj(),
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl1", "default").
+					Priority(100).
+					WorkloadPriorityClassRef("high").
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl2", "default").
+					Priority(100).
+					WorkloadPriorityClassRef("high").
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl3", "default").
+					Priority(100).
+					WorkloadPriorityClassRef("high").
+					Obj(),
+			},
+			clientFuncs: &interceptor.Funcs{
+				Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+					return fmt.Errorf("update failed for %s", obj.GetName())
+				},
+			},
+			wantError:       true,
+			wantSingleError: true,
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl1", "default").
+					Priority(100).
+					WorkloadPriorityClassRef("high").
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl2", "default").
+					Priority(100).
+					WorkloadPriorityClassRef("high").
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl3", "default").
+					Priority(100).
+					WorkloadPriorityClassRef("high").
+					Obj(),
+			},
+		},
 		"reconcile handles WPC not found": {
 			wpc:           utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(1000).Obj(),
 			workloads:     []kueue.Workload{},
@@ -281,6 +324,17 @@ func TestWorkloadPriorityClassReconcile(t *testing.T) {
 			} else if !tc.wantError && gotErr != nil {
 				t.Errorf("unexpected error: %v", gotErr)
 			}
+			if tc.wantSingleError && gotErr != nil {
+				named := 0
+				for _, wl := range tc.workloads {
+					if strings.Contains(gotErr.Error(), wl.Name) {
+						named++
+					}
+				}
+				if named != 1 {
+					t.Errorf("expected the error to name exactly one failed workload, got %d in %q", named, gotErr.Error())
+				}
+			}
 			// Verify workloads are in the expected state
 			for _, wantWl := range tc.wantWorkloads {
 				gotWl := &kueue.Workload{}
@@ -293,56 +347,5 @@ func TestWorkloadPriorityClassReconcile(t *testing.T) {
 				}
 			}
 		})
-	}
-}
-
-// TestWorkloadPriorityClassReconcileKeepsOneError pins the second half of the
-// fix: the sweep now goes through parallelize.Until, which keeps a single
-// error rather than accumulating one per failed Workload the way the old
-// errors.Join(updateErrors...) loop did. With three Workloads all failing
-// their update, the returned error must name exactly one of them.
-func TestWorkloadPriorityClassReconcileKeepsOneError(t *testing.T) {
-	ctx := t.Context()
-
-	wpc := utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(1000).Obj()
-	names := []string{"wl1", "wl2", "wl3"}
-	workloads := make([]kueue.Workload, len(names))
-	for i, name := range names {
-		workloads[i] = *utiltestingapi.MakeWorkload(name, "default").
-			Priority(100).
-			WorkloadPriorityClassRef("high").
-			Obj()
-	}
-
-	builder := utiltesting.NewClientBuilder().
-		WithObjects(wpc).
-		WithIndex(&kueue.Workload{}, indexer.WorkloadPriorityClassKey, indexer.IndexWorkloadPriorityClass).
-		WithStatusSubresource(&kueue.Workload{})
-	for i := range workloads {
-		builder = builder.WithObjects(&workloads[i])
-	}
-	builder = builder.WithInterceptorFuncs(interceptor.Funcs{
-		Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
-			return fmt.Errorf("update failed for %s", obj.GetName())
-		},
-	})
-	k8sClient := builder.Build()
-
-	reconciler := NewWorkloadPriorityClassReconciler(k8sClient, nil)
-	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: wpc.Name}}
-
-	_, gotErr := reconciler.Reconcile(ctx, req)
-	if gotErr == nil {
-		t.Fatalf("expected an error, got nil")
-	}
-
-	named := 0
-	for _, name := range names {
-		if strings.Contains(gotErr.Error(), name) {
-			named++
-		}
-	}
-	if named != 1 {
-		t.Errorf("expected the error to name exactly one failed workload, got %d in %q", named, gotErr.Error())
 	}
 }

--- a/pkg/controller/core/workloadpriorityclass_controller_test.go
+++ b/pkg/controller/core/workloadpriorityclass_controller_test.go
@@ -19,6 +19,8 @@ package core
 import (
 	"context"
 	stderrors "errors"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -291,5 +293,56 @@ func TestWorkloadPriorityClassReconcile(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestWorkloadPriorityClassReconcileKeepsOneError pins the second half of the
+// fix: the sweep now goes through parallelize.Until, which keeps a single
+// error rather than accumulating one per failed Workload the way the old
+// errors.Join(updateErrors...) loop did. With three Workloads all failing
+// their update, the returned error must name exactly one of them.
+func TestWorkloadPriorityClassReconcileKeepsOneError(t *testing.T) {
+	ctx := t.Context()
+
+	wpc := utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(1000).Obj()
+	names := []string{"wl1", "wl2", "wl3"}
+	workloads := make([]kueue.Workload, len(names))
+	for i, name := range names {
+		workloads[i] = *utiltestingapi.MakeWorkload(name, "default").
+			Priority(100).
+			WorkloadPriorityClassRef("high").
+			Obj()
+	}
+
+	builder := utiltesting.NewClientBuilder().
+		WithObjects(wpc).
+		WithIndex(&kueue.Workload{}, indexer.WorkloadPriorityClassKey, indexer.IndexWorkloadPriorityClass).
+		WithStatusSubresource(&kueue.Workload{})
+	for i := range workloads {
+		builder = builder.WithObjects(&workloads[i])
+	}
+	builder = builder.WithInterceptorFuncs(interceptor.Funcs{
+		Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			return fmt.Errorf("update failed for %s", obj.GetName())
+		},
+	})
+	k8sClient := builder.Build()
+
+	reconciler := NewWorkloadPriorityClassReconciler(k8sClient, nil)
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: wpc.Name}}
+
+	_, gotErr := reconciler.Reconcile(ctx, req)
+	if gotErr == nil {
+		t.Fatalf("expected an error, got nil")
+	}
+
+	named := 0
+	for _, name := range names {
+		if strings.Contains(gotErr.Error(), name) {
+			named++
+		}
+	}
+	if named != 1 {
+		t.Errorf("expected the error to name exactly one failed workload, got %d in %q", named, gotErr.Error())
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`WorkloadPriorityClassReconciler.Reconcile` lists every Workload that references the class and writes them in a plain `for` loop, one `client.Update` at a time, never reading `ctx` in the loop and accumulating one error per failed Workload via `errors.Join(updateErrors...)`. Since `WorkloadPriorityClassDefaulting` graduated to beta-default in v0.20, a single class (e.g. the default class) can cover every Workload in the cluster that does not set its own priority class, so the membership one reconcile walks is no longer bounded by how many users opted in.

This switches the sweep to `pkg/util/parallelize.Until`, the same helper the LeaderWorkerSet reconciler, the Pod controller, the elastic-job ungater, and the TAS topology ungater already use for this exact shape of write: it bounds concurrency (at most 8 workers), checks `ctx.Done()` before starting each item so a cancelled reconcile stops promptly instead of walking the rest of the list, and keeps a single error rather than joining one per item.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

This is the "shape of the write" half described in the issue; the issue also has a follow-up comment proposing that the sweep additionally skip terminal/finished Workloads. The issue author states that is a separate concern ("about which Workloads are eligible for it") and I've kept this PR to the write-shape fix only, to keep it small and reviewable on its own.

Validation performed:
- `go build ./...`
- `go test ./pkg/controller/core/... -count=1 -race` (existing tests plus a new one)
- `golangci-lint run ./pkg/controller/core/...` — 0 issues
- `go vet ./pkg/controller/core/...` and `gofmt -l` — clean
- Added `TestWorkloadPriorityClassReconcileKeepsOneError`, which fails three Workload updates on the same class and asserts the returned error names exactly one of them (not all three). Confirmed by temporarily reverting only the controller change that this test fails against the old `errors.Join` loop (reporting all three) and passes against the new code.

I did not stand up a live cluster or measure reconcile latency/memory at the scales the issue describes (a cluster-wide `default` class with a large Workload count); the fix follows the same bounded/cancellable pattern already used and tested for equivalent sweeps elsewhere in this codebase (see `pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go`), and the existing controller unit tests (single workload, multiple workloads, partial failure, not-found) all continue to pass unmodified.

#### Does this PR introduce a user-facing change?

```release-note
WorkloadPriorityClass: Fixed the WorkloadPriorityClass controller to update workloads referencing a changed class through a bounded, cancellable worker pool instead of a serial, uninterruptible loop, and to report a single update error instead of one per failed workload.
```

---
AI assistance: this change was drafted with Claude Code.

Fixes #13982

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Workload priority updates are now processed in parallel, improving reconciliation efficiency.

- **Bug Fixes**
  - Reconciliation now reports a single update error when multiple workload updates fail.
  - Already up-to-date workloads continue to be skipped.
  - Missing workloads remain handled gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->