### PR TITLE
multikueue: require explicit worker namespace binding

### DIFF
--- a/apis/kueue/v1beta1/multikueue_types.go
+++ b/apis/kueue/v1beta1/multikueue_types.go
@@ -28,6 +28,11 @@ const (
 	// of multikueue remote objects.
 	MultiKueueOriginLabel = "kueue.x-k8s.io/multikueue-origin"
 
+	// MultiKueueAllowedManagerNamespaceUIDsAnnotation is set on a worker
+	// Namespace to authorize same-named manager Namespaces by UID. The value is
+	// a JSON array of Kubernetes Namespace UIDs.
+	MultiKueueAllowedManagerNamespaceUIDsAnnotation = "kueue.x-k8s.io/multikueue-allowed-manager-namespace-uids"
+
 	// MultiKueueControllerName is the name used by the MultiKueue
 	// admission check controller.
 	MultiKueueControllerName = "kueue.x-k8s.io/multikueue"

--- a/apis/kueue/v1beta2/multikueue_types.go
+++ b/apis/kueue/v1beta2/multikueue_types.go
@@ -32,6 +32,11 @@ const (
 	// the management cluster on remote objects.
 	MultiKueueOriginUIDAnnotation = "kueue.x-k8s.io/multikueue-origin-uid"
 
+	// MultiKueueAllowedManagerNamespaceUIDsAnnotation is set on a worker
+	// Namespace to authorize same-named manager Namespaces by UID. The value is
+	// a JSON array of Kubernetes Namespace UIDs.
+	MultiKueueAllowedManagerNamespaceUIDsAnnotation = "kueue.x-k8s.io/multikueue-allowed-manager-namespace-uids"
+
 	// MultiKueueControllerName is the name used by the MultiKueue
 	// admission check controller.
 	MultiKueueControllerName = "kueue.x-k8s.io/multikueue"

--- a/keps/693-multikueue/README.md
+++ b/keps/693-multikueue/README.md
@@ -255,6 +255,28 @@ Worker ClusterQueue definitions may be different than in the management cluster.
 quota settings may be specific to the given location. And/or cluster queue may have different
 admission checks, use ProvisioningRequest, etc.
 
+The same namespace name also defines a trust relationship. Remote Jobs preserve
+namespaced references from the manager Job, but Kubernetes resolves those
+references in the worker namespace. Consequently, manager users who can submit
+MultiKueue workloads must be trusted to use same-named worker ServiceAccounts,
+Secrets, ConfigMaps, image pull secrets, persistent volume claims, and other
+namespaced dependencies.
+
+The worker administrator authorizes this relationship by setting the
+`kueue.x-k8s.io/multikueue-allowed-manager-namespace-uids` annotation on the
+worker Namespace to a JSON array containing the same-named manager Namespace
+UID. MultiKueue checks the binding before creating a remote Workload and again
+before reading or creating an executable remote object. Namespace UIDs prevent
+a deleted and recreated manager Namespace from inheriting the old
+authorization. Removing the binding stops remote status synchronization and
+new object creation, while cleanup of previously dispatched objects remains
+allowed.
+Multi-tenant installations must additionally use dedicated namespace pairs and
+worker admission policy to enforce this equivalence; the cluster-wide example
+credential alone does not provide namespace isolation. The
+`MultiKueueAllowUnboundWorkerNamespaces` feature gate restores the legacy
+name-only behavior for compatibility and is disabled by default.
+
 ### Subcomponents
 
 #### MultiKueueCluster Controller

--- a/pkg/controller/admissionchecks/multikueue/controllers.go
+++ b/pkg/controller/admissionchecks/multikueue/controllers.go
@@ -176,7 +176,7 @@ func SetupControllers(mgr ctrl.Manager, namespace string, opts ...SetupOption) e
 		}
 	}
 
