### PR TITLE
multikueue: validate remote PodGroup members

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -746,7 +746,8 @@ func (rc *remoteClient) runGC(ctx context.Context) {
 			}
 		}
 		wlLog.V(5).Info("MultiKueueGC deleting remote workload")
-		if err := remoteCl.Delete(ctx, &remoteWl, client.Preconditions{UID: ptr.To(remoteWl.UID)}); client.IgnoreNotFound(err) != nil {
+		uid := remoteWl.UID
+		if err := remoteCl.Delete(ctx, &remoteWl, client.Preconditions{UID: &uid}); client.IgnoreNotFound(err) != nil {
 			wlLog.Error(err, "Deleting remote workload")
 		}
 	}

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -719,14 +719,34 @@ func (rc *remoteClient) runGC(ctx context.Context) {
 			} else {
 				wlLog.V(5).Info("MultiKueueGC deleting workload owner", "ownerKey", ownerKey, "ownerKind", controller)
 				wlKey := types.NamespacedName{Name: controller.Name, Namespace: remoteWl.Namespace}
-				err := jobframework.DeleteRemoteObjectIfOwned(ctx, rc.localClient, remoteCl, adapter, wlKey, rc.origin)
-				if client.IgnoreNotFound(err) != nil {
-					wlLog.Error(err, "Deleting remote workload's owner", "ownerKey", ownerKey)
+				var err error
+				if cleanupAdapter, ok := adapter.(jobframework.MultiKueueAdapterWithRemoteObjectCleanup); ok {
+					if controller.UID == "" {
+						wlLog.V(2).Info("Skipping remote workload owner deletion because its controller reference has no UID", "ownerKey", ownerKey)
+					} else {
+						err = jobframework.DeleteRemoteObjectWithCleanupContextIfOwned(ctx, rc.localClient, remoteCl, cleanupAdapter, wlKey, jobframework.MultiKueueRemoteObjectCleanupContext{
+							RemoteObjectUID: controller.UID,
+							Association: jobframework.MultiKueueObjectAssociation{
+								Origin:       rc.origin,
+								WorkloadName: remoteWl.Name,
+							},
+							WorkloadKey:         client.ObjectKeyFromObject(&remoteWl),
+							WorkloadAnnotations: maps.Clone(remoteWl.Annotations),
+						})
+					}
+				} else {
+					err = jobframework.DeleteRemoteObjectIfOwned(ctx, rc.localClient, remoteCl, adapter, wlKey, rc.origin)
+				}
+				if err != nil {
+					if !apierrors.IsNotFound(err) {
+						wlLog.Error(err, "Deleting remote workload's owner", "ownerKey", ownerKey)
+					}
+					continue
 				}
 			}
 		}
 		wlLog.V(5).Info("MultiKueueGC deleting remote workload")
-		if err := remoteCl.Delete(ctx, &remoteWl); client.IgnoreNotFound(err) != nil {
+		if err := remoteCl.Delete(ctx, &remoteWl, client.Preconditions{UID: ptr.To(remoteWl.UID)}); client.IgnoreNotFound(err) != nil {
 			wlLog.Error(err, "Deleting remote workload")
 		}
 	}

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -43,6 +44,7 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/utils/clock"
 	testingclock "k8s.io/utils/clock/testing"
+	"k8s.io/utils/ptr"
 	inventoryv1alpha1 "sigs.k8s.io/cluster-inventory-api/apis/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -51,8 +53,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobs"
+	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -1171,6 +1175,214 @@ func TestRemoteClientGC(t *testing.T) {
 				t.Errorf("unexpected worker's jobs (-want/+got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestRemoteClientGCBindsPodOwnerUID(t *testing.T) {
+	const (
+		workloadName = "workload"
+		podName      = "pod"
+	)
+	workloadKey := types.NamespacedName{Name: workloadName, Namespace: TestNamespace}
+	podKey := types.NamespacedName{Name: podName, Namespace: TestNamespace}
+
+	for name, tc := range map[string]struct {
+		ownerUID types.UID
+		podUID   types.UID
+		wantPod  bool
+	}{
+		"matching owner UID deletes Pod": {
+			ownerUID: "pod-uid",
+			podUID:   "pod-uid",
+		},
+		"replacement UID preserves Pod": {
+			ownerUID: "original-pod-uid",
+			podUID:   "replacement-pod-uid",
+			wantPod:  true,
+		},
+		"empty owner UID preserves Pod": {
+			podUID:  "pod-uid",
+			wantPod: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx, _ := utiltesting.ContextWithLog(t)
+			remoteWorkload := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+				Name:      workloadKey.Name,
+				Namespace: workloadKey.Namespace,
+				Labels:    map[string]string{kueue.MultiKueueOriginLabel: defaultOrigin},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "Pod",
+					Name:       podKey.Name,
+					UID:        tc.ownerUID,
+					Controller: ptr.To(true),
+				}},
+			}}
+			remotePod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Name:      podKey.Name,
+				Namespace: podKey.Namespace,
+				UID:       tc.podUID,
+				Labels: map[string]string{
+					kueue.MultiKueueOriginLabel:               defaultOrigin,
+					controllerconstants.PrebuiltWorkloadLabel: workloadName,
+				},
+			}}
+
+			managerClient := getClientBuilder(ctx).Build()
+			workerClient := NewNeverCachingClient(getClientBuilder(ctx).WithObjects(remoteWorkload, remotePod).Build())
+			adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("pod"))
+			remote := newRemoteClient(managerClient, nil, nil, nil, defaultOrigin, "", adapters)
+			remote.client = workerClient
+			remote.connState.markConnected()
+
+			remote.runGC(ctx)
+
+			if err := workerClient.Get(ctx, workloadKey, &kueue.Workload{}); !apierrors.IsNotFound(err) {
+				t.Fatalf("remote Workload Get() error = %v, want NotFound", err)
+			}
+			gotPod := &corev1.Pod{}
+			err := workerClient.Get(ctx, podKey, gotPod)
+			if tc.wantPod {
+				if err != nil {
+					t.Fatalf("replacement Pod Get() error = %v", err)
+				}
+				if gotPod.UID != tc.podUID {
+					t.Fatalf("replacement Pod UID = %q, want %q", gotPod.UID, tc.podUID)
+				}
+			} else if !apierrors.IsNotFound(err) {
+				t.Fatalf("remote Pod Get() error = %v, want NotFound", err)
+			}
+		})
+	}
+}
+
+func TestRemoteClientGCRetriesPodGroupCleanupBeforeDeletingWorkload(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	const (
+		workloadName = "group"
+		anchorName   = "group-0"
+		memberName   = "group-1"
+	)
+	workloadKey := types.NamespacedName{Name: workloadName, Namespace: TestNamespace}
+	anchorKey := types.NamespacedName{Name: anchorName, Namespace: TestNamespace}
+	memberKey := types.NamespacedName{Name: memberName, Namespace: TestNamespace}
+	remoteWorkload := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+		Name:      workloadKey.Name,
+		Namespace: workloadKey.Namespace,
+		UID:       "workload-uid",
+		Labels:    map[string]string{kueue.MultiKueueOriginLabel: defaultOrigin},
+		Annotations: map[string]string{
+			podconstants.IsGroupWorkloadAnnotationKey: podconstants.IsGroupWorkloadAnnotationValue,
+		},
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "Pod",
+			Name:       anchorName,
+			UID:        "anchor-uid",
+			Controller: ptr.To(true),
+		}},
+	}}
+	makeRemotePod := func(key types.NamespacedName, uid types.UID) *corev1.Pod {
+		return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Name:      key.Name,
+			Namespace: key.Namespace,
+			UID:       uid,
+			Labels: map[string]string{
+				kueue.MultiKueueOriginLabel:               defaultOrigin,
+				controllerconstants.PrebuiltWorkloadLabel: workloadName,
+				podconstants.GroupNameLabel:               workloadName,
+			},
+		}}
+	}
+	anchor := makeRemotePod(anchorKey, "anchor-uid")
+	member := makeRemotePod(memberKey, "member-uid")
+	pageErr := errors.New("Pod list unavailable")
+	failPodList := true
+	baseWorkerClient := getClientBuilder(ctx).WithObjects(remoteWorkload, anchor, member).Build()
+	workerClient := NewNeverCachingClient(interceptor.NewClient(baseWorkerClient, interceptor.Funcs{
+		List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+			if _, isPodList := list.(*corev1.PodList); isPodList && failPodList {
+				failPodList = false
+				return pageErr
+			}
+			return c.List(ctx, list, opts...)
+		},
+	}))
+	managerClient := getClientBuilder(ctx).Build()
+	adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("pod"))
+	remote := newRemoteClient(managerClient, nil, nil, nil, defaultOrigin, "", adapters)
+	remote.client = workerClient
+	remote.connState.markConnected()
+
+	remote.runGC(ctx)
+	for key, obj := range map[types.NamespacedName]client.Object{
+		workloadKey: &kueue.Workload{},
+		anchorKey:   &corev1.Pod{},
+		memberKey:   &corev1.Pod{},
+	} {
+		if err := workerClient.Get(ctx, key, obj); err != nil {
+			t.Fatalf("object %q was deleted after failed cleanup: %v", key, err)
+		}
+	}
+
+	remote.runGC(ctx)
+	for key, obj := range map[types.NamespacedName]client.Object{
+		workloadKey: &kueue.Workload{},
+		anchorKey:   &corev1.Pod{},
+		memberKey:   &corev1.Pod{},
+	} {
+		if err := workerClient.Get(ctx, key, obj); !apierrors.IsNotFound(err) {
+			t.Errorf("object %q Get() error = %v after retry, want NotFound", key, err)
+		}
+	}
+}
+
+func TestRemoteClientGCUsesWorkloadUIDPrecondition(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	key := types.NamespacedName{Name: "workload", Namespace: TestNamespace}
+	original := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+		Name:      key.Name,
+		Namespace: key.Namespace,
+		UID:       "original-workload-uid",
+		Labels:    map[string]string{kueue.MultiKueueOriginLabel: defaultOrigin},
+	}}
+	replacement := original.DeepCopy()
+	replacement.UID = "replacement-workload-uid"
+	baseWorkerClient := getClientBuilder(ctx).WithObjects(original).Build()
+	workerClient := NewNeverCachingClient(interceptor.NewClient(baseWorkerClient, interceptor.Funcs{
+		Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			if _, isWorkload := obj.(*kueue.Workload); !isWorkload {
+				return c.Delete(ctx, obj, opts...)
+			}
+			deleteOptions := &client.DeleteOptions{}
+			for _, opt := range opts {
+				opt.ApplyToDelete(deleteOptions)
+			}
+			if deleteOptions.Preconditions == nil || deleteOptions.Preconditions.UID == nil || *deleteOptions.Preconditions.UID != original.UID {
+				t.Errorf("Workload Delete() UID precondition = %v, want %q", deleteOptions.Preconditions, original.UID)
+			}
+			if err := c.Delete(ctx, obj); err != nil {
+				return err
+			}
+			if err := c.Create(ctx, replacement); err != nil {
+				return err
+			}
+			return apierrors.NewConflict(kueue.Resource("workloads"), key.Name, errors.New("UID precondition failed"))
+		},
+	}))
+	remote := newRemoteClient(getClientBuilder(ctx).Build(), nil, nil, nil, defaultOrigin, "", nil)
+	remote.client = workerClient
+	remote.connState.markConnected()
+
+	remote.runGC(ctx)
+
+	got := &kueue.Workload{}
+	if err := workerClient.Get(ctx, key, got); err != nil {
+		t.Fatalf("replacement Workload Get() error = %v", err)
+	}
+	if got.UID != replacement.UID {
+		t.Fatalf("replacement Workload UID = %q, want %q", got.UID, replacement.UID)
 	}
 }
 

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -44,7 +44,6 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/utils/clock"
 	testingclock "k8s.io/utils/clock/testing"
-	"k8s.io/utils/ptr"
 	inventoryv1alpha1 "sigs.k8s.io/cluster-inventory-api/apis/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -1216,7 +1215,7 @@ func TestRemoteClientGCBindsPodOwnerUID(t *testing.T) {
 					Kind:       "Pod",
 					Name:       podKey.Name,
 					UID:        tc.ownerUID,
