### PR TITLE
Reset the shared metric vectors in the CustomMetricLabels job test

### DIFF
--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -6154,6 +6154,7 @@ var _ = ginkgo.Describe("Job controller with CustomMetricLabels", ginkgo.Label("
 	ginkgo.AfterEach(func() {
 		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
 		fwk.StopManager(ctx)
+		metrics.InitMetricVectors(nil)
 	})
 
 	ginkgo.It("should create workloads with copied labels and annotations based on CustomMetricLabels configuration", func() {


### PR DESCRIPTION
The `Job controller with CustomMetricLabels` integration block starts a manager with two ClusterQueue custom labels, which widens the shared metric vectors to five labels through `metrics.InitMetricVectors`, but its `AfterEach` only stopped the manager. Every sibling custom-label suite resets the vectors (`controller/core/custom_labels_test.go` in each `When`, the pod and elastic custom-label suites in `AfterAll`); this one did not, so the widened vectors survived the block.

A later spec that starts a manager with an empty config does not reset them either, since `NewCustomLabels` returns early for an empty config. So `Describe("Interacting with scheduler")` creating its `"cq"` ClusterQueue reports `PendingWorkloads` with the three fixed values against the five-label vector and panics the manager. It is order-dependent and stays latent until the specs are redistributed, which #14419 does by adding a second custom-label suite to the same package, making it deterministic on `pull-kueue-test-integration-shard-2-main`.

This adds the reset the other blocks already have.

**How verified**: the widen-without-reset reproduces the panic hermetically:

```go
cl := metrics.NewCustomLabels([]config.ControllerMetricsCustomLabel{{Name: "a"}, {Name: "b"}})
metrics.InitMetricVectors(cl)
metrics.PendingWorkloads.WithLabelValues("cq", "active", "standalone").Set(1) // panic: expected 5, got 3
```

`gofmt` and `go vet ./test/integration/singlecluster/controller/jobs/job/...` are clean.

Fixes #14744

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test cleanup by resetting metric data after test resources are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->