### PR TITLE
metrics: correct comment on RecordPodSchedulingGateRemovalSeconds

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1069,7 +1069,9 @@ func RecordWorkloadCreationLatency(jobKind string, latency time.Duration, custom
 }
 
 func RecordPodSchedulingGateRemovalSeconds(name string, clusterQueue kueue.ClusterQueueReference, isGroup bool, latency time.Duration, tracker *roletracker.RoleTracker) {
-	// latency spans the apiserver clock (LastTransitionTime) and the controller clock, so skew can make it negative.
+	// WorkloadAdmitted.LastTransitionTime is set by the Kueue controller manager, not obtained from the Kubernetes API server.
+	// Latency can be negative when the controller's current time is earlier than the recorded transition time (e.g. after a
+	// leader handoff or wall-clock adjustment), so clamp negative observations to zero.
 	PodSchedulingGateRemovalSeconds.WithLabelValues(name, string(clusterQueue), strconv.FormatBool(isGroup), roletracker.GetRole(tracker)).Observe(max(0, latency.Seconds()))
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Updates the comment for `RecordPodSchedulingGateRemovalSeconds` in `pkg/metrics/metrics.go` to clarify that `WorkloadAdmitted.LastTransitionTime` is set by the Kueue controller manager rather than the Kubernetes API server, while explaining why clock skew across leader handoffs or wall-clock adjustments can still result in negative latency.

#### Which issue(s) this PR fixes:
Fixes #14730

#### Special notes for your reviewer:
AI usage disclosure: AI assistant was used to draft the comment and PR description.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