-					Controller: ptr.To(true),
+					Controller: new(true),
 				}},
 			}}
 			remotePod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
@@ -1280,7 +1279,7 @@ func TestRemoteClientGCRetriesPodGroupCleanupBeforeDeletingWorkload(t *testing.T
 			Kind:       "Pod",
 			Name:       anchorName,
 			UID:        "anchor-uid",
-			Controller: ptr.To(true),
+			Controller: new(true),
 		}},
 	}}
 	makeRemotePod := func(key types.NamespacedName, uid types.UID) *corev1.Pod {

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -161,7 +161,7 @@ func (g *wlGroup) bestMatchByCondition(conditionType string) (*metav1.Condition,
 func (g *wlGroup) RemoveRemoteObjects(ctx context.Context, cluster string) error {
 	remoteClient := g.remoteClients[cluster].getClient()
 	origin := g.remoteClients[cluster].origin
-	if err := jobframework.DeleteRemoteObjectIfOwned(ctx, g.localClient, remoteClient, g.jobAdapter, g.controllerKey, origin); err != nil {
+	if err := jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, g.localClient, remoteClient, g.jobAdapter, g.controllerKey, g.local, origin); err != nil {
 		return fmt.Errorf("deleting remote controller object: %w", err)
 	}
 

--- a/pkg/controller/jobframework/multikueue.go
+++ b/pkg/controller/jobframework/multikueue.go
@@ -54,6 +54,32 @@ type MultiKueueAdapter interface {
 	GVK() schema.GroupVersionKind
 }
 
+// MultiKueueObjectAssociation identifies the origin and remote Workload that
+// mutable MultiKueue metadata associates with an object.
+type MultiKueueObjectAssociation struct {
+	Origin       string
+	WorkloadName string
+}
+
+// MultiKueueRemoteObjectCleanupContext carries the expected remote object
+// identity and the Workload metadata needed for adapter-specific cleanup.
+// WorkloadAnnotations must be a copy so later API mutations cannot change the
+// cleanup decision.
+type MultiKueueRemoteObjectCleanupContext struct {
+	RemoteObjectUID     types.UID
+	Association         MultiKueueObjectAssociation
+	WorkloadKey         types.NamespacedName
+	WorkloadAnnotations map[string]string
+}
+
+// MultiKueueAdapterWithRemoteObjectCleanup is an optional extension for adapters
+// whose cleanup must remain bound to an exact remote controller-object instance.
+// Multi-object cleanup is one use case.
+type MultiKueueAdapterWithRemoteObjectCleanup interface {
+	MultiKueueAdapter
+	DeleteRemoteObjectWithCleanupContext(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, cleanupContext MultiKueueRemoteObjectCleanupContext) error
+}
+
 // MultiKueueWatcher optional interface that can be implemented by a MultiKueueAdapter
 // to receive job related watch events from the worker cluster.
 // If not implemented, MultiKueue will only receive events related to the job's workload.

--- a/pkg/controller/jobframework/multikueue.go
+++ b/pkg/controller/jobframework/multikueue.go
@@ -77,7 +77,13 @@ type MultiKueueRemoteObjectCleanupContext struct {
 // Multi-object cleanup is one use case.
 type MultiKueueAdapterWithRemoteObjectCleanup interface {
 	MultiKueueAdapter
-	DeleteRemoteObjectWithCleanupContext(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, cleanupContext MultiKueueRemoteObjectCleanupContext) error
+	DeleteRemoteObjectWithCleanupContext(
+		ctx context.Context,
+		localClient client.Client,
+		remoteClient client.Client,
+		key types.NamespacedName,
+		cleanupContext MultiKueueRemoteObjectCleanupContext,
+	) error
 }
 
 // MultiKueueWatcher optional interface that can be implemented by a MultiKueueAdapter

--- a/pkg/controller/jobframework/multikueue_test.go
+++ b/pkg/controller/jobframework/multikueue_test.go
@@ -28,15 +28,29 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/component-base/featuregate"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	mocks "sigs.k8s.io/kueue/internal/mocks/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 )
+
+type cleanupTrackingAdapter struct {
+	jobframework.MultiKueueAdapter
+	cleanupContext *jobframework.MultiKueueRemoteObjectCleanupContext
+}
+
+func (a *cleanupTrackingAdapter) DeleteRemoteObjectWithCleanupContext(_ context.Context, _, _ client.Client, _ types.NamespacedName, cleanupContext jobframework.MultiKueueRemoteObjectCleanupContext) error {
+	a.cleanupContext = &cleanupContext
+	cleanupContext.WorkloadAnnotations["mutated-by-adapter"] = "true"
+	return nil
+}
 
 func TestValidateRemoteObjectOwnership(t *testing.T) {
 	key := types.NamespacedName{Name: "test", Namespace: "default"}
@@ -112,6 +126,97 @@ func TestValidateRemoteObjectOwnership(t *testing.T) {
 	}
 }
 
+func TestValidateMultiKueueObjectAssociation(t *testing.T) {
+	const (
+		origin       = "origin-1"
+		workloadName = "workload-1"
+	)
+	longWorkloadName := "workload-name-that-is-longer-than-the-sixty-three-character-label-limit"
+
+	tests := map[string]struct {
+		featureGate bool
+		labels      map[string]string
+		annotations map[string]string
+		wantErr     error
+		workload    string
+	}{
+		"label survives gate enable": {
+			featureGate: true,
+			labels: map[string]string{
+				kueue.MultiKueueOriginLabel:     origin,
+				constants.PrebuiltWorkloadLabel: workloadName,
+			},
+		},
+		"annotation survives gate disable": {
+			featureGate: false,
+			labels:      map[string]string{kueue.MultiKueueOriginLabel: origin},
+			annotations: map[string]string{constants.PrebuiltWorkloadAnnotation: workloadName},
+		},
+		"matching label and annotation are accepted": {
+			featureGate: true,
+			labels: map[string]string{
+				kueue.MultiKueueOriginLabel:     origin,
+				constants.PrebuiltWorkloadLabel: workloadName,
+			},
+			annotations: map[string]string{constants.PrebuiltWorkloadAnnotation: workloadName},
+		},
+		"conflicting label and annotation are rejected": {
+			featureGate: false,
+			labels: map[string]string{
+				kueue.MultiKueueOriginLabel:     origin,
+				constants.PrebuiltWorkloadLabel: workloadName,
+			},
+			annotations: map[string]string{constants.PrebuiltWorkloadAnnotation: "another-workload"},
+			wantErr:     jobframework.ErrRemoteObjectNotOwnedByMultiKueue,
+		},
+		"long annotation survives gate disable": {
+			featureGate: false,
+			labels:      map[string]string{kueue.MultiKueueOriginLabel: origin},
+			annotations: map[string]string{constants.PrebuiltWorkloadAnnotation: longWorkloadName},
+			workload:    longWorkloadName,
+		},
+		"wrong origin is rejected": {
+			featureGate: true,
+			labels: map[string]string{
+				kueue.MultiKueueOriginLabel:     "another-origin",
+				constants.PrebuiltWorkloadLabel: workloadName,
+			},
+			wantErr: jobframework.ErrRemoteObjectNotOwnedByMultiKueue,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: tc.featureGate})
+			job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+				Name:        "job",
+				Namespace:   "default",
+				Labels:      tc.labels,
+				Annotations: tc.annotations,
+			}}
+			expectedWorkload := tc.workload
+			if expectedWorkload == "" {
+				expectedWorkload = workloadName
+			}
+			err := jobframework.ValidateMultiKueueObjectAssociation(job, jobframework.MultiKueueObjectAssociation{
+				Origin:       origin,
+				WorkloadName: expectedWorkload,
+			})
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Fatalf("ValidateMultiKueueObjectAssociation() error (-want,+got):\n%s", diff)
+			}
+		})
+	}
+
+	t.Run("empty origin is rejected", func(t *testing.T) {
+		job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "job", Namespace: "default"}}
+		err := jobframework.ValidateMultiKueueObjectAssociation(job, jobframework.MultiKueueObjectAssociation{WorkloadName: workloadName})
+		if !errors.Is(err, jobframework.ErrMultiKueueOriginEmpty) {
+			t.Fatalf("ValidateMultiKueueObjectAssociation() error = %v, want %v", err, jobframework.ErrMultiKueueOriginEmpty)
+		}
+	})
+}
+
 func TestDeleteRemoteObjectIfOwned(t *testing.T) {
 	makeJob := func(key types.NamespacedName, labels map[string]string) *batchv1.Job {
 		return &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace, Labels: labels}}
@@ -185,4 +290,127 @@ func TestDeleteRemoteObjectIfOwned(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDeleteRemoteObjectForWorkloadIfOwned(t *testing.T) {
+	key := types.NamespacedName{Name: "test-job", Namespace: "default"}
+	const (
+		origin       = "origin-1"
+		workloadName = "workload-1"
+	)
+	makeRemoteJob := func(remoteWorkloadName string) *batchv1.Job {
+		return &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+			Name:      key.Name,
+			Namespace: key.Namespace,
+			UID:       "remote-uid",
+			Labels: map[string]string{
+				kueue.MultiKueueOriginLabel:     origin,
+				constants.PrebuiltWorkloadLabel: remoteWorkloadName,
+			},
+		}}
+	}
+	makeClients := func(t *testing.T, remoteObjects ...client.Object) (client.Client, client.Client) {
+		t.Helper()
+		scheme := runtime.NewScheme()
+		if err := batchv1.AddToScheme(scheme); err != nil {
+			t.Fatalf("adding batch scheme: %v", err)
+		}
+		return fake.NewClientBuilder().WithScheme(scheme).Build(), fake.NewClientBuilder().WithScheme(scheme).WithObjects(remoteObjects...).Build()
+	}
+
+	t.Run("cleanup-aware adapter receives exact identity and copied Workload context", func(t *testing.T) {
+		localClient, remoteClient := makeClients(t, makeRemoteJob(workloadName))
+		mockCtrl := gomock.NewController(t)
+		baseAdapter := mocks.NewMockMultiKueueAdapter(mockCtrl)
+		baseAdapter.EXPECT().GVK().Return(batchv1.SchemeGroupVersion.WithKind("Job")).AnyTimes()
+		adapter := &cleanupTrackingAdapter{MultiKueueAdapter: baseAdapter}
+		localWorkload := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+			Name:        workloadName,
+			Namespace:   key.Namespace,
+			Annotations: map[string]string{"context": "manager"},
+		}}
+
+		ctx, _ := utiltesting.ContextWithLog(t)
+		if err := jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, localClient, remoteClient, adapter, key, localWorkload, origin); err != nil {
+			t.Fatalf("DeleteRemoteObjectForWorkloadIfOwned() error = %v", err)
+		}
+		if adapter.cleanupContext == nil {
+			t.Fatal("cleanup-aware adapter was not called")
+		}
+		if adapter.cleanupContext.RemoteObjectUID != "remote-uid" {
+			t.Fatalf("RemoteObjectUID = %q, want remote-uid", adapter.cleanupContext.RemoteObjectUID)
+		}
+		if adapter.cleanupContext.WorkloadKey != (types.NamespacedName{Name: workloadName, Namespace: key.Namespace}) {
+			t.Fatalf("WorkloadKey = %q", adapter.cleanupContext.WorkloadKey)
+		}
+		if _, mutated := localWorkload.Annotations["mutated-by-adapter"]; mutated {
+			t.Fatal("adapter mutation changed the manager Workload annotations")
+		}
+	})
+
+	t.Run("cleanup-aware adapter rejects another Workload association", func(t *testing.T) {
+		localClient, remoteClient := makeClients(t, makeRemoteJob("another-workload"))
+		mockCtrl := gomock.NewController(t)
+		baseAdapter := mocks.NewMockMultiKueueAdapter(mockCtrl)
+		baseAdapter.EXPECT().GVK().Return(batchv1.SchemeGroupVersion.WithKind("Job")).AnyTimes()
+		adapter := &cleanupTrackingAdapter{MultiKueueAdapter: baseAdapter}
+		localWorkload := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{Name: workloadName, Namespace: key.Namespace}}
+
+		ctx, _ := utiltesting.ContextWithLog(t)
+		if err := jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, localClient, remoteClient, adapter, key, localWorkload, origin); err != nil {
+			t.Fatalf("DeleteRemoteObjectForWorkloadIfOwned() error = %v", err)
+		}
+		if adapter.cleanupContext != nil {
+			t.Fatal("cleanup-aware adapter was called for another Workload")
+		}
+	})
+
+	t.Run("cleanup-aware adapter rejects an unexpected remote UID", func(t *testing.T) {
+		localClient, remoteClient := makeClients(t, makeRemoteJob(workloadName))
+		mockCtrl := gomock.NewController(t)
+		baseAdapter := mocks.NewMockMultiKueueAdapter(mockCtrl)
+		baseAdapter.EXPECT().GVK().Return(batchv1.SchemeGroupVersion.WithKind("Job")).AnyTimes()
+		adapter := &cleanupTrackingAdapter{MultiKueueAdapter: baseAdapter}
+
+		ctx, _ := utiltesting.ContextWithLog(t)
+		err := jobframework.DeleteRemoteObjectWithCleanupContextIfOwned(ctx, localClient, remoteClient, adapter, key, jobframework.MultiKueueRemoteObjectCleanupContext{
+			RemoteObjectUID: "another-uid",
+			Association: jobframework.MultiKueueObjectAssociation{
+				Origin:       origin,
+				WorkloadName: workloadName,
+			},
+			WorkloadKey: types.NamespacedName{Name: workloadName, Namespace: key.Namespace},
+		})
+		if err != nil {
+			t.Fatalf("DeleteRemoteObjectWithCleanupContextIfOwned() error = %v", err)
+		}
+		if adapter.cleanupContext != nil {
+			t.Fatal("cleanup-aware adapter was called for an unexpected remote UID")
+		}
+	})
+
+	t.Run("legacy adapter retains origin-only fallback", func(t *testing.T) {
+		localClient, remoteClient := makeClients(t, makeRemoteJob("another-workload"))
+		mockCtrl := gomock.NewController(t)
+		adapter := mocks.NewMockMultiKueueAdapter(mockCtrl)
+		adapter.EXPECT().GVK().Return(batchv1.SchemeGroupVersion.WithKind("Job")).AnyTimes()
+		adapter.EXPECT().DeleteRemoteObject(gomock.Any(), gomock.Any(), gomock.Any(), key).Return(nil)
+		localWorkload := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{Name: workloadName, Namespace: key.Namespace}}
+
+		ctx, _ := utiltesting.ContextWithLog(t)
+		if err := jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, localClient, remoteClient, adapter, key, localWorkload, origin); err != nil {
+			t.Fatalf("DeleteRemoteObjectForWorkloadIfOwned() error = %v", err)
+		}
+	})
+
+	t.Run("nil Workload is rejected", func(t *testing.T) {
+		localClient, remoteClient := makeClients(t)
+		mockCtrl := gomock.NewController(t)
+		adapter := mocks.NewMockMultiKueueAdapter(mockCtrl)
+		ctx, _ := utiltesting.ContextWithLog(t)
+		err := jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, localClient, remoteClient, adapter, key, nil, origin)
+		if !errors.Is(err, jobframework.ErrMultiKueueWorkloadNameEmpty) {
+			t.Fatalf("DeleteRemoteObjectForWorkloadIfOwned() error = %v, want %v", err, jobframework.ErrMultiKueueWorkloadNameEmpty)
+		}
+	})
 }