-	wlRec := newWlReconciler(mgr.GetClient(), helper, cRec, options.origin, mgr.GetEventRecorder(constants.WorkloadControllerName),
+	wlRec := newWlReconciler(mgr.GetClient(), mgr.GetAPIReader(), helper, cRec, options.origin, mgr.GetEventRecorder(constants.WorkloadControllerName),
 		options.workerLostTimeout, options.eventsBatchPeriod, options.adapters, options.dispatcherName, options.roleTracker)
 	return wlRec.setupWithManager(mgr)
 }

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -18,6 +18,7 @@ package multikueue
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"slices"
@@ -28,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -67,6 +69,8 @@ import (
 var (
 	realClock                      = clock.RealClock{}
 	singleClusterPreemptionTimeout = 5 * time.Minute
+
+	errWorkerNamespaceNotBound = errors.New("worker Namespace is not bound to the manager Namespace")
 )
 
 // syncDeferredRequeueAfter is the delay used to re-reconcile a workload after
@@ -89,18 +93,19 @@ var (
 const syncDeferredRequeueAfter = 2 * time.Second
 
 type wlReconciler struct {
-	client            client.Client
-	helper            *admissioncheck.MultiKueueStoreHelper
-	clusters          *clustersReconciler
-	origin            string
-	workerLostTimeout time.Duration
-	deletedWlCache    *utilmaps.SyncMap[string, *kueue.Workload]
-	eventsBatchPeriod time.Duration
-	adapters          map[string]jobframework.MultiKueueAdapter
-	recorder          events.EventRecorder
-	clock             clock.Clock
-	dispatcherName    string
-	roleTracker       *roletracker.RoleTracker
+	client                 client.Client
+	managerNamespaceReader client.Reader
+	helper                 *admissioncheck.MultiKueueStoreHelper
+	clusters               *clustersReconciler
+	origin                 string
+	workerLostTimeout      time.Duration
+	deletedWlCache         *utilmaps.SyncMap[string, *kueue.Workload]
+	eventsBatchPeriod      time.Duration
+	adapters               map[string]jobframework.MultiKueueAdapter
+	recorder               events.EventRecorder
+	clock                  clock.Clock
+	dispatcherName         string
+	roleTracker            *roletracker.RoleTracker
 }
 
 var _ reconcile.Reconciler = (*wlReconciler)(nil)
@@ -117,6 +122,222 @@ type wlGroup struct {
 }
 
 type Option func(reconciler *wlReconciler)
+
+func validateWorkerNamespaceBinding(ctx context.Context, managerReader, workerReader client.Reader, namespace string) error {
+	if features.Enabled(features.MultiKueueAllowUnboundWorkerNamespaces) {
+		ctrl.LoggerFrom(ctx).V(4).Info("Allowing an unbound worker Namespace because the MultiKueueAllowUnboundWorkerNamespaces feature gate is enabled", "namespace", namespace)
+		return nil
+	}
+
+	managerNamespace := &corev1.Namespace{}
+	if err := managerReader.Get(ctx, types.NamespacedName{Name: namespace}, managerNamespace); err != nil {
+		return fmt.Errorf("%w: reading manager Namespace %q: %w", errWorkerNamespaceNotBound, namespace, err)
+	}
+	if managerNamespace.UID == "" {
+		return fmt.Errorf("%w: manager Namespace %q has no UID", errWorkerNamespaceNotBound, namespace)
+	}
+
+	workerNamespace := &corev1.Namespace{}
+	if err := workerReader.Get(ctx, types.NamespacedName{Name: namespace}, workerNamespace); err != nil {
+		return fmt.Errorf("%w: reading worker Namespace %q: %w", errWorkerNamespaceNotBound, namespace, err)
+	}
+
+	rawAllowedUIDs := workerNamespace.Annotations[kueue.MultiKueueAllowedManagerNamespaceUIDsAnnotation]
+	if rawAllowedUIDs == "" {
+		return fmt.Errorf("%w: worker Namespace %q is missing annotation %q", errWorkerNamespaceNotBound, namespace, kueue.MultiKueueAllowedManagerNamespaceUIDsAnnotation)
+	}
+
+	var allowedUIDs []types.UID
+	if err := json.Unmarshal([]byte(rawAllowedUIDs), &allowedUIDs); err != nil {
+		return fmt.Errorf("%w: worker Namespace %q has malformed annotation %q: %w", errWorkerNamespaceNotBound, namespace, kueue.MultiKueueAllowedManagerNamespaceUIDsAnnotation, err)
+	}
+	if !slices.Contains(allowedUIDs, managerNamespace.UID) {
+		return fmt.Errorf("%w: worker Namespace %q does not authorize manager Namespace UID %q", errWorkerNamespaceNotBound, namespace, managerNamespace.UID)
+	}
+	return nil
+}
+
+// namespaceAuthorizingClient protects remote reads and non-cleanup writes,
+// including adapters that create multiple objects or re-check existence
+// internally. Cleanup intentionally uses the underlying worker client.
+type namespaceAuthorizingClient struct {
+	delegate               client.Client
+	managerNamespaceReader client.Reader
+}
+
+var _ client.Client = (*namespaceAuthorizingClient)(nil)
+
+func (c *namespaceAuthorizingClient) authorizeNamespace(ctx context.Context, namespace, operation string) error {
+	if namespace == "" {
+		return nil
+	}
+	if err := validateWorkerNamespaceBinding(ctx, c.managerNamespaceReader, c.delegate, namespace); err != nil {
+		return fmt.Errorf("authorizing worker Namespace before %s: %w", operation, err)
+	}
+	return nil
+}
+
+func (c *namespaceAuthorizingClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if err := c.authorizeNamespace(ctx, key.Namespace, fmt.Sprintf("reading %T %q", obj, key)); err != nil {
+		return err
+	}
+	return c.delegate.Get(ctx, key, obj, opts...)
+}
+
+func (c *namespaceAuthorizingClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	listOptions := &client.ListOptions{}
+	for _, opt := range opts {
+		opt.ApplyToList(listOptions)
+	}
+	if listOptions.Namespace == "" {
+		return fmt.Errorf("authorizing worker Namespace before listing %T: an explicit Namespace is required", list)
+	}
+	if err := c.authorizeNamespace(ctx, listOptions.Namespace, fmt.Sprintf("listing %T", list)); err != nil {
+		return err
+	}
+	return c.delegate.List(ctx, list, opts...)
+}
+
+func (c *namespaceAuthorizingClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if err := c.authorizeNamespace(ctx, obj.GetNamespace(), fmt.Sprintf("creating %T %q", obj, client.ObjectKeyFromObject(obj))); err != nil {
+		return err
+	}
+	return c.delegate.Create(ctx, obj, opts...)
+}
+
+func (c *namespaceAuthorizingClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	if err := c.authorizeNamespace(ctx, obj.GetNamespace(), fmt.Sprintf("deleting %T %q", obj, client.ObjectKeyFromObject(obj))); err != nil {
+		return err
+	}
+	return c.delegate.Delete(ctx, obj, opts...)
+}
+
+func (c *namespaceAuthorizingClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	if err := c.authorizeNamespace(ctx, obj.GetNamespace(), fmt.Sprintf("updating %T %q", obj, client.ObjectKeyFromObject(obj))); err != nil {
+		return err
+	}
+	return c.delegate.Update(ctx, obj, opts...)
+}
+
+func (c *namespaceAuthorizingClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	if err := c.authorizeNamespace(ctx, obj.GetNamespace(), fmt.Sprintf("patching %T %q", obj, client.ObjectKeyFromObject(obj))); err != nil {
+		return err
+	}
+	return c.delegate.Patch(ctx, obj, patch, opts...)
+}
+
+type applyConfigurationWithNamespace interface {
+	GetNamespace() *string
+}
+
+func (c *namespaceAuthorizingClient) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
+	withNamespace, ok := obj.(applyConfigurationWithNamespace)
+	if !ok {
+		return fmt.Errorf("authorizing worker Namespace before applying %T: cannot determine Namespace", obj)
+	}
+	if namespace := withNamespace.GetNamespace(); namespace != nil {
+		if err := c.authorizeNamespace(ctx, *namespace, fmt.Sprintf("applying %T", obj)); err != nil {
+			return err
+		}
+	}
+	return c.delegate.Apply(ctx, obj, opts...)
+}
+
+func (c *namespaceAuthorizingClient) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
+	deleteOptions := (&client.DeleteAllOfOptions{}).ApplyOptions(opts)
+	if deleteOptions.Namespace == "" {
+		return fmt.Errorf("authorizing worker Namespace before deleting all %T: an explicit Namespace is required", obj)
+	}
+	if err := c.authorizeNamespace(ctx, deleteOptions.Namespace, fmt.Sprintf("deleting all %T", obj)); err != nil {
+		return err
+	}
+	return c.delegate.DeleteAllOf(ctx, obj, opts...)
+}
+
+type namespaceAuthorizingSubResourceClient struct {
+	delegate client.SubResourceClient
+	parent   *namespaceAuthorizingClient
+}
+
+var _ client.SubResourceClient = (*namespaceAuthorizingSubResourceClient)(nil)
+
+func (c *namespaceAuthorizingSubResourceClient) Get(ctx context.Context, obj client.Object, subResource client.Object, opts ...client.SubResourceGetOption) error {
+	if err := c.parent.authorizeNamespace(ctx, obj.GetNamespace(), fmt.Sprintf("reading a subresource of %T %q", obj, client.ObjectKeyFromObject(obj))); err != nil {
+		return err
+	}
+	return c.delegate.Get(ctx, obj, subResource, opts...)
+}
+
+func (c *namespaceAuthorizingSubResourceClient) Create(ctx context.Context, obj client.Object, subResource client.Object, opts ...client.SubResourceCreateOption) error {
+	if err := c.parent.authorizeNamespace(ctx, obj.GetNamespace(), fmt.Sprintf("creating a subresource of %T %q", obj, client.ObjectKeyFromObject(obj))); err != nil {
+		return err
+	}
+	return c.delegate.Create(ctx, obj, subResource, opts...)
+}
+
+func (c *namespaceAuthorizingSubResourceClient) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	if err := c.parent.authorizeNamespace(ctx, obj.GetNamespace(), fmt.Sprintf("updating a subresource of %T %q", obj, client.ObjectKeyFromObject(obj))); err != nil {
+		return err
+	}
+	return c.delegate.Update(ctx, obj, opts...)
+}
+
+func (c *namespaceAuthorizingSubResourceClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+	if err := c.parent.authorizeNamespace(ctx, obj.GetNamespace(), fmt.Sprintf("patching a subresource of %T %q", obj, client.ObjectKeyFromObject(obj))); err != nil {
+		return err
+	}
+	return c.delegate.Patch(ctx, obj, patch, opts...)
+}
+
+func (c *namespaceAuthorizingSubResourceClient) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
+	withNamespace, ok := obj.(applyConfigurationWithNamespace)
+	if !ok {
+		return fmt.Errorf("authorizing worker Namespace before applying a subresource of %T: cannot determine Namespace", obj)
+	}
+	if namespace := withNamespace.GetNamespace(); namespace != nil {
+		if err := c.parent.authorizeNamespace(ctx, *namespace, fmt.Sprintf("applying a subresource of %T", obj)); err != nil {
+			return err
+		}
+	}
+	return c.delegate.Apply(ctx, obj, opts...)
+}
+
+func (c *namespaceAuthorizingClient) Status() client.SubResourceWriter {
+	return c.SubResource("status")
+}
+
+func (c *namespaceAuthorizingClient) SubResource(subResource string) client.SubResourceClient {
+	return &namespaceAuthorizingSubResourceClient{
+		delegate: c.delegate.SubResource(subResource),
+		parent:   c,
+	}
+}
+
+func (c *namespaceAuthorizingClient) Scheme() *runtime.Scheme {
+	return c.delegate.Scheme()
+}
+
+func (c *namespaceAuthorizingClient) RESTMapper() apimeta.RESTMapper {
+	return c.delegate.RESTMapper()
+}
+
+func (c *namespaceAuthorizingClient) GroupVersionKindFor(obj runtime.Object) (schema.GroupVersionKind, error) {
+	return c.delegate.GroupVersionKindFor(obj)
+}
+
+func (c *namespaceAuthorizingClient) IsObjectNamespaced(obj runtime.Object) (bool, error) {
+	return c.delegate.IsObjectNamespaced(obj)
+}
+
+func (w *wlReconciler) namespaceAuthorizingClient(workerClient client.Client) client.Client {
+	if features.Enabled(features.MultiKueueAllowUnboundWorkerNamespaces) {
+		return workerClient
+	}
+	return &namespaceAuthorizingClient{
+		delegate:               workerClient,
+		managerNamespaceReader: w.managerNamespaceReader,
+	}
+}
 
 func WithClock(_ testing.TB, c clock.Clock) Option {
 	return func(r *wlReconciler) {
@@ -394,8 +615,24 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 		return reconcile.Result{}, errors.Join(errs...)
 	}
 
+	// Remote Workloads remain visible through the raw client so cleanup can run
+	// after revocation, but their spec and status must not influence any manager
+	// decision unless the worker Namespace is still authorized.
+	for remote, remoteWl := range group.remotes {
+		if remoteWl == nil {
+			continue
+		}
+		if err := validateWorkerNamespaceBinding(ctx, w.managerNamespaceReader, group.remoteClients[remote].getClient(), group.local.Namespace); err != nil {
+			return reconcile.Result{}, fmt.Errorf("authorizing worker Namespace for cluster %q before using remote Workload: %w", remote, err)
+		}
+	}
+
 	// 3. Finish the local workload when the remote workload is finished.
 	if remoteFinishedCond, remote := group.bestMatchByCondition(kueue.WorkloadFinished); remoteFinishedCond != nil {
+		remoteCl := w.namespaceAuthorizingClient(group.remoteClients[remote].getClient())
+		if err := validateWorkerNamespaceBinding(ctx, w.managerNamespaceReader, remoteCl, group.local.Namespace); err != nil {
+			return reconcile.Result{}, fmt.Errorf("authorizing worker Namespace for cluster %q before using remote Workload status: %w", remote, err)
+		}
 		// A remote OutOfSync finish is a sync failure, not a job completion: reset to Retry to
 		// re-dispatch rather than finishing (which would strand the manager Job). Always return so
 		// it never falls through to Finish; patch only while still Ready so a re-reconcile can't
@@ -418,7 +655,6 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 		// it should not be problematic, but the "From remote xxxx:" could be lost ....
 
 		if group.jobAdapter != nil {
-			remoteCl := group.remoteClients[remote].getClient()
 			if _, err := jobframework.ValidateRemoteObjectOwnership(ctx, remoteCl, group.controllerKey, group.jobAdapter.GVK(), w.origin); err != nil {
 				log.Error(err, "validating remote controller object", "workerCluster", remote)
 				return reconcile.Result{}, err
@@ -442,7 +678,10 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 	// 4. Handle workload eviction
 	remoteEvictCond, evictedRemote := group.bestMatchByCondition(kueue.WorkloadEvicted)
 	if remoteEvictCond != nil {
-		remoteCl := group.remoteClients[evictedRemote].getClient()
+		remoteCl := w.namespaceAuthorizingClient(group.remoteClients[evictedRemote].getClient())
+		if err := validateWorkerNamespaceBinding(ctx, w.managerNamespaceReader, remoteCl, group.local.Namespace); err != nil {
+			return reconcile.Result{}, fmt.Errorf("authorizing worker Namespace for cluster %q before using remote Workload status: %w", evictedRemote, err)
+		}
 		remoteWl := group.remotes[evictedRemote]
 
 		log = log.WithValues("remote", evictedRemote, "remoteWorkload", klog.KObj(remoteWl))
@@ -499,7 +738,7 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 				remotePreemptionGates = remWl.Spec.PreemptionGates
 			}
 
-			remClient := group.remoteClients[rem]
+			remoteCl := w.namespaceAuthorizingClient(group.remoteClients[rem].getClient())
 
 			updateRemote := false
 
@@ -522,7 +761,7 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 					remWl.Spec.PreemptionGates = remotePreemptionGates
 				}
 
-				if err := remClient.getClient().Update(ctx, remWl); err != nil {
+				if err := remoteCl.Update(ctx, remWl); err != nil {
 					return reconcile.Result{}, fmt.Errorf("failed to update remote workload: %w", err)
 				}
 				continue
@@ -551,6 +790,11 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 	//     of sync): the admitted remote is gone, so retry immediately.
 	if remoteCond == nil && acs.State == kueue.CheckStateReady {
 		admitting := ptr.Deref(group.local.Status.ClusterName, "")
+		if remoteClient, found := group.remoteClients[admitting]; found {
+			if err := validateWorkerNamespaceBinding(ctx, w.managerNamespaceReader, remoteClient.getClient(), group.local.Namespace); err != nil {
+				return reconcile.Result{}, fmt.Errorf("authorizing worker Namespace for cluster %q before handling its missing admitted status: %w", admitting, err)
+			}
+		}
 		if admitting != "" && slices.Contains(group.unavailableClusters, admitting) {
 			lostSince := w.admittingWorkerLostSince(admitting)
 			if remainingWaitTime := w.workerLostTimeout - w.clock.Since(lostSince); remainingWaitTime > 0 {
@@ -582,7 +826,10 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 			}
 		}
 
-		remoteCl := group.remoteClients[admittingRemote].getClient()
+		remoteCl := w.namespaceAuthorizingClient(group.remoteClients[admittingRemote].getClient())
+		if err := validateWorkerNamespaceBinding(ctx, w.managerNamespaceReader, remoteCl, group.local.Namespace); err != nil {
+			return reconcile.Result{}, fmt.Errorf("authorizing worker Namespace for cluster %q before using remote Workload status: %w", admittingRemote, err)
+		}
 		remoteWl := group.remotes[admittingRemote]
 
 		log = log.WithValues("remote", admittingRemote, "remoteWorkload", klog.KObj(remoteWl))
@@ -641,9 +888,9 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 		remWlName, requeueIn := w.workloadToOpenPreemptionGate(ctx, group)
 		if remWlName != nil {
 			remWl := group.remotes[*remWlName]
-			remClient := group.remoteClients[*remWlName]
+			remoteCl := w.namespaceAuthorizingClient(group.remoteClients[*remWlName].getClient())
 			workload.OpenPreemptionGate(remWl, constants.MultiKueuePreemptionGate, metav1.NewTime(w.clock.Now()))
-			if err := remClient.getClient().Status().Update(ctx, remWl); err != nil {
+			if err := remoteCl.Status().Update(ctx, remWl); err != nil {
 				return reconcile.Result{}, fmt.Errorf("failed to update remote workload: %w", err)
 			}
 		}
@@ -817,9 +1064,10 @@ func (w *wlReconciler) syncToSingleCluster(ctx context.Context, log klog.Logger,
 		if clusterName == targetCluster {
 			if remoteWl == nil {
 				clone := cloneForCreate(group.local, group.remoteClients[clusterName].origin, false)
-				if err := group.remoteClients[clusterName].getClient().Create(ctx, clone); err != nil {
+				remoteCl := w.namespaceAuthorizingClient(group.remoteClients[clusterName].getClient())
+				if err := remoteCl.Create(ctx, clone); err != nil {
 					log.V(2).Error(err, "creating remote workload", "cluster", clusterName)
-					errs = append(errs, err)
+					errs = append(errs, fmt.Errorf("creating remote Workload in cluster %q: %w", clusterName, err))
 				} else {
 					metrics.ReportMultiKueueWorkloadDispatched(admittedClusterQueue(group.local), clusterName, w.roleTracker)
 				}
@@ -939,9 +1187,10 @@ func (w *wlReconciler) nominateAndSynchronizeWorkers(ctx context.Context, group 
 		if slices.Contains(nominatedWorkers, rem) {
 			if remoteWl == nil {
 				clone := cloneForCreate(group.local, group.remoteClients[rem].origin, true)
-				if err := group.remoteClients[rem].getClient().Create(ctx, clone); err != nil {
+				remoteCl := w.namespaceAuthorizingClient(group.remoteClients[rem].getClient())
+				if err := remoteCl.Create(ctx, clone); err != nil {
 					log.V(2).Error(err, "creating remote object", "remote", rem)
-					errs = append(errs, err)
+					errs = append(errs, fmt.Errorf("creating remote Workload in cluster %q: %w", rem, err))
 				} else {
 					metrics.ReportMultiKueueWorkloadDispatched(admittedClusterQueue(group.local), rem, w.roleTracker)
 				}
@@ -976,24 +1225,25 @@ func (w *wlReconciler) Generic(_ event.GenericEvent) bool {
 	return true
 }
 
-func newWlReconciler(c client.Client, helper *admissioncheck.MultiKueueStoreHelper, cRec *clustersReconciler, origin string,
+func newWlReconciler(c client.Client, managerNamespaceReader client.Reader, helper *admissioncheck.MultiKueueStoreHelper, cRec *clustersReconciler, origin string,
 	recorder events.EventRecorder, workerLostTimeout, eventsBatchPeriod time.Duration,
 	adapters map[string]jobframework.MultiKueueAdapter, dispatcherName string, roleTracker *roletracker.RoleTracker,
 	options ...Option,
 ) *wlReconciler {
 	r := &wlReconciler{
-		client:            c,
-		helper:            helper,
-		clusters:          cRec,
-		origin:            origin,
-		workerLostTimeout: workerLostTimeout,
-		deletedWlCache:    utilmaps.NewSyncMap[string, *kueue.Workload](0),
-		eventsBatchPeriod: eventsBatchPeriod,
-		adapters:          adapters,
-		recorder:          recorder,
-		clock:             realClock,
-		dispatcherName:    dispatcherName,
-		roleTracker:       roleTracker,
+		client:                 c,
+		managerNamespaceReader: managerNamespaceReader,
+		helper:                 helper,
+		clusters:               cRec,
+		origin:                 origin,
+		workerLostTimeout:      workerLostTimeout,
+		deletedWlCache:         utilmaps.NewSyncMap[string, *kueue.Workload](0),
+		eventsBatchPeriod:      eventsBatchPeriod,
+		adapters:               adapters,
+		recorder:               recorder,
+		clock:                  realClock,
+		dispatcherName:         dispatcherName,
+		roleTracker:            roleTracker,
 	}
 	for _, option := range options {
 		option(r)

--- a/pkg/controller/admissionchecks/multikueue/workload_namespace_binding_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_namespace_binding_test.go
@@ -1,0 +1,913 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multikueue
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	config "sigs.k8s.io/kueue/apis/config/v1beta2"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/controller/admissionchecks/multikueue/externalframeworks"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/features"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+)
+
+func TestValidateWorkerNamespaceBinding(t *testing.T) {
+	const namespace = "team-a"
+	managerNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace, UID: "manager-uid"}}
+
+	tests := map[string]struct {
+		managerObjects []client.Object
+		workerObjects  []client.Object
+		wantErr        bool
+	}{
+		"matching UID": {
+			managerObjects: []client.Object{managerNamespace},
+			workerObjects: []client.Object{&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+				Annotations: map[string]string{
+					kueue.MultiKueueAllowedManagerNamespaceUIDsAnnotation: `["manager-uid"]`,
+				},
+			}}},
+		},
+		"one of multiple matching UIDs": {
+			managerObjects: []client.Object{managerNamespace},
+			workerObjects: []client.Object{&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+				Annotations: map[string]string{
+					kueue.MultiKueueAllowedManagerNamespaceUIDsAnnotation: `["other-manager","manager-uid"]`,
+				},
+			}}},
+		},
+		"missing manager Namespace": {
+			workerObjects: []client.Object{&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}},
+			wantErr:       true,
+		},
+		"manager Namespace without UID": {
+			managerObjects: []client.Object{&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}},
+			workerObjects:  []client.Object{&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}},
+			wantErr:        true,
+		},
+		"missing worker Namespace": {
+			managerObjects: []client.Object{managerNamespace},
+			wantErr:        true,
+		},
+		"missing annotation": {
+			managerObjects: []client.Object{managerNamespace},
+			workerObjects:  []client.Object{&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}},
+			wantErr:        true,
+		},
+		"malformed annotation": {
+			managerObjects: []client.Object{managerNamespace},
+			workerObjects: []client.Object{&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+				Annotations: map[string]string{
+					kueue.MultiKueueAllowedManagerNamespaceUIDsAnnotation: `manager-uid`,
+				},
+			}}},
+			wantErr: true,
+		},
+		"different UID": {
+			managerObjects: []client.Object{managerNamespace},
+			workerObjects: []client.Object{&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+				Annotations: map[string]string{
+					kueue.MultiKueueAllowedManagerNamespaceUIDsAnnotation: `["old-manager-uid"]`,
+				},
+			}}},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.MultiKueueAllowUnboundWorkerNamespaces, false)
+			managerClient := utiltesting.NewClientBuilder().WithObjects(tc.managerObjects...).Build()
+			workerClient := utiltesting.NewClientBuilder().WithObjects(tc.workerObjects...).Build()
+
+			err := validateWorkerNamespaceBinding(context.Background(), managerClient, workerClient, namespace)
+			if tc.wantErr {
+				if !errors.Is(err, errWorkerNamespaceNotBound) {
+					t.Fatalf("validateWorkerNamespaceBinding() error = %v, want %v", err, errWorkerNamespaceNotBound)
+				}
+			} else if err != nil {
+				t.Fatalf("validateWorkerNamespaceBinding() unexpected error = %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateWorkerNamespaceBindingCompatibilityGate(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.MultiKueueAllowUnboundWorkerNamespaces, true)
+	if err := validateWorkerNamespaceBinding(context.Background(), utiltesting.NewClientBuilder().Build(), utiltesting.NewClientBuilder().Build(), "team-a"); err != nil {
+		t.Fatalf("validateWorkerNamespaceBinding() unexpected error with compatibility gate = %v", err)
+	}
+}
+
+func TestNamespaceAuthorizingClientCompatibilityGatePreservesLegacyClient(t *testing.T) {
+	const namespace = "team-a"
+	features.SetFeatureGateDuringTest(t, features.MultiKueueAllowUnboundWorkerNamespaces, true)
+	remoteWorkload := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{Name: "workload", Namespace: namespace}}
+	rawWorkerClient := NewNeverCachingClient(utiltesting.NewClientBuilder().WithObjects(remoteWorkload).Build())
+	workerClient := (&wlReconciler{}).namespaceAuthorizingClient(rawWorkerClient)
+
+	if err := workerClient.DeleteAllOf(context.Background(), &kueue.Workload{}, client.InNamespace(namespace)); err != nil {
+		t.Fatalf("DeleteAllOf() in compatibility mode: %v", err)
+	}
+	if err := rawWorkerClient.Get(context.Background(), client.ObjectKeyFromObject(remoteWorkload), &kueue.Workload{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("worker Workload get error = %v, want NotFound", err)
+	}
+}
+
+func TestSyncToSingleClusterRequiresWorkerNamespaceBinding(t *testing.T) {
+	const (
+		namespace = "team-a"
+		cluster   = "worker1"
+	)
+	managerNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace, UID: types.UID("manager-uid")}}
+	localWorkload := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{Name: "workload", Namespace: namespace}}
+	managerClient := utiltesting.NewClientBuilder().WithObjects(managerNamespace, localWorkload).Build()
+
+	for name, tc := range map[string]struct {
+		workerNamespace   *corev1.Namespace
+		allowUnbound      bool
+		wantNotBoundError bool
+	}{
+		"unbound": {
+			workerNamespace:   &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}},
+			wantNotBoundError: true,
+		},
+		"bound": {
+			workerNamespace: &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+				Annotations: map[string]string{
+					kueue.MultiKueueAllowedManagerNamespaceUIDsAnnotation: `["manager-uid"]`,
+				},
+			}},
+		},
+		"unbound compatibility mode": {
+			workerNamespace: &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}},
+			allowUnbound:    true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.MultiKueueAllowUnboundWorkerNamespaces, tc.allowUnbound)
+			workerClient := NewNeverCachingClient(utiltesting.NewClientBuilder().WithObjects(tc.workerNamespace).Build())
+			group := &wlGroup{
+				local:         localWorkload,
+				remotes:       map[string]*kueue.Workload{cluster: nil},
+				remoteClients: map[string]*remoteClient{cluster: {client: workerClient, origin: "origin"}},
+			}
+			reconciler := &wlReconciler{client: managerClient, managerNamespaceReader: managerClient}
+
+			_, err := reconciler.syncToSingleCluster(context.Background(), logr.Discard(), group, cluster)
+			remoteWorkload := &kueue.Workload{}
+			getErr := workerClient.Get(context.Background(), client.ObjectKeyFromObject(localWorkload), remoteWorkload)
+			if tc.wantNotBoundError {
+				if !errors.Is(err, errWorkerNamespaceNotBound) {
+					t.Fatalf("syncToSingleCluster() error = %v, want %v", err, errWorkerNamespaceNotBound)
+				}
+				if !apierrors.IsNotFound(getErr) {
+					t.Fatalf("worker Workload get error = %v, want NotFound", getErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("syncToSingleCluster() unexpected error = %v", err)
+			}
+			if getErr != nil {
+				t.Fatalf("worker Workload was not created: %v", getErr)
+			}
+		})
+	}
+}
+
+func TestNamespaceBindingGuardsExternalFrameworkCreate(t *testing.T) {
+	const namespace = "team-a"
+	features.SetFeatureGateDuringTest(t, features.MultiKueueAllowUnboundWorkerNamespaces, false)
+
+	gvk := schema.GroupVersionKind{Group: "example.test", Version: "v1", Kind: "TestJob"}
+	key := types.NamespacedName{Name: "job", Namespace: namespace}
+	localJob := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": gvk.GroupVersion().String(),
+		"kind":       gvk.Kind,
+		"metadata": map[string]any{
+			"name":      key.Name,
+			"namespace": key.Namespace,
+		},
+		"spec": map[string]any{"value": "preserved"},
+	}}
+	localJob.SetGroupVersionKind(gvk)
+	managerNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace, UID: "manager-uid"}}
+	managerClient := utiltesting.NewClientBuilder().WithObjects(managerNamespace, localJob).Build()
+	workerClient := NewNeverCachingClient(utiltesting.NewClientBuilder().WithObjects(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}},
+	).Build())
+	reconciler := &wlReconciler{managerNamespaceReader: managerClient}
+
+	adapter := externalframeworks.NewAdapter(gvk)
+	_, err := adapter.SyncJob(context.Background(), managerClient, reconciler.namespaceAuthorizingClient(workerClient), key, "workload", "origin")
+	if !errors.Is(err, errWorkerNamespaceNotBound) {
+		t.Fatalf("SyncJob() error = %v, want %v", err, errWorkerNamespaceNotBound)
+	}
+	remoteJob := &unstructured.Unstructured{}
+	remoteJob.SetGroupVersionKind(gvk)
+	if err := workerClient.Get(context.Background(), key, remoteJob); !apierrors.IsNotFound(err) {
+		t.Fatalf("worker external Job get error = %v, want NotFound", err)
+	}
+}
+
+func TestNamespaceAuthorizingClientRejectsWritesAfterRevocation(t *testing.T) {
+	const namespace = "team-a"
+	features.SetFeatureGateDuringTest(t, features.MultiKueueAllowUnboundWorkerNamespaces, false)
+
+	for name, write := range map[string]func(context.Context, client.Client, *kueue.Workload) error{
+		"update": func(ctx context.Context, workerClient client.Client, remoteWorkload *kueue.Workload) error {
+			remoteWorkload.Annotations = map[string]string{"changed": "true"}
+			return workerClient.Update(ctx, remoteWorkload)
+		},
+		"status update": func(ctx context.Context, workerClient client.Client, remoteWorkload *kueue.Workload) error {
+			remoteWorkload.Status.Conditions = []metav1.Condition{{Type: "Changed", Status: metav1.ConditionTrue}}
+			return workerClient.Status().Update(ctx, remoteWorkload)
+		},
+		"status patch": func(ctx context.Context, workerClient client.Client, remoteWorkload *kueue.Workload) error {
+			original := remoteWorkload.DeepCopy()
+			remoteWorkload.Status.Conditions = []metav1.Condition{{Type: "Changed", Status: metav1.ConditionTrue}}
+			return workerClient.Status().Patch(ctx, remoteWorkload, client.MergeFrom(original))
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			managerNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace, UID: "manager-uid"}}
+			managerClient := utiltesting.NewClientBuilder().WithObjects(managerNamespace).Build()
+			remoteWorkload := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{Name: "workload", Namespace: namespace}}
+			rawWorkerClient := NewNeverCachingClient(utiltesting.NewClientBuilder().WithObjects(
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}},
+				remoteWorkload,
+			).WithStatusSubresource(remoteWorkload).Build())
+			reconciler := &wlReconciler{managerNamespaceReader: managerClient}
+			workerClient := reconciler.namespaceAuthorizingClient(rawWorkerClient)
+			stored := &kueue.Workload{}
+			if err := rawWorkerClient.Get(context.Background(), client.ObjectKeyFromObject(remoteWorkload), stored); err != nil {
+				t.Fatalf("getting worker Workload: %v", err)
+			}
+
+			err := write(context.Background(), workerClient, stored)
+			if !errors.Is(err, errWorkerNamespaceNotBound) {
+				t.Fatalf("write error = %v, want %v", err, errWorkerNamespaceNotBound)
+			}
+			unchanged := &kueue.Workload{}
+			if err := rawWorkerClient.Get(context.Background(), client.ObjectKeyFromObject(remoteWorkload), unchanged); err != nil {
+				t.Fatalf("getting worker Workload after rejected write: %v", err)
+			}
+			if len(unchanged.Annotations) != 0 || len(unchanged.Status.Conditions) != 0 {
+				t.Fatalf("worker Workload changed after rejected write: annotations=%v conditions=%v", unchanged.Annotations, unchanged.Status.Conditions)
+			}
+		})
+	}
+}
+
+func TestNamespaceAuthorizingClientRejectsListsAfterRevocation(t *testing.T) {
+	const namespace = "team-a"
+	features.SetFeatureGateDuringTest(t, features.MultiKueueAllowUnboundWorkerNamespaces, false)
+	managerNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace, UID: "manager-uid"}}
+	managerClient := utiltesting.NewClientBuilder().WithObjects(managerNamespace).Build()
+	rawWorkerClient := NewNeverCachingClient(utiltesting.NewClientBuilder().WithObjects(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}},
+	).Build())
+	workerClient := (&wlReconciler{managerNamespaceReader: managerClient}).namespaceAuthorizingClient(rawWorkerClient)
+
+	if err := workerClient.List(context.Background(), &kueue.WorkloadList{}); err == nil {
+		t.Fatal("all-Namespace List() unexpectedly succeeded")
+	}
+	if err := workerClient.List(context.Background(), &kueue.WorkloadList{}, client.InNamespace(namespace)); !errors.Is(err, errWorkerNamespaceNotBound) {
+		t.Fatalf("namespaced List() error = %v, want %v", err, errWorkerNamespaceNotBound)
+	}
+}
+
+func TestNamespaceAuthorizingClientAllowsNamespacedDeleteAllOf(t *testing.T) {
+	const namespace = "team-a"
+	features.SetFeatureGateDuringTest(t, features.MultiKueueAllowUnboundWorkerNamespaces, false)
+	managerNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace, UID: "manager-uid"}}
+	managerClient := utiltesting.NewClientBuilder().WithObjects(managerNamespace).Build()
+	remoteWorkload := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{Name: "workload", Namespace: namespace}}
+	rawWorkerClient := NewNeverCachingClient(utiltesting.NewClientBuilder().WithObjects(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+			Name: namespace,
+			Annotations: map[string]string{
+				kueue.MultiKueueAllowedManagerNamespaceUIDsAnnotation: `["manager-uid"]`,
+			},
+		}},
+		remoteWorkload,
+	).Build())
+	workerClient := (&wlReconciler{managerNamespaceReader: managerClient}).namespaceAuthorizingClient(rawWorkerClient)
+
+	if err := workerClient.DeleteAllOf(context.Background(), &kueue.Workload{}, client.InNamespace(namespace)); err != nil {
+		t.Fatalf("DeleteAllOf() in authorized Namespace: %v", err)
+	}
+	if err := rawWorkerClient.Get(context.Background(), client.ObjectKeyFromObject(remoteWorkload), &kueue.Workload{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("worker Workload get error = %v, want NotFound", err)
+	}
+}
+
+func TestSyncToSingleClusterUsesLiveManagerNamespaceUID(t *testing.T) {
+	const (
+		namespace = "team-a"
+		cluster   = "worker1"
+	)
+	features.SetFeatureGateDuringTest(t, features.MultiKueueAllowUnboundWorkerNamespaces, false)
+
+	localWorkload := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{Name: "workload", Namespace: namespace}}
+	staleManagerClient := utiltesting.NewClientBuilder().WithObjects(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace, UID: "old-manager-uid"}},
+		localWorkload,
+	).Build()
+	liveManagerReader := utiltesting.NewClientBuilder().WithObjects(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace, UID: "new-manager-uid"}},
+	).Build()
+	workerClient := NewNeverCachingClient(utiltesting.NewClientBuilder().WithObjects(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+			Name: namespace,
+			Annotations: map[string]string{
+				kueue.MultiKueueAllowedManagerNamespaceUIDsAnnotation: `["old-manager-uid"]`,
+			},
+		}},
+	).Build())
+	group := &wlGroup{
+		local:         localWorkload,
+		remotes:       map[string]*kueue.Workload{cluster: nil},
+		remoteClients: map[string]*remoteClient{cluster: {client: workerClient, origin: "origin"}},
+	}
+	reconciler := &wlReconciler{client: staleManagerClient, managerNamespaceReader: liveManagerReader}
+
+	_, err := reconciler.syncToSingleCluster(context.Background(), logr.Discard(), group, cluster)
+	if !errors.Is(err, errWorkerNamespaceNotBound) {
+		t.Fatalf("syncToSingleCluster() error = %v, want %v", err, errWorkerNamespaceNotBound)
+	}
+	if err := workerClient.Get(context.Background(), client.ObjectKeyFromObject(localWorkload), &kueue.Workload{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("worker Workload get error = %v, want NotFound", err)
+	}
+}
+
+type namespaceBindingSyncStub struct {
+	syncCalls int
+	createKey *types.NamespacedName
+}
+
+var _ jobframework.MultiKueueAdapter = (*namespaceBindingSyncStub)(nil)
+
+func (s *namespaceBindingSyncStub) SyncJob(ctx context.Context, _, remoteClient client.Client, _ types.NamespacedName, _, origin string) (bool, error) {
+	s.syncCalls++
+	if s.createKey != nil {
+		return false, remoteClient.Create(ctx, &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+			Name:      s.createKey.Name,
+			Namespace: s.createKey.Namespace,
+			Labels:    map[string]string{kueue.MultiKueueOriginLabel: origin},
+		}})
+	}
+	return false, nil
+}
+
+func (s *namespaceBindingSyncStub) DeleteRemoteObject(_ context.Context, _, _ client.Client, _ types.NamespacedName) error {
+	return nil
+}
+
+func (s *namespaceBindingSyncStub) IsJobManagedByKueue(_ context.Context, _ client.Client, _ types.NamespacedName) (bool, string, error) {
+	return true, "", nil
+}
+
+func (s *namespaceBindingSyncStub) GVK() schema.GroupVersionKind {
+	return batchv1.SchemeGroupVersion.WithKind("Job")
+}
+
+type namespaceBindingCleanupStub struct {
+	deleteCalls int
+}
+
+var _ jobframework.MultiKueueAdapter = (*namespaceBindingCleanupStub)(nil)
+
+func (*namespaceBindingCleanupStub) SyncJob(context.Context, client.Client, client.Client, types.NamespacedName, string, string) (bool, error) {
+	return false, nil
+}
+
+func (s *namespaceBindingCleanupStub) DeleteRemoteObject(ctx context.Context, _ client.Client, remoteClient client.Client, key types.NamespacedName) error {
+	remoteJob := &batchv1.Job{}
+	if err := remoteClient.Get(ctx, key, remoteJob); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	s.deleteCalls++
+	return remoteClient.Delete(ctx, remoteJob)
+}
+
+func (*namespaceBindingCleanupStub) IsJobManagedByKueue(context.Context, client.Client, types.NamespacedName) (bool, string, error) {
+	return true, "", nil
+}
+
+func (*namespaceBindingCleanupStub) GVK() schema.GroupVersionKind {
+	return batchv1.SchemeGroupVersion.WithKind("Job")
+}
+
+func TestReconcileGroupRequiresBindingBeforeRemoteObjectCreate(t *testing.T) {
+	const (
+		namespace = "team-a"
+		cluster   = "worker1"
+		acName    = kueue.AdmissionCheckReference("ac1")
+	)
+	features.SetFeatureGateDuringTest(t, features.MultiKueueAllowUnboundWorkerNamespaces, false)
+
+	for name, tc := range map[string]struct {
+		managerUID               types.UID
+		allowedUIDs              string
+		existingRemoteController bool
+		wantErr                  bool
+	}{
+		"unbound": {
+			managerUID: "manager-uid",
+			wantErr:    true,
+		},
+		"manager Namespace recreated with existing remote controller": {
+			managerUID:               "new-manager-uid",
+			allowedUIDs:              `["old-manager-uid"]`,
+			existingRemoteController: true,
+			wantErr:                  true,
+		},
+		"bound": {
+			managerUID:  "manager-uid",
+			allowedUIDs: `["manager-uid"]`,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			now := time.Now()
+			localWorkload := utiltestingapi.MakeWorkload("workload", namespace).
+				ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").Obj(), now).
+				AdmittedAt(true, now).
+				AdmissionCheck(kueue.AdmissionCheckState{
+					Name:               acName,
+					State:              kueue.CheckStateReady,
+					LastTransitionTime: metav1.NewTime(now),
+				}).
+				ClusterName(cluster).
+				Obj()
+			remoteWorkload := utiltestingapi.MakeWorkload("workload", namespace).
+				Condition(metav1.Condition{
+					Type:               kueue.WorkloadAdmitted,
+					Status:             metav1.ConditionTrue,
+					Reason:             "Admitted",
+					LastTransitionTime: metav1.NewTime(now),
+				}).
+				Obj()
+
+			managerNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace, UID: tc.managerUID}}
+			workerNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+			if tc.allowedUIDs != "" {
+				workerNamespace.Annotations = map[string]string{
+					kueue.MultiKueueAllowedManagerNamespaceUIDsAnnotation: tc.allowedUIDs,
+				}
+			}
+
+			managerClient := utiltesting.NewClientBuilder().WithObjects(managerNamespace, localWorkload).WithStatusSubresource(localWorkload).Build()
+			workerObjects := []client.Object{workerNamespace, remoteWorkload}
+			if tc.existingRemoteController {
+				workerObjects = append(workerObjects, &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+					Name:      "job",
+					Namespace: namespace,
+					Labels:    map[string]string{kueue.MultiKueueOriginLabel: "origin"},
+				}})
+			}
+			workerClient := NewNeverCachingClient(utiltesting.NewClientBuilder().WithObjects(workerObjects...).WithStatusSubresource(remoteWorkload).Build())
+			adapter := &namespaceBindingSyncStub{}
+			group := &wlGroup{
+				local:       localWorkload,
+				localClient: managerClient,
+				remotes:     map[string]*kueue.Workload{cluster: remoteWorkload},
+				remoteClients: map[string]*remoteClient{
+					cluster: {client: workerClient, origin: "origin"},
+				},
+				acName:        acName,
+				jobAdapter:    adapter,
+				controllerKey: types.NamespacedName{Name: "job", Namespace: namespace},
+			}
+			reconciler := &wlReconciler{
+				client:                 managerClient,
+				managerNamespaceReader: managerClient,
+				clock:                  realClock,
+				origin:                 "origin",
+				workerLostTimeout:      defaultWorkerLostTimeout,
+				recorder:               &utiltesting.EventRecorder{},
+				dispatcherName:         config.MultiKueueDispatcherModeAllAtOnce,
+			}
+
+			_, err := reconciler.reconcileGroup(context.Background(), group)
+			if tc.wantErr {
+				if !errors.Is(err, errWorkerNamespaceNotBound) {
+					t.Fatalf("reconcileGroup() error = %v, want %v", err, errWorkerNamespaceNotBound)
+				}
+				if adapter.syncCalls != 0 {
+					t.Fatalf("SyncJob() calls = %d, want 0", adapter.syncCalls)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("reconcileGroup() unexpected error = %v", err)
+			}
+			if adapter.syncCalls != 1 {
+				t.Fatalf("SyncJob() calls = %d, want 1", adapter.syncCalls)
+			}
+		})
+	}
+}
+
+func TestReconcileGroupRechecksBindingAtAdapterCreate(t *testing.T) {
+	const (
+		namespace = "team-a"
+		cluster   = "worker1"
+		origin    = "origin"
+		acName    = kueue.AdmissionCheckReference("ac1")
+	)
+	features.SetFeatureGateDuringTest(t, features.MultiKueueAllowUnboundWorkerNamespaces, false)
+	now := time.Now()
+	localWorkload := utiltestingapi.MakeWorkload("workload", namespace).
+		ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").Obj(), now).
+		AdmittedAt(true, now).
+		AdmissionCheck(kueue.AdmissionCheckState{
+			Name:               acName,
+			State:              kueue.CheckStateReady,
+			LastTransitionTime: metav1.NewTime(now),
+		}).
+		ClusterName(cluster).
+		Obj()
+	remoteWorkload := utiltestingapi.MakeWorkload("workload", namespace).
+		Condition(metav1.Condition{
+			Type:               kueue.WorkloadAdmitted,
+			Status:             metav1.ConditionTrue,
+			Reason:             "Admitted",
+			LastTransitionTime: metav1.NewTime(now),
+		}).
+		Obj()
+	managerNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace, UID: "manager-uid"}}
+	managerClient := utiltesting.NewClientBuilder().WithObjects(managerNamespace, localWorkload).WithStatusSubresource(localWorkload).Build()
+
+	workerNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: namespace,
+		Annotations: map[string]string{
+			kueue.MultiKueueAllowedManagerNamespaceUIDsAnnotation: `["manager-uid"]`,
+		},
+	}}
+	remoteController := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name:      "controller",
+		Namespace: namespace,
+		Labels:    map[string]string{kueue.MultiKueueOriginLabel: origin},
+	}}
+	namespaceGets := 0
+	workerClient := NewNeverCachingClient(utiltesting.NewClientBuilder().WithObjects(workerNamespace, remoteWorkload, remoteController).
+		WithStatusSubresource(remoteWorkload).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if err := c.Get(ctx, key, obj, opts...); err != nil {
+					return err
+				}
+				if key.Namespace == "" && key.Name == namespace {
+					namespaceGets++
+					if namespaceGets >= 4 {
+						delete(obj.GetAnnotations(), kueue.MultiKueueAllowedManagerNamespaceUIDsAnnotation)
+					}
+				}
+				return nil
+			},
+		}).Build())
+	memberKey := types.NamespacedName{Name: "member", Namespace: namespace}
+	adapter := &namespaceBindingSyncStub{createKey: &memberKey}
+	group := &wlGroup{
+		local:       localWorkload,
+		localClient: managerClient,
+		remotes:     map[string]*kueue.Workload{cluster: remoteWorkload},
+		remoteClients: map[string]*remoteClient{
+			cluster: {client: workerClient, origin: origin},
+		},
+		acName:        acName,
+		jobAdapter:    adapter,
+		controllerKey: client.ObjectKeyFromObject(remoteController),
+	}
+	reconciler := &wlReconciler{
+		client:                 managerClient,
+		managerNamespaceReader: managerClient,
+		clock:                  realClock,
+		origin:                 origin,
+		workerLostTimeout:      defaultWorkerLostTimeout,
+		recorder:               &utiltesting.EventRecorder{},
+		dispatcherName:         config.MultiKueueDispatcherModeAllAtOnce,
+	}
+
+	_, err := reconciler.reconcileGroup(context.Background(), group)
+	if !errors.Is(err, errWorkerNamespaceNotBound) {
+		t.Fatalf("reconcileGroup() error = %v, want %v", err, errWorkerNamespaceNotBound)
+	}
+	if adapter.syncCalls != 1 {
+		t.Fatalf("SyncJob() calls = %d, want 1", adapter.syncCalls)
+	}
+	if err := workerClient.Get(context.Background(), memberKey, &batchv1.Job{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("worker member Job get error = %v, want NotFound", err)
+	}
+}
+
+func TestReconcileGroupRejectsRevokedRemoteStatusBeforeManagerStateChange(t *testing.T) {
+	const (
+		namespace = "team-a"
+		cluster   = "worker1"
+		acName    = kueue.AdmissionCheckReference("ac1")
+	)
+	features.SetFeatureGateDuringTest(t, features.MultiKueueAllowUnboundWorkerNamespaces, false)
+
+	for name, remotePresent := range map[string]bool{
+		"remote admitted condition removed": true,
+		"remote Workload removed":           false,
+	} {
+		t.Run(name, func(t *testing.T) {
+			now := time.Now()
+			localWorkload := utiltestingapi.MakeWorkload("workload", namespace).
+				ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").Obj(), now).
+				AdmittedAt(true, now).
+				AdmissionCheck(kueue.AdmissionCheckState{
+					Name:               acName,
+					State:              kueue.CheckStateReady,
+					LastTransitionTime: metav1.NewTime(now),
+				}).
+				ClusterName(cluster).
+				Obj()
+			managerNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace, UID: "manager-uid"}}
+			managerClient := utiltesting.NewClientBuilder().WithObjects(managerNamespace, localWorkload).WithStatusSubresource(localWorkload).Build()
+			workerObjects := []client.Object{&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}}
+			var remoteWorkload *kueue.Workload
+			if remotePresent {
+				remoteWorkload = localWorkload.DeepCopy()
+				remoteWorkload.Status = kueue.WorkloadStatus{}
+				workerObjects = append(workerObjects, remoteWorkload)
+			}
+			workerClient := NewNeverCachingClient(utiltesting.NewClientBuilder().WithObjects(workerObjects...).Build())
+			group := &wlGroup{
+				local:         localWorkload,
+				localClient:   managerClient,
+				remotes:       map[string]*kueue.Workload{cluster: remoteWorkload},
+				remoteClients: map[string]*remoteClient{cluster: {client: workerClient, origin: "origin"}},
+				acName:        acName,
+			}
+			reconciler := &wlReconciler{
+				client:                 managerClient,
+				managerNamespaceReader: managerClient,
+				clock:                  realClock,
+				workerLostTimeout:      defaultWorkerLostTimeout,
+			}
+
+			_, err := reconciler.reconcileGroup(context.Background(), group)
+			if !errors.Is(err, errWorkerNamespaceNotBound) {
+				t.Fatalf("reconcileGroup() error = %v, want %v", err, errWorkerNamespaceNotBound)
+			}
+			stored := &kueue.Workload{}
+			if err := managerClient.Get(context.Background(), client.ObjectKeyFromObject(localWorkload), stored); err != nil {
+				t.Fatalf("getting manager Workload: %v", err)
+			}
+			if got := stored.Status.AdmissionChecks[0].State; got != kueue.CheckStateReady {
+				t.Fatalf("manager AdmissionCheck state = %q, want %q", got, kueue.CheckStateReady)
+			}
+		})
+	}
+}
+
+func TestReconcileGroupRetainsMissingRemoteStatusBehaviorWhenAuthorized(t *testing.T) {
+	const (
+		namespace = "team-a"
+		cluster   = "worker1"
+		acName    = kueue.AdmissionCheckReference("ac1")
+	)
+
+	for name, tc := range map[string]struct {
+		compatibilityMode bool
+		workerAnnotations map[string]string
+	}{
+		"bound Namespace": {
+			workerAnnotations: map[string]string{
+				kueue.MultiKueueAllowedManagerNamespaceUIDsAnnotation: `["manager-uid"]`,
+			},
+		},
+		"compatibility mode": {
+			compatibilityMode: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.MultiKueueAllowUnboundWorkerNamespaces, tc.compatibilityMode)
+			now := time.Now()
+			localWorkload := utiltestingapi.MakeWorkload("workload", namespace).
+				ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").Obj(), now).
+				AdmittedAt(true, now).
+				AdmissionCheck(kueue.AdmissionCheckState{
+					Name:               acName,
+					State:              kueue.CheckStateReady,
+					LastTransitionTime: metav1.NewTime(now),
+				}).
+				ClusterName(cluster).
+				Obj()
+			managerNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace, UID: "manager-uid"}}
+			managerClient := utiltesting.NewClientBuilder().WithObjects(managerNamespace, localWorkload).WithStatusSubresource(localWorkload).Build()
+			workerClient := NewNeverCachingClient(utiltesting.NewClientBuilder().WithObjects(
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace, Annotations: tc.workerAnnotations}},
+			).Build())
+			group := &wlGroup{
+				local:         localWorkload,
+				localClient:   managerClient,
+				remotes:       map[string]*kueue.Workload{cluster: nil},
+				remoteClients: map[string]*remoteClient{cluster: {client: workerClient, origin: "origin"}},
+				acName:        acName,
+			}
+			reconciler := &wlReconciler{
+				client:                 managerClient,
+				managerNamespaceReader: managerClient,
+				clock:                  realClock,
+				workerLostTimeout:      defaultWorkerLostTimeout,
+			}
+
+			if _, err := reconciler.reconcileGroup(context.Background(), group); err != nil {
+				t.Fatalf("reconcileGroup() unexpected error = %v", err)
+			}
+			stored := &kueue.Workload{}
+			if err := managerClient.Get(context.Background(), client.ObjectKeyFromObject(localWorkload), stored); err != nil {
+				t.Fatalf("getting manager Workload: %v", err)
+			}
+			if got := stored.Status.AdmissionChecks[0].State; got != kueue.CheckStateRetry {
+				t.Fatalf("manager AdmissionCheck state = %q, want %q", got, kueue.CheckStateRetry)
+			}
+		})
+	}
+}
+
+func TestReconcileGroupRejectsRevokedSelectedWorkerBeforeDeletingAuthorizedWorker(t *testing.T) {
+	const (
+		namespace         = "team-a"
+		authorizedCluster = "worker1"
+		revokedCluster    = "worker2"
+		origin            = "origin"
+		acName            = kueue.AdmissionCheckReference("ac1")
+	)
+	features.SetFeatureGateDuringTest(t, features.MultiKueueAllowUnboundWorkerNamespaces, false)
+	now := time.Now()
+	localWorkload := utiltestingapi.MakeWorkload("workload", namespace).
+		ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").Obj(), now).
+		AdmissionCheck(kueue.AdmissionCheckState{
+			Name:               acName,
+			State:              kueue.CheckStatePending,
+			LastTransitionTime: metav1.NewTime(now),
+		}).
+		Obj()
+	managerNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace, UID: "manager-uid"}}
+	managerClient := utiltesting.NewClientBuilder().WithObjects(managerNamespace, localWorkload).WithStatusSubresource(localWorkload).Build()
+
+	authorizedRemote := localWorkload.DeepCopy()
+	authorizedRemote.Status = kueue.WorkloadStatus{}
+	authorizedJob := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name:      "job",
+		Namespace: namespace,
+		Labels:    map[string]string{kueue.MultiKueueOriginLabel: origin},
+	}}
+	authorizedWorkerClient := NewNeverCachingClient(utiltesting.NewClientBuilder().WithObjects(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+			Name: namespace,
+			Annotations: map[string]string{
+				kueue.MultiKueueAllowedManagerNamespaceUIDsAnnotation: `["manager-uid"]`,
+			},
+		}},
+		authorizedRemote,
+		authorizedJob,
+	).Build())
+	revokedRemote := localWorkload.DeepCopy()
+	revokedRemote.Status = kueue.WorkloadStatus{Conditions: []metav1.Condition{{
+		Type:               kueue.WorkloadAdmitted,
+		Status:             metav1.ConditionTrue,
+		Reason:             "Admitted",
+		LastTransitionTime: metav1.NewTime(now),
+	}}}
+	revokedWorkerClient := NewNeverCachingClient(utiltesting.NewClientBuilder().WithObjects(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}},
+		revokedRemote,
+	).Build())
+	adapter := &namespaceBindingCleanupStub{}
+	group := &wlGroup{
+		local:       localWorkload,
+		localClient: managerClient,
+		remotes: map[string]*kueue.Workload{
+			authorizedCluster: authorizedRemote,
+			revokedCluster:    revokedRemote,
+		},
+		remoteClients: map[string]*remoteClient{
+			authorizedCluster: {client: authorizedWorkerClient, origin: origin},
+			revokedCluster:    {client: revokedWorkerClient, origin: origin},
+		},
+		acName:        acName,
+		jobAdapter:    adapter,
+		controllerKey: types.NamespacedName{Name: authorizedJob.Name, Namespace: namespace},
+	}
+	reconciler := &wlReconciler{
+		client:                 managerClient,
+		managerNamespaceReader: managerClient,
+		clock:                  realClock,
+		origin:                 origin,
+		workerLostTimeout:      defaultWorkerLostTimeout,
+		dispatcherName:         config.MultiKueueDispatcherModeAllAtOnce,
+	}
+
+	_, err := reconciler.reconcileGroup(context.Background(), group)
+	if !errors.Is(err, errWorkerNamespaceNotBound) {
+		t.Fatalf("reconcileGroup() error = %v, want %v", err, errWorkerNamespaceNotBound)
+	}
+	if err := authorizedWorkerClient.Get(context.Background(), client.ObjectKeyFromObject(authorizedRemote), &kueue.Workload{}); err != nil {
+		t.Fatalf("authorized worker Workload was deleted: %v", err)
+	}
+	if err := authorizedWorkerClient.Get(context.Background(), client.ObjectKeyFromObject(authorizedJob), &batchv1.Job{}); err != nil {
+		t.Fatalf("authorized worker Job was deleted: %v", err)
+	}
+	if adapter.deleteCalls != 0 {
+		t.Fatalf("DeleteRemoteObject() calls = %d, want 0", adapter.deleteCalls)
+	}
+	stored := &kueue.Workload{}
+	if err := managerClient.Get(context.Background(), client.ObjectKeyFromObject(localWorkload), stored); err != nil {
+		t.Fatalf("getting manager Workload: %v", err)
+	}
+	if got := stored.Status.AdmissionChecks[0].State; got != kueue.CheckStatePending {
+		t.Fatalf("manager AdmissionCheck state = %q, want %q", got, kueue.CheckStatePending)
+	}
+}
+
+func TestReconcileGroupAllowsCleanupAfterNamespaceRevocation(t *testing.T) {
+	const (
+		namespace = "team-a"
+		cluster   = "worker1"
+		origin    = "origin"
+	)
+	features.SetFeatureGateDuringTest(t, features.MultiKueueAllowUnboundWorkerNamespaces, false)
+	localWorkload := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{Name: "workload", Namespace: namespace}}
+	managerClient := utiltesting.NewClientBuilder().WithObjects(localWorkload).Build()
+	remoteWorkload := localWorkload.DeepCopy()
+	remoteJob := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name:      "job",
+		Namespace: namespace,
+		Labels:    map[string]string{kueue.MultiKueueOriginLabel: origin},
+	}}
+	workerClient := NewNeverCachingClient(utiltesting.NewClientBuilder().WithObjects(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}},
+		remoteWorkload,
+		remoteJob,
+	).Build())
+	adapter := &namespaceBindingCleanupStub{}
+	group := &wlGroup{
+		local:         localWorkload,
+		localClient:   managerClient,
+		remotes:       map[string]*kueue.Workload{cluster: remoteWorkload},
+		remoteClients: map[string]*remoteClient{cluster: {client: workerClient, origin: origin}},
+		jobAdapter:    adapter,
+		controllerKey: types.NamespacedName{Name: remoteJob.Name, Namespace: namespace},
+	}
+	reconciler := &wlReconciler{
+		managerNamespaceReader: managerClient,
+		workerLostTimeout:      defaultWorkerLostTimeout,
+	}
+
+	if _, err := reconciler.reconcileGroup(context.Background(), group); err != nil {
+		t.Fatalf("reconcileGroup() cleanup after revocation: %v", err)
+	}
+	if adapter.deleteCalls != 1 {
+		t.Fatalf("DeleteRemoteObject() calls = %d, want 1", adapter.deleteCalls)
+	}
+	if err := workerClient.Get(context.Background(), client.ObjectKeyFromObject(remoteJob), &batchv1.Job{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("worker Job get error = %v, want NotFound", err)
+	}
+	if err := workerClient.Get(context.Background(), client.ObjectKeyFromObject(remoteWorkload), &kueue.Workload{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("worker Workload get error = %v, want NotFound", err)
+	}
+}

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -61,6 +61,7 @@ import (
 var errFake = errors.New("fake error")
 
 func TestWlReconcile(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.MultiKueueAllowUnboundWorkerNamespaces, true)
 	now := time.Now().Truncate(time.Second)
 	earlier := now.Add(-time.Second)
 	muchEarlier := now.Add(-time.Hour)
@@ -2168,7 +2169,7 @@ func TestWlReconcile(t *testing.T) {
 
 				helper, _ := admissioncheck.NewMultiKueueStoreHelper(managerClient)
 				mkDispatcherName := ptr.Deref(tc.dispatcherName, config.MultiKueueDispatcherModeAllAtOnce)
-				reconciler := newWlReconciler(managerClient, helper, cRec, defaultOrigin, recorder, defaultWorkerLostTimeout, time.Second, adapters, mkDispatcherName, nil, WithClock(t, fakeClock))
+				reconciler := newWlReconciler(managerClient, managerClient, helper, cRec, defaultOrigin, recorder, defaultWorkerLostTimeout, time.Second, adapters, mkDispatcherName, nil, WithClock(t, fakeClock))
 
 				for _, val := range tc.managersDeletedWorkloads {
 					reconciler.Delete(event.DeleteEvent{
@@ -2323,6 +2324,7 @@ func TestOrphanedRemoteWorkloadCleanedAfterReconnect(t *testing.T) {
 	recorder := &utiltesting.EventRecorder{}
 	reconciler := newWlReconciler(
 		managerClient,
+		managerClient,
 		helper,
 		cRec,
 		defaultOrigin,
@@ -2426,6 +2428,7 @@ func setupAdmittedMetricTest(ctx context.Context, t *testing.T, acState kueue.Ch
 	recorder := &utiltesting.EventRecorder{}
 	return newWlReconciler(
 		managerClient,
+		managerClient,
 		helper,
 		cRec,
 		defaultOrigin,
@@ -2445,6 +2448,7 @@ func admittedMetricValue(t *testing.T) float64 {
 }
 
 func TestMultiKueueWorkloadAdmittedMetricIncrementedOnceOnAdmission(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.MultiKueueAllowUnboundWorkerNamespaces, true)
 	features.SetFeatureGateDuringTest(t, features.WorkloadIdentifierAnnotations, false)
 	metrics.MultiKueueWorkloadsAdmittedTotal.Reset()
 	t.Cleanup(metrics.MultiKueueWorkloadsAdmittedTotal.Reset)
@@ -2472,6 +2476,7 @@ func TestMultiKueueWorkloadAdmittedMetricIncrementedOnceOnAdmission(t *testing.T
 }
 
 func TestMultiKueueWorkloadAdmittedMetricNotIncrementedOnRetryOrRejected(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.MultiKueueAllowUnboundWorkerNamespaces, true)
 	features.SetFeatureGateDuringTest(t, features.WorkloadIdentifierAnnotations, false)
 
 	for _, state := range []kueue.CheckState{kueue.CheckStateRetry, kueue.CheckStateRejected} {
@@ -2504,6 +2509,7 @@ type createCall struct {
 }
 
 func TestNominateAndSynchronizeWorkers_MoreCases(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.MultiKueueAllowUnboundWorkerNamespaces, true)
 	const externalMultiKueueDispatcherController = "external.com/mk-dispatcher"
 
 	remoteNames := make([]string, 9)
@@ -2644,10 +2650,12 @@ func TestNominateAndSynchronizeWorkers_MoreCases(t *testing.T) {
 				acName:        "ac1",
 			}
 
+			managerClient := wlClientBuilder.Build()
 			wlRec := &wlReconciler{
-				clock:          fakeClock,
-				dispatcherName: tt.dispatcherMode,
-				client:         wlClientBuilder.Build(),
+				clock:                  fakeClock,
+				dispatcherName:         tt.dispatcherMode,
+				client:                 managerClient,
+				managerNamespaceReader: managerClient,
 			}
 
 			ctx, _ := utiltesting.ContextWithLog(t)
@@ -3150,6 +3158,7 @@ func (s *deferredSyncStubAdapter) GVK() schema.GroupVersionKind {
 // workerLostTimeout away and the manager Job's Status.Active never catches
 // up within any reasonable test or operator observation window.
 func TestReconcileGroup_SyncDeferred_ShortRequeue(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.MultiKueueAllowUnboundWorkerNamespaces, true)
 	ctx, _ := utiltesting.ContextWithLog(t)
 	now := time.Now()
 	fakeClock := testingclock.NewFakeClock(now)
@@ -3202,12 +3211,13 @@ func TestReconcileGroup_SyncDeferred_ShortRequeue(t *testing.T) {
 	}
 
 	reconciler := &wlReconciler{
-		client:            managerClient,
-		clock:             fakeClock,
-		origin:            defaultOrigin,
-		workerLostTimeout: defaultWorkerLostTimeout,
-		recorder:          &utiltesting.EventRecorder{},
-		dispatcherName:    config.MultiKueueDispatcherModeAllAtOnce,
+		client:                 managerClient,
+		managerNamespaceReader: managerClient,
+		clock:                  fakeClock,
+		origin:                 defaultOrigin,
+		workerLostTimeout:      defaultWorkerLostTimeout,
+		recorder:               &utiltesting.EventRecorder{},
+		dispatcherName:         config.MultiKueueDispatcherModeAllAtOnce,
 	}
 
 	gotResult, gotErr := reconciler.reconcileGroup(ctx, group)

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -82,6 +82,12 @@ const (
 	// Enables clearing ttlSecondsAfterFinished when creating remote batch Jobs.
 	MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster featuregate.Feature = "MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster"
 
+	// MultiKueueAllowUnboundWorkerNamespaces restores legacy name-only worker
+	// Namespace selection. Enabling it permits a manager Namespace to dispatch
+	// into a same-named worker Namespace without the worker administrator
+	// explicitly authorizing the manager Namespace UID.
+	MultiKueueAllowUnboundWorkerNamespaces featuregate.Feature = "MultiKueueAllowUnboundWorkerNamespaces"
+
 	// owner: @mimowo
 	//
 	// Enable Topology Aware Scheduling allowing to optimize placement of Pods
@@ -677,6 +683,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 	MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster: {
 		{Version: version.MustParse("0.20"), Default: true, PreRelease: featuregate.Beta},
+	},
+
+	MultiKueueAllowUnboundWorkerNamespaces: {
+		{Version: version.MustParse("0.20"), Default: false, PreRelease: featuregate.Alpha},
 	},
 	TopologyAwareScheduling: {
 		{Version: version.MustParse("0.9"), Default: false, PreRelease: featuregate.Alpha},

--- a/site/content/en/docs/concepts/multikueue.md
+++ b/site/content/en/docs/concepts/multikueue.md
@@ -193,6 +193,56 @@ Kueue handles delegation to the appropriate worker cluster without requiring any
 
 ## Security Considerations
 
+### Namespace trust boundary
+
+MultiKueue preserves the Job or Pod specification when it creates the remote
+object, and uses the same namespace name on the manager and worker clusters.
+Kubernetes resolves namespaced references in that specification against the
+worker namespace. This includes ServiceAccounts (including the implicit
+`default` ServiceAccount), Secrets, ConfigMaps, image pull secrets, persistent
+volume claims, and Secret references used by volume drivers.
+
+As a result, matching namespace names are an authorization boundary, not only
+a naming convention. A user who can submit a MultiKueue Job in a manager
+namespace can cause the remote workload to use same-named objects in the
+worker namespace. Kubernetes does not authorize each of these references when
+the remote Job or Pod is created.
+
+Before creating a remote Workload or executable object, MultiKueue requires the
+worker Namespace annotation
+`kueue.x-k8s.io/multikueue-allowed-manager-namespace-uids` to contain the UID
+of the same-named manager Namespace. The annotation value is a JSON array of
+UID strings. The worker administrator controls this binding; namespace-name
+equality alone is not authorization. Removing the binding stops MultiKueue
+from consuming remote status or creating objects in that namespace. Cleanup
+of previously dispatched objects remains allowed so revocation does not strand
+worker resources.
+
+For multi-tenant deployments:
+
+- Treat each manager/worker namespace pair as one trust domain. Only dispatch
+  workloads from users who are also trusted to use the referenced resources in
+  the matching worker namespace.
+- Use dedicated worker namespaces for different tenants. Do not map an
+  untrusted manager namespace to a worker namespace containing more-privileged
+  ServiceAccounts, Secrets, ConfigMaps, or persistent data.
+- Give dispatched workloads a dedicated, least-privileged ServiceAccount and
+  disable service account token automounting when API access is not required.
+- Enforce the allowed ServiceAccounts and volume, environment, and image-pull
+  references with worker-cluster admission policy. Resource existence checks
+  at dispatch time are not sufficient because a same-named object can be
+  created or replaced later.
+
+The example kubeconfig script grants the MultiKueue manager cluster-wide
+create, watch, and delete access for supported workload types. It is intended
+for a worker cluster whose eligible namespaces are all in the same trust
+domain; it does not provide tenant isolation by namespace.
+
+The alpha `MultiKueueAllowUnboundWorkerNamespaces` feature gate restores the
+legacy name-only behavior. It is disabled by default and should only be enabled
+for compatibility in environments where every same-named namespace is already
+one trust domain.
+
 ### KubeConfig Location Types
 
 MultiKueueCluster supports three sources for cluster credentials:

--- a/site/content/en/docs/tasks/dev/setup_multikueue_development_environment.md
+++ b/site/content/en/docs/tasks/dev/setup_multikueue_development_environment.md
@@ -175,7 +175,13 @@ Create ServiceAccounts and kubeconfigs for MultiKueue on both workers:
 
 ```bash
 SERVICE_ACCOUNT="multikueue-sa"
+MANAGER_NAMESPACE_UID=$(kubectl --context kind-manager get namespace default -o jsonpath='{.metadata.uid}')
 for cluster in worker1 worker2; do
+  # Authorize this manager Namespace to dispatch into the same-named worker Namespace.
+  kubectl --context kind-${cluster} annotate namespace default \
+    kueue.x-k8s.io/multikueue-allowed-manager-namespace-uids="[\"${MANAGER_NAMESPACE_UID}\"]" \
+    --overwrite
+
   # Create ServiceAccount
   kubectl --context kind-${cluster} create sa ${SERVICE_ACCOUNT} -n kueue-system
 
@@ -192,6 +198,11 @@ for cluster in worker1 worker2; do
     --verb=get,list,watch \
     --resource=clusterqueues.kueue.x-k8s.io,localqueues.kueue.x-k8s.io
 
+  # Namespace access is read-only and kept separate from object mutation.
+  kubectl --context kind-${cluster} create clusterrole multikueue-role-namespaces \
+    --verb=get \
+    --resource=namespaces
+
   # Create ClusterRoleBindings
   kubectl --context kind-${cluster} create clusterrolebinding multikueue-crb \
     --clusterrole=multikueue-role \
@@ -203,6 +214,10 @@ for cluster in worker1 worker2; do
 
   kubectl --context kind-${cluster} create clusterrolebinding multikueue-crb-queues \
     --clusterrole=multikueue-role-queues \
+    --serviceaccount=kueue-system:${SERVICE_ACCOUNT}
+
+  kubectl --context kind-${cluster} create clusterrolebinding multikueue-crb-namespaces \
+    --clusterrole=multikueue-role-namespaces \
     --serviceaccount=kueue-system:${SERVICE_ACCOUNT}
 
   # Create a secret bound to the new service account

--- a/site/content/en/docs/tasks/manage/setup_multikueue.md
+++ b/site/content/en/docs/tasks/manage/setup_multikueue.md
@@ -25,8 +25,49 @@ kubectl config use-context worker1-cluster
 ```
 {{% /alert %}}
 
+Authorize the manager namespace UID on the same-named worker namespace. The
+UID binding prevents a different manager namespace that happens to have the
+same name from using worker resources. For this tutorial's `default`
+namespace, run:
+
+```bash
+manager_namespace_uid=$(kubectl --context manager-cluster get namespace default -o jsonpath='{.metadata.uid}')
+kubectl --context worker1-cluster annotate namespace default \
+  kueue.x-k8s.io/multikueue-allowed-manager-namespace-uids="[\"${manager_namespace_uid}\"]" \
+  --overwrite
+```
+
+Repeat the annotation for every manager/worker namespace pair that can receive
+MultiKueue workloads. The annotation value is a JSON array so a worker
+namespace can authorize redundant manager clusters. Recreate the binding when
+a manager namespace is deleted and recreated because its UID changes.
+
+Removing the annotation revokes synchronization as well as creation. Running
+worker objects are left in place, but their status is not consumed until the
+binding is restored; MultiKueue can still clean them up when the manager
+Workload is finished or deleted.
+
 When MultiKueue dispatches a workload from the manager cluster to a worker cluster, it expects that the job's namespace and LocalQueue also exist in the worker cluster.
 In other words, you should ensure that the worker cluster configuration mirrors the one of the manager cluster in terms of namespaces and LocalQueues.
+
+{{% alert title="Security Notice" color="warning" %}}
+
+A mirrored namespace is also a trust boundary. MultiKueue copies the workload
+specification, so namespaced references such as ServiceAccounts, Secrets,
+ConfigMaps, image pull secrets, and persistent volume claims resolve in the
+worker namespace. This also applies when `serviceAccountName` is omitted: the
+worker namespace's `default` ServiceAccount is used.
+
+Only pair namespaces whose users have equivalent authorization on both
+clusters. In multi-tenant environments, use dedicated worker namespaces and
+worker admission policies to prevent dispatched workloads from selecting
+more-privileged worker resources. Avoid using the shared `default` namespace
+for production tenant workloads.
+
+See [MultiKueue security considerations](/docs/concepts/multikueue/#security-considerations)
+for the complete trust model.
+
+{{% /alert %}}
 
 To create the sample queue setup in the `default` namespace, you can apply the following manifest:
 
@@ -35,6 +76,29 @@ To create the sample queue setup in the `default` namespace, you can apply the f
 ### MultiKueue Specific Kubeconfig
 
 In order to delegate the jobs in a worker cluster, the manager cluster needs to be able to create, delete, and watch workloads and their parent Jobs.
+
+The example script creates a ClusterRoleBinding, so its credential can operate
+on supported workload types in every namespace. Use it only when all eligible
+worker namespaces belong to the same trust domain. It is not a namespace-level
+tenant-isolation mechanism.
+
+#### Upgrading an existing installation
+
+Before upgrading the manager to a version that enforces namespace UID
+bindings:
+
+1. Add `get` permission for core `namespaces` to every MultiKueue worker
+   credential. Do not grant Namespace update or patch permission.
+2. Annotate every eligible worker Namespace with the UID of each authorized
+   same-named manager Namespace, as shown above.
+3. Roll all manager replicas to the new version. Old replicas do not enforce
+   the binding, so a mixed-version deployment does not provide the new
+   security guarantee until the rollout is complete.
+
+If pre-annotation is not possible, start the upgraded manager with
+`MultiKueueAllowUnboundWorkerNamespaces=true`, update worker RBAC and Namespace
+bindings, and then restart every manager replica with the gate disabled. The
+gate restores the legacy name-only trust behavior while it is enabled.
 
 While `kubectl` is set up to use the worker cluster, download: 
 {{< include "examples/multikueue/create-multikueue-kubeconfig.sh" "bash" >}}

--- a/site/content/zh-CN/docs/tasks/manage/setup_multikueue.md
+++ b/site/content/zh-CN/docs/tasks/manage/setup_multikueue.md
@@ -28,6 +28,29 @@ kubectl config use-context worker1-cluster
 当 MultiKueue 将工作负载从管理集群分发到工作集群时，它期望作业的命名空间和 LocalQueue 也存在于工作集群中。
 换句话说，您应该确保工作集群配置在命名空间和 LocalQueues 方面与管理集群的配置保持一致。
 
+还必须用同名管理集群 Namespace 的 UID 显式授权工作集群 Namespace。
+对于本教程中的 `default` Namespace，请运行：
+
+```bash
+manager_namespace_uid=$(kubectl --context manager-cluster get namespace default -o jsonpath='{.metadata.uid}')
+kubectl --context worker1-cluster annotate namespace default \
+  kueue.x-k8s.io/multikueue-allowed-manager-namespace-uids="[\"${manager_namespace_uid}\"]" \
+  --overwrite
+```
+
+每一对可能接收 MultiKueue 工作负载的管理/工作 Namespace 都需要此注解。
+如果管理 Namespace 被删除并重新创建，其 UID 会改变，因此必须重新授权。
+
+{{% alert title="安全提示" color="warning" %}}
+
+同名 Namespace 是安全边界，而不只是命名约定。MultiKueue 会复制工作负载规范，
+其中的 ServiceAccount、Secret、ConfigMap、镜像拉取 Secret 和 PVC 等引用会在工作集群
+Namespace 中解析。仅应配对两端用户具有等价权限的 Namespace；多租户环境应使用专用的
+工作 Namespace 和准入策略。移除此注解会停止远程状态同步和新对象创建，但 MultiKueue
+仍可清理以前分发的对象。
+
+{{% /alert %}}
+
 要在 `default` 命名空间中创建示例队列设置，您可以应用以下清单：
 
 {{< include "examples/admin/single-clusterqueue-setup.yaml" "yaml" >}}
@@ -35,6 +58,9 @@ kubectl config use-context worker1-cluster
 ### MultiKueue 专用 kubeconfig
 
 为了在工作集群中委托 Job，管理集群需要能够创建、删除和监视工作负载及其父 Job。
+
+示例脚本创建的是集群范围的权限，并额外授予读取 Namespace 的权限以校验 UID 绑定。
+它不会按 Namespace 提供租户隔离，也不应获得修改 Namespace 的权限。
 
 当 `kubectl` 设置为使用工作集群时，下载：
 {{< include "examples/multikueue/create-multikueue-kubeconfig.sh" "bash" >}}
@@ -47,6 +73,12 @@ chmod +x create-multikueue-kubeconfig.sh
 ```
 
 这将创建一个 kubeconfig，可以在管理集群中使用它来委托当前工作集群中的 Job。
+
+升级现有安装时，应先为每个工作集群凭据添加 core `namespaces` 的 `get` 权限并完成上述
+Namespace 注解，然后再滚动升级所有管理器副本。旧副本不会执行此校验，因此混合版本
+部署在升级完成前不具备新的安全保证。如果无法预先迁移，可以暂时启用
+`MultiKueueAllowUnboundWorkerNamespaces=true`，完成 RBAC 和注解迁移后，再在所有管理器
+副本上禁用此特性门控。
 
 ### Kubeflow 安装
 

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -221,6 +221,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.15"
+- name: MultiKueueAllowUnboundWorkerNamespaces
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.20"
 - name: MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster
   versionedSpecs:
   - default: true

--- a/site/static/examples/multikueue/create-multikueue-kubeconfig.sh
+++ b/site/static/examples/multikueue/create-multikueue-kubeconfig.sh
@@ -22,7 +22,10 @@ KUBECONFIG_OUT=${1:-kubeconfig}
 MULTIKUEUE_SA=multikueue-sa
 NAMESPACE=kueue-system
 
-# Creating a restricted MultiKueue role, service account and role binding"
+echo "WARNING: this example grants MultiKueue access to supported workloads in every namespace." >&2
+echo "Use it only when all eligible worker namespaces are in the same trust domain." >&2
+
+# Create the MultiKueue service account and cluster-wide workload permissions.
 kubectl apply -f - <<EOF
 apiVersion: v1
 kind: ServiceAccount
@@ -35,6 +38,12 @@ kind: ClusterRole
 metadata:
   name: ${MULTIKUEUE_SA}-role
 rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
 - apiGroups:
   - batch
   resources:

--- a/site/static/examples/multikueue/dev/setup-kind-multikueue-tas.sh
+++ b/site/static/examples/multikueue/dev/setup-kind-multikueue-tas.sh
@@ -126,7 +126,13 @@ done
 
 # Create worker kubeconfigs
 echo "[4/5] Creating worker kubeconfigs..."
+MANAGER_NAMESPACE_UID=$(kubectl --context kind-manager get namespace default -o jsonpath='{.metadata.uid}')
 for cluster in ${WORKER_CLUSTERS}; do
+    # Authorize this manager Namespace to dispatch into the same-named worker Namespace.
+    kubectl --context "kind-${cluster}" annotate namespace default \
+      kueue.x-k8s.io/multikueue-allowed-manager-namespace-uids="[\"${MANAGER_NAMESPACE_UID}\"]" \
+      --overwrite
+
     # Create ServiceAccount
     kubectl --context "kind-${cluster}" create sa ${SERVICE_ACCOUNT} -n kueue-system 2>/dev/null || true
 
@@ -144,6 +150,10 @@ for cluster in ${WORKER_CLUSTERS}; do
       --verb=get,list,watch \
       --resource=clusterqueues.kueue.x-k8s.io,localqueues.kueue.x-k8s.io 2>/dev/null || true
 
+    kubectl --context "kind-${cluster}" create clusterrole multikueue-role-namespaces \
+      --verb=get \
+      --resource=namespaces 2>/dev/null || true
+
     # Create ClusterRoleBindings
 
     kubectl --context "kind-${cluster}" create clusterrolebinding multikueue-crb \
@@ -156,6 +166,10 @@ for cluster in ${WORKER_CLUSTERS}; do
 
     kubectl --context "kind-${cluster}" create clusterrolebinding multikueue-crb-queues \
       --clusterrole=multikueue-role-queues \
+      --serviceaccount=kueue-system:${SERVICE_ACCOUNT} 2>/dev/null || true
+
+    kubectl --context "kind-${cluster}" create clusterrolebinding multikueue-crb-namespaces \
+      --clusterrole=multikueue-role-namespaces \
       --serviceaccount=kueue-system:${SERVICE_ACCOUNT} 2>/dev/null || true
     
     # Create a secret bound to the new service account

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -221,6 +221,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.15"
+- name: MultiKueueAllowUnboundWorkerNamespaces
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.20"
 - name: MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster
   versionedSpecs:
   - default: true

--- a/test/e2e/multikueue/baseline/e2e_test.go
+++ b/test/e2e/multikueue/baseline/e2e_test.go
@@ -98,8 +98,8 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 
 	ginkgo.BeforeEach(func() {
 		managerNs = util.CreateNamespaceFromPrefixWithLog(ctx, k8sManagerClient, "multikueue-")
-		worker1Ns = util.CreateNamespaceWithLog(ctx, k8sWorker1Client, managerNs.Name)
-		worker2Ns = util.CreateNamespaceWithLog(ctx, k8sWorker2Client, managerNs.Name)
+		worker1Ns = util.CreateWorkerNamespaceForMultiKueue(ctx, k8sWorker1Client, managerNs)
+		worker2Ns = util.CreateWorkerNamespaceForMultiKueue(ctx, k8sWorker2Client, managerNs)
 
 		workerCluster1 = utiltestingapi.MakeMultiKueueClusterWithGeneratedName("worker1-").KubeConfig(kueue.SecretLocationType, "multikueue1").Obj()
 		util.MustCreate(ctx, k8sManagerClient, workerCluster1)

--- a/test/e2e/multikueue/baseline/tas_test.go
+++ b/test/e2e/multikueue/baseline/tas_test.go
@@ -98,8 +98,8 @@ var _ = ginkgo.Describe("MultiKueue with TopologyAwareScheduling", func() {
 
 	ginkgo.BeforeEach(func() {
 		managerNs = util.CreateNamespaceFromPrefixWithLog(ctx, k8sManagerClient, "multikueue-tas-")
-		worker1Ns = util.CreateNamespaceWithLog(ctx, k8sWorker1Client, managerNs.Name)
-		worker2Ns = util.CreateNamespaceWithLog(ctx, k8sWorker2Client, managerNs.Name)
+		worker1Ns = util.CreateWorkerNamespaceForMultiKueue(ctx, k8sWorker1Client, managerNs)
+		worker2Ns = util.CreateWorkerNamespaceForMultiKueue(ctx, k8sWorker2Client, managerNs)
 
 		workerCluster1 = utiltestingapi.MakeMultiKueueClusterWithGeneratedName("worker1-").KubeConfig(kueue.SecretLocationType, "multikueue1").Obj()
 		util.MustCreate(ctx, k8sManagerClient, workerCluster1)
@@ -408,8 +408,8 @@ var _ = ginkgo.Describe("MultiKueue TAS with asymmetric quotas", func() {
 
 	ginkgo.BeforeEach(func() {
 		managerNs = util.CreateNamespaceFromPrefixWithLog(ctx, k8sManagerClient, "multikueue-tas-")
-		worker1Ns = util.CreateNamespaceWithLog(ctx, k8sWorker1Client, managerNs.Name)
-		worker2Ns = util.CreateNamespaceWithLog(ctx, k8sWorker2Client, managerNs.Name)
+		worker1Ns = util.CreateWorkerNamespaceForMultiKueue(ctx, k8sWorker1Client, managerNs)
+		worker2Ns = util.CreateWorkerNamespaceForMultiKueue(ctx, k8sWorker2Client, managerNs)
 
 		managerTopology = utiltestingapi.MakeDefaultOneLevelTopology("default-" + managerNs.Name)
 		util.MustCreate(ctx, k8sManagerClient, managerTopology)

--- a/test/e2e/multikueue/dra/dra_test.go
+++ b/test/e2e/multikueue/dra/dra_test.go
@@ -64,8 +64,8 @@ var _ = ginkgo.Describe("MultiKueue with DRA", ginkgo.Label("feature:dra", "area
 
 	ginkgo.BeforeEach(func() {
 		managerNs = util.CreateNamespaceFromPrefixWithLog(ctx, k8sManagerClient, "multikueuedra-")
-		worker1Ns = util.CreateNamespaceWithLog(ctx, k8sWorker1Client, managerNs.Name)
-		worker2Ns = util.CreateNamespaceWithLog(ctx, k8sWorker2Client, managerNs.Name)
+		worker1Ns = util.CreateWorkerNamespaceForMultiKueue(ctx, k8sWorker1Client, managerNs)
+		worker2Ns = util.CreateWorkerNamespaceForMultiKueue(ctx, k8sWorker2Client, managerNs)
 
 		workerCluster1 = utiltestingapi.MakeMultiKueueCluster("worker1").KubeConfig(kueue.SecretLocationType, "multikueue1").Obj()
 		util.MustCreate(ctx, k8sManagerClient, workerCluster1)

--- a/test/e2e/multikueue/extended/e2e_test.go
+++ b/test/e2e/multikueue/extended/e2e_test.go
@@ -113,8 +113,8 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 
 	ginkgo.BeforeEach(func() {
 		managerNs = util.CreateNamespaceFromPrefixWithLog(ctx, k8sManagerClient, "multikueue-")
-		worker1Ns = util.CreateNamespaceWithLog(ctx, k8sWorker1Client, managerNs.Name)
-		worker2Ns = util.CreateNamespaceWithLog(ctx, k8sWorker2Client, managerNs.Name)
+		worker1Ns = util.CreateWorkerNamespaceForMultiKueue(ctx, k8sWorker1Client, managerNs)
+		worker2Ns = util.CreateWorkerNamespaceForMultiKueue(ctx, k8sWorker2Client, managerNs)
 
 		workerCluster1 = utiltestingapi.MakeMultiKueueClusterWithGeneratedName("worker1-").KubeConfig(kueue.SecretLocationType, "multikueue1").Obj()
 		util.MustCreate(ctx, k8sManagerClient, workerCluster1)

--- a/test/e2e/multikueue/sequential/e2e_test.go
+++ b/test/e2e/multikueue/sequential/e2e_test.go
@@ -97,8 +97,8 @@ var _ = ginkgo.Describe("MultiKueue Sequential", func() {
 
 	ginkgo.BeforeEach(func() {
 		managerNs = util.CreateNamespaceFromPrefixWithLog(ctx, k8sManagerClient, "multikueue-")
-		worker1Ns = util.CreateNamespaceWithLog(ctx, k8sWorker1Client, managerNs.Name)
-		worker2Ns = util.CreateNamespaceWithLog(ctx, k8sWorker2Client, managerNs.Name)
+		worker1Ns = util.CreateWorkerNamespaceForMultiKueue(ctx, k8sWorker1Client, managerNs)
+		worker2Ns = util.CreateWorkerNamespaceForMultiKueue(ctx, k8sWorker2Client, managerNs)
 
 		workerCluster1 = utiltestingapi.MakeMultiKueueCluster("worker1").KubeConfig(kueue.SecretLocationType, "multikueue1").Obj()
 		util.MustCreate(ctx, k8sManagerClient, workerCluster1)

--- a/test/integration/multikueue/cluster_role_sharing_test.go
+++ b/test/integration/multikueue/cluster_role_sharing_test.go
@@ -90,8 +90,8 @@ var _ = ginkgo.Describe("MultiKueue Cluster Role Sharing", ginkgo.Label("area:mu
 
 	ginkgo.BeforeEach(func() {
 		managerNs = util.CreateNamespaceFromPrefixWithLog(managerTestCluster.ctx, managerTestCluster.client, "multikueue-")
-		worker1Ns = util.CreateNamespaceWithLog(worker1TestCluster.ctx, worker1TestCluster.client, managerNs.Name)
-		worker2Ns = util.CreateNamespaceWithLog(worker2TestCluster.ctx, worker2TestCluster.client, managerNs.Name)
+		worker1Ns = util.CreateWorkerNamespaceForMultiKueue(worker1TestCluster.ctx, worker1TestCluster.client, managerNs)
+		worker2Ns = util.CreateWorkerNamespaceForMultiKueue(worker2TestCluster.ctx, worker2TestCluster.client, managerNs)
 
 		w1Kubeconfig, err := worker1TestCluster.kubeConfigBytes()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/test/integration/multikueue/dispatcher_test.go
+++ b/test/integration/multikueue/dispatcher_test.go
@@ -79,8 +79,8 @@ var _ = ginkgo.Describe("MultiKueueDispatcherIncremental", ginkgo.Label("area:mu
 
 	ginkgo.BeforeEach(func() {
 		managerNs = util.CreateNamespaceFromPrefixWithLog(managerTestCluster.ctx, managerTestCluster.client, "multikueue-")
-		worker1Ns = util.CreateNamespaceWithLog(worker1TestCluster.ctx, worker1TestCluster.client, managerNs.Name)
-		worker2Ns = util.CreateNamespaceWithLog(worker2TestCluster.ctx, worker2TestCluster.client, managerNs.Name)
+		worker1Ns = util.CreateWorkerNamespaceForMultiKueue(worker1TestCluster.ctx, worker1TestCluster.client, managerNs)
+		worker2Ns = util.CreateWorkerNamespaceForMultiKueue(worker2TestCluster.ctx, worker2TestCluster.client, managerNs)
 
 		w1Kubeconfig, err := worker1TestCluster.kubeConfigBytes()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -258,8 +258,8 @@ var _ = ginkgo.Describe("MultiKueueDispatcherExternal", ginkgo.Label("area:multi
 
 	ginkgo.BeforeEach(func() {
 		managerNs = util.CreateNamespaceFromPrefixWithLog(managerTestCluster.ctx, managerTestCluster.client, "multikueue-")
-		worker1Ns = util.CreateNamespaceWithLog(worker1TestCluster.ctx, worker1TestCluster.client, managerNs.Name)
-		worker2Ns = util.CreateNamespaceWithLog(worker2TestCluster.ctx, worker2TestCluster.client, managerNs.Name)
+		worker1Ns = util.CreateWorkerNamespaceForMultiKueue(worker1TestCluster.ctx, worker1TestCluster.client, managerNs)
+		worker2Ns = util.CreateWorkerNamespaceForMultiKueue(worker2TestCluster.ctx, worker2TestCluster.client, managerNs)
 
 		w1Kubeconfig, err := worker1TestCluster.kubeConfigBytes()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -579,8 +579,8 @@ var _ = ginkgo.Describe("MultiKueueDispatcherAllAtOnce", ginkgo.Label("area:mult
 
 	ginkgo.BeforeEach(func() {
 		managerNs = util.CreateNamespaceFromPrefixWithLog(managerTestCluster.ctx, managerTestCluster.client, "multikueue-")
-		worker1Ns = util.CreateNamespaceWithLog(worker1TestCluster.ctx, worker1TestCluster.client, managerNs.Name)
-		worker2Ns = util.CreateNamespaceWithLog(worker2TestCluster.ctx, worker2TestCluster.client, managerNs.Name)
+		worker1Ns = util.CreateWorkerNamespaceForMultiKueue(worker1TestCluster.ctx, worker1TestCluster.client, managerNs)
+		worker2Ns = util.CreateWorkerNamespaceForMultiKueue(worker2TestCluster.ctx, worker2TestCluster.client, managerNs)
 
 		w1Kubeconfig, err := worker1TestCluster.kubeConfigBytes()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -793,8 +793,8 @@ var _ = ginkgo.Describe("MultiKueueConfig Re-evaluation", ginkgo.Label("area:mul
 
 	ginkgo.BeforeEach(func() {
 		managerNs = util.CreateNamespaceFromPrefixWithLog(managerTestCluster.ctx, managerTestCluster.client, "multikueue-re-eval-")
-		worker1Ns = util.CreateNamespaceWithLog(worker1TestCluster.ctx, worker1TestCluster.client, managerNs.Name)
-		worker2Ns = util.CreateNamespaceWithLog(worker2TestCluster.ctx, worker2TestCluster.client, managerNs.Name)
+		worker1Ns = util.CreateWorkerNamespaceForMultiKueue(worker1TestCluster.ctx, worker1TestCluster.client, managerNs)
+		worker2Ns = util.CreateWorkerNamespaceForMultiKueue(worker2TestCluster.ctx, worker2TestCluster.client, managerNs)
 
 		w1Kubeconfig, err := worker1TestCluster.kubeConfigBytes()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/test/integration/multikueue/dra_test.go
+++ b/test/integration/multikueue/dra_test.go
@@ -76,8 +76,8 @@ var _ = ginkgo.Describe("MultiKueue with DRA", ginkgo.Label("area:multikueue", "
 		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.KueueDRAIntegration, true)
 
 		managerNs = util.CreateNamespaceFromPrefixWithLog(managerTestCluster.ctx, managerTestCluster.client, "multikueue-dra-")
-		worker1Ns = util.CreateNamespaceWithLog(worker1TestCluster.ctx, worker1TestCluster.client, managerNs.Name)
-		worker2Ns = util.CreateNamespaceWithLog(worker2TestCluster.ctx, worker2TestCluster.client, managerNs.Name)
+		worker1Ns = util.CreateWorkerNamespaceForMultiKueue(worker1TestCluster.ctx, worker1TestCluster.client, managerNs)
+		worker2Ns = util.CreateWorkerNamespaceForMultiKueue(worker2TestCluster.ctx, worker2TestCluster.client, managerNs)
 
 		w1Kubeconfig, err := worker1TestCluster.kubeConfigBytes()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/test/integration/multikueue/enabled_integration_test.go
+++ b/test/integration/multikueue/enabled_integration_test.go
@@ -74,7 +74,7 @@ var _ = ginkgo.Describe("MultiKueue when not all integrations are enabled", gink
 
 	ginkgo.BeforeEach(func() {
 		managerNs = util.CreateNamespaceFromPrefixWithLog(managerTestCluster.ctx, managerTestCluster.client, "multikueue-")
-		worker1Ns = util.CreateNamespaceWithLog(worker1TestCluster.ctx, worker1TestCluster.client, managerNs.Name)
+		worker1Ns = util.CreateWorkerNamespaceForMultiKueue(worker1TestCluster.ctx, worker1TestCluster.client, managerNs)
 
 		w1Kubeconfig, err := worker1TestCluster.kubeConfigBytes()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/test/integration/multikueue/external_job_test.go
+++ b/test/integration/multikueue/external_job_test.go
@@ -175,15 +175,15 @@ var _ = ginkgo.Describe(
 					managerTestCluster.client,
 					"multikueue-",
 				)
-				worker1Ns = util.CreateNamespaceWithLog(
+				worker1Ns = util.CreateWorkerNamespaceForMultiKueue(
 					worker1TestCluster.ctx,
 					worker1TestCluster.client,
-					managerNs.Name,
+					managerNs,
 				)
-				worker2Ns = util.CreateNamespaceWithLog(
+				worker2Ns = util.CreateWorkerNamespaceForMultiKueue(
 					worker2TestCluster.ctx,
 					worker2TestCluster.client,
-					managerNs.Name,
+					managerNs,
 				)
 
 				w1Kubeconfig, err := worker1TestCluster.kubeConfigBytes()

--- a/test/integration/multikueue/helpers_test.go
+++ b/test/integration/multikueue/helpers_test.go
@@ -273,8 +273,8 @@ func setupMultiKueueFixture() *multiKueueFixture {
 	f := &multiKueueFixture{}
 
 	f.managerNs = util.CreateNamespaceFromPrefixWithLog(managerTestCluster.ctx, managerTestCluster.client, "multikueue-")
-	f.worker1Ns = util.CreateNamespaceWithLog(worker1TestCluster.ctx, worker1TestCluster.client, f.managerNs.Name)
-	f.worker2Ns = util.CreateNamespaceWithLog(worker2TestCluster.ctx, worker2TestCluster.client, f.managerNs.Name)
+	f.worker1Ns = util.CreateWorkerNamespaceForMultiKueue(worker1TestCluster.ctx, worker1TestCluster.client, f.managerNs)
+	f.worker2Ns = util.CreateWorkerNamespaceForMultiKueue(worker2TestCluster.ctx, worker2TestCluster.client, f.managerNs)
 
 	w1Kubeconfig, err := worker1TestCluster.kubeConfigBytes()
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -18,6 +18,7 @@ package multikueue
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -165,6 +166,39 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 				condition.LastTransitionTime = completedJobCondition.LastTransitionTime
 				return condition
 			}, gomega.Equal(completedJobCondition))))
+		})
+	})
+
+	ginkgo.It("Should dispatch only to worker Namespaces that authorize the manager Namespace UID", func() {
+		delete(f.worker2Ns.Annotations, kueue.MultiKueueAllowedManagerNamespaceUIDsAnnotation)
+		gomega.Expect(worker2TestCluster.client.Update(worker2TestCluster.ctx, f.worker2Ns)).To(gomega.Succeed())
+
+		job := testingjob.MakeJob("namespace-binding", f.managerNs.Name).
+			Queue(kueue.LocalQueueName(f.managerLq.Name)).
+			Obj()
+		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, job)
+		wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: f.managerNs.Name}
+
+		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).
+			PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()).
+			Obj()
+		util.SetQuotaReservation(managerTestCluster.ctx, managerTestCluster.client, wlLookupKey, admission)
+
+		ginkgo.By("creating a remote Workload only in the authorized worker", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, wlLookupKey, &kueue.Workload{})).To(gomega.Succeed())
+				g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, wlLookupKey, &kueue.Workload{})).To(utiltesting.BeNotFoundError())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("authorizing worker2 and creating its remote Workload on retry", func() {
+			f.worker2Ns.Annotations = map[string]string{
+				kueue.MultiKueueAllowedManagerNamespaceUIDsAnnotation: fmt.Sprintf("[%q]", f.managerNs.UID),
+			}
+			gomega.Expect(worker2TestCluster.client.Update(worker2TestCluster.ctx, f.worker2Ns)).To(gomega.Succeed())
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, wlLookupKey, &kueue.Workload{})).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})
 

--- a/test/integration/multikueue/no_gc_test.go
+++ b/test/integration/multikueue/no_gc_test.go
@@ -73,8 +73,8 @@ var _ = ginkgo.Describe("MultiKueue no GC", ginkgo.Label("area:multikueue", "fea
 
 	ginkgo.BeforeEach(func() {
 		managerNs = util.CreateNamespaceFromPrefixWithLog(managerTestCluster.ctx, managerTestCluster.client, "multikueue-")
-		worker1Ns = util.CreateNamespaceWithLog(worker1TestCluster.ctx, worker1TestCluster.client, managerNs.Name)
-		worker2Ns = util.CreateNamespaceWithLog(worker2TestCluster.ctx, worker2TestCluster.client, managerNs.Name)
+		worker1Ns = util.CreateWorkerNamespaceForMultiKueue(worker1TestCluster.ctx, worker1TestCluster.client, managerNs)
+		worker2Ns = util.CreateWorkerNamespaceForMultiKueue(worker2TestCluster.ctx, worker2TestCluster.client, managerNs)
 
 		w1Kubeconfig, err := worker1TestCluster.kubeConfigBytes()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/test/integration/multikueue/provisioning_test.go
+++ b/test/integration/multikueue/provisioning_test.go
@@ -82,8 +82,8 @@ var _ = ginkgo.Describe("MultiKueue with ProvisioningRequest", ginkgo.Label("are
 
 	ginkgo.BeforeEach(func() {
 		managerNs = util.CreateNamespaceFromPrefixWithLog(managerTestCluster.ctx, managerTestCluster.client, "mk-prov-")
-		worker1Ns = util.CreateNamespaceWithLog(worker1TestCluster.ctx, worker1TestCluster.client, managerNs.Name)
-		worker2Ns = util.CreateNamespaceWithLog(worker2TestCluster.ctx, worker2TestCluster.client, managerNs.Name)
+		worker1Ns = util.CreateWorkerNamespaceForMultiKueue(worker1TestCluster.ctx, worker1TestCluster.client, managerNs)
+		worker2Ns = util.CreateWorkerNamespaceForMultiKueue(worker2TestCluster.ctx, worker2TestCluster.client, managerNs)
 
 		w1Kubeconfig, err := worker1TestCluster.kubeConfigBytes()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/test/integration/multikueue/scheduler/scheduler_test.go
+++ b/test/integration/multikueue/scheduler/scheduler_test.go
@@ -91,8 +91,8 @@ var _ = ginkgo.Describe("MultiKueue with scheduler", ginkgo.Label("area:multikue
 
 	ginkgo.BeforeEach(func() {
 		managerNs = util.CreateNamespaceFromPrefixWithLog(managerTestCluster.ctx, managerTestCluster.client, "multikueue-")
-		worker1Ns = util.CreateNamespaceWithLog(worker1TestCluster.ctx, worker1TestCluster.client, managerNs.Name)
-		worker2Ns = util.CreateNamespaceWithLog(worker2TestCluster.ctx, worker2TestCluster.client, managerNs.Name)
+		worker1Ns = util.CreateWorkerNamespaceForMultiKueue(worker1TestCluster.ctx, worker1TestCluster.client, managerNs)
+		worker2Ns = util.CreateWorkerNamespaceForMultiKueue(worker2TestCluster.ctx, worker2TestCluster.client, managerNs)
 
 		w1Kubeconfig, err := worker1TestCluster.kubeConfigBytes()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/test/integration/multikueue/setup_test.go
+++ b/test/integration/multikueue/setup_test.go
@@ -89,8 +89,8 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 
 	ginkgo.BeforeEach(func() {
 		managerNs = util.CreateNamespaceFromPrefixWithLog(managerTestCluster.ctx, managerTestCluster.client, "multikueue-")
-		worker1Ns = util.CreateNamespaceWithLog(worker1TestCluster.ctx, worker1TestCluster.client, managerNs.Name)
-		worker2Ns = util.CreateNamespaceWithLog(worker2TestCluster.ctx, worker2TestCluster.client, managerNs.Name)
+		worker1Ns = util.CreateWorkerNamespaceForMultiKueue(worker1TestCluster.ctx, worker1TestCluster.client, managerNs)
+		worker2Ns = util.CreateWorkerNamespaceForMultiKueue(worker2TestCluster.ctx, worker2TestCluster.client, managerNs)
 
 		w1Kubeconfig, err := worker1TestCluster.kubeConfigBytes()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/test/integration/multikueue/tas/tas_test.go
+++ b/test/integration/multikueue/tas/tas_test.go
@@ -98,8 +98,8 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Label("area:multikue
 
 	ginkgo.BeforeEach(func() {
 		managerNs = util.CreateNamespaceFromPrefixWithLog(managerTestCluster.ctx, managerTestCluster.client, "multikueue-")
-		worker1Ns = util.CreateNamespaceWithLog(worker1TestCluster.ctx, worker1TestCluster.client, managerNs.Name)
-		worker2Ns = util.CreateNamespaceWithLog(worker2TestCluster.ctx, worker2TestCluster.client, managerNs.Name)
+		worker1Ns = util.CreateWorkerNamespaceForMultiKueue(worker1TestCluster.ctx, worker1TestCluster.client, managerNs)
+		worker2Ns = util.CreateWorkerNamespaceForMultiKueue(worker2TestCluster.ctx, worker2TestCluster.client, managerNs)
 
 		w1Kubeconfig, err := worker1TestCluster.kubeConfigBytes()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/test/util/multikueue.go
+++ b/test/util/multikueue.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"context"
+	"encoding/json"
 	"regexp"
 
 	kfmpi "github.com/kubeflow/mpi-operator/pkg/apis/kubeflow/v2beta1"
@@ -53,6 +54,19 @@ func PolicyRule(group, resource string, verbs ...string) rbacv1.PolicyRule {
 		Resources: []string{resource},
 		Verbs:     verbs,
 	}
+}
+
+// CreateWorkerNamespaceForMultiKueue creates a worker Namespace that authorizes
+// the same-named manager Namespace UID for MultiKueue dispatch.
+func CreateWorkerNamespaceForMultiKueue(ctx context.Context, workerClient client.Client, managerNamespace *corev1.Namespace) *corev1.Namespace {
+	ginkgo.GinkgoHelper()
+	allowedManagerUIDs, err := json.Marshal([]types.UID{managerNamespace.UID})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	workerNamespace := utiltesting.MakeNamespace(managerNamespace.Name)
+	workerNamespace.Annotations = map[string]string{
+		kueue.MultiKueueAllowedManagerNamespaceUIDsAnnotation: string(allowedManagerUIDs),
+	}
+	return CreateNamespaceFromObjectWithLog(ctx, workerClient, workerNamespace)
 }
 
 var resourceVerbs = []string{"create", "update", "patch", "delete", "get", "list", "watch"}
@@ -130,6 +144,7 @@ func MultiKueueRulesForManager(ctx context.Context, k8sClient client.Client) []r
 	cfg := GetKueueConfiguration(ctx, k8sClient)
 
 	rules := []rbacv1.PolicyRule{
+		PolicyRule(corev1.SchemeGroupVersion.Group, "namespaces", "get"),
 		PolicyRule(kueue.SchemeGroupVersion.Group, "workloads", resourceVerbs...),
 		PolicyRule(kueue.SchemeGroupVersion.Group, "workloads/status", "get", "patch", "update"),
 		PolicyRule(kueue.SchemeGroupVersion.Group, "clusterqueues", "get", "list", "watch"),


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind api-change
/area multikueue

#### What this PR does / why we need it:

MultiKueue currently copies manager workloads into the same-named worker
Namespace. Without an explicit trust relationship, a manager-cluster tenant can
cause the worker credential to create a Pod that resolves namespaced references
such as ServiceAccounts, Secrets, ConfigMaps, image pull secrets, and PVCs in a
worker Namespace that the worker administrator did not authorize for that
manager Namespace.

This change requires each worker Namespace to list the UID of the same-named
manager Namespace in the
`kueue.x-k8s.io/multikueue-allowed-manager-namespace-uids` annotation before
MultiKueue can dispatch, read status, or perform non-cleanup writes there. The
check uses an uncached manager Namespace reader and is enforced at the remote
client operation boundary so built-in, multi-object, and external adapters are
covered. Cleanup remains available after revocation.

It also:

- adds only `get` access to Namespaces to the documented worker credential;
- adds a default-disabled compatibility gate,
  `MultiKueueAllowUnboundWorkerNamespaces`, for staged upgrades;
- documents the trust boundary, revocation behavior, and mixed-version upgrade
  sequence in the KEP and user guides; and
- adds unit, race, compile, and live three-cluster integration coverage for
  denied, authorized, revoked, compatibility, cleanup, stale-cache, and
  create-race behavior.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

AI usage disclosure: This pull request was developed with assistance from
OpenAI Codex. The author reviewed the changes and validation results.

Focused validation:

```text
go test ./pkg/controller/admissionchecks/multikueue ./pkg/features ./test/util -count=1
go test -race ./pkg/controller/admissionchecks/multikueue -count=1
go vet ./pkg/controller/admissionchecks/multikueue ./pkg/features ./test/util
go test ./test/integration/multikueue/... -run '^$' -count=1
go test ./test/e2e/multikueue/... -run '^$' -count=1
shellcheck site/static/examples/multikueue/create-multikueue-kubeconfig.sh site/static/examples/multikueue/dev/setup-kind-multikueue-tas.sh
bash hack/tools/compatibility-lifecycle/generate.sh
```

A focused envtest run against three API servers also passed the new dispatch
regression: 1 passed, 70 skipped.

#### Does this PR introduce a user-facing change?

```release-note
action required: MultiKueue now requires each worker Namespace to explicitly authorize its same-named manager Namespace UID in the `kueue.x-k8s.io/multikueue-allowed-manager-namespace-uids` annotation before dispatching or synchronizing workloads. Worker credentials need `get` on Namespaces. During migration, operators may temporarily enable `MultiKueueAllowUnboundWorkerNamespaces=true`, which retains the prior insecure behavior.
```
