### PR TITLE
multikueue: harden kubeconfig loading

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	go.uber.org/mock v0.6.0
 	go.uber.org/zap v1.28.0
 	golang.org/x/sync v0.22.0
+	golang.org/x/sys v0.47.0
 	gopkg.in/inf.v0 v0.9.1
 	k8s.io/api v0.36.4
 	k8s.io/apiextensions-apiserver v0.36.4
@@ -145,7 +146,6 @@ require (
 	golang.org/x/mod v0.40.0 // indirect
 	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.41.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/keps/693-multikueue/README.md
+++ b/keps/693-multikueue/README.md
@@ -154,7 +154,7 @@ deployments with very high job throughput (above 1M jobs per day).
 
 * **Arbitrary file read via `locationType=Path`**: When `KubeConfig.LocationType`
   is set to `Path`, the controller reads the file at the user-supplied location
-  using `os.ReadFile`. Without path restrictions, any principal with
+  into memory. Without path restrictions, any principal with
   `create`/`update` access to `MultiKueueCluster` resources could read arbitrary
   files from the controller pod's filesystem (e.g. the projected service account
   token). This is mitigated by:
@@ -166,6 +166,8 @@ deployments with very high job throughput (above 1M jobs per day).
   * Canonicalizing and validating the path: the controller cleans the path,
     rejects `..` segments, resolves symlinks, and requires the resolved absolute
     path to reside under the prefix directory.
+  * Opening the path without following a final symlink or blocking on a special
+    file, requiring a regular file, and limiting its size to 1 MiB.
   * Recommended deployment practice is to use `locationType=Secret` or
     `ClusterProfile` instead of `Path` in production environments.
 

--- a/pkg/controller/admissionchecks/multikueue/kubeconfig_file_other.go
+++ b/pkg/controller/admissionchecks/multikueue/kubeconfig_file_other.go
@@ -1,0 +1,28 @@
+//go:build plan9 || windows
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multikueue
+
+import (
+	"errors"
+	"os"
+)
+
+func openKubeConfigFile(path string) (*os.File, error) {
+	return nil, errors.New("secure path-based kubeconfig loading is not supported on this platform")
+}

--- a/pkg/controller/admissionchecks/multikueue/kubeconfig_file_unix.go
+++ b/pkg/controller/admissionchecks/multikueue/kubeconfig_file_unix.go
@@ -1,0 +1,29 @@
+//go:build aix || android || darwin || dragonfly || freebsd || hurd || illumos || ios || linux || netbsd || openbsd || solaris || zos
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multikueue
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func openKubeConfigFile(path string) (*os.File, error) {
+	return os.OpenFile(path, os.O_RDONLY|unix.O_NONBLOCK|unix.O_NOFOLLOW, 0)
+}

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -20,10 +20,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"maps"
 	"net"
 	"net/url"
-	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -86,6 +86,10 @@ const (
 	// not exercise that path today; the cap is a guard. See #11206.
 	initialEstablishTimeout = 1 * time.Minute
 	maxEstablishTimeout     = 10 * time.Minute
+
+	// Kubernetes Secrets are limited to 1 MiB, so path-based kubeconfigs should
+	// not permit larger inputs than their recommended Secret-based equivalent.
+	maxKubeConfigSize = 1 << 20
 )
 
 var (
@@ -969,6 +973,12 @@ func validateKubeconfig(kubeconfig []byte) error {
 			if authInfo.TokenFile != "" {
 				return errors.New("tokenFile is not allowed")
 			}
+			if authInfo.ClientCertificate != "" {
+				return errors.New("client-certificate file paths are not allowed, use client-certificate-data")
+			}
+			if authInfo.ClientKey != "" {
+				return errors.New("client-key file paths are not allowed, use client-key-data")
+			}
 		}
 	}
 	// Validate each cluster config