--- a/pkg/controller/jobframework/multikueue_test.go
+++ b/pkg/controller/jobframework/multikueue_test.go
@@ -46,7 +46,12 @@ type cleanupTrackingAdapter struct {
 	cleanupContext *jobframework.MultiKueueRemoteObjectCleanupContext
 }
 
-func (a *cleanupTrackingAdapter) DeleteRemoteObjectWithCleanupContext(_ context.Context, _, _ client.Client, _ types.NamespacedName, cleanupContext jobframework.MultiKueueRemoteObjectCleanupContext) error {
+func (a *cleanupTrackingAdapter) DeleteRemoteObjectWithCleanupContext(
+	_ context.Context,
+	_, _ client.Client,
+	_ types.NamespacedName,
+	cleanupContext jobframework.MultiKueueRemoteObjectCleanupContext,
+) error {
 	a.cleanupContext = &cleanupContext
 	cleanupContext.WorkloadAnnotations["mutated-by-adapter"] = "true"
 	return nil

--- a/pkg/controller/jobframework/utils.go
+++ b/pkg/controller/jobframework/utils.go
@@ -283,6 +283,60 @@ func NewWorkload(name string, obj client.Object, podSets []kueue.PodSet, labelKe
 
 var ErrRemoteObjectNotOwnedByMultiKueue = errors.New("remote object is not owned by MultiKueue")
 var ErrMultiKueueOriginEmpty = errors.New("multikueue origin is empty")
+var ErrMultiKueueWorkloadNameEmpty = errors.New("multikueue workload name is empty")
+
+// MultiKueueWorkloadNameFor returns the prebuilt Workload identifier carried by
+// obj. It reads both supported metadata representations independently of the
+// current feature-gate state so rolling upgrades and rollbacks remain safe.
+func MultiKueueWorkloadNameFor(obj client.Object) (string, error) {
+	labelValue := obj.GetLabels()[controllerconstants.PrebuiltWorkloadLabel]
+	annotationValue := obj.GetAnnotations()[controllerconstants.PrebuiltWorkloadAnnotation]
+	if labelValue != "" && annotationValue != "" && labelValue != annotationValue {
+		return "", fmt.Errorf("%w: conflicting prebuilt Workload identifiers on %T %q", ErrRemoteObjectNotOwnedByMultiKueue, obj, client.ObjectKeyFromObject(obj))
+	}
+	if annotationValue != "" {
+		return annotationValue, nil
+	}
+	if labelValue != "" {
+		return labelValue, nil
+	}
+	return "", fmt.Errorf("%w: missing prebuilt Workload identifier on %T %q", ErrRemoteObjectNotOwnedByMultiKueue, obj, client.ObjectKeyFromObject(obj))
+}
+
+// ValidateMultiKueueObjectAssociation checks that obj carries metadata for the
+// expected MultiKueue origin and remote Workload. This is an association check,
+// not proof that the object was created by MultiKueue.
+func ValidateMultiKueueObjectAssociation(obj client.Object, association MultiKueueObjectAssociation) error {
+	if association.Origin == "" {
+		return ErrMultiKueueOriginEmpty
+	}
+	if association.WorkloadName == "" {
+		return ErrMultiKueueWorkloadNameEmpty
+	}
+	if obj.GetLabels()[kueue.MultiKueueOriginLabel] != association.Origin {
+		return fmt.Errorf("%w: unexpected MultiKueue origin on %T %q", ErrRemoteObjectNotOwnedByMultiKueue, obj, client.ObjectKeyFromObject(obj))
+	}
+	objWorkloadName, err := MultiKueueWorkloadNameFor(obj)
+	if err != nil {
+		return err
+	}
+	if objWorkloadName != association.WorkloadName {
+		return fmt.Errorf("%w: %T %q belongs to Workload %q, expected %q", ErrRemoteObjectNotOwnedByMultiKueue, obj, client.ObjectKeyFromObject(obj), objWorkloadName, association.WorkloadName)
+	}
+	return nil
+}
+
+func getRemoteObjectForOrigin(ctx context.Context, remoteClient client.Client, key types.NamespacedName, gvk schema.GroupVersionKind, origin string) (*metav1.PartialObjectMetadata, error) {
+	remoteObject := &metav1.PartialObjectMetadata{}
+	remoteObject.SetGroupVersionKind(gvk)
+	if err := remoteClient.Get(ctx, key, remoteObject); err != nil {
+		return nil, err
+	}
+	if objOrigin, owned := remoteObject.GetLabels()[kueue.MultiKueueOriginLabel]; !owned || objOrigin != origin {
+		return nil, fmt.Errorf("%w: expected %q=%q on %T %q", ErrRemoteObjectNotOwnedByMultiKueue, kueue.MultiKueueOriginLabel, origin, remoteObject, client.ObjectKeyFromObject(remoteObject))
+	}
+	return remoteObject, nil
+}
 
 // ValidateRemoteObjectOwnership retrieves the remote object and validates it is owned by this MultiKueue origin.
 // Returns (false, ErrMultiKueueOriginEmpty) if origin is empty.
@@ -297,17 +351,11 @@ func ValidateRemoteObjectOwnership(ctx context.Context, remoteClient client.Clie
 		return false, ErrMultiKueueOriginEmpty
 	}
 
-	remoteObject := &metav1.PartialObjectMetadata{}
-	remoteObject.SetGroupVersionKind(gvk)
-	if err := remoteClient.Get(ctx, key, remoteObject); err != nil {
+	if _, err := getRemoteObjectForOrigin(ctx, remoteClient, key, gvk, origin); err != nil {
 		if client.IgnoreNotFound(err) == nil {
 			return false, nil
 		}
 		return false, err
-	}
-
-	if objOrigin, owned := remoteObject.GetLabels()[kueue.MultiKueueOriginLabel]; !owned || objOrigin != origin {
-		return false, fmt.Errorf("%w: expected %q=%q on %T %q", ErrRemoteObjectNotOwnedByMultiKueue, kueue.MultiKueueOriginLabel, origin, remoteObject, client.ObjectKeyFromObject(remoteObject))
 	}
 
 	return true, nil
@@ -325,18 +373,88 @@ func DeleteRemoteObjectIfOwned(ctx context.Context, localClient client.Client, r
 		return ErrMultiKueueOriginEmpty
 	}
 
-	found, err := ValidateRemoteObjectOwnership(ctx, remoteClient, key, adapter.GVK(), origin)
+	_, err := getRemoteObjectForOrigin(ctx, remoteClient, key, adapter.GVK(), origin)
 	if err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			log.V(2).Info("Skipping remote object deletion because object was not found")
+			return nil
+		}
 		if errors.Is(err, ErrRemoteObjectNotOwnedByMultiKueue) {
 			log.V(2).Info("Skipping remote object deletion because object is not owned by this MultiKueue origin")
 			return nil
 		}
 		return err
 	}
-	if !found {
-		log.V(2).Info("Skipping remote object deletion because object was not found")
-		return nil
-	}
 
 	return adapter.DeleteRemoteObject(ctx, localClient, remoteClient, key)
+}
+
+// DeleteRemoteObjectWithCleanupContextIfOwned validates the remote controller
+// object's association and identity before delegating to a cleanup-aware adapter.
+// When RemoteObjectUID is empty, the helper binds the context to the exact UID it
+// observes. A non-empty UID is treated as an expected identity and must match.
+func DeleteRemoteObjectWithCleanupContextIfOwned(ctx context.Context, localClient client.Client, remoteClient client.Client, adapter MultiKueueAdapterWithRemoteObjectCleanup, key types.NamespacedName, cleanupContext MultiKueueRemoteObjectCleanupContext) error {
+	log := ctrl.LoggerFrom(ctx).WithValues("remoteObject", key, "adapterGVK", adapter.GVK().String(), "origin", cleanupContext.Association.Origin, "workload", cleanupContext.Association.WorkloadName, "remoteObjectUID", cleanupContext.RemoteObjectUID)
+	if cleanupContext.Association.Origin == "" {
+		log.Error(ErrMultiKueueOriginEmpty, "Skipping remote object deletion because origin is empty")
+		return ErrMultiKueueOriginEmpty
+	}
+	if cleanupContext.Association.WorkloadName == "" {
+		log.Error(ErrMultiKueueWorkloadNameEmpty, "Skipping remote object deletion because Workload name is empty")
+		return ErrMultiKueueWorkloadNameEmpty
+	}
+	if cleanupContext.WorkloadKey.Name != cleanupContext.Association.WorkloadName || cleanupContext.WorkloadKey.Namespace != key.Namespace {
+		return fmt.Errorf("%w: cleanup Workload %q does not match association %q in namespace %q", ErrRemoteObjectNotOwnedByMultiKueue, cleanupContext.WorkloadKey, cleanupContext.Association.WorkloadName, key.Namespace)
+	}
+
+	remoteObject, err := getRemoteObjectForOrigin(ctx, remoteClient, key, adapter.GVK(), cleanupContext.Association.Origin)
+	if err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			log.V(2).Info("Skipping remote object deletion because object was not found")
+			return nil
+		}
+		if errors.Is(err, ErrRemoteObjectNotOwnedByMultiKueue) {
+			log.V(2).Info("Skipping remote object deletion because object is not associated with this MultiKueue origin")
+			return nil
+		}
+		return err
+	}
+	if err := ValidateMultiKueueObjectAssociation(remoteObject, cleanupContext.Association); err != nil {
+		if errors.Is(err, ErrRemoteObjectNotOwnedByMultiKueue) {
+			log.V(2).Info("Skipping remote object deletion because object is not associated with the expected Workload")
+			return nil
+		}
+		return err
+	}
+	if cleanupContext.RemoteObjectUID != "" && remoteObject.UID != cleanupContext.RemoteObjectUID {
+		log.V(2).Info("Skipping remote object deletion because its UID does not match the expected identity", "observedRemoteObjectUID", remoteObject.UID)
+		return nil
+	}
+	cleanupContext.RemoteObjectUID = remoteObject.UID
+	return adapter.DeleteRemoteObjectWithCleanupContext(ctx, localClient, remoteClient, key, cleanupContext)
+}
+
+// DeleteRemoteObjectForWorkloadIfOwned uses manager-side Workload metadata to
+// validate cleanup for adapters implementing MultiKueueAdapterWithRemoteObjectCleanup.
+// Other adapters intentionally retain the legacy origin-only deletion behavior
+// for compatibility and must not treat this helper as a Workload-binding check.
+func DeleteRemoteObjectForWorkloadIfOwned(ctx context.Context, localClient client.Client, remoteClient client.Client, adapter MultiKueueAdapter, key types.NamespacedName, localWorkload *kueue.Workload, origin string) error {
+	if localWorkload == nil {
+		return ErrMultiKueueWorkloadNameEmpty
+	}
+	cleanupAdapter, ok := adapter.(MultiKueueAdapterWithRemoteObjectCleanup)
+	if !ok {
+		return DeleteRemoteObjectIfOwned(ctx, localClient, remoteClient, adapter, key, origin)
+	}
+
+	workloadAnnotations := map[string]string(nil)
+	maps.Copy(&workloadAnnotations, localWorkload.Annotations)
+	return DeleteRemoteObjectWithCleanupContextIfOwned(ctx, localClient, remoteClient, cleanupAdapter, key, MultiKueueRemoteObjectCleanupContext{
+		Association: MultiKueueObjectAssociation{
+			Origin:       origin,
+			WorkloadName: localWorkload.Name,
+		},
+		WorkloadKey:         client.ObjectKeyFromObject(localWorkload),
+		WorkloadAnnotations: workloadAnnotations,
+	})
 }

--- a/pkg/controller/jobframework/utils.go
+++ b/pkg/controller/jobframework/utils.go
@@ -393,7 +393,14 @@ func DeleteRemoteObjectIfOwned(ctx context.Context, localClient client.Client, r
 // object's association and identity before delegating to a cleanup-aware adapter.
 // When RemoteObjectUID is empty, the helper binds the context to the exact UID it
 // observes. A non-empty UID is treated as an expected identity and must match.
-func DeleteRemoteObjectWithCleanupContextIfOwned(ctx context.Context, localClient client.Client, remoteClient client.Client, adapter MultiKueueAdapterWithRemoteObjectCleanup, key types.NamespacedName, cleanupContext MultiKueueRemoteObjectCleanupContext) error {
+func DeleteRemoteObjectWithCleanupContextIfOwned(
+	ctx context.Context,
+	localClient client.Client,
+	remoteClient client.Client,
+	adapter MultiKueueAdapterWithRemoteObjectCleanup,
+	key types.NamespacedName,
+	cleanupContext MultiKueueRemoteObjectCleanupContext,
+) error {
 	log := ctrl.LoggerFrom(ctx).WithValues("remoteObject", key, "adapterGVK", adapter.GVK().String(), "origin", cleanupContext.Association.Origin, "workload", cleanupContext.Association.WorkloadName, "remoteObjectUID", cleanupContext.RemoteObjectUID)
 	if cleanupContext.Association.Origin == "" {
 		log.Error(ErrMultiKueueOriginEmpty, "Skipping remote object deletion because origin is empty")

--- a/pkg/controller/jobs/pod/indexer.go
+++ b/pkg/controller/jobs/pod/indexer.go
@@ -18,13 +18,16 @@ package pod
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
 	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
 )
 
 const (
-	PodGroupNameCacheKey = "PodGroupNameCacheKey"
+	PodGroupNameCacheKey           = "PodGroupNameCacheKey"
+	multiKueuePodGroupNameCacheKey = "MultiKueuePodGroupNameCacheKey"
 )
 
 func IndexPodGroupName(o client.Object) []string {
@@ -37,4 +40,25 @@ func IndexPodGroupName(o client.Object) []string {
 		return []string{groupName}
 	}
 	return nil
+}
+
+// indexMultiKueuePodGroupName indexes both supported group-name representations
+// so MultiKueue can finish an in-flight dispatch across feature-gate changes.
+func indexMultiKueuePodGroupName(o client.Object) []string {
+	pod, ok := o.(*corev1.Pod)
+	if !ok {
+		return nil
+	}
+
+	groupNames := sets.New[string]()
+	if groupName := pod.Labels[podconstants.GroupNameLabel]; groupName != "" {
+		groupNames.Insert(groupName)
+	}
+	if groupName := pod.Annotations[podconstants.GroupNameAnnotation]; groupName != "" {
+		groupNames.Insert(groupName)
+	}
+	if groupNames.Len() == 0 {
+		return nil
+	}
+	return groupNames.UnsortedList()
 }

--- a/pkg/controller/jobs/pod/indexer_test.go
+++ b/pkg/controller/jobs/pod/indexer_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
@@ -50,6 +51,55 @@ func TestIndexPodGroupName(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			got := IndexPodGroupName(tc.object)
 			if diff := cmp.Diff(tc.wantKeys, got); diff != "" {
+				t.Errorf("Unexpected keys (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestIndexMultiKueuePodGroupName(t *testing.T) {
+	cases := map[string]struct {
+		object   client.Object
+		wantKeys []string
+	}{
+		"non-pod object": {
+			object: testingnode.MakeNode("node").Label(podconstants.GroupNameLabel, "group-1").Obj(),
+		},
+		"pod without group name": {
+			object: testingpod.MakePod("pod", "ns").Obj(),
+		},
+		"pod with label group name": {
+			object: testingpod.MakePod("pod", "ns").
+				GroupNameLabel("group-1").
+				Obj(),
+			wantKeys: []string{"group-1"},
+		},
+		"pod with annotation group name": {
+			object: testingpod.MakePod("pod", "ns").
+				GroupNameAnnotation("group-1").
+				Obj(),
+			wantKeys: []string{"group-1"},
+		},
+		"pod with matching label and annotation group names": {
+			object: testingpod.MakePod("pod", "ns").
+				GroupNameLabel("group-1").
+				GroupNameAnnotation("group-1").
+				Obj(),
+			wantKeys: []string{"group-1"},
+		},
+		"pod with distinct label and annotation group names": {
+			object: testingpod.MakePod("pod", "ns").
+				GroupNameLabel("group-1").
+				GroupNameAnnotation("group-2").
+				Obj(),
+			wantKeys: []string{"group-1", "group-2"},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := indexMultiKueuePodGroupName(tc.object)
+			if diff := cmp.Diff(tc.wantKeys, got, cmpopts.SortSlices(func(a, b string) bool { return a < b })); diff != "" {
 				t.Errorf("Unexpected keys (-want,+got):\n%s", diff)
 			}
 		})

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -589,6 +589,9 @@ func SetupIndexes(ctx context.Context, indexer client.FieldIndexer) error {
 	if err := indexer.IndexField(ctx, &corev1.Pod{}, PodGroupNameCacheKey, IndexPodGroupName); err != nil {
 		return err
 	}
+	if err := indexer.IndexField(ctx, &corev1.Pod{}, multiKueuePodGroupNameCacheKey, indexMultiKueuePodGroupName); err != nil {
+		return err
+	}
 	if err := jobframework.SetupWorkloadOwnerIndex(ctx, indexer, gvk); err != nil {
 		return err
 	}

--- a/pkg/controller/jobs/pod/pod_multikueue_adapter.go
+++ b/pkg/controller/jobs/pod/pod_multikueue_adapter.go
@@ -23,22 +23,28 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
 	"sigs.k8s.io/kueue/pkg/util/api"
 	clientutil "sigs.k8s.io/kueue/pkg/util/client"
-	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
 )
 
 type multiKueueAdapter struct{}
 
+const remotePodCleanupPageSize int64 = 100
+
 var _ jobframework.MultiKueueAdapter = (*multiKueueAdapter)(nil)
+var _ jobframework.MultiKueueAdapterWithRemoteObjectCleanup = (*multiKueueAdapter)(nil)
 
 func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
@@ -49,9 +55,12 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 		return false, err
 	}
 
-	groupName := utilpod.GetPodGroupName(&localPod)
+	groupName, err := multiKueuePodGroupName(&localPod)
+	if err != nil {
+		return false, err
+	}
 	if groupName == "" {
-		return false, syncLocalPodWithRemote(ctx, localClient, remoteClient, &localPod, workloadName, origin, &log)
+		return false, syncLocalPodWithRemote(ctx, localClient, remoteClient, &localPod, workloadName, origin, groupName, &log)
 	}
 
 	return false, syncPodGroup(ctx, localClient, remoteClient, key, workloadName, origin, groupName)
@@ -63,24 +72,130 @@ func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, localClient 
 	if err != nil {
 		return client.IgnoreNotFound(err)
 	}
-
-	groupName := utilpod.GetPodGroupName(&pod)
-	if groupName == "" {
-		return client.IgnoreNotFound(remoteClient.Delete(ctx, &pod))
-	}
-
-	localPodGroup, err := listLocalPods(ctx, localClient, key.Namespace, groupName)
+	workloadName, err := jobframework.MultiKueueWorkloadNameFor(&pod)
 	if err != nil {
 		return err
 	}
+	groupName, err := multiKueuePodGroupName(&pod)
+	if err != nil {
+		return err
+	}
+	workloadAnnotations := map[string]string(nil)
+	if groupName != "" {
+		workloadAnnotations = map[string]string{podconstants.IsGroupWorkloadAnnotationKey: podconstants.IsGroupWorkloadAnnotationValue}
+	}
+	return b.deleteRemoteObjectWithCleanupContext(ctx, remoteClient, key, jobframework.MultiKueueRemoteObjectCleanupContext{
+		RemoteObjectUID: pod.UID,
+		Association: jobframework.MultiKueueObjectAssociation{
+			Origin:       pod.Labels[kueue.MultiKueueOriginLabel],
+			WorkloadName: workloadName,
+		},
+		WorkloadKey:         types.NamespacedName{Name: workloadName, Namespace: pod.Namespace},
+		WorkloadAnnotations: workloadAnnotations,
+	}, groupName)
+}
 
-	for _, localPod := range localPodGroup.Items {
-		if err = client.IgnoreNotFound(remoteClient.Delete(ctx, &localPod)); err != nil {
-			return err
-		}
+func (b *multiKueueAdapter) DeleteRemoteObjectWithCleanupContext(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, cleanupContext jobframework.MultiKueueRemoteObjectCleanupContext) error {
+	groupName, err := expectedMultiKueuePodGroupName(ctx, localClient, key, cleanupContext)
+	if err != nil {
+		return err
+	}
+	return b.deleteRemoteObjectWithCleanupContext(ctx, remoteClient, key, cleanupContext, groupName)
+}
+
+func (b *multiKueueAdapter) deleteRemoteObjectWithCleanupContext(ctx context.Context, remoteClient client.Client, key types.NamespacedName, cleanupContext jobframework.MultiKueueRemoteObjectCleanupContext, groupName string) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	pod := corev1.Pod{}
+	if err := remoteClient.Get(ctx, key, &pod); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	if pod.UID != cleanupContext.RemoteObjectUID {
+		return fmt.Errorf("%w: remote Pod %q was replaced before cleanup", jobframework.ErrRemoteObjectNotOwnedByMultiKueue, klog.KObj(&pod))
+	}
+	if err := validateRemotePodAssociation(&pod, cleanupContext.Association, groupName); err != nil {
+		return err
 	}
 
-	return nil
+	if groupName == "" {
+		return deleteRemotePodIfAssociated(ctx, remoteClient, &pod, cleanupContext.Association, groupName, &log)
+	}
+
+	listOptions := &client.ListOptions{
+		Namespace:     key.Namespace,
+		LabelSelector: labels.SelectorFromSet(labels.Set{kueue.MultiKueueOriginLabel: cleanupContext.Association.Origin}),
+		Limit:         remotePodCleanupPageSize,
+	}
+	for {
+		remotePodGroup := corev1.PodList{}
+		if err := remoteClient.List(ctx, &remotePodGroup, listOptions); err != nil {
+			return err
+		}
+		currentAnchor := corev1.Pod{}
+		if err := remoteClient.Get(ctx, key, &currentAnchor); err != nil {
+			return err
+		}
+		if currentAnchor.UID != cleanupContext.RemoteObjectUID {
+			return fmt.Errorf("%w: remote Pod %q was replaced during PodGroup cleanup", jobframework.ErrRemoteObjectNotOwnedByMultiKueue, klog.KObj(&currentAnchor))
+		}
+		if err := validateRemotePodAssociation(&currentAnchor, cleanupContext.Association, groupName); err != nil {
+			return err
+		}
+		for i := range remotePodGroup.Items {
+			remotePod := &remotePodGroup.Items[i]
+			podKey := client.ObjectKeyFromObject(remotePod)
+			if podKey == key {
+				if remotePod.UID != cleanupContext.RemoteObjectUID {
+					return fmt.Errorf("%w: remote Pod %q was replaced during PodGroup cleanup", jobframework.ErrRemoteObjectNotOwnedByMultiKueue, klog.KObj(remotePod))
+				}
+				continue
+			}
+			if err := deleteRemotePodIfAssociated(ctx, remoteClient, remotePod, cleanupContext.Association, groupName, &log); err != nil {
+				return err
+			}
+		}
+		if remotePodGroup.Continue == "" {
+			break
+		}
+		listOptions.Continue = remotePodGroup.Continue
+	}
+
+	// Keep the anchor until all pages and member deletions succeed so a retry can
+	// still recover after a transient list or delete failure.
+	return deleteRemotePodIfAssociated(ctx, remoteClient, &pod, cleanupContext.Association, groupName, &log)
+}
+
+func expectedMultiKueuePodGroupName(ctx context.Context, localClient client.Client, key types.NamespacedName, cleanupContext jobframework.MultiKueueRemoteObjectCleanupContext) (string, error) {
+	var podGroupName string
+	localPod := corev1.Pod{}
+	if err := localClient.Get(ctx, key, &localPod); err == nil {
+		var groupErr error
+		podGroupName, groupErr = multiKueuePodGroupName(&localPod)
+		if groupErr != nil {
+			return "", groupErr
+		}
+	} else if client.IgnoreNotFound(err) != nil {
+		return "", err
+	}
+
+	if cleanupContext.WorkloadKey.Name != "" {
+		if cleanupContext.WorkloadKey.Name != cleanupContext.Association.WorkloadName || cleanupContext.WorkloadKey.Namespace != key.Namespace {
+			return "", fmt.Errorf("Workload %q does not match cleanup association %q", cleanupContext.WorkloadKey, cleanupContext.Association.WorkloadName)
+		}
+		workloadGroupName := ""
+		if cleanupContext.WorkloadAnnotations[podconstants.IsGroupWorkloadAnnotationKey] == podconstants.IsGroupWorkloadAnnotationValue {
+			workloadGroupName = cleanupContext.WorkloadKey.Name
+		}
+		if podGroupName != "" && podGroupName != workloadGroupName {
+			return "", fmt.Errorf("manager PodGroup %q does not match Workload group %q", podGroupName, workloadGroupName)
+		}
+		return workloadGroupName, nil
+	}
+
+	// The local Pod can still provide group context to direct adapter callers that
+	// do not have Workload context. Production Workload cleanup and GC always reach
+	// the branch above even after the manager Pods are finalized.
+	return podGroupName, nil
 }
 
 func (b *multiKueueAdapter) IsJobManagedByKueue(ctx context.Context, c client.Client, key types.NamespacedName) (bool, string, error) {
@@ -103,9 +218,9 @@ func (*multiKueueAdapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedN
 		return nil, errors.New("not a pod")
 	}
 
-	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(pod)
-	if prebuiltWorkload == "" {
-		return nil, fmt.Errorf("no prebuilt workload found for pod: %s", klog.KObj(pod))
+	prebuiltWorkload, err := jobframework.MultiKueueWorkloadNameFor(pod)
+	if err != nil {
+		return nil, fmt.Errorf("getting prebuilt Workload for Pod %q: %w", klog.KObj(pod), err)
 	}
 
 	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: pod.Namespace}}, nil
@@ -120,7 +235,14 @@ func syncPodGroup(ctx context.Context, localClient client.Client, remoteClient c
 	}
 
 	for _, localPod := range localPodGroup.Items {
-		if err = syncLocalPodWithRemote(ctx, localClient, remoteClient, &localPod, workloadName, origin, &log); err != nil {
+		localGroupName, err := multiKueuePodGroupName(&localPod)
+		if err != nil {
+			return err
+		}
+		if localGroupName != groupName {
+			return fmt.Errorf("Pod %q belongs to PodGroup %q, expected %q", klog.KObj(&localPod), localGroupName, groupName)
+		}
+		if err = syncLocalPodWithRemote(ctx, localClient, remoteClient, &localPod, workloadName, origin, groupName, &log); err != nil {
 			return err
 		}
 	}
@@ -130,7 +252,7 @@ func syncPodGroup(ctx context.Context, localClient client.Client, remoteClient c
 
 func listLocalPods(ctx context.Context, localClient client.Client, namespace, groupName string) (*corev1.PodList, error) {
 	pods := &corev1.PodList{}
-	if err := localClient.List(ctx, pods, client.InNamespace(namespace), client.MatchingFields{PodGroupNameCacheKey: groupName}); err != nil {
+	if err := localClient.List(ctx, pods, client.InNamespace(namespace), client.MatchingFields{multiKueuePodGroupNameCacheKey: groupName}); err != nil {
 		return nil, err
 	}
 	return pods, nil
@@ -141,7 +263,7 @@ func syncLocalPodWithRemote(
 	localClient client.Client,
 	remoteClient client.Client,
 	localPod *corev1.Pod,
-	workloadName, origin string,
+	workloadName, origin, groupName string,
 	log *logr.Logger,
 ) error {
 	key := types.NamespacedName{Name: localPod.Name, Namespace: localPod.Namespace}
@@ -155,6 +277,10 @@ func syncLocalPodWithRemote(
 
 	// If the remote pod exists
 	if err == nil {
+		if err := validateRemotePodAssociation(&remotePod, jobframework.MultiKueueObjectAssociation{Origin: origin, WorkloadName: workloadName}, groupName); err != nil {
+			return err
+		}
+
 		// Skip syncing if the local pod is terminating
 		if !localPod.DeletionTimestamp.IsZero() {
 			log.V(2).Info("Skipping sync since the local pod is terminating", "podName", localPod.Name)
@@ -210,6 +336,50 @@ func syncLocalPodWithRemote(
 	}
 
 	return nil
+}
+
+func multiKueuePodGroupName(pod *corev1.Pod) (string, error) {
+	labelValue := pod.Labels[podconstants.GroupNameLabel]
+	annotationValue := pod.Annotations[podconstants.GroupNameAnnotation]
+	if labelValue != "" && annotationValue != "" && labelValue != annotationValue {
+		return "", fmt.Errorf("%w: conflicting PodGroup identifiers on Pod %q", jobframework.ErrRemoteObjectNotOwnedByMultiKueue, klog.KObj(pod))
+	}
+	if annotationValue != "" {
+		return annotationValue, nil
+	}
+	return labelValue, nil
+}
+
+func validateRemotePodAssociation(pod *corev1.Pod, association jobframework.MultiKueueObjectAssociation, groupName string) error {
+	if err := jobframework.ValidateMultiKueueObjectAssociation(pod, association); err != nil {
+		return err
+	}
+	podGroupName, err := multiKueuePodGroupName(pod)
+	if err != nil {
+		return err
+	}
+	if podGroupName != groupName {
+		return fmt.Errorf("%w: Pod %q belongs to PodGroup %q, expected %q", jobframework.ErrRemoteObjectNotOwnedByMultiKueue, klog.KObj(pod), podGroupName, groupName)
+	}
+	return nil
+}
+
+func deleteRemotePodIfAssociated(
+	ctx context.Context,
+	remoteClient client.Client,
+	pod *corev1.Pod,
+	association jobframework.MultiKueueObjectAssociation,
+	groupName string,
+	log *logr.Logger,
+) error {
+	if err := validateRemotePodAssociation(pod, association, groupName); err != nil {
+		if errors.Is(err, jobframework.ErrRemoteObjectNotOwnedByMultiKueue) {
+			log.V(4).Info("Preserving remote Pod that is not associated with this MultiKueue dispatch", "pod", klog.KObj(pod))
+			return nil
+		}
+		return err
+	}
+	return client.IgnoreNotFound(remoteClient.Delete(ctx, pod, client.Preconditions{UID: ptr.To(pod.UID)}))
 }
 
 // findPodCondition returns a pointer to the condition of the given type, or nil

--- a/pkg/controller/jobs/pod/pod_multikueue_adapter.go
+++ b/pkg/controller/jobs/pod/pod_multikueue_adapter.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -95,7 +94,13 @@ func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, localClient 
 	}, groupName)
 }
 
-func (b *multiKueueAdapter) DeleteRemoteObjectWithCleanupContext(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, cleanupContext jobframework.MultiKueueRemoteObjectCleanupContext) error {
+func (b *multiKueueAdapter) DeleteRemoteObjectWithCleanupContext(
+	ctx context.Context,
+	localClient client.Client,
+	remoteClient client.Client,
+	key types.NamespacedName,
+	cleanupContext jobframework.MultiKueueRemoteObjectCleanupContext,
+) error {
 	groupName, err := expectedMultiKueuePodGroupName(ctx, localClient, key, cleanupContext)
 	if err != nil {
 		return err
@@ -180,7 +185,7 @@ func expectedMultiKueuePodGroupName(ctx context.Context, localClient client.Clie
 
 	if cleanupContext.WorkloadKey.Name != "" {
 		if cleanupContext.WorkloadKey.Name != cleanupContext.Association.WorkloadName || cleanupContext.WorkloadKey.Namespace != key.Namespace {
-			return "", fmt.Errorf("Workload %q does not match cleanup association %q", cleanupContext.WorkloadKey, cleanupContext.Association.WorkloadName)
+			return "", fmt.Errorf("workload %q does not match cleanup association %q", cleanupContext.WorkloadKey, cleanupContext.Association.WorkloadName)
 		}
 		workloadGroupName := ""
 		if cleanupContext.WorkloadAnnotations[podconstants.IsGroupWorkloadAnnotationKey] == podconstants.IsGroupWorkloadAnnotationValue {
@@ -379,7 +384,7 @@ func deleteRemotePodIfAssociated(
 		}
 		return err
 	}
-	return client.IgnoreNotFound(remoteClient.Delete(ctx, pod, client.Preconditions{UID: ptr.To(pod.UID)}))
+	return client.IgnoreNotFound(remoteClient.Delete(ctx, pod, client.Preconditions{UID: &pod.UID}))
 }
 
 // findPodCondition returns a pointer to the condition of the given type, or nil

--- a/pkg/controller/jobs/pod/pod_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/pod/pod_multikueue_adapter_test.go
@@ -19,18 +19,23 @@ package pod
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/component-base/featuregate"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -47,7 +52,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 		cmpopts.EquateEmpty(),
 	}
 
-	basePodName := "test-pod"
+	basePodName := "wl1"
 	basePodBuilder := utiltestingpod.MakePod(basePodName, TestNamespace)
 
 	groupSize := 3
@@ -60,6 +65,9 @@ func TestMultiKueueAdapter(t *testing.T) {
 		PrebuiltWorkloadLabel("wl1").
 		Label(kueue.MultiKueueOriginLabel, "origin1").
 		MakePodGroupWrappers(groupSize)
+	for i := range podGroupWithWl {
+		podGroupWithWl[i].UID(fmt.Sprintf("worker-pod-%d", i))
+	}
 
 	podGroupWithWlAnnotations := basePodBuilder.
 		Clone().
@@ -70,6 +78,16 @@ func TestMultiKueueAdapter(t *testing.T) {
 		PrebuiltWorkloadAnnotation("wl1").
 		Label(kueue.MultiKueueOriginLabel, "origin1").
 		MakePodGroupWrappersWithWorkloadAnnotations(groupSize)
+	for i := range workerPodGroupWithAnnotations {
+		workerPodGroupWithAnnotations[i].UID(fmt.Sprintf("worker-pod-%d", i))
+	}
+	groupWorkload := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+		Name:      "wl1",
+		Namespace: TestNamespace,
+		Annotations: map[string]string{
+			podconstants.IsGroupWorkloadAnnotationKey: podconstants.IsGroupWorkloadAnnotationValue,
+		},
+	}}
 
 	cases := map[string]struct {
 		managersPods []corev1.Pod
@@ -81,6 +99,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 		wantManagersPods []corev1.Pod
 		wantWorkerPods   []corev1.Pod
 		featureGates     map[featuregate.Feature]bool
+		ignoreWorkerUIDs bool
 	}{
 		"sync creates missing remote pod": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
@@ -103,7 +122,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync status from remote pod": {
-			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
 			managersPods: []corev1.Pod{
 				*basePodBuilder.DeepCopy(),
 			},
@@ -276,7 +295,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync creates missing remote pods of the group": {
-			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			featureGates:     map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			ignoreWorkerUIDs: true,
 			managersPods: []corev1.Pod{
 				*podGroup[0].DeepCopy(),
 				*podGroup[1].DeepCopy(),
@@ -333,7 +353,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 		},
-		"remote pod group is deleted": {
+		"sync rejects remote pod group member from another workload": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersPods: []corev1.Pod{
 				*podGroup[0].DeepCopy(),
@@ -343,15 +363,339 @@ func TestMultiKueueAdapter(t *testing.T) {
 			workerPods: []corev1.Pod{
 				*podGroupWithWl[0].DeepCopy(),
 				*podGroupWithWl[1].DeepCopy(),
+				*podGroupWithWl[2].Clone().
+					PrebuiltWorkloadLabel("another-workload").
+					StatusPhase(corev1.PodRunning).
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, "wl1", "origin1")
+				return err
+			},
+			wantError: jobframework.ErrRemoteObjectNotOwnedByMultiKueue,
+			wantManagersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].DeepCopy(),
+			},
+			wantWorkerPods: []corev1.Pod{
+				*podGroupWithWl[0].DeepCopy(),
+				*podGroupWithWl[1].DeepCopy(),
+				*podGroupWithWl[2].Clone().
+					PrebuiltWorkloadLabel("another-workload").
+					StatusPhase(corev1.PodRunning).
+					Obj(),
+			},
+		},
+		"sync rejects remote pod with another group identity": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			managersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].DeepCopy(),
+			},
+			workerPods: []corev1.Pod{
+				*podGroupWithWl[0].DeepCopy(),
+				*podGroupWithWl[1].DeepCopy(),
+				*podGroupWithWl[2].Clone().
+					GroupNameLabel("another-group").
+					StatusPhase(corev1.PodRunning).
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, "wl1", "origin1")
+				return err
+			},
+			wantError: jobframework.ErrRemoteObjectNotOwnedByMultiKueue,
+			wantManagersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].DeepCopy(),
+			},
+			wantWorkerPods: []corev1.Pod{
+				*podGroupWithWl[0].DeepCopy(),
+				*podGroupWithWl[1].DeepCopy(),
+				*podGroupWithWl[2].Clone().
+					GroupNameLabel("another-group").
+					StatusPhase(corev1.PodRunning).
+					Obj(),
+			},
+		},
+		"sync status from annotation pod group after gate disable": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			managersPods: []corev1.Pod{
+				*podGroupWithWlAnnotations[0].DeepCopy(),
+				*podGroupWithWlAnnotations[1].DeepCopy(),
+				*podGroupWithWlAnnotations[2].DeepCopy(),
+			},
+			workerPods: []corev1.Pod{
+				*workerPodGroupWithAnnotations[0].DeepCopy(),
+				*workerPodGroupWithAnnotations[1].DeepCopy(),
+				*workerPodGroupWithAnnotations[2].Clone().
+					StatusPhase(corev1.PodRunning).
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, "wl1", "origin1")
+				return err
+			},
+			wantManagersPods: []corev1.Pod{
+				*podGroupWithWlAnnotations[0].DeepCopy(),
+				*podGroupWithWlAnnotations[1].DeepCopy(),
+				*podGroupWithWlAnnotations[2].Clone().
+					StatusPhase(corev1.PodRunning).
+					Obj(),
+			},
+			wantWorkerPods: []corev1.Pod{
+				*workerPodGroupWithAnnotations[0].DeepCopy(),
+				*workerPodGroupWithAnnotations[1].DeepCopy(),
+				*workerPodGroupWithAnnotations[2].Clone().
+					StatusPhase(corev1.PodRunning).
+					Obj(),
+			},
+		},
+		"sync status from label pod group after gate enable": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+			managersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].DeepCopy(),
+			},
+			workerPods: []corev1.Pod{
+				*podGroupWithWl[0].DeepCopy(),
+				*podGroupWithWl[1].DeepCopy(),
+				*podGroupWithWl[2].Clone().
+					StatusPhase(corev1.PodRunning).
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, "wl1", "origin1")
+				return err
+			},
+			wantManagersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].Clone().
+					StatusPhase(corev1.PodRunning).
+					Obj(),
+			},
+			wantWorkerPods: []corev1.Pod{
+				*podGroupWithWl[0].DeepCopy(),
+				*podGroupWithWl[1].DeepCopy(),
+				*podGroupWithWl[2].Clone().
+					StatusPhase(corev1.PodRunning).
+					Obj(),
+			},
+		},
+		"sync rejects conflicting remote anchor group identities": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			managersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].DeepCopy(),
+			},
+			workerPods: []corev1.Pod{
+				*podGroupWithWl[0].Clone().GroupNameAnnotation("another-group").Obj(),
+				*podGroupWithWl[1].DeepCopy(),
 				*podGroupWithWl[2].DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.DeleteRemoteObject(ctx, managerClient, workerClient, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace})
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, "wl1", "origin1")
+				return err
+			},
+			wantError: jobframework.ErrRemoteObjectNotOwnedByMultiKueue,
+			wantManagersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].DeepCopy(),
+			},
+			wantWorkerPods: []corev1.Pod{
+				*podGroupWithWl[0].Clone().GroupNameAnnotation("another-group").Obj(),
+				*podGroupWithWl[1].DeepCopy(),
+				*podGroupWithWl[2].DeepCopy(),
+			},
+		},
+		"sync rejects conflicting remote member group identities": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			managersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].DeepCopy(),
+			},
+			workerPods: []corev1.Pod{
+				*podGroupWithWl[0].DeepCopy(),
+				*podGroupWithWl[1].DeepCopy(),
+				*podGroupWithWl[2].Clone().GroupNameAnnotation("another-group").Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, "wl1", "origin1")
+				return err
+			},
+			wantError: jobframework.ErrRemoteObjectNotOwnedByMultiKueue,
+			wantManagersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].DeepCopy(),
+			},
+			wantWorkerPods: []corev1.Pod{
+				*podGroupWithWl[0].DeepCopy(),
+				*podGroupWithWl[1].DeepCopy(),
+				*podGroupWithWl[2].Clone().GroupNameAnnotation("another-group").Obj(),
+			},
+		},
+		"sync rejects unlabelled remote pod group member": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			managersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].DeepCopy(),
+			},
+			workerPods: []corev1.Pod{
+				*podGroupWithWl[0].DeepCopy(),
+				*podGroupWithWl[1].DeepCopy(),
+				*utiltestingpod.MakePod(podGroup[2].Obj().Name, TestNamespace).
+					UID("victim-uid").
+					StatusPhase(corev1.PodRunning).
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, "wl1", "origin1")
+				return err
+			},
+			wantError: jobframework.ErrRemoteObjectNotOwnedByMultiKueue,
+			wantManagersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].DeepCopy(),
+			},
+			wantWorkerPods: []corev1.Pod{
+				*podGroupWithWl[0].DeepCopy(),
+				*podGroupWithWl[1].DeepCopy(),
+				*utiltestingpod.MakePod(podGroup[2].Obj().Name, TestNamespace).
+					UID("victim-uid").
+					StatusPhase(corev1.PodRunning).
+					Obj(),
+			},
+		},
+		"remote pod group is deleted": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			managersPods: []corev1.Pod{
+				*podGroupWithWlAnnotations[0].DeepCopy(),
+				*podGroupWithWlAnnotations[1].DeepCopy(),
+				*podGroupWithWlAnnotations[2].DeepCopy(),
+			},
+			workerPods: []corev1.Pod{
+				*workerPodGroupWithAnnotations[0].DeepCopy(),
+				*workerPodGroupWithAnnotations[1].DeepCopy(),
+				*workerPodGroupWithAnnotations[2].DeepCopy(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				return jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, managerClient, workerClient, adapter, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, groupWorkload, "origin1")
+			},
+			wantManagersPods: []corev1.Pod{
+				*podGroupWithWlAnnotations[0].DeepCopy(),
+				*podGroupWithWlAnnotations[1].DeepCopy(),
+				*podGroupWithWlAnnotations[2].DeepCopy(),
+			},
+		},
+		"remote pod group cleanup preserves unlabelled member": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			managersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].DeepCopy(),
+			},
+			workerPods: []corev1.Pod{
+				*podGroupWithWl[0].DeepCopy(),
+				*podGroupWithWl[1].DeepCopy(),
+				*utiltestingpod.MakePod(podGroup[2].Obj().Name, TestNamespace).
+					UID("victim-uid").
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				return jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, managerClient, workerClient, adapter, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, groupWorkload, "origin1")
 			},
 			wantManagersPods: []corev1.Pod{
 				*podGroup[0].DeepCopy(),
 				*podGroup[1].DeepCopy(),
 				*podGroup[2].DeepCopy(),
+			},
+			wantWorkerPods: []corev1.Pod{
+				*utiltestingpod.MakePod(podGroup[2].Obj().Name, TestNamespace).
+					UID("victim-uid").
+					Obj(),
+			},
+		},
+		"remote pod group cleanup uses Workload context after manager Pods are finalized": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			workerPods: []corev1.Pod{
+				*podGroupWithWl[0].DeepCopy(),
+				*podGroupWithWl[1].DeepCopy(),
+				*utiltestingpod.MakePod(podGroup[2].Obj().Name, TestNamespace).
+					UID("victim-uid").
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				return jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, managerClient, workerClient, adapter, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, groupWorkload, "origin1")
+			},
+			wantWorkerPods: []corev1.Pod{
+				*utiltestingpod.MakePod(podGroup[2].Obj().Name, TestNamespace).
+					UID("victim-uid").
+					Obj(),
+			},
+		},
+		"remote pod group cleanup preserves member from another workload": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			managersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].DeepCopy(),
+			},
+			workerPods: []corev1.Pod{
+				*podGroupWithWl[0].DeepCopy(),
+				*podGroupWithWl[1].DeepCopy(),
+				*podGroupWithWl[2].Clone().
+					PrebuiltWorkloadLabel("another-workload").
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				return jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, managerClient, workerClient, adapter, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, groupWorkload, "origin1")
+			},
+			wantManagersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].DeepCopy(),
+			},
+			wantWorkerPods: []corev1.Pod{
+				*podGroupWithWl[2].Clone().
+					PrebuiltWorkloadLabel("another-workload").
+					Obj(),
+			},
+		},
+		"remote pod group cleanup preserves foreign anchor": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			managersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].DeepCopy(),
+			},
+			workerPods: []corev1.Pod{
+				*podGroupWithWl[0].Clone().PrebuiltWorkloadLabel("another-workload").Obj(),
+				*podGroupWithWl[1].Clone().PrebuiltWorkloadLabel("another-workload").Obj(),
+				*podGroupWithWl[2].Clone().PrebuiltWorkloadLabel("another-workload").Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				return jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, managerClient, workerClient, adapter, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, groupWorkload, "origin1")
+			},
+			wantManagersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].DeepCopy(),
+			},
+			wantWorkerPods: []corev1.Pod{
+				*podGroupWithWl[0].Clone().PrebuiltWorkloadLabel("another-workload").Obj(),
+				*podGroupWithWl[1].Clone().PrebuiltWorkloadLabel("another-workload").Obj(),
+				*podGroupWithWl[2].Clone().PrebuiltWorkloadLabel("another-workload").Obj(),
 			},
 		},
 		"sync creates missing remote pod, WorkloadIdentifierAnnotations enabled": {
@@ -374,7 +718,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync creates missing remote pods of the group, WorkloadIdentifierAnnotations enabled": {
-			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+			featureGates:     map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+			ignoreWorkerUIDs: true,
 			managersPods: []corev1.Pod{
 				*podGroupWithWlAnnotations[0].DeepCopy(),
 				*podGroupWithWlAnnotations[1].DeepCopy(),
@@ -401,14 +746,14 @@ func TestMultiKueueAdapter(t *testing.T) {
 			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			managerBuilder := utiltesting.NewClientBuilder().
 				WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge}).
-				WithIndex(&corev1.Pod{}, PodGroupNameCacheKey, IndexPodGroupName)
+				WithIndex(&corev1.Pod{}, multiKueuePodGroupNameCacheKey, indexMultiKueuePodGroupName)
 			managerBuilder = managerBuilder.WithLists(&corev1.PodList{Items: tc.managersPods})
 			managerBuilder = managerBuilder.WithStatusSubresource(slices.Map(tc.managersPods, func(w *corev1.Pod) client.Object { return w })...)
 			managerClient := managerBuilder.Build()
 
 			workerBuilder := utiltesting.NewClientBuilder().
 				WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge}).