@@ -1001,14 +1011,28 @@ type validateRestConfigOptions struct {
 }
 
 func validateRestConfig(restConfig *rest.Config, opts validateRestConfigOptions) error {
+	if restConfig == nil {
+		return errors.New("REST config is nil")
+	}
 	// Block dangerous auth mechanisms
 	// BearerTokenFile is not allowed.
 	// Instead BearerToken is allowed due to service account tokens usage.
 	if restConfig.BearerTokenFile != "" {
 		return errors.New("bearerTokenFile is not allowed")
 	}
-	// lowercase the host to allow FQDN with uppercase letters
-	if !isValidHostname(strings.ToLower(restConfig.Host)) {
+	if restConfig.CAFile != "" {
+		return errors.New("CAFile is not allowed, use CAData")
+	}
+	if restConfig.CertFile != "" {
+		return errors.New("CertFile is not allowed, use CertData")
+	}
+	if restConfig.KeyFile != "" {
+		return errors.New("KeyFile is not allowed, use KeyData")
+	}
+	if restConfig.Insecure {
+		return errors.New("insecure TLS verification is not allowed")
+	}
+	if !isValidServerEndpoint(restConfig.Host) {
 		return errors.New("untrusted server endpoint")
 	}
 	if restConfig.Username != "" || restConfig.Password != "" {
@@ -1023,14 +1047,14 @@ func validateRestConfig(restConfig *rest.Config, opts validateRestConfigOptions)
 	return nil
 }
 
-func isValidHostname(server string) bool {
+func isValidServerEndpoint(server string) bool {
 	u, err := url.Parse(server)
-	if err != nil {
+	if err != nil || !strings.EqualFold(u.Scheme, "https") || u.User != nil {
 		return false
 	}
-	host, _, err := net.SplitHostPort(u.Host)
-	if err != nil {
-		host = u.Host // If no port is present
+	host := strings.ToLower(u.Hostname())
+	if host == "" {
+		return false
 	}
 	// Check if host is a valid IP
 	if net.ParseIP(host) != nil {
@@ -1144,7 +1168,35 @@ func (c *clustersReconciler) getKubeConfigFromPath(rawPath string) ([]byte, erro
 	if err != nil {
 		return nil, err
 	}
-	return os.ReadFile(validated)
+	return readKubeConfigFile(validated)
+}
+
+func readKubeConfigFile(path string) ([]byte, error) {
+	file, err := openKubeConfigFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open kubeconfig file: %w", err)
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("cannot stat kubeconfig file: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, errors.New("kubeconfig path must reference a regular file")
+	}
+	if info.Size() > maxKubeConfigSize {
+		return nil, fmt.Errorf("kubeconfig file exceeds the %d-byte size limit", maxKubeConfigSize)
+	}
+
+	contents, err := io.ReadAll(io.LimitReader(file, maxKubeConfigSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("cannot read kubeconfig file: %w", err)
+	}
+	if len(contents) > maxKubeConfigSize {
+		return nil, fmt.Errorf("kubeconfig file exceeds the %d-byte size limit", maxKubeConfigSize)
+	}
+	return contents, nil
 }
 
 func (c *clustersReconciler) updateStatus(ctx context.Context, cluster *kueue.MultiKueueCluster, active bool, reason, message string) error {

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_security_other_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_security_other_test.go
@@ -1,0 +1,31 @@
+//go:build plan9 || windows
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multikueue
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestReadKubeConfigFileIsUnsupported(t *testing.T) {
+	_, err := readKubeConfigFile("ignored")
+	if err == nil || !strings.Contains(err.Error(), "not supported") {
+		t.Fatalf("readKubeConfigFile() error = %v, want unsupported-platform error", err)
+	}
+}

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_security_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_security_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multikueue
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/client-go/rest"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+func TestValidateRestConfigSecurityBoundaries(t *testing.T) {
+	tests := map[string]struct {
+		config  *rest.Config
+		opts    validateRestConfigOptions
+		wantErr string
+	}{
+		"nil config": {
+			wantErr: "REST config is nil",
+		},
+		"HTTP endpoint": {
+			config:  &rest.Config{Host: "http://api.example.com"},
+			wantErr: "untrusted server endpoint",
+		},
+		"endpoint with user info": {
+			config:  &rest.Config{Host: "https://user:password@api.example.com"},
+			wantErr: "untrusted server endpoint",
+		},
+		"invalid endpoint hostname": {
+			config:  &rest.Config{Host: "https://invalid_host.example.com"},
+			wantErr: "untrusted server endpoint",
+		},
+		"insecure TLS": {
+			config: &rest.Config{
+				Host: "https://api.example.com",
+				TLSClientConfig: rest.TLSClientConfig{
+					Insecure: true,
+				},
+			},
+			wantErr: "insecure TLS verification is not allowed",
+		},
+		"CA file": {
+			config: &rest.Config{
+				Host: "https://api.example.com",
+				TLSClientConfig: rest.TLSClientConfig{
+					CAFile: "/tmp/ca.crt",
+				},
+			},
+			wantErr: "CAFile is not allowed",
+		},
+		"client certificate file": {
+			config: &rest.Config{
+				Host: "https://api.example.com",
+				TLSClientConfig: rest.TLSClientConfig{
+					CertFile: "/tmp/client.crt",
+				},
+			},
+			wantErr: "CertFile is not allowed",
+		},
+		"client key file": {
+			config: &rest.Config{
+				Host: "https://api.example.com",
+				TLSClientConfig: rest.TLSClientConfig{
+					KeyFile: "/tmp/client.key",
+				},
+			},
+			wantErr: "KeyFile is not allowed",
+		},
+		"inline token and TLS credentials": {
+			config: &rest.Config{
+				Host:        "HTTPS://API.EXAMPLE.COM:6443",
+				BearerToken: "token",
+				TLSClientConfig: rest.TLSClientConfig{
+					CAData:   []byte("ca"),
+					CertData: []byte("certificate"),
+					KeyData:  []byte("key"),
+				},
+			},
+		},
+		"HTTPS IPv6 endpoint": {
+			config: &rest.Config{Host: "https://[2001:db8::1]:6443"},
+		},
+		"allowed exec provider": {
+			config: &rest.Config{
+				Host: "https://api.example.com",
+				ExecProvider: &clientcmdapi.ExecConfig{
+					Command: "credential-provider",
+				},
+			},
+			opts: validateRestConfigOptions{allowExecProvider: true},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := validateRestConfig(tc.config, tc.opts)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateRestConfig() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("validateRestConfig() error = %v, want error containing %q", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_security_unix_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_security_unix_test.go
@@ -1,0 +1,151 @@
+//go:build aix || android || darwin || dragonfly || freebsd || hurd || illumos || ios || linux || netbsd || openbsd || solaris || zos
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multikueue
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestReadKubeConfigFile(t *testing.T) {
+	tests := map[string]struct {
+		setup       func(*testing.T) string
+		wantSize    int
+		wantContent []byte
+		wantErr     string
+	}{
+		"regular file": {
+			setup: func(t *testing.T) string {
+				path := filepath.Join(t.TempDir(), "worker.kubeconfig")
+				contents := []byte("apiVersion: v1")
+				if err := os.WriteFile(path, contents, 0600); err != nil {
+					t.Fatalf("os.WriteFile() error = %v", err)
+				}
+				return path
+			},
+			wantSize:    len("apiVersion: v1"),
+			wantContent: []byte("apiVersion: v1"),
+		},
+		"file at size limit": {
+			setup: func(t *testing.T) string {
+				path := filepath.Join(t.TempDir(), "worker.kubeconfig")
+				if err := os.WriteFile(path, make([]byte, maxKubeConfigSize), 0600); err != nil {
+					t.Fatalf("os.WriteFile() error = %v", err)
+				}
+				return path
+			},
+			wantSize: maxKubeConfigSize,
+		},
+		"file over size limit": {
+			setup: func(t *testing.T) string {
+				path := filepath.Join(t.TempDir(), "worker.kubeconfig")
+				if err := os.WriteFile(path, make([]byte, maxKubeConfigSize+1), 0600); err != nil {
+					t.Fatalf("os.WriteFile() error = %v", err)
+				}
+				return path
+			},
+			wantErr: "size limit",
+		},
+		"directory": {
+			setup: func(t *testing.T) string {
+				return t.TempDir()
+			},
+			wantErr: "regular file",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			contents, err := readKubeConfigFile(tc.setup(t))
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("readKubeConfigFile() error = %v, want error containing %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("readKubeConfigFile() error = %v", err)
+			}
+			if len(contents) != tc.wantSize {
+				t.Fatalf("readKubeConfigFile() size = %d, want %d", len(contents), tc.wantSize)
+			}
+			if tc.wantContent != nil && !bytes.Equal(contents, tc.wantContent) {
+				t.Fatalf("readKubeConfigFile() contents = %q, want %q", contents, tc.wantContent)
+			}
+		})
+	}
+}
+
+func TestReadKubeConfigFileRejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	if err := os.WriteFile(target, []byte("apiVersion: v1"), 0600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+	link := filepath.Join(dir, "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("os.Symlink() error = %v", err)
+	}
+
+	if _, err := readKubeConfigFile(link); err == nil {
+		t.Fatal("readKubeConfigFile() error = nil, want symlink rejection")
+	}
+}
+
+func TestReadKubeConfigFileRejectsFIFOWithoutBlocking(t *testing.T) {
+	fifo := filepath.Join(t.TempDir(), "kubeconfig.fifo")
+	if err := unix.Mkfifo(fifo, 0600); err != nil {
+		t.Fatalf("unix.Mkfifo() error = %v", err)
+	}
+
+	result := make(chan error, 1)
+	go func() {
+		_, err := readKubeConfigFile(fifo)
+		result <- err
+	}()
+
+	select {
+	case err := <-result:
+		if err == nil || !strings.Contains(err.Error(), "regular file") {
+			t.Fatalf("readKubeConfigFile() error = %v, want regular-file rejection", err)
+		}
+	case <-time.After(2 * time.Second):
+		// Unblock implementations that open FIFOs in blocking mode before
+		// failing the test, so the regression does not leak a goroutine.
+		writerDone := make(chan error, 1)
+		go func() {
+			writerDone <- os.WriteFile(fifo, []byte("not a kubeconfig"), 0600)
+		}()
+		select {
+		case <-result:
+		case <-time.After(2 * time.Second):
+		}
+		select {
+		case <-writerDone:
+		case <-time.After(2 * time.Second):
+		}
+		t.Fatal("readKubeConfigFile() blocked while opening a FIFO")
+	}
+}

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -1202,6 +1202,38 @@ func TestValidateKubeconfig(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		"client-certificate file disallowed": {
+			cfgFn: func() *clientcmdapi.Config {
+				config := kubeconfigBase.DeepCopy()
+				config.AuthInfos["u"].ClientCertificate = "/tmp/client.crt"
+				return config
+			},
+			wantErr: true,
+		},
+		"client-key file disallowed": {
+			cfgFn: func() *clientcmdapi.Config {
+				config := kubeconfigBase.DeepCopy()
+				config.AuthInfos["u"].ClientKey = "/tmp/client.key"
+				return config
+			},
+			wantErr: true,
+		},
+		"HTTP server disallowed": {
+			cfgFn: func() *clientcmdapi.Config {
+				config := kubeconfigBase.DeepCopy()
+				config.Clusters["test"].Server = "http://10.10.10.10"
+				return config
+			},
+			wantErr: true,
+		},
+		"inline client credentials allowed": {
+			cfgFn: func() *clientcmdapi.Config {
+				config := kubeconfigBase.DeepCopy()
+				config.AuthInfos["u"].ClientCertificateData = []byte("certificate")
+				config.AuthInfos["u"].ClientKeyData = []byte("key")
+				return config
+			},
+		},
 		"valid config": {
 			cfgFn: func() *clientcmdapi.Config {
 				return kubeconfigBase.DeepCopy()

--- a/site/content/en/docs/concepts/multikueue.md
+++ b/site/content/en/docs/concepts/multikueue.md
@@ -212,6 +212,14 @@ To disable this validation, set the feature gate:
 `--feature-gates=MultiKueueKubeConfigPathValidation=false`.
 Disabling this restores the legacy behavior of allowing any file path, which can
 expose sensitive files on the controller's filesystem to be read as a kubeconfig.
+In either mode, the referenced kubeconfig must be a regular file no larger than
+1 MiB; special files are opened without blocking and rejected.
+
+MultiKueue requires HTTPS API server endpoints without embedded user information
+for every credential source. File-backed CA certificates and client certificate
+credentials are rejected. Kubeconfigs must use their inline `*-data` fields, and
+`ClusterProfile` access providers must return inline `CAData`, `CertData`, and
+`KeyData` in the REST config.
 
 For production deployments, use `ClusterProfile` or `Secret` instead of `Path`.
 

--- a/site/content/en/docs/tasks/manage/setup_multikueue.md
+++ b/site/content/en/docs/tasks/manage/setup_multikueue.md
@@ -99,6 +99,10 @@ restricts kubeconfig file paths to the hardcoded prefix
 - Reject paths containing `..` segments after cleaning.
 - Resolve symlinks and reject any path that resolves outside the prefix.
 
+Regardless of the feature gate setting, path-based kubeconfigs must be regular
+files no larger than 1 MiB. The controller opens these files without following a
+final symlink and without blocking on special files such as FIFOs.
+
 To disable this validation, set the feature gate:
 
 ```bash
@@ -122,6 +126,12 @@ spec:
       locationType: Path
       location: /etc/multikueue/kubeconfigs/worker1.kubeconfig
 ```
+
+For every credential source, the API server endpoint must use HTTPS and must not
+contain user information. Kubeconfigs must use the inline
+`certificate-authority-data`, `client-certificate-data`, and `client-key-data`
+fields. `ClusterProfile` access providers must return inline `CAData`, `CertData`,
+and `KeyData` in the REST config. File-backed variants are rejected.
 
 ### Create a sample setup
 

--- a/test/integration/multikueue/setup_test.go
+++ b/test/integration/multikueue/setup_test.go
@@ -347,7 +347,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 						Type:    kueue.MultiKueueClusterActive,
 						Status:  metav1.ConditionFalse,
 						Reason:  "BadKubeConfig",
-						Message: fmt.Sprintf("load client config failed: open %s: no such file or directory", fsKubeConfig),
+						Message: fmt.Sprintf("load client config failed: cannot open kubeconfig file: open %s: no such file or directory", fsKubeConfig),
 					}, util.IgnoreConditionTimestampsAndObservedGeneration)))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area multikueue

#### What this PR does / why we need it:

Hardens MultiKueue credential loading at its kubeconfig and ClusterProfile trust boundaries:

- requires HTTPS API server endpoints without URL user information;
- rejects file-backed CA, client certificate, and client key credentials while preserving inline data;
- rejects insecure TLS settings returned by ClusterProfile providers;
- opens path-based kubeconfigs without blocking on FIFOs or following a final symlink on supported Unix platforms;
- requires path-based kubeconfigs to be regular files no larger than 1 MiB, with a second read bound protecting against file growth after stat;
- fails closed for path-based loading on Windows and Plan 9, where equivalent safe-open guarantees are not implemented.

The change promotes the already-vendored `golang.org/x/sys` dependency from indirect to direct use for the Unix nonblocking and no-follow open flags.

Regression tests cover FIFO prompt return, symlink and directory rejection, exact and oversized file limits, HTTP and userinfo endpoints, direct REST-config file credentials and insecure TLS, and the legitimate inline-credential, HTTPS DNS/IPv6, allowed exec-provider, and exact-limit paths.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

AI disclosure: This PR was developed with assistance from OpenAI Codex. The submitter reviewed the resulting source, tests, documentation, and security behavior.

Local verification:

- `go test ./pkg/controller/admissionchecks/multikueue`
- `go test -race ./pkg/controller/admissionchecks/multikueue`
- `go vet ./pkg/controller/admissionchecks/multikueue`
- `go test ./pkg/controller/admissionchecks/multikueue -run TestReadKubeConfigFileRejectsFIFOWithoutBlocking -count=20`
- Windows/amd64 package test cross-compilation
- `go mod verify`
- `gofmt -l` and `git diff --check`

The repository-wide `make fmt-verify` target could not run on the macOS development host because the project requires GNU sed. The changed Go files were checked directly with `gofmt`, and the focused package tests passed.

The existing feature-gate-off behavior still permits selecting arbitrary regular-file paths. The default-enabled gate remains responsible for prefix containment. The safe open protects the final path component; deployments should keep the allowed prefix on a trusted, read-only local mount.

#### Does this PR introduce a user-facing change?

```release-note
action required: MultiKueue worker API endpoints must use HTTPS, and file-backed CA/client certificate credentials must be replaced with inline data. Path-based kubeconfigs must be regular files no larger than 1 MiB; final symlinks are rejected when legacy path validation is disabled. Path-based loading is unsupported on Windows and Plan 9.
```