-				WithIndex(&corev1.Pod{}, PodGroupNameCacheKey, IndexPodGroupName)
+				WithIndex(&corev1.Pod{}, multiKueuePodGroupNameCacheKey, indexMultiKueuePodGroupName)
 			workerBuilder = workerBuilder.WithLists(&corev1.PodList{Items: tc.workerPods})
 			workerClient := workerBuilder.Build()
 
@@ -435,10 +780,325 @@ func TestMultiKueueAdapter(t *testing.T) {
 			if err := workerClient.List(ctx, gotWorkerPods); err != nil {
 				t.Errorf("unexpected list worker's pod error %s", err)
 			} else {
-				if diff := cmp.Diff(tc.wantWorkerPods, gotWorkerPods.Items, objCheckOpts...); diff != "" {
+				workerCheckOpts := append(cmp.Options{}, objCheckOpts...)
+				if tc.ignoreWorkerUIDs {
+					workerCheckOpts = append(workerCheckOpts, cmpopts.IgnoreFields(metav1.ObjectMeta{}, "UID"))
+				}
+				if diff := cmp.Diff(tc.wantWorkerPods, gotWorkerPods.Items, workerCheckOpts...); diff != "" {
 					t.Errorf("unexpected worker's pod (-want/+got):\n%s", diff)
 				}
 			}
 		})
+	}
+}
+
+func TestMultiKueueWorkloadKeysForSurvivesFeatureGateChanges(t *testing.T) {
+	features.SetFeatureGatesDuringTest(t, map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false})
+	pod := utiltestingpod.MakePod("pod", TestNamespace).
+		PrebuiltWorkloadAnnotation("workload").
+		Obj()
+
+	got, err := (&multiKueueAdapter{}).WorkloadKeysFor(pod)
+	if err != nil {
+		t.Fatalf("WorkloadKeysFor() error = %v", err)
+	}
+	want := []types.NamespacedName{{Name: "workload", Namespace: TestNamespace}}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("WorkloadKeysFor() (-want,+got):\n%s", diff)
+	}
+}
+
+func TestDeleteRemotePodGroupPaginationKeepsAnchorForRetry(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	const (
+		groupName = "workload"
+		origin    = "origin"
+	)
+	anchor := utiltestingpod.MakePod("anchor", TestNamespace).
+		UID("anchor-uid").
+		GroupNameLabel(groupName).
+		PrebuiltWorkloadLabel(groupName).
+		Label(kueue.MultiKueueOriginLabel, origin).
+		Obj()
+	member1 := utiltestingpod.MakePod("member-1", TestNamespace).
+		UID("member-1-uid").
+		GroupNameLabel(groupName).
+		PrebuiltWorkloadLabel(groupName).
+		Label(kueue.MultiKueueOriginLabel, origin).
+		Obj()
+	member2 := utiltestingpod.MakePod("member-2", TestNamespace).
+		UID("member-2-uid").
+		GroupNameLabel(groupName).
+		PrebuiltWorkloadLabel(groupName).
+		Label(kueue.MultiKueueOriginLabel, origin).
+		Obj()
+	collision := utiltestingpod.MakePod("collision", TestNamespace).
+		UID("collision-uid").
+		GroupNameLabel(groupName).
+		PrebuiltWorkloadLabel("another-workload").
+		Label(kueue.MultiKueueOriginLabel, origin).
+		Obj()
+	foreignOrigin := utiltestingpod.MakePod("foreign-origin", TestNamespace).
+		UID("foreign-origin-uid").
+		GroupNameLabel(groupName).
+		PrebuiltWorkloadLabel(groupName).
+		Label(kueue.MultiKueueOriginLabel, "another-origin").
+		Obj()
+
+	baseClient := utiltesting.NewClientBuilder().WithObjects(anchor, member1, member2, collision, foreignOrigin).Build()
+	listCall := 0
+	pageErr := errors.New("second page unavailable")
+	workerClient := interceptor.NewClient(baseClient, interceptor.Funcs{
+		List: func(_ context.Context, _ client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+			listCall++
+			listOptions := &client.ListOptions{}
+			for _, opt := range opts {
+				opt.ApplyToList(listOptions)
+			}
+			if listOptions.Namespace != TestNamespace {
+				t.Errorf("List() namespace = %q, want %q", listOptions.Namespace, TestNamespace)
+			}
+			if listOptions.Limit != remotePodCleanupPageSize {
+				t.Errorf("List() limit = %d, want %d", listOptions.Limit, remotePodCleanupPageSize)
+			}
+			wantSelector := kueue.MultiKueueOriginLabel + "=" + origin
+			if listOptions.LabelSelector == nil || listOptions.LabelSelector.String() != wantSelector {
+				t.Errorf("List() selector = %v, want %q", listOptions.LabelSelector, wantSelector)
+			}
+			podList, ok := list.(*corev1.PodList)
+			if !ok {
+				t.Fatalf("List() object = %T, want *corev1.PodList", list)
+			}
+			switch listCall {
+			case 1:
+				*podList = corev1.PodList{
+					ListMeta: metav1.ListMeta{Continue: "page-2"},
+					Items:    []corev1.Pod{*anchor.DeepCopy(), *member1.DeepCopy()},
+				}
+			case 2:
+				if listOptions.Continue != "page-2" {
+					t.Errorf("second List() continue = %q, want page-2", listOptions.Continue)
+				}
+				return pageErr
+			case 3:
+				*podList = corev1.PodList{
+					ListMeta: metav1.ListMeta{Continue: "page-2"},
+					Items:    []corev1.Pod{*anchor.DeepCopy()},
+				}
+			case 4:
+				if listOptions.Continue != "page-2" {
+					t.Errorf("retry second List() continue = %q, want page-2", listOptions.Continue)
+				}
+				*podList = corev1.PodList{Items: []corev1.Pod{*member2.DeepCopy(), *collision.DeepCopy()}}
+			default:
+				t.Fatalf("unexpected List() call %d", listCall)
+			}
+			return nil
+		},
+	})
+
+	managerClient := utiltesting.NewClientBuilder().Build()
+	localWorkload := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+		Name:      groupName,
+		Namespace: TestNamespace,
+		Annotations: map[string]string{
+			podconstants.IsGroupWorkloadAnnotationKey: podconstants.IsGroupWorkloadAnnotationValue,
+		},
+	}}
+	adapter := &multiKueueAdapter{}
+	key := client.ObjectKeyFromObject(anchor)
+
+	err := jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, managerClient, workerClient, adapter, key, localWorkload, origin)
+	if !errors.Is(err, pageErr) {
+		t.Fatalf("first cleanup error = %v, want %v", err, pageErr)
+	}
+	if err := workerClient.Get(ctx, key, &corev1.Pod{}); err != nil {
+		t.Fatalf("anchor was deleted before all pages succeeded: %v", err)
+	}
+	if err := workerClient.Get(ctx, client.ObjectKeyFromObject(member1), &corev1.Pod{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("first-page member Get() error = %v, want NotFound", err)
+	}
+
+	if err := jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, managerClient, workerClient, adapter, key, localWorkload, origin); err != nil {
+		t.Fatalf("retry cleanup error = %v", err)
+	}
+	for _, deletedPod := range []*corev1.Pod{anchor, member1, member2} {
+		if err := workerClient.Get(ctx, client.ObjectKeyFromObject(deletedPod), &corev1.Pod{}); !apierrors.IsNotFound(err) {
+			t.Errorf("deleted Pod %q Get() error = %v, want NotFound", deletedPod.Name, err)
+		}
+	}
+	for _, preservedPod := range []*corev1.Pod{collision, foreignOrigin} {
+		got := &corev1.Pod{}
+		if err := workerClient.Get(ctx, client.ObjectKeyFromObject(preservedPod), got); err != nil {
+			t.Errorf("preserved Pod %q Get() error = %v", preservedPod.Name, err)
+		} else if got.UID != preservedPod.UID {
+			t.Errorf("preserved Pod %q UID = %q, want %q", preservedPod.Name, got.UID, preservedPod.UID)
+		}
+	}
+}
+
+func TestDeleteRemotePodGroupRejectsReplacementBeforePageDeletion(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	const (
+		groupName = "workload"
+		origin    = "origin"
+	)
+	makePod := func(name string, uid types.UID) *corev1.Pod {
+		return utiltestingpod.MakePod(name, TestNamespace).
+			UID(string(uid)).
+			GroupNameLabel(groupName).
+			PrebuiltWorkloadLabel(groupName).
+			Label(kueue.MultiKueueOriginLabel, origin).
+			Obj()
+	}
+	anchor := makePod("anchor", "anchor-uid")
+	member := makePod("member", "member-uid")
+	replacementAnchor := makePod(anchor.Name, "replacement-anchor-uid")
+	replacementMember := makePod(member.Name, "replacement-member-uid")
+
+	baseClient := utiltesting.NewClientBuilder().WithObjects(anchor, member).Build()
+	listCalled := false
+	workerClient := interceptor.NewClient(baseClient, interceptor.Funcs{
+		List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, _ ...client.ListOption) error {
+			if listCalled {
+				t.Fatal("unexpected second List() call")
+			}
+			listCalled = true
+			if err := c.Delete(ctx, anchor); err != nil {
+				return err
+			}
+			if err := c.Delete(ctx, member); err != nil {
+				return err
+			}
+			if err := c.Create(ctx, replacementAnchor); err != nil {
+				return err
+			}
+			if err := c.Create(ctx, replacementMember); err != nil {
+				return err
+			}
+			podList := list.(*corev1.PodList)
+			// Put the replacement member first to prove no page item is deleted
+			// before the anchor is revalidated.
+			podList.Items = []corev1.Pod{*replacementMember.DeepCopy(), *replacementAnchor.DeepCopy()}
+			return nil
+		},
+	})
+	localWorkload := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+		Name:      groupName,
+		Namespace: TestNamespace,
+		Annotations: map[string]string{
+			podconstants.IsGroupWorkloadAnnotationKey: podconstants.IsGroupWorkloadAnnotationValue,
+		},
+	}}
+
+	err := jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, utiltesting.NewClientBuilder().Build(), workerClient, &multiKueueAdapter{}, client.ObjectKeyFromObject(anchor), localWorkload, origin)
+	if !errors.Is(err, jobframework.ErrRemoteObjectNotOwnedByMultiKueue) {
+		t.Fatalf("cleanup error = %v, want %v", err, jobframework.ErrRemoteObjectNotOwnedByMultiKueue)
+	}
+	for _, replacement := range []*corev1.Pod{replacementAnchor, replacementMember} {
+		got := &corev1.Pod{}
+		if err := workerClient.Get(ctx, client.ObjectKeyFromObject(replacement), got); err != nil {
+			t.Fatalf("replacement Pod %q Get() error = %v", replacement.Name, err)
+		}
+		if got.UID != replacement.UID {
+			t.Fatalf("replacement Pod %q UID = %q, want %q", replacement.Name, got.UID, replacement.UID)
+		}
+	}
+}
+
+func TestDeleteRemotePodUsesUIDPrecondition(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	key := types.NamespacedName{Name: "pod", Namespace: TestNamespace}
+	original := utiltestingpod.MakePod(key.Name, key.Namespace).
+		UID("original-uid").
+		PrebuiltWorkloadLabel("workload").
+		Label(kueue.MultiKueueOriginLabel, "origin").
+		Obj()
+	replacement := original.DeepCopy()
+	replacement.UID = "replacement-uid"
+
+	baseClient := utiltesting.NewClientBuilder().WithObjects(original).Build()
+	workerClient := interceptor.NewClient(baseClient, interceptor.Funcs{
+		Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			deleteOptions := &client.DeleteOptions{}
+			for _, opt := range opts {
+				opt.ApplyToDelete(deleteOptions)
+			}
+			if deleteOptions.Preconditions == nil || deleteOptions.Preconditions.UID == nil || *deleteOptions.Preconditions.UID != original.UID {
+				t.Errorf("Delete() UID precondition = %v, want %q", deleteOptions.Preconditions, original.UID)
+			}
+			if err := c.Delete(ctx, obj); err != nil {
+				return err
+			}
+			if err := c.Create(ctx, replacement); err != nil {
+				return err
+			}
+			return apierrors.NewConflict(schema.GroupResource{Resource: "pods"}, key.Name, errors.New("UID precondition failed"))
+		},
+	})
+
+	adapter := &multiKueueAdapter{}
+	managerClient := utiltesting.NewClientBuilder().WithObjects(utiltestingpod.MakePod(key.Name, key.Namespace).Obj()).Build()
+	err := adapter.DeleteRemoteObject(ctx, managerClient, workerClient, key)
+	if !apierrors.IsConflict(err) {
+		t.Fatalf("DeleteRemoteObject() error = %v, want conflict", err)
+	}
+	got := &corev1.Pod{}
+	if err := workerClient.Get(ctx, key, got); err != nil {
+		t.Fatalf("Get() replacement Pod: %v", err)
+	}
+	if got.UID != replacement.UID {
+		t.Fatalf("replacement Pod UID = %q, want %q", got.UID, replacement.UID)
+	}
+}
+
+func TestDeleteRemotePodRejectsReplacementBeforeAdapterCleanup(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	key := types.NamespacedName{Name: "pod", Namespace: TestNamespace}
+	original := utiltestingpod.MakePod(key.Name, key.Namespace).
+		UID("original-uid").
+		PrebuiltWorkloadLabel("workload").
+		Label(kueue.MultiKueueOriginLabel, "origin").
+		Obj()
+	replacement := original.DeepCopy()
+	replacement.UID = "replacement-uid"
+
+	getCount := 0
+	deleteCalled := false
+	baseClient := utiltesting.NewClientBuilder().WithObjects(original).Build()
+	workerClient := interceptor.NewClient(baseClient, interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			getCount++
+			if getCount == 2 {
+				if err := c.Delete(ctx, original); err != nil {
+					return err
+				}
+				if err := c.Create(ctx, replacement); err != nil {
+					return err
+				}
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+		Delete: func(context.Context, client.WithWatch, client.Object, ...client.DeleteOption) error {
+			deleteCalled = true
+			return nil
+		},
+	})
+
+	managerClient := utiltesting.NewClientBuilder().WithObjects(utiltestingpod.MakePod(key.Name, key.Namespace).Obj()).Build()
+	adapter := &multiKueueAdapter{}
+	err := adapter.DeleteRemoteObject(ctx, managerClient, workerClient, key)
+	if !errors.Is(err, jobframework.ErrRemoteObjectNotOwnedByMultiKueue) {
+		t.Fatalf("DeleteRemoteObject() error = %v, want %v", err, jobframework.ErrRemoteObjectNotOwnedByMultiKueue)
+	}
+	if deleteCalled {
+		t.Fatal("Delete() called for a replacement Pod")
+	}
+	got := &corev1.Pod{}
+	if err := workerClient.Get(ctx, key, got); err != nil {
+		t.Fatalf("Get() replacement Pod: %v", err)
+	}
+	if got.UID != replacement.UID {
+		t.Fatalf("replacement Pod UID = %q, want %q", got.UID, replacement.UID)
 	}
 }

--- a/pkg/controller/jobs/pod/pod_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/pod/pod_multikueue_adapter_test.go
@@ -590,7 +590,15 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*workerPodGroupWithAnnotations[2].DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, managerClient, workerClient, adapter, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, groupWorkload, "origin1")
+				return jobframework.DeleteRemoteObjectForWorkloadIfOwned(
+					ctx,
+					managerClient,
+					workerClient,
+					adapter,
+					types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace},
+					groupWorkload,
+					"origin1",
+				)
 			},
 			wantManagersPods: []corev1.Pod{
 				*podGroupWithWlAnnotations[0].DeepCopy(),

--- a/test/integration/multikueue/pod_test.go
+++ b/test/integration/multikueue/pod_test.go
@@ -33,8 +33,10 @@ import (
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	workloadpod "sigs.k8s.io/kueue/pkg/controller/jobs/pod"
 	"sigs.k8s.io/kueue/pkg/util/admissioncheck"
+	utilapi "sigs.k8s.io/kueue/pkg/util/api"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
@@ -275,6 +277,96 @@ var _ = ginkgo.Describe("MultiKueue Pod", ginkgo.Label("area:multikueue", "featu
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			}
 			waitForWorkloadToFinishAndRemoteWorkloadToBeDeleted(wlLookupKey, "Pods succeeded: 3/3.")
+		})
+	})
+
+	ginkgo.It("Should preserve a colliding worker PodGroup member", func() {
+		groupName := "collision-group"
+		podGroup := testingpod.MakePod(groupName, f.managerNs.Name).
+			Queue(f.managerLq.Name).
+			ManagedByKueueLabel().
+			KueueFinalizer().
+			KueueSchedulingGate().
+			MakeGroup(3)
+		for _, pod := range podGroup {
+			util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, pod)
+		}
+
+		wlKey := types.NamespacedName{Name: groupName, Namespace: f.managerNs.Name}
+		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).
+			PodSets(utiltestingapi.MakePodSetAssignment("bf90803c").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Count(3).Obj()).
+			Obj()
+
+		ginkgo.By("dispatching the Workload before the worker admits it", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlKey, &kueue.Workload{})).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			util.SetQuotaReservation(managerTestCluster.ctx, managerTestCluster.client, wlKey, admission)
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, wlKey, &kueue.Workload{})).To(gomega.Succeed())
+				g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, wlKey, &kueue.Workload{})).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		victimKey := client.ObjectKeyFromObject(podGroup[2])
+		victim := testingpod.MakePod(victimKey.Name, victimKey.Namespace).Obj()
+		util.MustCreate(worker1TestCluster.ctx, worker1TestCluster.client, victim)
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, victimKey, victim)).To(gomega.Succeed())
+			victim.Status.Phase = corev1.PodRunning
+			g.Expect(worker1TestCluster.client.Status().Update(worker1TestCluster.ctx, victim)).To(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		victimUID := victim.UID
+		for i := range 2 {
+			remotePod := &corev1.Pod{
+				ObjectMeta: utilapi.CloneObjectMetaForCreation(&podGroup[i].ObjectMeta),
+				Spec:       *podGroup[i].Spec.DeepCopy(),
+			}
+			jobframework.SetMultiKueueMeta(remotePod, groupName, "multikueue")
+			util.MustCreate(worker1TestCluster.ctx, worker1TestCluster.client, remotePod)
+		}
+
+		ginkgo.By("admitting the worker Workload and rejecting the colliding member", func() {
+			util.SetQuotaReservation(worker1TestCluster.ctx, worker1TestCluster.client, wlKey, admission)
+			gomega.Eventually(func(g gomega.Gomega) {
+				remoteAnchor := &corev1.Pod{}
+				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, client.ObjectKeyFromObject(podGroup[0]), remoteAnchor)).To(gomega.Succeed())
+				remoteAnchor.Status.Phase = corev1.PodRunning
+				g.Expect(worker1TestCluster.client.Status().Update(worker1TestCluster.ctx, remoteAnchor)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			gomega.Eventually(func(g gomega.Gomega) {
+				managerAnchor := &corev1.Pod{}
+				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, client.ObjectKeyFromObject(podGroup[0]), managerAnchor)).To(gomega.Succeed())
+				g.Expect(managerAnchor.Status.Phase).To(gomega.Equal(corev1.PodRunning))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			gomega.Consistently(func(g gomega.Gomega) {
+				managerPod := &corev1.Pod{}
+				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, victimKey, managerPod)).To(gomega.Succeed())
+				g.Expect(managerPod.Status.Phase).NotTo(gomega.Equal(corev1.PodRunning))
+				workerPod := &corev1.Pod{}
+				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, victimKey, workerPod)).To(gomega.Succeed())
+				g.Expect(workerPod.UID).To(gomega.Equal(victimUID))
+			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("cleaning up legitimate remote objects without deleting the victim", func() {
+			util.SetQuotaReservation(managerTestCluster.ctx, managerTestCluster.client, wlKey, nil)
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, wlKey, &kueue.Workload{})).To(utiltesting.BeNotFoundError())
+				anchor := &corev1.Pod{}
+				if err := worker1TestCluster.client.Get(worker1TestCluster.ctx, client.ObjectKeyFromObject(podGroup[0]), anchor); err == nil {
+					// The worker Pod controller can keep a malformed group's Pods in
+					// Terminating while it reports that the group has too few runnable
+					// members. A deletion timestamp is sufficient to prove MultiKueue
+					// targeted the legitimate anchor for cleanup.
+					g.Expect(anchor.DeletionTimestamp.IsZero()).To(gomega.BeFalse())
+				} else {
+					g.Expect(err).To(utiltesting.BeNotFoundError())
+				}
+				workerPod := &corev1.Pod{}
+				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, victimKey, workerPod)).To(gomega.Succeed())
+				g.Expect(workerPod.UID).To(gomega.Equal(victimUID))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area multikueue

#### What this PR does / why we need it:

MultiKueue previously validated only one PodGroup anchor before copying status from or deleting other same-named worker Pods. This change:

- validates each remote member against the expected origin, Workload, and PodGroup;
- separates migration-aware identifiers from ordinary PodGroup indexing;
- uses UID-preconditioned, origin-filtered, paginated cleanup with anchor-last retry safety;
- binds garbage-collection Pod cleanup to the remote Workload owner UID and protects Workload deletion with a UID precondition;
- preserves watch routing across identifier feature-gate transitions.

Scope note: these checks prevent unlabelled or mismatched same-name collisions and within-operation UID replacement. Mutable metadata remains association evidence, not proof of creation; exact worker-forged metadata and persisted remote identities are a separate follow-up.

This change was developed with AI assistance; I reviewed and tested every change.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

Verification:

- go test ./pkg/controller/jobframework ./pkg/controller/admissionchecks/multikueue/... ./pkg/controller/jobs/... -count=1
- go test -race ./pkg/controller/jobframework ./pkg/controller/jobs/pod ./pkg/controller/admissionchecks/multikueue -count=1
- go vet ./pkg/controller/jobframework ./pkg/controller/admissionchecks/multikueue/... ./pkg/controller/jobs/...
- go test ./test/integration/multikueue -run ^$ -count=1
- three-cluster Ginkgo integration under the race detector: 1 passed, 70 skipped, 0 failed

Independent security, structure, and regression-test reviews found no shipping blockers for this scoped collision hardening.

#### Does this PR introduce a user-facing change?

```release-note
MultiKueue now validates each remote PodGroup member against the expected Workload and PodGroup before synchronizing status or deleting it.
```