### PR TITLE
multikueue: bind remote objects to manager identities

### DIFF
--- a/keps/693-multikueue/README.md
+++ b/keps/693-multikueue/README.md
@@ -152,6 +152,51 @@ deployments with very high job throughput (above 1M jobs per day).
     learning the state of the world from the worker clusters (not covered
     by this KEP).
 
+* **Remote object name collisions**: Workloads and Jobs use the same Namespace
+  and name in the manager and worker clusters. MultiKueue therefore validates
+  the origin, prebuilt Workload association where the execution object belongs
+  to one Workload, and exact manager-object UID before
+  consuming status or mutating or deleting an existing worker object. Every
+  adapter-declared primary execution object carries its corresponding manager
+  execution-object UID, and every remote Workload carries the manager Workload UID, in the
+  `kueue.x-k8s.io/multikueue-origin-uid` annotation. Deletes use worker-object
+  UID preconditions so a replacement cannot be deleted after validation.
+  The admitted manager Workload is the identity authority: its owner references
+  retain the original execution-object UIDs, and the guarded client cross-checks
+  any live same-name manager object directly from the API server against that
+  controller-recorded mapping before remote creation or status use. A same-name
+  manager replacement cannot consume the original Workload's admission.
+  Uncorrelated objects are preserved for administrator review instead of being
+  garbage-collected.
+
+  Shared objects for multi-Workload integrations, such as LeaderWorkerSet, are
+  intentionally not bound to one Workload name. They are instead bound to the
+  MultiKueue origin and exact manager object UID, and each remote Workload is
+  independently bound to its same-name manager Workload UID.
+
+  These metadata checks prevent accidental collisions and confused-deputy
+  deletion, but they are not cryptographic proof of provenance. A principal
+  that can read and mutate worker objects, including by patching or replacing
+  them, can copy the labels and annotations.
+  Worker-cluster object mutation therefore remains inside the MultiKueue trust
+  boundary until authenticated remote-object provenance is implemented.
+  Manager principals that can patch or replace the UID-bearing owner references
+  on Kueue Workloads are also inside this trust boundary. The standard batch-user
+  role does not grant that mutation, but the Workload editor role does.
+
+  A running leader serializes reconcile and garbage-collection work for each
+  remote Workload and performs uncached manager-Workload checks before and after
+  remote creation. This does not make writes to two API servers transactional:
+  a leader crash or handoff after the worker commits a write, or an ambiguous
+  worker API error, can still leave an orphan. Without an authenticated manager
+  Workload, later garbage collection preserves that object for manual review.
+
+  Objects created by older managers do not consistently have these UID
+  bindings. Live migration is not supported because adapters can create more
+  than one execution object and custom adapters define their own mappings.
+  Upgrades must drain active MultiKueue dispatches before any upgraded manager
+  becomes leader; old and new leaders must not overlap during that rollout.
+
 * **Arbitrary file read via `locationType=Path`**: When `KubeConfig.LocationType`
   is set to `Path`, the controller reads the file at the user-supplied location
   using `os.ReadFile`. Without path restrictions, any principal with
@@ -336,12 +381,24 @@ Will monitor the workloads in the management cluster and manage their MultiKueue
 AdmissionCheckStates.
 
 When distributing a workload across clusters, the MultiKueue Workload Controller will first create
-a Kueue-internal workload object in each of the currently "nominated" worker clusters
+a Kueue-internal workload object in each of the currently "nominated" worker clusters. The remote
+Workload records the manager Workload UID in `kueue.x-k8s.io/multikueue-origin-uid`
 (see [MultiKueue Dispatcher API](#multikueue-dispatcher-api) for details).
 Only after the workload is admitted on one cluster and cleaned
 up on the other clusters, the real job will be created, to match the workload. That gives the guarantee
 that the workload will not start in more than one cluster. The workload will
 get the annotation stating where it is actually running.
+
+Each execution object created after admission records the UID of its exact
+manager-side counterpart in the same annotation. The guarded remote client is
+limited to the adapter's declared GVK; secondary-GVK reads and writes are
+rejected because they cannot be associated automatically. Multi-object adapters
+that use the declared GVK bind every object they create; for example, every
+PodGroup member records its same-name manager Pod UID and its cleanup extension
+receives the controller-recorded UID map retained by the manager Workload.
+The manager Workload's owner-reference UID mapping, not a live same-name object,
+is authoritative; the live object must still exist with the recorded UID before
+the guarded client creates or consumes its worker counterpart.
 
 When the job is running, MultiKueue Workload Controller will copy its status from worker cluster
 to the management cluster, to keep the impression that the job is running in the management 
@@ -359,7 +416,10 @@ In case of duplicates, all but one of them will be removed.
 
 Will monitor the workloads in the remote clusters to detect and remove
 those that were created by MultiKueue but were not deleted by the MultiKueue Workload Controller
-in the normal flow, due to a temporary connectivity outage to the remote cluster.
+in the normal flow, due to a temporary connectivity outage to the remote cluster. A remote
+Workload is removed only when a same-name manager Workload is awaiting deletion and its UID
+matches the remote Workload's origin UID annotation. Missing or mismatched manager identity is
+not sufficient evidence for deletion, so the garbage collector preserves the remote Workload.
 
 The garbage collector will run periodically with a configurable time interval.
 
@@ -372,10 +432,20 @@ interfaces:
 
 ```go
 type MultiKueueAdapter interface {
-	SyncJob(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) error
-	DeleteRemoteObject(ctx context.Context, remoteClient client.Client, key types.NamespacedName) error
+	SyncJob(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) (deferred bool, err error)
+	DeleteRemoteObject(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName) error
 	IsJobManagedByKueue(ctx context.Context, localClient client.Client, key types.NamespacedName) (bool, string, error)
-    ...
+	GVK() schema.GroupVersionKind
+}
+
+type MultiKueueAdapterWithRemoteObjectCleanup interface {
+	MultiKueueAdapter
+	DeleteRemoteObjectWithCleanupContext(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, cleanupContext MultiKueueRemoteObjectCleanupContext) error
+}
+
+type MultiKueueAdapterWithWorkloadReassignment interface {
+	MultiKueueAdapter
+	CanReassignWorkload(ctx context.Context, localClient client.Client, key types.NamespacedName) (bool, error)
 }
 ```
 Used by the [MultiKueue Workload Controller](#multikueue-workload-controller) to interact with the owner of the reconciled workloads.
@@ -385,6 +455,15 @@ Used by the [MultiKueue Workload Controller](#multikueue-workload-controller) to
 - If the remote job exists, get its status and update the status of the local job accordingly.
 
 `DeleteRemoteObject` - will delete the job from a remote cluster.
+
+The remote client passed to these methods authorizes only objects of `GVK()`.
+It validates origin, Workload association, exact manager-object UID, worker UID,
+and resource version as applicable. Cross-GVK access, subresource reads, apply,
+and writes that cannot carry a checked identity are rejected. Same-GVK
+multi-object adapters use `MultiKueueAdapterWithRemoteObjectCleanup` to receive
+the exact cleanup identities persisted in the manager Workload. Elastic
+adapters use `MultiKueueAdapterWithWorkloadReassignment` to authorize a stable,
+UID-bound object moving between Workload slices.
 
 `IsJobManagedByKueue` - will check if a specific job is managed by kueue making it a candidate for remote execution.
 

--- a/pkg/controller/admissionchecks/multikueue/clusterqueue_test.go
+++ b/pkg/controller/admissionchecks/multikueue/clusterqueue_test.go
@@ -455,14 +455,14 @@ func TestCQReconcile(t *testing.T) {
 
 			adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("batch/job"))
 			recorder := &utiltesting.EventRecorder{}
-			cRec := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, nil, nil, recorder)
+			cRec := newClustersReconciler(c, c, TestNamespace, 0, defaultOrigin, nil, adapters, nil, nil, recorder)
 			cRec.rootContext = ctx
 			for worker, wState := range tc.workers {
 				workerClient := NewNeverCachingClient(utiltesting.NewClientBuilder().
 					WithObjects(asObjs(wState.cqs)...).
 					WithObjects(asObjs(wState.lqs)...).
 					Build())
-				rc := newRemoteClient(c, nil, nil, nil, defaultOrigin, worker, adapters)
+				rc := newRemoteClient(c, c, nil, nil, nil, defaultOrigin, worker, adapters)
 				rc.client = workerClient
 				// newRemoteClient starts disconnected; mark the active workers connected.
 				if !wState.inactive {

--- a/pkg/controller/admissionchecks/multikueue/controllers.go
+++ b/pkg/controller/admissionchecks/multikueue/controllers.go
@@ -153,7 +153,7 @@ func SetupControllers(mgr ctrl.Manager, namespace string, opts ...SetupOption) e
 	}
 
 	cRec := newClustersReconciler(
-		mgr.GetClient(), namespace, options.gcInterval, options.origin, fsWatcher,
+		mgr.GetClient(), mgr.GetAPIReader(), namespace, options.gcInterval, options.origin, fsWatcher,
 		options.adapters, cpAccessProvider, options.roleTracker,
 		mgr.GetEventRecorder("multikueue-cluster"),
 	)

--- a/pkg/controller/admissionchecks/multikueue/externalframeworks/adapter_test.go
+++ b/pkg/controller/admissionchecks/multikueue/externalframeworks/adapter_test.go
@@ -17,21 +17,226 @@ limitations under the License.
 package externalframeworks
 
 import (
+	"context"
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/component-base/featuregate"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/features"
 )
+
+func metadataCompatibleUnstructuredClient(obj *unstructured.Unstructured) client.Client {
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(obj.GroupVersionKind(), &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(obj.GroupVersionKind().GroupVersion().WithKind(obj.GetKind()+"List"), &unstructured.UnstructuredList{})
+	base := fake.NewClientBuilder().WithScheme(scheme).WithObjects(obj).WithStatusSubresource(obj).Build()
+	return interceptor.NewClient(base, interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, target client.Object, opts ...client.GetOption) error {
+			if metadata, ok := target.(*metav1.PartialObjectMetadata); ok && metadata.GroupVersionKind() == obj.GroupVersionKind() && key == client.ObjectKeyFromObject(obj) {
+				metadata.SetName(obj.GetName())
+				metadata.SetNamespace(obj.GetNamespace())
+				metadata.SetUID(obj.GetUID())
+				metadata.SetResourceVersion(obj.GetResourceVersion())
+				metadata.SetLabels(obj.GetLabels())
+				metadata.SetAnnotations(obj.GetAnnotations())
+				return nil
+			}
+			return c.Get(ctx, key, target, opts...)
+		},
+	})
+}
+
+func externalBoundWorkload(name string, key types.NamespacedName, gvk schema.GroupVersionKind, managerUID types.UID) *kueue.Workload {
+	return &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+		Name:      name,
+		Namespace: key.Namespace,
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: gvk.GroupVersion().String(),
+			Kind:       gvk.Kind,
+			Name:       key.Name,
+			UID:        managerUID,
+		}},
+	}}
+}
+
+func TestAdapterOwnershipWrapperRejectsMismatchedWorkload(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "security.example.com", Version: "v1", Kind: "GuardedJob"}
+	key := types.NamespacedName{Name: "test-job", Namespace: "default"}
+	const (
+		origin       = "origin1"
+		workloadName = "workload-1"
+	)
+
+	localObj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": gvk.GroupVersion().String(),
+		"kind":       gvk.Kind,
+		"metadata": map[string]any{
+			"name":      key.Name,
+			"namespace": key.Namespace,
+			"uid":       "manager-object-uid",
+		},
+		"spec": map[string]any{"managedBy": kueue.MultiKueueControllerName},
+	}}
+	remoteObj := localObj.DeepCopy()
+	remoteObj.SetUID("remote-object-uid")
+	jobframework.SetMultiKueueMeta(remoteObj, "other-workload", origin)
+	remoteAnnotations := remoteObj.GetAnnotations()
+	if remoteAnnotations == nil {
+		remoteAnnotations = make(map[string]string)
+	}
+	remoteAnnotations[kueue.MultiKueueOriginUIDAnnotation] = "manager-object-uid"
+	remoteObj.SetAnnotations(remoteAnnotations)
+	if err := unstructured.SetNestedField(remoteObj.Object, "Succeeded", "status", "phase"); err != nil {
+		t.Fatalf("setting remote status: %v", err)
+	}
+
+	managerClient := metadataCompatibleUnstructuredClient(localObj)
+	workerClient := metadataCompatibleUnstructuredClient(remoteObj)
+	adapter := &Adapter{gvk: gvk}
+
+	if _, err := jobframework.SyncJobWithRemoteObjectOwnership(
+		t.Context(),
+		managerClient,
+		managerClient,
+		workerClient,
+		adapter,
+		key,
+		externalBoundWorkload(workloadName, key, gvk, "manager-object-uid"),
+		origin,
+	); !errors.Is(
+		err,
+		jobframework.ErrRemoteObjectNotOwnedByMultiKueue,
+	) {
+		t.Fatalf("SyncJobWithRemoteObjectOwnership() error = %v, want %v", err, jobframework.ErrRemoteObjectNotOwnedByMultiKueue)
+	}
+	gotLocal := &unstructured.Unstructured{}
+	gotLocal.SetGroupVersionKind(gvk)
+	if err := managerClient.Get(t.Context(), key, gotLocal); err != nil {
+		t.Fatalf("getting manager object: %v", err)
+	}
+	if _, found, err := unstructured.NestedFieldNoCopy(gotLocal.Object, "status"); err != nil || found {
+		t.Fatalf("manager status found = %v, error = %v, want no copied status", found, err)
+	}
+
+	err := jobframework.DeleteRemoteObjectWithCleanupContextIfOwned(t.Context(), managerClient, workerClient, adapter, key, jobframework.MultiKueueRemoteObjectCleanupContext{
+		RemoteObjectUID: remoteObj.GetUID(),
+		Association: jobframework.MultiKueueObjectAssociation{
+			Origin:           origin,
+			WorkloadName:     workloadName,
+			ManagerObjectUID: "manager-object-uid",
+		},
+		WorkloadKey: types.NamespacedName{Name: workloadName, Namespace: key.Namespace},
+	})
+	if !errors.Is(err, jobframework.ErrRemoteObjectNotOwnedByMultiKueue) {
+		t.Fatalf("DeleteRemoteObjectWithCleanupContextIfOwned() error = %v, want %v", err, jobframework.ErrRemoteObjectNotOwnedByMultiKueue)
+	}
+	gotRemote := &unstructured.Unstructured{}
+	gotRemote.SetGroupVersionKind(gvk)
+	if err := workerClient.Get(t.Context(), key, gotRemote); err != nil {
+		t.Fatalf("getting worker object after guarded deletion: %v", err)
+	}
+}
+
+func TestAdapterOwnershipWrapperSyncsAndCleansMatchingUnstructuredObject(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "security.example.com", Version: "v1", Kind: "GuardedJob"}
+	key := types.NamespacedName{Name: "test-job", Namespace: "default"}
+	const (
+		origin       = "origin1"
+		workloadName = "workload-1"
+		managerUID   = "manager-object-uid"
+	)
+	localObj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": gvk.GroupVersion().String(),
+		"kind":       gvk.Kind,
+		"metadata": map[string]any{
+			"name":      key.Name,
+			"namespace": key.Namespace,
+			"uid":       managerUID,
+		},
+		"spec": map[string]any{"managedBy": kueue.MultiKueueControllerName},
+	}}
+	remoteObj := localObj.DeepCopy()
+	remoteObj.SetUID("remote-object-uid")
+	jobframework.SetMultiKueueMeta(remoteObj, workloadName, origin)
+	remoteAnnotations := remoteObj.GetAnnotations()
+	if remoteAnnotations == nil {
+		remoteAnnotations = make(map[string]string)
+	}
+	remoteAnnotations[kueue.MultiKueueOriginUIDAnnotation] = managerUID
+	remoteObj.SetAnnotations(remoteAnnotations)
+	if err := unstructured.SetNestedField(remoteObj.Object, "Succeeded", "status", "phase"); err != nil {
+		t.Fatalf("setting remote status: %v", err)
+	}
+
+	managerClient := metadataCompatibleUnstructuredClient(localObj)
+	workerClient := metadataCompatibleUnstructuredClient(remoteObj)
+	adapter := &Adapter{gvk: gvk}
+	for name, probe := range map[string]struct {
+		client client.Client
+		object client.Object
+	}{
+		"manager object":   {client: managerClient, object: func() client.Object { obj := &unstructured.Unstructured{}; obj.SetGroupVersionKind(gvk); return obj }()},
+		"manager metadata": {client: managerClient, object: func() client.Object { obj := &metav1.PartialObjectMetadata{}; obj.SetGroupVersionKind(gvk); return obj }()},
+		"worker object":    {client: workerClient, object: func() client.Object { obj := &unstructured.Unstructured{}; obj.SetGroupVersionKind(gvk); return obj }()},
+	} {
+		if err := probe.client.Get(t.Context(), key, probe.object); err != nil {
+			t.Fatalf("getting %s before wrapped sync: %v", name, err)
+		}
+	}
+	if _, err := jobframework.SyncJobWithRemoteObjectOwnership(
+		t.Context(),
+		managerClient,
+		managerClient,
+		workerClient,
+		adapter,
+		key,
+		externalBoundWorkload(workloadName, key, gvk, managerUID),
+		origin,
+	); err != nil {
+		t.Fatalf("SyncJobWithRemoteObjectOwnership() error = %v", err)
+	}
+	gotLocal := &unstructured.Unstructured{}
+	gotLocal.SetGroupVersionKind(gvk)
+	if err := managerClient.Get(t.Context(), key, gotLocal); err != nil {
+		t.Fatalf("getting manager object: %v", err)
+	}
+	if phase, found, err := unstructured.NestedString(gotLocal.Object, "status", "phase"); err != nil || !found || phase != "Succeeded" {
+		t.Fatalf("manager status phase = %q, found = %v, error = %v", phase, found, err)
+	}
+
+	if err := jobframework.DeleteRemoteObjectWithCleanupContextIfOwned(t.Context(), managerClient, workerClient, adapter, key, jobframework.MultiKueueRemoteObjectCleanupContext{
+		RemoteObjectUID: remoteObj.GetUID(),
+		Association: jobframework.MultiKueueObjectAssociation{
+			Origin:           origin,
+			WorkloadName:     workloadName,
+			ManagerObjectUID: managerUID,
+		},
+		WorkloadKey: types.NamespacedName{Name: workloadName, Namespace: key.Namespace},
+	}); err != nil {
+		t.Fatalf("DeleteRemoteObjectWithCleanupContextIfOwned() error = %v", err)
+	}
+	gotRemote := &unstructured.Unstructured{}
+	gotRemote.SetGroupVersionKind(gvk)
+	if err := workerClient.Get(t.Context(), key, gotRemote); !apierrors.IsNotFound(err) {
+		t.Fatalf("worker object Get() error = %v, want NotFound", err)
+	}
+}
 
 func TestAdapter_IsJobManagedByKueue(t *testing.T) {
 	tests := []struct {

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -65,6 +65,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/features"
@@ -121,6 +122,7 @@ func (c *clientConfig) toRESTConfig() (*rest.Config, error) {
 type remoteClient struct {
 	clusterName  string
 	localClient  client.Client
+	localReader  client.Reader
 	client       SelectivelyCachingClient
 	wlUpdateCh   chan<- event.GenericEvent
 	watchEndedCh chan<- event.GenericEvent
@@ -151,6 +153,14 @@ type remoteClient struct {
 	builderOverride clientWithWatchBuilder
 
 	mu sync.RWMutex
+
+	workloadLocksMu sync.Mutex
+	workloadLocks   map[types.NamespacedName]*workloadLifecycleLock
+}
+
+type workloadLifecycleLock struct {
+	mu   sync.Mutex
+	refs int
 }
 
 // connectionState holds a remote client's connection status. Its own mutex guards the fields
@@ -201,20 +211,23 @@ func (c *connectionState) markDisconnected(now time.Time) (wasConnected bool) {
 
 func newRemoteClient(
 	localClient client.Client,
+	localReader client.Reader,
 	wlUpdateCh, watchEndedCh chan<- event.GenericEvent,
 	cqUpdateCh chan<- event.TypedGenericEvent[kueue.ClusterQueueReference],
 	origin, clusterName string,
 	adapters map[string]jobframework.MultiKueueAdapter,
 ) *remoteClient {
 	rc := &remoteClient{
-		clusterName:  clusterName,
-		wlUpdateCh:   wlUpdateCh,
-		watchEndedCh: watchEndedCh,
-		cqUpdateCh:   cqUpdateCh,
-		localClient:  localClient,
-		origin:       origin,
-		adapters:     adapters,
-		clock:        clock.RealClock{},
+		clusterName:   clusterName,
+		wlUpdateCh:    wlUpdateCh,
+		watchEndedCh:  watchEndedCh,
+		cqUpdateCh:    cqUpdateCh,
+		localClient:   localClient,
+		localReader:   localReader,
+		origin:        origin,
+		adapters:      adapters,
+		clock:         clock.RealClock{},
+		workloadLocks: make(map[types.NamespacedName]*workloadLifecycleLock),
 	}
 	// Start in the disconnected state, tracking the loss from creation. If the worker is
 	// unreachable when the client is created (e.g. the admitting worker is down right after a
@@ -223,6 +236,31 @@ func newRemoteClient(
 	// the grace never starting and the workload requeuing forever.
 	rc.connState.markDisconnected(rc.clock.Now())
 	return rc
+}
+
+func (rc *remoteClient) lockWorkload(key types.NamespacedName) func() {
+	rc.workloadLocksMu.Lock()
+	if rc.workloadLocks == nil {
+		rc.workloadLocks = make(map[types.NamespacedName]*workloadLifecycleLock)
+	}
+	entry := rc.workloadLocks[key]
+	if entry == nil {
+		entry = &workloadLifecycleLock{}
+		rc.workloadLocks[key] = entry
+	}
+	entry.refs++
+	rc.workloadLocksMu.Unlock()
+
+	entry.mu.Lock()
+	return func() {
+		entry.mu.Unlock()
+		rc.workloadLocksMu.Lock()
+		entry.refs--
+		if entry.refs == 0 {
+			delete(rc.workloadLocks, key)
+		}
+		rc.workloadLocksMu.Unlock()
+	}
 }
 
 func newClientWithWatch(ctx context.Context, config *clientConfig, options client.Options) (SelectivelyCachingClient, error) {
@@ -672,9 +710,10 @@ func (rc *remoteClient) queueWatchEndedEvent(ctx context.Context) {
 	}
 }
 
-// runGC - lists all the remote workloads having the same multikueue-origin and remove those who
-// no longer have a local correspondent (missing or awaiting deletion). If the remote workload
-// is owned by a job, also delete the job.
+// runGC lists remote Workloads having the same MultiKueue origin and removes
+// those whose authenticated manager Workload is awaiting deletion. A missing
+// local Workload is not sufficient proof of ownership: another manager can use
+// the same public origin value, so uncorrelated remote objects are preserved.
 func (rc *remoteClient) runGC(ctx context.Context) {
 	log := ctrl.LoggerFrom(ctx)
 
@@ -696,60 +735,121 @@ func (rc *remoteClient) runGC(ctx context.Context) {
 		return
 	}
 
-	for _, remoteWl := range wls.Items {
-		localWl := &kueue.Workload{}
-		wlLog := log.WithValues("remoteWl", klog.KObj(&remoteWl))
-		err := rc.localClient.Get(ctx, client.ObjectKeyFromObject(&remoteWl), localWl)
-		if client.IgnoreNotFound(err) != nil {
-			wlLog.Error(err, "Reading local workload")
-			continue
+	for i := range wls.Items {
+		rc.gcRemoteWorkload(ctx, remoteCl, &wls.Items[i])
+	}
+}
+
+func (rc *remoteClient) gcRemoteWorkload(ctx context.Context, remoteCl client.Client, listedRemote *kueue.Workload) {
+	wlLog := ctrl.LoggerFrom(ctx).WithValues("remoteWl", klog.KObj(listedRemote))
+	key := client.ObjectKeyFromObject(listedRemote)
+	unlock := rc.lockWorkload(key)
+	defer unlock()
+
+	remoteWl, err := currentRemoteWorkload(ctx, remoteCl, listedRemote)
+	if apierrors.IsNotFound(err) {
+		return
+	}
+	if err != nil {
+		wlLog.Error(err, "Reading current remote Workload")
+		return
+	}
+
+	localWl := &kueue.Workload{}
+	err = rc.localReader.Get(ctx, key, localWl)
+	if client.IgnoreNotFound(err) != nil {
+		wlLog.Error(err, "Reading local workload")
+		return
+	}
+	if apierrors.IsNotFound(err) {
+		wlLog.V(3).Info("Preserving remote Workload because no manager Workload is available to authenticate it")
+		return
+	}
+	if localWl.DeletionTimestamp.IsZero() {
+		return
+	}
+	if err := validateRemoteWorkloadOwnership(localWl, remoteWl, rc.origin); err != nil {
+		wlLog.Error(err, "Preserving remote Workload because its manager identity does not match")
+		return
+	}
+
+	// If the authenticated remote Workload has a controller (owning Job),
+	// delete the controller only when it has the exact Workload association.
+	if controller := metav1.GetControllerOf(remoteWl); controller != nil {
+		if controller.UID == "" {
+			wlLog.V(2).Info("Preserving remote Workload because its controller reference has no UID")
+			return
+		}
+		ownerKey := klog.KRef(remoteWl.Namespace, controller.Name)
+		adapterKey := schema.FromAPIVersionAndKind(controller.APIVersion, controller.Kind).String()
+		adapter, found := rc.adapters[adapterKey]
+		if !found {
+			wlLog.V(2).Info("Preserving remote Workload because no adapter can clean up its owner", "adapterKey", adapterKey, "ownerKey", ownerKey)
+			return
 		}
 
-		if err == nil && localWl.DeletionTimestamp.IsZero() {
-			// The local workload exists and isn't being deleted, so the remote workload is still relevant.
-			continue
+		wlLog.V(5).Info("MultiKueueGC deleting workload owner", "ownerKey", ownerKey, "ownerKind", controller)
+		wlKey := types.NamespacedName{Name: controller.Name, Namespace: remoteWl.Namespace}
+		managerObjectUIDs, err := jobframework.MultiKueueManagerObjectUIDsForWorkload(localWl, adapter.GVK())
+		if err != nil {
+			wlLog.Error(err, "Preserving remote Workload because its manager controller identity is unavailable")
+			return
 		}
-
-		// if the remote wl has a controller(owning Job), delete the job
-		if controller := metav1.GetControllerOf(&remoteWl); controller != nil {
-			ownerKey := klog.KRef(remoteWl.Namespace, controller.Name)
-			adapterKey := schema.FromAPIVersionAndKind(controller.APIVersion, controller.Kind).String()
-			if adapter, found := rc.adapters[adapterKey]; !found {
-				wlLog.V(2).Info("No adapter found", "adapterKey", adapterKey, "ownerKey", ownerKey)
-			} else {
-				wlLog.V(5).Info("MultiKueueGC deleting workload owner", "ownerKey", ownerKey, "ownerKind", controller)
-				wlKey := types.NamespacedName{Name: controller.Name, Namespace: remoteWl.Namespace}
-				var err error
-				if cleanupAdapter, ok := adapter.(jobframework.MultiKueueAdapterWithRemoteObjectCleanup); ok {
-					if controller.UID == "" {
-						wlLog.V(2).Info("Skipping remote workload owner deletion because its controller reference has no UID", "ownerKey", ownerKey)
-					} else {
-						err = jobframework.DeleteRemoteObjectWithCleanupContextIfOwned(ctx, rc.localClient, remoteCl, cleanupAdapter, wlKey, jobframework.MultiKueueRemoteObjectCleanupContext{
-							RemoteObjectUID: controller.UID,
-							Association: jobframework.MultiKueueObjectAssociation{
-								Origin:       rc.origin,
-								WorkloadName: remoteWl.Name,
-							},
-							WorkloadKey:         client.ObjectKeyFromObject(&remoteWl),
-							WorkloadAnnotations: maps.Clone(remoteWl.Annotations),
-						})
-					}
-				} else {
-					err = jobframework.DeleteRemoteObjectIfOwned(ctx, rc.localClient, remoteCl, adapter, wlKey, rc.origin)
-				}
-				if err != nil {
-					if !apierrors.IsNotFound(err) {
-						wlLog.Error(err, "Deleting remote workload's owner", "ownerKey", ownerKey)
-					}
-					continue
-				}
+		managerObjectUID := managerObjectUIDs[controller.Name]
+		fallbackUID, fallbackErr := managerControllerUIDForWorkload(localWl)
+		if managerObjectUID == "" {
+			if fallbackErr != nil {
+				wlLog.Error(fallbackErr, "Preserving remote Workload because its manager controller identity is unavailable")
+				return
 			}
+			managerObjectUID = fallbackUID
+		} else if fallbackErr == nil && fallbackUID != managerObjectUID {
+			wlLog.Error(
+				fmt.Errorf("manager Workload has conflicting controller UIDs %q and %q", managerObjectUID, fallbackUID),
+				"Preserving remote Workload because its manager controller identity is ambiguous",
+			)
+			return
 		}
-		wlLog.V(5).Info("MultiKueueGC deleting remote workload")
-		if err := remoteCl.Delete(ctx, &remoteWl, client.Preconditions{UID: ptr.To(remoteWl.UID)}); client.IgnoreNotFound(err) != nil {
-			wlLog.Error(err, "Deleting remote workload")
+		managerObjectUIDs[controller.Name] = managerObjectUID
+		err = jobframework.DeleteRemoteObjectWithCleanupContextIfOwned(ctx, rc.localClient, remoteCl, adapter, wlKey, jobframework.MultiKueueRemoteObjectCleanupContext{
+			RemoteObjectUID: controller.UID,
+			Association: jobframework.MultiKueueObjectAssociation{
+				Origin:           rc.origin,
+				WorkloadName:     remoteWl.Name,
+				ManagerObjectUID: managerObjectUID,
+			},
+			WorkloadKey:         key,
+			WorkloadAnnotations: maps.Clone(remoteWl.Annotations),
+			ManagerObjectUIDs:   managerObjectUIDs,
+		})
+		if client.IgnoreNotFound(err) != nil {
+			wlLog.Error(err, "Deleting remote workload's owner", "ownerKey", ownerKey)
+			return
 		}
 	}
+
+	wlLog.V(5).Info("MultiKueueGC deleting remote workload")
+	if err := deleteRemoteWorkload(ctx, remoteCl, remoteWl); err != nil {
+		wlLog.Error(err, "Deleting remote workload")
+	}
+}
+
+func managerControllerUIDForWorkload(workload *kueue.Workload) (types.UID, error) {
+	labelUID := types.UID(workload.Labels[controllerconstants.JobUIDLabel])
+	ownerUID := types.UID("")
+	if owner := metav1.GetControllerOf(workload); owner != nil {
+		ownerUID = owner.UID
+	}
+	if labelUID != "" && ownerUID != "" && labelUID != ownerUID {
+		return "", fmt.Errorf("manager Workload %q has conflicting controller UIDs %q and %q", klog.KObj(workload), labelUID, ownerUID)
+	}
+	if labelUID != "" {
+		return labelUID, nil
+	}
+	if ownerUID != "" {
+		return ownerUID, nil
+	}
+	return "", fmt.Errorf("manager Workload %q has no controller UID", klog.KObj(workload))
 }
 
 // clustersReconciler implements the reconciler for all MultiKueueClusters.
@@ -761,6 +861,7 @@ const defaultKubeConfigPathPrefix = "/etc/multikueue/kubeconfigs"
 
 type clustersReconciler struct {
 	localClient          client.Client
+	localReader          client.Reader
 	configNamespace      string
 	kubeConfigPathPrefix string
 	recorder             events.EventRecorder
@@ -852,7 +953,7 @@ func (c *clustersReconciler) findOrCreateRemoteClient(clusterName, origin string
 
 	client, found := c.remoteClients[clusterName]
 	if !found {
-		client = newRemoteClient(c.localClient, c.wlUpdateCh, c.watchEndedCh, c.cqUpdateCh, origin, clusterName, c.adapters)
+		client = newRemoteClient(c.localClient, c.localReader, c.wlUpdateCh, c.watchEndedCh, c.cqUpdateCh, origin, clusterName, c.adapters)
 		if c.builderOverride != nil {
 			client.builderOverride = c.builderOverride
 		}
@@ -1231,6 +1332,7 @@ func (c *clustersReconciler) getRemoteClients() []*remoteClient {
 
 func newClustersReconciler(
 	c client.Client,
+	localReader client.Reader,
 	namespace string,
 	gcInterval time.Duration,
 	origin string,
@@ -1242,6 +1344,7 @@ func newClustersReconciler(
 ) *clustersReconciler {
 	return &clustersReconciler{
 		localClient:                  c,
+		localReader:                  localReader,
 		configNamespace:              namespace,
 		kubeConfigPathPrefix:         defaultKubeConfigPathPrefix,
 		recorder:                     recorder,

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -746,7 +746,8 @@ func (rc *remoteClient) runGC(ctx context.Context) {
 			}
 		}
 		wlLog.V(5).Info("MultiKueueGC deleting remote workload")
-		if err := remoteCl.Delete(ctx, &remoteWl, client.Preconditions{UID: ptr.To(remoteWl.UID)}); client.IgnoreNotFound(err) != nil {
+		uid := remoteWl.UID
+		if err := remoteCl.Delete(ctx, &remoteWl, client.Preconditions{UID: &uid}); client.IgnoreNotFound(err) != nil {
 			wlLog.Error(err, "Deleting remote workload")
 		}
 	}

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -719,14 +719,34 @@ func (rc *remoteClient) runGC(ctx context.Context) {
 			} else {
 				wlLog.V(5).Info("MultiKueueGC deleting workload owner", "ownerKey", ownerKey, "ownerKind", controller)
 				wlKey := types.NamespacedName{Name: controller.Name, Namespace: remoteWl.Namespace}
-				err := jobframework.DeleteRemoteObjectIfOwned(ctx, rc.localClient, remoteCl, adapter, wlKey, rc.origin)
-				if client.IgnoreNotFound(err) != nil {
-					wlLog.Error(err, "Deleting remote workload's owner", "ownerKey", ownerKey)
+				var err error
+				if cleanupAdapter, ok := adapter.(jobframework.MultiKueueAdapterWithRemoteObjectCleanup); ok {
+					if controller.UID == "" {
+						wlLog.V(2).Info("Skipping remote workload owner deletion because its controller reference has no UID", "ownerKey", ownerKey)
+					} else {
+						err = jobframework.DeleteRemoteObjectWithCleanupContextIfOwned(ctx, rc.localClient, remoteCl, cleanupAdapter, wlKey, jobframework.MultiKueueRemoteObjectCleanupContext{
+							RemoteObjectUID: controller.UID,
+							Association: jobframework.MultiKueueObjectAssociation{
+								Origin:       rc.origin,
+								WorkloadName: remoteWl.Name,
+							},
+							WorkloadKey:         client.ObjectKeyFromObject(&remoteWl),
+							WorkloadAnnotations: maps.Clone(remoteWl.Annotations),
+						})
+					}
+				} else {
+					err = jobframework.DeleteRemoteObjectIfOwned(ctx, rc.localClient, remoteCl, adapter, wlKey, rc.origin)
+				}
+				if err != nil {
+					if !apierrors.IsNotFound(err) {
+						wlLog.Error(err, "Deleting remote workload's owner", "ownerKey", ownerKey)
+					}
+					continue
 				}
 			}
 		}
 		wlLog.V(5).Info("MultiKueueGC deleting remote workload")
-		if err := remoteCl.Delete(ctx, &remoteWl); client.IgnoreNotFound(err) != nil {
+		if err := remoteCl.Delete(ctx, &remoteWl, client.Preconditions{UID: ptr.To(remoteWl.UID)}); client.IgnoreNotFound(err) != nil {
 			wlLog.Error(err, "Deleting remote workload")
 		}
 	}

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -43,6 +44,7 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/utils/clock"
 	testingclock "k8s.io/utils/clock/testing"
+	"k8s.io/utils/ptr"
 	inventoryv1alpha1 "sigs.k8s.io/cluster-inventory-api/apis/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -51,8 +53,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobs"
+	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -1171,6 +1175,214 @@ func TestRemoteClientGC(t *testing.T) {
 				t.Errorf("unexpected worker's jobs (-want/+got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestRemoteClientGCBindsPodOwnerUID(t *testing.T) {
+	const (
+		workloadName = "workload"
+		podName      = "pod"
+	)
+	workloadKey := types.NamespacedName{Name: workloadName, Namespace: TestNamespace}
+	podKey := types.NamespacedName{Name: podName, Namespace: TestNamespace}
+
+	for name, tc := range map[string]struct {
+		ownerUID types.UID
+		podUID   types.UID
+		wantPod  bool
+	}{
+		"matching owner UID deletes Pod": {
+			ownerUID: "pod-uid",
+			podUID:   "pod-uid",
+		},
+		"replacement UID preserves Pod": {
+			ownerUID: "original-pod-uid",
+			podUID:   "replacement-pod-uid",
+			wantPod:  true,
+		},
+		"empty owner UID preserves Pod": {
+			podUID:  "pod-uid",
+			wantPod: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx, _ := utiltesting.ContextWithLog(t)
+			remoteWorkload := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+				Name:      workloadKey.Name,
+				Namespace: workloadKey.Namespace,
+				Labels:    map[string]string{kueue.MultiKueueOriginLabel: defaultOrigin},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "Pod",
+					Name:       podKey.Name,
+					UID:        tc.ownerUID,
+					Controller: ptr.To(true),
+				}},
+			}}
+			remotePod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Name:      podKey.Name,
+				Namespace: podKey.Namespace,
+				UID:       tc.podUID,
+				Labels: map[string]string{
+					kueue.MultiKueueOriginLabel:               defaultOrigin,
+					controllerconstants.PrebuiltWorkloadLabel: workloadName,
+				},
+			}}
+
+			managerClient := getClientBuilder(ctx).Build()
+			workerClient := NewNeverCachingClient(getClientBuilder(ctx).WithObjects(remoteWorkload, remotePod).Build())
+			adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("pod"))
+			remote := newRemoteClient(managerClient, nil, nil, nil, defaultOrigin, "", adapters)
+			remote.client = workerClient
+			remote.connState.markConnected()
+
+			remote.runGC(ctx)
+
+			if err := workerClient.Get(ctx, workloadKey, &kueue.Workload{}); !apierrors.IsNotFound(err) {
+				t.Fatalf("remote Workload Get() error = %v, want NotFound", err)
+			}
+			gotPod := &corev1.Pod{}
+			err := workerClient.Get(ctx, podKey, gotPod)
+			if tc.wantPod {
+				if err != nil {
+					t.Fatalf("replacement Pod Get() error = %v", err)
+				}
+				if gotPod.UID != tc.podUID {
+					t.Fatalf("replacement Pod UID = %q, want %q", gotPod.UID, tc.podUID)
+				}
+			} else if !apierrors.IsNotFound(err) {
+				t.Fatalf("remote Pod Get() error = %v, want NotFound", err)
+			}
+		})
+	}
+}
+
+func TestRemoteClientGCRetriesPodGroupCleanupBeforeDeletingWorkload(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	const (
+		workloadName = "group"
+		anchorName   = "group-0"
+		memberName   = "group-1"
+	)
+	workloadKey := types.NamespacedName{Name: workloadName, Namespace: TestNamespace}
+	anchorKey := types.NamespacedName{Name: anchorName, Namespace: TestNamespace}
+	memberKey := types.NamespacedName{Name: memberName, Namespace: TestNamespace}
+	remoteWorkload := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+		Name:      workloadKey.Name,
+		Namespace: workloadKey.Namespace,
+		UID:       "workload-uid",
+		Labels:    map[string]string{kueue.MultiKueueOriginLabel: defaultOrigin},
+		Annotations: map[string]string{
+			podconstants.IsGroupWorkloadAnnotationKey: podconstants.IsGroupWorkloadAnnotationValue,
+		},
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "Pod",
+			Name:       anchorName,
+			UID:        "anchor-uid",
+			Controller: ptr.To(true),
+		}},
+	}}
+	makeRemotePod := func(key types.NamespacedName, uid types.UID) *corev1.Pod {
+		return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Name:      key.Name,
+			Namespace: key.Namespace,
+			UID:       uid,
+			Labels: map[string]string{
+				kueue.MultiKueueOriginLabel:               defaultOrigin,
+				controllerconstants.PrebuiltWorkloadLabel: workloadName,
+				podconstants.GroupNameLabel:               workloadName,
+			},
+		}}
+	}
+	anchor := makeRemotePod(anchorKey, "anchor-uid")
+	member := makeRemotePod(memberKey, "member-uid")
+	pageErr := errors.New("Pod list unavailable")
+	failPodList := true
+	baseWorkerClient := getClientBuilder(ctx).WithObjects(remoteWorkload, anchor, member).Build()
+	workerClient := NewNeverCachingClient(interceptor.NewClient(baseWorkerClient, interceptor.Funcs{
+		List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+			if _, isPodList := list.(*corev1.PodList); isPodList && failPodList {
+				failPodList = false
+				return pageErr
+			}
+			return c.List(ctx, list, opts...)
+		},
+	}))
+	managerClient := getClientBuilder(ctx).Build()
+	adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("pod"))
+	remote := newRemoteClient(managerClient, nil, nil, nil, defaultOrigin, "", adapters)
+	remote.client = workerClient
+	remote.connState.markConnected()
+
+	remote.runGC(ctx)
+	for key, obj := range map[types.NamespacedName]client.Object{
+		workloadKey: &kueue.Workload{},
+		anchorKey:   &corev1.Pod{},
+		memberKey:   &corev1.Pod{},
+	} {
+		if err := workerClient.Get(ctx, key, obj); err != nil {
+			t.Fatalf("object %q was deleted after failed cleanup: %v", key, err)
+		}
+	}
+
+	remote.runGC(ctx)
+	for key, obj := range map[types.NamespacedName]client.Object{
+		workloadKey: &kueue.Workload{},
+		anchorKey:   &corev1.Pod{},
+		memberKey:   &corev1.Pod{},
+	} {
+		if err := workerClient.Get(ctx, key, obj); !apierrors.IsNotFound(err) {
+			t.Errorf("object %q Get() error = %v after retry, want NotFound", key, err)
+		}
+	}
+}
+
+func TestRemoteClientGCUsesWorkloadUIDPrecondition(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	key := types.NamespacedName{Name: "workload", Namespace: TestNamespace}
+	original := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+		Name:      key.Name,
+		Namespace: key.Namespace,
+		UID:       "original-workload-uid",
+		Labels:    map[string]string{kueue.MultiKueueOriginLabel: defaultOrigin},
+	}}
+	replacement := original.DeepCopy()
+	replacement.UID = "replacement-workload-uid"
+	baseWorkerClient := getClientBuilder(ctx).WithObjects(original).Build()
+	workerClient := NewNeverCachingClient(interceptor.NewClient(baseWorkerClient, interceptor.Funcs{
+		Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			if _, isWorkload := obj.(*kueue.Workload); !isWorkload {
+				return c.Delete(ctx, obj, opts...)
+			}
+			deleteOptions := &client.DeleteOptions{}
+			for _, opt := range opts {
+				opt.ApplyToDelete(deleteOptions)
+			}
+			if deleteOptions.Preconditions == nil || deleteOptions.Preconditions.UID == nil || *deleteOptions.Preconditions.UID != original.UID {
+				t.Errorf("Workload Delete() UID precondition = %v, want %q", deleteOptions.Preconditions, original.UID)
+			}
+			if err := c.Delete(ctx, obj); err != nil {
+				return err
+			}
+			if err := c.Create(ctx, replacement); err != nil {
+				return err
+			}
+			return apierrors.NewConflict(kueue.Resource("workloads"), key.Name, errors.New("UID precondition failed"))
+		},
+	}))
+	remote := newRemoteClient(getClientBuilder(ctx).Build(), nil, nil, nil, defaultOrigin, "", nil)
+	remote.client = workerClient
+	remote.connState.markConnected()
+
+	remote.runGC(ctx)
+
+	got := &kueue.Workload{}
+	if err := workerClient.Get(ctx, key, got); err != nil {
+		t.Fatalf("replacement Workload Get() error = %v", err)
+	}
+	if got.UID != replacement.UID {
+		t.Fatalf("replacement Workload UID = %q, want %q", got.UID, replacement.UID)
 	}
 }
 

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -44,7 +44,6 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/utils/clock"
 	testingclock "k8s.io/utils/clock/testing"
-	"k8s.io/utils/ptr"
 	inventoryv1alpha1 "sigs.k8s.io/cluster-inventory-api/apis/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -94,6 +93,7 @@ func newTestClient(ctx context.Context, kubeconfig []byte, restConfig *rest.Conf
 	ret := &remoteClient{
 		config:      &clientConfig{Kubeconfig: kubeconfig, RestConfig: restConfig},
 		localClient: localClient,
+		localReader: localClient,
 		watchCancel: watchCancel,
 		clock:       clock.RealClock{},
 
@@ -690,7 +690,7 @@ func TestUpdateConfig(t *testing.T) {
 
 			adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("batch/job"))
 			recorder := &utiltesting.EventRecorder{}
-			reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, tc.cpAccessProvider, nil, recorder)
+			reconciler := newClustersReconciler(c, c, TestNamespace, 0, defaultOrigin, nil, adapters, tc.cpAccessProvider, nil, recorder)
 
 			reconciler.rootContext = ctx
 
@@ -866,7 +866,7 @@ func TestReconnectBackoff(t *testing.T) {
 
 			adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("batch/job"))
 			recorder := &utiltesting.EventRecorder{}
-			reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, &testClusterProfileAccessProvider{}, nil, recorder)
+			reconciler := newClustersReconciler(c, c, TestNamespace, 0, defaultOrigin, nil, adapters, &testClusterProfileAccessProvider{}, nil, recorder)
 			reconciler.rootContext = ctx
 
 			var buildCalls int
@@ -876,7 +876,7 @@ func TestReconnectBackoff(t *testing.T) {
 				return inner(builderCtx, cfg, opts)
 			}
 
-			rc := newRemoteClient(c, reconciler.wlUpdateCh, reconciler.watchEndedCh, reconciler.cqUpdateCh, defaultOrigin, "worker1", adapters)
+			rc := newRemoteClient(c, c, reconciler.wlUpdateCh, reconciler.watchEndedCh, reconciler.cqUpdateCh, defaultOrigin, "worker1", adapters)
 			rc.clock = fc
 			rc.builderOverride = reconciler.builderOverride
 			reconciler.remoteClients["worker1"] = rc
@@ -923,7 +923,7 @@ func TestDisconnectedClientReconnectsWithSameConfig(t *testing.T) {
 
 	adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("batch/job"))
 	recorder := &utiltesting.EventRecorder{}
-	reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, &testClusterProfileAccessProvider{}, nil, recorder)
+	reconciler := newClustersReconciler(c, c, TestNamespace, 0, defaultOrigin, nil, adapters, &testClusterProfileAccessProvider{}, nil, recorder)
 	reconciler.rootContext = ctx
 
 	var buildCalls int
@@ -1002,10 +1002,10 @@ func TestActiveConditionSurfacesBackoff(t *testing.T) {
 	managerClient := getClientBuilder(ctx).WithObjects(cluster).WithStatusSubresource(cluster).Build()
 	adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("batch/job"))
 	recorder := &utiltesting.EventRecorder{}
-	cRec := newClustersReconciler(managerClient, TestNamespace, 0, defaultOrigin, nil, adapters, &NoOpClusterProfileAccessProvider{}, nil, recorder)
+	cRec := newClustersReconciler(managerClient, managerClient, TestNamespace, 0, defaultOrigin, nil, adapters, &NoOpClusterProfileAccessProvider{}, nil, recorder)
 
 	nextRetry := time.Now().Truncate(time.Second).Add(20 * time.Second)
-	rc := newRemoteClient(managerClient, nil, nil, nil, defaultOrigin, "", adapters)
+	rc := newRemoteClient(managerClient, managerClient, nil, nil, nil, defaultOrigin, "", adapters)
 	rc.failedConnAttempts = 3
 	rc.retryConnNextAttempt = metav1.NewTime(nextRetry)
 	cRec.remoteClients["worker1"] = rc
@@ -1043,8 +1043,24 @@ func TestActiveConditionSurfacesBackoff(t *testing.T) {
 }
 
 func TestRemoteClientGC(t *testing.T) {
-	baseJobBuilder := testingjob.MakeJob("job1", TestNamespace)
-	baseWlBuilder := utiltestingapi.MakeWorkload("wl1", TestNamespace).ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "test-uuid")
+	baseJobBuilder := testingjob.MakeJob("job1", TestNamespace).UID("test-uuid")
+	remoteJobBuilder := baseJobBuilder.Clone().
+		UID("remote-job-uid").
+		PrebuiltWorkloadLabel("wl1").
+		Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+		SetAnnotation(kueue.MultiKueueOriginUIDAnnotation, "test-uuid")
+	baseWlBuilder := utiltestingapi.MakeWorkload("wl1", TestNamespace).
+		UID("manager-wl-uid").
+		ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "test-uuid")
+	remoteWlBuilder := utiltestingapi.MakeWorkload("wl1", TestNamespace).
+		UID("remote-wl-uid").
+		ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "remote-job-uid").
+		Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+		Annotation(kueue.MultiKueueOriginUIDAnnotation, "manager-wl-uid")
+	deletingManagerWl := *baseWlBuilder.Clone().
+		DeletionTimestamp(time.Now()).
+		Finalizers(kueue.ResourceInUseFinalizerName).
+		Obj()
 
 	cases := map[string]struct {
 		managersWorkloads []kueue.Workload
@@ -1060,9 +1076,7 @@ func TestRemoteClientGC(t *testing.T) {
 				*baseWlBuilder.DeepCopy(),
 			},
 			workersWorkloads: []kueue.Workload{
-				*baseWlBuilder.Clone().
-					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
-					Obj(),
+				*remoteWlBuilder.DeepCopy(),
 			},
 			managersJobs: []batchv1.Job{
 				*baseJobBuilder.DeepCopy(),
@@ -1071,50 +1085,92 @@ func TestRemoteClientGC(t *testing.T) {
 				*baseJobBuilder.DeepCopy(),
 			},
 			wantWorkersWorkloads: []kueue.Workload{
-				*baseWlBuilder.Clone().
-					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
-					Obj(),
+				*remoteWlBuilder.DeepCopy(),
 			},
 			wantWorkersJobs: []batchv1.Job{
 				*baseJobBuilder.DeepCopy(),
 			},
 		},
-		"missing worker workloads are deleted": {
+		"uncorrelated remote workloads are preserved": {
 			workersWorkloads: []kueue.Workload{
-				*baseWlBuilder.Clone().
-					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
-					Obj(),
+				*remoteWlBuilder.DeepCopy(),
 			},
 			managersJobs: []batchv1.Job{
 				*baseJobBuilder.DeepCopy(),
 			},
+			wantWorkersWorkloads: []kueue.Workload{
+				*remoteWlBuilder.DeepCopy(),
+			},
 		},
-		"missing worker workloads are deleted (no job adapter)": {
+		"uncorrelated remote workloads are preserved without a job adapter": {
 			workersWorkloads: []kueue.Workload{
-				*baseWlBuilder.Clone().
+				*remoteWlBuilder.Clone().
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("NptAJob"), "job1", "test-uuid").
-					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Obj(),
+			},
+			wantWorkersWorkloads: []kueue.Workload{
+				*remoteWlBuilder.Clone().
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("NptAJob"), "job1", "test-uuid").
 					Obj(),
 			},
 		},
-		"missing worker workloads and their owner jobs are deleted": {
+		"uncorrelated remote workloads cannot make GC delete owner jobs": {
 			workersWorkloads: []kueue.Workload{
-				*baseWlBuilder.Clone().
-					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
-					Obj(),
+				*remoteWlBuilder.DeepCopy(),
 			},
 			managersJobs: []batchv1.Job{
 				*baseJobBuilder.DeepCopy(),
 			},
 			workersJobs: []batchv1.Job{
 				*baseJobBuilder.Clone().
+					PrebuiltWorkloadLabel("wl1").
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Obj(),
+			},
+			wantWorkersWorkloads: []kueue.Workload{
+				*remoteWlBuilder.DeepCopy(),
+			},
+			wantWorkersJobs: []batchv1.Job{
+				*baseJobBuilder.Clone().
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
 					Obj(),
 			},
 		},
+		"authenticated remote workload and owner job are deleted with the manager workload": {
+			managersWorkloads: []kueue.Workload{deletingManagerWl},
+			workersWorkloads: []kueue.Workload{
+				*remoteWlBuilder.DeepCopy(),
+			},
+			managersJobs: []batchv1.Job{
+				*baseJobBuilder.DeepCopy(),
+			},
+			workersJobs: []batchv1.Job{
+				*remoteJobBuilder.DeepCopy(),
+			},
+		},
+		"remote workload with a different manager UID is preserved": {
+			managersWorkloads: []kueue.Workload{deletingManagerWl},
+			workersWorkloads: []kueue.Workload{
+				*remoteWlBuilder.Clone().
+					Annotation(kueue.MultiKueueOriginUIDAnnotation, "other-manager-uid").
+					Obj(),
+			},
+			workersJobs: []batchv1.Job{
+				*remoteJobBuilder.DeepCopy(),
+			},
+			wantWorkersWorkloads: []kueue.Workload{
+				*remoteWlBuilder.Clone().
+					Annotation(kueue.MultiKueueOriginUIDAnnotation, "other-manager-uid").
+					Obj(),
+			},
+			wantWorkersJobs: []batchv1.Job{
+				*remoteJobBuilder.DeepCopy(),
+			},
+		},
 		"unrelated workers and jobs are not deleted": {
 			workersWorkloads: []kueue.Workload{
-				*baseWlBuilder.Clone().
+				*remoteWlBuilder.Clone().
 					Label(kueue.MultiKueueOriginLabel, "other-gc-key").
 					Obj(),
 			},
@@ -1122,7 +1178,7 @@ func TestRemoteClientGC(t *testing.T) {
 				*baseJobBuilder.DeepCopy(),
 			},
 			wantWorkersWorkloads: []kueue.Workload{
-				*baseWlBuilder.Clone().
+				*remoteWlBuilder.Clone().
 					Label(kueue.MultiKueueOriginLabel, "other-gc-key").
 					Obj(),
 			},
@@ -1149,7 +1205,7 @@ func TestRemoteClientGC(t *testing.T) {
 			worker1Client := NewNeverCachingClient(worker1Builder.Build())
 
 			adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("batch/job"))
-			w1remoteClient := newRemoteClient(managerClient, nil, nil, nil, defaultOrigin, "", adapters)
+			w1remoteClient := newRemoteClient(managerClient, managerClient, nil, nil, nil, defaultOrigin, "", adapters)
 			w1remoteClient.client = worker1Client
 			w1remoteClient.connState.markConnected()
 
@@ -1187,22 +1243,25 @@ func TestRemoteClientGCBindsPodOwnerUID(t *testing.T) {
 	podKey := types.NamespacedName{Name: podName, Namespace: TestNamespace}
 
 	for name, tc := range map[string]struct {
-		ownerUID types.UID
-		podUID   types.UID
-		wantPod  bool
+		ownerUID     types.UID
+		podUID       types.UID
+		wantPod      bool
+		wantWorkload bool
 	}{
 		"matching owner UID deletes Pod": {
 			ownerUID: "pod-uid",
 			podUID:   "pod-uid",
 		},
 		"replacement UID preserves Pod": {
-			ownerUID: "original-pod-uid",
-			podUID:   "replacement-pod-uid",
-			wantPod:  true,
+			ownerUID:     "original-pod-uid",
+			podUID:       "replacement-pod-uid",
+			wantPod:      true,
+			wantWorkload: true,
 		},
 		"empty owner UID preserves Pod": {
-			podUID:  "pod-uid",
-			wantPod: true,
+			podUID:       "pod-uid",
+			wantPod:      true,
+			wantWorkload: true,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -1210,13 +1269,17 @@ func TestRemoteClientGCBindsPodOwnerUID(t *testing.T) {
 			remoteWorkload := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
 				Name:      workloadKey.Name,
 				Namespace: workloadKey.Namespace,
+				UID:       "remote-workload-uid",
 				Labels:    map[string]string{kueue.MultiKueueOriginLabel: defaultOrigin},
+				Annotations: map[string]string{
+					kueue.MultiKueueOriginUIDAnnotation: "manager-workload-uid",
+				},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion: corev1.SchemeGroupVersion.String(),
 					Kind:       "Pod",
 					Name:       podKey.Name,
 					UID:        tc.ownerUID,
-					Controller: ptr.To(true),
+					Controller: new(true),
 				}},
 			}}
 			remotePod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
@@ -1227,19 +1290,39 @@ func TestRemoteClientGCBindsPodOwnerUID(t *testing.T) {
 					kueue.MultiKueueOriginLabel:               defaultOrigin,
 					controllerconstants.PrebuiltWorkloadLabel: workloadName,
 				},
+				Annotations: map[string]string{kueue.MultiKueueOriginUIDAnnotation: "manager-pod-uid"},
+			}}
+			managerWorkload := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+				Name:              workloadKey.Name,
+				Namespace:         workloadKey.Namespace,
+				UID:               "manager-workload-uid",
+				DeletionTimestamp: new(metav1.Now()),
+				Finalizers:        []string{kueue.ResourceInUseFinalizerName},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "Pod",
+					Name:       podKey.Name,
+					UID:        "manager-pod-uid",
+					Controller: new(true),
+				}},
 			}}
 
-			managerClient := getClientBuilder(ctx).Build()
+			managerClient := getClientBuilder(ctx).WithObjects(managerWorkload).Build()
 			workerClient := NewNeverCachingClient(getClientBuilder(ctx).WithObjects(remoteWorkload, remotePod).Build())
 			adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("pod"))
-			remote := newRemoteClient(managerClient, nil, nil, nil, defaultOrigin, "", adapters)
+			remote := newRemoteClient(managerClient, managerClient, nil, nil, nil, defaultOrigin, "", adapters)
 			remote.client = workerClient
 			remote.connState.markConnected()
 
 			remote.runGC(ctx)
 
-			if err := workerClient.Get(ctx, workloadKey, &kueue.Workload{}); !apierrors.IsNotFound(err) {
-				t.Fatalf("remote Workload Get() error = %v, want NotFound", err)
+			workloadErr := workerClient.Get(ctx, workloadKey, &kueue.Workload{})
+			if tc.wantWorkload {
+				if workloadErr != nil {
+					t.Fatalf("preserved remote Workload Get() error = %v", workloadErr)
+				}
+			} else if !apierrors.IsNotFound(workloadErr) {
+				t.Fatalf("remote Workload Get() error = %v, want NotFound", workloadErr)
 			}
 			gotPod := &corev1.Pod{}
 			err := workerClient.Get(ctx, podKey, gotPod)
@@ -1274,13 +1357,14 @@ func TestRemoteClientGCRetriesPodGroupCleanupBeforeDeletingWorkload(t *testing.T
 		Labels:    map[string]string{kueue.MultiKueueOriginLabel: defaultOrigin},
 		Annotations: map[string]string{
 			podconstants.IsGroupWorkloadAnnotationKey: podconstants.IsGroupWorkloadAnnotationValue,
+			kueue.MultiKueueOriginUIDAnnotation:       "manager-workload-uid",
 		},
 		OwnerReferences: []metav1.OwnerReference{{
 			APIVersion: corev1.SchemeGroupVersion.String(),
 			Kind:       "Pod",
 			Name:       anchorName,
 			UID:        "anchor-uid",
-			Controller: ptr.To(true),
+			Controller: new(true),
 		}},
 	}}
 	makeRemotePod := func(key types.NamespacedName, uid types.UID) *corev1.Pod {
@@ -1293,10 +1377,12 @@ func TestRemoteClientGCRetriesPodGroupCleanupBeforeDeletingWorkload(t *testing.T
 				controllerconstants.PrebuiltWorkloadLabel: workloadName,
 				podconstants.GroupNameLabel:               workloadName,
 			},
+			Annotations: map[string]string{kueue.MultiKueueOriginUIDAnnotation: "manager-anchor-uid"},
 		}}
 	}
 	anchor := makeRemotePod(anchorKey, "anchor-uid")
 	member := makeRemotePod(memberKey, "member-uid")
+	member.Annotations[kueue.MultiKueueOriginUIDAnnotation] = "manager-member-uid"
 	pageErr := errors.New("Pod list unavailable")
 	failPodList := true
 	baseWorkerClient := getClientBuilder(ctx).WithObjects(remoteWorkload, anchor, member).Build()
@@ -1309,9 +1395,31 @@ func TestRemoteClientGCRetriesPodGroupCleanupBeforeDeletingWorkload(t *testing.T
 			return c.List(ctx, list, opts...)
 		},
 	}))
-	managerClient := getClientBuilder(ctx).Build()
+	managerWorkload := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+		Name:              workloadKey.Name,
+		Namespace:         workloadKey.Namespace,
+		UID:               "manager-workload-uid",
+		DeletionTimestamp: new(metav1.Now()),
+		Finalizers:        []string{kueue.ResourceInUseFinalizerName},
+		Annotations: map[string]string{
+			podconstants.IsGroupWorkloadAnnotationKey: podconstants.IsGroupWorkloadAnnotationValue,
+		},
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "Pod",
+			Name:       anchorName,
+			UID:        "manager-anchor-uid",
+			Controller: new(true),
+		}, {
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "Pod",
+			Name:       memberName,
+			UID:        "manager-member-uid",
+		}},
+	}}
+	managerClient := getClientBuilder(ctx).WithObjects(managerWorkload).Build()
 	adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("pod"))
-	remote := newRemoteClient(managerClient, nil, nil, nil, defaultOrigin, "", adapters)
+	remote := newRemoteClient(managerClient, managerClient, nil, nil, nil, defaultOrigin, "", adapters)
 	remote.client = workerClient
 	remote.connState.markConnected()
 
@@ -1342,10 +1450,11 @@ func TestRemoteClientGCUsesWorkloadUIDPrecondition(t *testing.T) {
 	ctx, _ := utiltesting.ContextWithLog(t)
 	key := types.NamespacedName{Name: "workload", Namespace: TestNamespace}
 	original := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
-		Name:      key.Name,
-		Namespace: key.Namespace,
-		UID:       "original-workload-uid",
-		Labels:    map[string]string{kueue.MultiKueueOriginLabel: defaultOrigin},
+		Name:        key.Name,
+		Namespace:   key.Namespace,
+		UID:         "original-workload-uid",
+		Labels:      map[string]string{kueue.MultiKueueOriginLabel: defaultOrigin},
+		Annotations: map[string]string{kueue.MultiKueueOriginUIDAnnotation: "manager-workload-uid"},
 	}}
 	replacement := original.DeepCopy()
 	replacement.UID = "replacement-workload-uid"
@@ -1371,7 +1480,15 @@ func TestRemoteClientGCUsesWorkloadUIDPrecondition(t *testing.T) {
 			return apierrors.NewConflict(kueue.Resource("workloads"), key.Name, errors.New("UID precondition failed"))
 		},
 	}))
-	remote := newRemoteClient(getClientBuilder(ctx).Build(), nil, nil, nil, defaultOrigin, "", nil)
+	managerWorkload := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+		Name:              key.Name,
+		Namespace:         key.Namespace,
+		UID:               "manager-workload-uid",
+		DeletionTimestamp: new(metav1.Now()),
+		Finalizers:        []string{kueue.ResourceInUseFinalizerName},
+	}}
+	managerClient := getClientBuilder(ctx).WithObjects(managerWorkload).Build()
+	remote := newRemoteClient(managerClient, managerClient, nil, nil, nil, defaultOrigin, "", nil)
 	remote.client = workerClient
 	remote.connState.markConnected()
 
@@ -1545,7 +1662,7 @@ func TestClustersReconcilerEventFilters(t *testing.T) {
 			ctx, _ := utiltesting.ContextWithLog(t)
 			c := getClientBuilder(ctx).Build()
 			recorder := &utiltesting.EventRecorder{}
-			reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, newKubeConfigFSWatcher(), nil, &NoOpClusterProfileAccessProvider{}, nil, recorder)
+			reconciler := newClustersReconciler(c, c, TestNamespace, 0, defaultOrigin, newKubeConfigFSWatcher(), nil, &NoOpClusterProfileAccessProvider{}, nil, recorder)
 			reconciler.rootContext = ctx
 
 			if got := tc.invoke(reconciler); got != tc.wantReconcile {
@@ -1795,7 +1912,7 @@ func TestSetRemoteClientConfigDoesNotBlockOtherClusters(t *testing.T) {
 		Build()
 
 	recorder := &utiltesting.EventRecorder{}
-	reconciler := newClustersReconciler(localClient, TestNamespace, 0, defaultOrigin, nil, nil, &NoOpClusterProfileAccessProvider{}, nil, recorder)
+	reconciler := newClustersReconciler(localClient, localClient, TestNamespace, 0, defaultOrigin, nil, nil, &NoOpClusterProfileAccessProvider{}, nil, recorder)
 	reconciler.rootContext = ctx
 	reconciler.builderOverride = gatedBuilder
 	t.Cleanup(func() {

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -44,7 +44,6 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/utils/clock"
 	testingclock "k8s.io/utils/clock/testing"
-	"k8s.io/utils/ptr"
 	inventoryv1alpha1 "sigs.k8s.io/cluster-inventory-api/apis/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -1216,7 +1215,7 @@ func TestRemoteClientGCBindsPodOwnerUID(t *testing.T) {
 					Kind:       "Pod",
 					Name:       podKey.Name,
 					UID:        tc.ownerUID,
-					Controller: ptr.To(true),
+					Controller: new(true),
 				}},
 			}}
 			remotePod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
@@ -1280,7 +1279,7 @@ func TestRemoteClientGCRetriesPodGroupCleanupBeforeDeletingWorkload(t *testing.T
 			Kind:       "Pod",
 			Name:       anchorName,
 			UID:        "anchor-uid",
-			Controller: ptr.To(true),
+			Controller: new(true),
 		}},
 	}}
 	makeRemotePod := func(key types.NamespacedName, uid types.UID) *corev1.Pod {

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -161,7 +161,7 @@ func (g *wlGroup) bestMatchByCondition(conditionType string) (*metav1.Condition,
 func (g *wlGroup) RemoveRemoteObjects(ctx context.Context, cluster string) error {
 	remoteClient := g.remoteClients[cluster].getClient()
 	origin := g.remoteClients[cluster].origin
-	if err := jobframework.DeleteRemoteObjectIfOwned(ctx, g.localClient, remoteClient, g.jobAdapter, g.controllerKey, origin); err != nil {
+	if err := jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, g.localClient, remoteClient, g.jobAdapter, g.controllerKey, g.local, origin); err != nil {
 		return fmt.Errorf("deleting remote controller object: %w", err)
 	}
 

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -26,6 +26,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -67,6 +68,7 @@ import (
 var (
 	realClock                      = clock.RealClock{}
 	singleClusterPreemptionTimeout = 5 * time.Minute
+	errRemoteWorkloadNotOwned      = errors.New("remote Workload is not owned by this MultiKueue dispatch")
 )
 
 // syncDeferredRequeueAfter is the delay used to re-reconcile a workload after
@@ -156,31 +158,193 @@ func (g *wlGroup) bestMatchByCondition(conditionType string) (*metav1.Condition,
 }
 
 // RemoveRemoteObjects deletes the remote controller object and workload for a cluster.
-// The controller object is deleted first to handle cases where GC has already removed
-// the remote workload.
+// The controller object is deleted before an existing remote Workload, but is preserved
+// if that Workload is absent because there is no longer manager-specific evidence that
+// a same-name controller object belongs to this dispatch.
 func (g *wlGroup) RemoveRemoteObjects(ctx context.Context, cluster string) error {
-	remoteClient := g.remoteClients[cluster].getClient()
-	origin := g.remoteClients[cluster].origin
-	if err := jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, g.localClient, remoteClient, g.jobAdapter, g.controllerKey, g.local, origin); err != nil {
-		return fmt.Errorf("deleting remote controller object: %w", err)
-	}
-
-	remWl := g.remotes[cluster]
-	if remWl == nil {
+	expectedRemote := g.remotes[cluster]
+	if expectedRemote == nil {
 		return nil
 	}
 
+	remote := g.remoteClients[cluster]
+	unlock := remote.lockWorkload(client.ObjectKeyFromObject(g.local))
+	defer unlock()
+
+	remWl, err := currentRemoteWorkload(ctx, remote.getClient(), expectedRemote)
+	if apierrors.IsNotFound(err) {
+		g.remotes[cluster] = nil
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("reading current remote Workload before cleanup: %w", err)
+	}
+	if err := g.removeRemoteObjectsLocked(ctx, cluster, remWl); err != nil {
+		return err
+	}
+	g.remotes[cluster] = nil
+	return nil
+}
+
+// removeRemoteObjectsLocked removes an authenticated remote dispatch. The
+// caller must hold the corresponding remoteClient workload lock.
+func (g *wlGroup) removeRemoteObjectsLocked(ctx context.Context, cluster string, remWl *kueue.Workload) error {
+	remote := g.remoteClients[cluster]
+	remoteClient := remote.getClient()
+	if err := validateRemoteWorkloadOwnership(g.local, remWl, remote.origin); err != nil {
+		return fmt.Errorf("validating remote Workload before cleanup: %w", err)
+	}
+	if g.jobAdapter != nil {
+		if err := jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, g.localClient, remoteClient, g.jobAdapter, g.controllerKey, g.local, remote.origin); err != nil {
+			return fmt.Errorf("deleting remote controller object: %w", err)
+		}
+	} else if metav1.GetControllerOf(remWl) != nil {
+		return errors.New("deleting remote controller object: no adapter is available")
+	}
+
+	if err := deleteRemoteWorkload(ctx, remoteClient, remWl); err != nil {
+		return err
+	}
+	return nil
+}
+
+func deleteRemoteWorkload(ctx context.Context, remoteClient client.Client, remWl *kueue.Workload) error {
 	if controllerutil.RemoveFinalizer(remWl, kueue.ResourceInUseFinalizerName) {
 		if err := remoteClient.Update(ctx, remWl); err != nil {
 			return fmt.Errorf("removing remote workloads finalizer: %w", err)
 		}
 	}
 
-	err := remoteClient.Delete(ctx, remWl)
+	uid := remWl.UID
+	err := remoteClient.Delete(ctx, remWl, client.Preconditions{UID: &uid})
 	if client.IgnoreNotFound(err) != nil {
 		return fmt.Errorf("deleting remote workload: %w", err)
 	}
-	g.remotes[cluster] = nil
+	return nil
+}
+
+func currentManagerWorkload(ctx context.Context, reader client.Reader, expected *kueue.Workload, requireActive bool) (*kueue.Workload, error) {
+	if reader == nil || expected == nil || expected.UID == "" {
+		return nil, fmt.Errorf("%w: expected manager Workload identity is unavailable", errRemoteWorkloadNotOwned)
+	}
+	current := &kueue.Workload{}
+	if err := reader.Get(ctx, client.ObjectKeyFromObject(expected), current); err != nil {
+		return nil, fmt.Errorf("%w: reading current manager Workload: %v", errRemoteWorkloadNotOwned, err)
+	}
+	if current.UID != expected.UID {
+		return nil, fmt.Errorf("%w: manager Workload UID changed from %q to %q", errRemoteWorkloadNotOwned, expected.UID, current.UID)
+	}
+	if requireActive && !current.DeletionTimestamp.IsZero() {
+		return nil, fmt.Errorf("%w: manager Workload is awaiting deletion", errRemoteWorkloadNotOwned)
+	}
+	return current, nil
+}
+
+func currentRemoteWorkload(ctx context.Context, remoteClient client.Client, expected *kueue.Workload) (*kueue.Workload, error) {
+	if expected == nil || expected.UID == "" {
+		return nil, fmt.Errorf("%w: expected remote Workload identity is unavailable", errRemoteWorkloadNotOwned)
+	}
+	current := &kueue.Workload{}
+	if err := remoteClient.Get(ctx, client.ObjectKeyFromObject(expected), current); err != nil {
+		return nil, err
+	}
+	if current.UID != expected.UID {
+		return nil, fmt.Errorf("%w: remote Workload UID changed from %q to %q", errRemoteWorkloadNotOwned, expected.UID, current.UID)
+	}
+	return current, nil
+}
+
+// withActiveRemoteWorkload serializes all non-cleanup writes for a dispatch
+// against GC and normal cleanup. It revalidates the manager Workload through
+// the uncached API reader before and after fn. If deletion starts while fn is
+// running, the just-written remote objects are removed before the lock is
+// released.
+func (g *wlGroup) withActiveRemoteWorkload(ctx context.Context, cluster string, fn func(*kueue.Workload, *kueue.Workload, client.Client) error) error {
+	remote := g.remoteClients[cluster]
+	unlock := remote.lockWorkload(client.ObjectKeyFromObject(g.local))
+	defer unlock()
+
+	local, err := currentManagerWorkload(ctx, remote.localReader, g.local, true)
+	if err != nil {
+		return err
+	}
+	remWl, err := currentRemoteWorkload(ctx, remote.getClient(), g.remotes[cluster])
+	if err != nil {
+		return err
+	}
+	if err := validateRemoteWorkloadOwnership(local, remWl, remote.origin); err != nil {
+		return err
+	}
+
+	writeErr := fn(local, remWl, remote.getClient())
+	_, lifecycleErr := currentManagerWorkload(ctx, remote.localReader, local, true)
+	if lifecycleErr == nil {
+		return writeErr
+	}
+
+	cleanupErr := g.removeRemoteObjectsLocked(ctx, cluster, remWl)
+	if cleanupErr == nil {
+		g.remotes[cluster] = nil
+	}
+	return errors.Join(writeErr, fmt.Errorf("manager Workload changed during remote write: %w", lifecycleErr), cleanupErr)
+}
+
+func (g *wlGroup) syncJob(ctx context.Context, cluster string) (bool, error) {
+	var deferred bool
+	err := g.withActiveRemoteWorkload(ctx, cluster, func(local, _ *kueue.Workload, remoteClient client.Client) error {
+		var err error
+		deferred, err = jobframework.SyncJobWithRemoteObjectOwnership(
+			ctx,
+			g.localClient,
+			g.remoteClients[cluster].localReader,
+			remoteClient,
+			g.jobAdapter,
+			g.controllerKey,
+			local,
+			g.remoteClients[cluster].origin,
+		)
+		return err
+	})
+	return deferred, err
+}
+
+func (g *wlGroup) createRemoteWorkload(ctx context.Context, cluster string, preemptionGated bool) error {
+	remote := g.remoteClients[cluster]
+	unlock := remote.lockWorkload(client.ObjectKeyFromObject(g.local))
+	defer unlock()
+
+	local, err := currentManagerWorkload(ctx, remote.localReader, g.local, true)
+	if err != nil {
+		return err
+	}
+	clone := cloneForCreate(local, remote.origin, preemptionGated)
+	if err := remote.getClient().Create(ctx, clone); err != nil {
+		return err
+	}
+	if _, err := currentManagerWorkload(ctx, remote.localReader, local, true); err != nil {
+		cleanupErr := deleteRemoteWorkload(ctx, remote.getClient(), clone)
+		return errors.Join(fmt.Errorf("manager Workload changed during remote creation: %w", err), cleanupErr)
+	}
+	return nil
+}
+
+func validateRemoteWorkloadOwnership(local, remote *kueue.Workload, origin string) error {
+	if local == nil || remote == nil {
+		return fmt.Errorf("%w: manager and remote Workloads are required", errRemoteWorkloadNotOwned)
+	}
+	key := client.ObjectKeyFromObject(remote)
+	if origin == "" {
+		return fmt.Errorf("%w: MultiKueue origin is empty", errRemoteWorkloadNotOwned)
+	}
+	if remote.Labels[kueue.MultiKueueOriginLabel] != origin {
+		return fmt.Errorf("%w: expected %q=%q on Workload %q", errRemoteWorkloadNotOwned, kueue.MultiKueueOriginLabel, origin, key)
+	}
+	if local.UID == "" {
+		return fmt.Errorf("%w: manager Workload %q has no UID", errRemoteWorkloadNotOwned, client.ObjectKeyFromObject(local))
+	}
+	if remote.Annotations[kueue.MultiKueueOriginUIDAnnotation] != string(local.UID) {
+		return fmt.Errorf("%w: expected %q=%q on Workload %q", errRemoteWorkloadNotOwned, kueue.MultiKueueOriginUIDAnnotation, local.UID, key)
+	}
 	return nil
 }
 
@@ -357,6 +521,8 @@ func (w *wlReconciler) readGroup(ctx context.Context, local *kueue.Workload, acN
 		}
 		if err != nil {
 			wl = nil
+		} else if err := validateRemoteWorkloadOwnership(local, wl, rClient.origin); err != nil {
+			return nil, fmt.Errorf("validating remote Workload %q in cluster %q: %w", klog.KObj(wl), remote, err)
 		}
 		grp.remotes[remote] = wl
 	}
@@ -418,15 +584,9 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 		// it should not be problematic, but the "From remote xxxx:" could be lost ....
 
 		if group.jobAdapter != nil {
-			remoteCl := group.remoteClients[remote].getClient()
-			if _, err := jobframework.ValidateRemoteObjectOwnership(ctx, remoteCl, group.controllerKey, group.jobAdapter.GVK(), w.origin); err != nil {
-				log.Error(err, "validating remote controller object", "workerCluster", remote)
-				return reconcile.Result{}, err
-			}
-
 			// The deferred flag is irrelevant here: the remote workload is
 			// Finished, so determineStatusUpdate always syncs (never defers).
-			if _, err := group.jobAdapter.SyncJob(ctx, w.client, remoteCl, group.controllerKey, group.local.Name, w.origin); err != nil {
+			if _, err := group.syncJob(ctx, remote); err != nil {
 				log.V(2).Error(err, "copying remote controller status", "workerCluster", remote)
 				// we should retry this
 				return reconcile.Result{}, err
@@ -442,7 +602,6 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 	// 4. Handle workload eviction
 	remoteEvictCond, evictedRemote := group.bestMatchByCondition(kueue.WorkloadEvicted)
 	if remoteEvictCond != nil {
-		remoteCl := group.remoteClients[evictedRemote].getClient()
 		remoteWl := group.remotes[evictedRemote]
 
 		log = log.WithValues("remote", evictedRemote, "remoteWorkload", klog.KObj(remoteWl))
@@ -450,12 +609,7 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 
 		// workload evicted on manager cluster
 		if workloadevict.IsEvicted(group.local) {
-			if _, err := jobframework.ValidateRemoteObjectOwnership(ctx, remoteCl, group.controllerKey, group.jobAdapter.GVK(), w.origin); err != nil {
-				log.Error(err, "validating remote controller object", "cluster", evictedRemote)
-				return reconcile.Result{}, err
-			}
-
-			deferred, err := group.jobAdapter.SyncJob(ctx, w.client, remoteCl, group.controllerKey, group.local.Name, w.origin)
+			deferred, err := group.syncJob(ctx, evictedRemote)
 			if err != nil {
 				log.Error(err, "Syncing remote controller object")
 				// We'll retry this in the next reconciling.
@@ -499,8 +653,6 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 				remotePreemptionGates = remWl.Spec.PreemptionGates
 			}
 
-			remClient := group.remoteClients[rem]
-
 			updateRemote := false
 
 			// For elastic workloads detect a scale-down event and propagate changes to the remote.
@@ -522,7 +674,11 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 					remWl.Spec.PreemptionGates = remotePreemptionGates
 				}
 
-				if err := remClient.getClient().Update(ctx, remWl); err != nil {
+				desiredSpec := remWl.Spec.DeepCopy()
+				if err := group.withActiveRemoteWorkload(ctx, rem, func(_ *kueue.Workload, currentRemote *kueue.Workload, remoteClient client.Client) error {
+					currentRemote.Spec = *desiredSpec
+					return remoteClient.Update(ctx, currentRemote)
+				}); err != nil {
 					return reconcile.Result{}, fmt.Errorf("failed to update remote workload: %w", err)
 				}
 				continue
@@ -582,7 +738,6 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 			}
 		}
 
-		remoteCl := group.remoteClients[admittingRemote].getClient()
 		remoteWl := group.remotes[admittingRemote]
 
 		log = log.WithValues("remote", admittingRemote, "remoteWorkload", klog.KObj(remoteWl))
@@ -590,12 +745,14 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 
 		evictedCond := apimeta.FindStatusCondition(group.local.Status.Conditions, kueue.WorkloadEvicted)
 		if workload.HasQuotaReservation(group.local) && evictedCond != nil && evictedCond.Status == metav1.ConditionTrue {
-			err := workloadpatching.PatchAdmissionStatus(ctx, remoteCl, remoteWl, w.clock, func(remoteWl *kueue.Workload) (bool, error) {
-				return workload.SetDeactivationTarget(
-					remoteWl,
-					kueue.WorkloadEvictedOnManagerCluster,
-					api.TruncateConditionMessage(fmt.Sprintf("Evicted on manager: %s", evictedCond.Message)),
-				), nil
+			err := group.withActiveRemoteWorkload(ctx, admittingRemote, func(_ *kueue.Workload, currentRemote *kueue.Workload, remoteClient client.Client) error {
+				return workloadpatching.PatchAdmissionStatus(ctx, remoteClient, currentRemote, w.clock, func(remoteWl *kueue.Workload) (bool, error) {
+					return workload.SetDeactivationTarget(
+						remoteWl,
+						kueue.WorkloadEvictedOnManagerCluster,
+						api.TruncateConditionMessage(fmt.Sprintf("Evicted on manager: %s", evictedCond.Message)),
+					), nil
+				})
 			})
 			if err != nil {
 				log.Error(err, "Failed to patch workload status")
@@ -603,12 +760,7 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 			return reconcile.Result{}, err
 		}
 
-		if _, err := jobframework.ValidateRemoteObjectOwnership(ctx, remoteCl, group.controllerKey, group.jobAdapter.GVK(), w.origin); err != nil {
-			log.Error(err, "validating remote controller object", "cluster", admittingRemote)
-			return reconcile.Result{}, err
-		}
-
-		syncDeferred, err := group.jobAdapter.SyncJob(ctx, w.client, remoteCl, group.controllerKey, group.local.Name, w.origin)
+		syncDeferred, err := group.syncJob(ctx, admittingRemote)
 		if err != nil {
 			log.Error(err, "Syncing remote controller object")
 			// We'll retry this in the next reconciling.
@@ -640,10 +792,10 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 	if features.Enabled(features.MultiKueueOrchestratedPreemption) {
 		remWlName, requeueIn := w.workloadToOpenPreemptionGate(ctx, group)
 		if remWlName != nil {
-			remWl := group.remotes[*remWlName]
-			remClient := group.remoteClients[*remWlName]
-			workload.OpenPreemptionGate(remWl, constants.MultiKueuePreemptionGate, metav1.NewTime(w.clock.Now()))
-			if err := remClient.getClient().Status().Update(ctx, remWl); err != nil {
+			if err := group.withActiveRemoteWorkload(ctx, *remWlName, func(_ *kueue.Workload, currentRemote *kueue.Workload, remoteClient client.Client) error {
+				workload.OpenPreemptionGate(currentRemote, constants.MultiKueuePreemptionGate, metav1.NewTime(w.clock.Now()))
+				return remoteClient.Status().Update(ctx, currentRemote)
+			}); err != nil {
 				return reconcile.Result{}, fmt.Errorf("failed to update remote workload: %w", err)
 			}
 		}
@@ -816,8 +968,7 @@ func (w *wlReconciler) syncToSingleCluster(ctx context.Context, log klog.Logger,
 	for clusterName, remoteWl := range group.remotes {
 		if clusterName == targetCluster {
 			if remoteWl == nil {
-				clone := cloneForCreate(group.local, group.remoteClients[clusterName].origin, false)
-				if err := group.remoteClients[clusterName].getClient().Create(ctx, clone); err != nil {
+				if err := group.createRemoteWorkload(ctx, clusterName, false); err != nil {
 					log.V(2).Error(err, "creating remote workload", "cluster", clusterName)
 					errs = append(errs, err)
 				} else {
@@ -938,8 +1089,7 @@ func (w *wlReconciler) nominateAndSynchronizeWorkers(ctx context.Context, group 
 	for rem, remoteWl := range group.remotes {
 		if slices.Contains(nominatedWorkers, rem) {
 			if remoteWl == nil {
-				clone := cloneForCreate(group.local, group.remoteClients[rem].origin, true)
-				if err := group.remoteClients[rem].getClient().Create(ctx, clone); err != nil {
+				if err := group.createRemoteWorkload(ctx, rem, true); err != nil {
 					log.V(2).Error(err, "creating remote object", "remote", rem)
 					errs = append(errs, err)
 				} else {
@@ -1413,6 +1563,10 @@ func cloneForCreate(orig *kueue.Workload, origin string, preemptionGated bool) *
 		remoteWl.Labels = make(map[string]string, 1)
 	}
 	remoteWl.Labels[kueue.MultiKueueOriginLabel] = origin
+	if remoteWl.Annotations == nil {
+		remoteWl.Annotations = make(map[string]string, 1)
+	}
+	remoteWl.Annotations[kueue.MultiKueueOriginUIDAnnotation] = string(orig.UID)
 	orig.Spec.DeepCopyInto(&remoteWl.Spec)
 
 	if features.Enabled(features.MultiKueueOrchestratedPreemption) && preemptionGated {

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -29,6 +30,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -103,6 +105,7 @@ func TestWlReconcile(t *testing.T) {
 		worker2Jobs              []batchv1.Job
 
 		wantError             error
+		wantAnyError          bool
 		wantResult            *reconcile.Result
 		wantEvents            []utiltesting.EventRecord
 		wantManagersWorkloads []kueue.Workload
@@ -213,6 +216,29 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Obj(),
+			},
+		},
+		"missing workload does not delete a same-name worker Job without a remote workload": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			reconcileFor: "wl1",
+			managersDeletedWorkloads: []*kueue.Workload{
+				baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Obj(),
+			},
+			worker1Jobs: []batchv1.Job{
+				*baseJobBuilder.Clone().
+					PrebuiltWorkloadLabel("wl1").
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Obj(),
+			},
+			wantWorker1Jobs: []batchv1.Job{
+				*baseJobBuilder.Clone().
+					PrebuiltWorkloadLabel("wl1").
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
 					Obj(),
 			},
 		},
@@ -500,6 +526,61 @@ func TestWlReconcile(t *testing.T) {
 					Obj(),
 			},
 		},
+		"forged remote Workload and Job identity cannot drive manager status": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			reconcileFor: "wl1",
+			managersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Obj(),
+			},
+			managersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			worker1Workloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Annotation(kueue.MultiKueueOriginUIDAnnotation, "foreign-manager-workload-uid").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					AdmittedAt(true, now).
+					FinishedAt(now).
+					Obj(),
+			},
+			worker1Jobs: []batchv1.Job{
+				*baseJobBuilder.Clone().
+					PrebuiltWorkloadLabel("wl1").
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					SetAnnotation(kueue.MultiKueueOriginUIDAnnotation, "foreign-manager-job-uid").
+					Active(7).
+					Obj(),
+			},
+			wantManagersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Obj(),
+			},
+			wantManagersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			wantWorker1Workloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Annotation(kueue.MultiKueueOriginUIDAnnotation, "foreign-manager-workload-uid").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					AdmittedAt(true, now).
+					FinishedAt(now).
+					Obj(),
+			},
+			wantWorker1Jobs: []batchv1.Job{
+				*baseJobBuilder.Clone().
+					PrebuiltWorkloadLabel("wl1").
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					SetAnnotation(kueue.MultiKueueOriginUIDAnnotation, "foreign-manager-job-uid").
+					Active(7).
+					Obj(),
+			},
+			wantAnyError: true,
+		},
 		"remote wl admitted - other workers deleted": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			reconcileFor: "wl1",
@@ -731,7 +812,9 @@ func TestWlReconcile(t *testing.T) {
 			},
 			useSecondWorker: true,
 			worker2Workloads: []kueue.Workload{
-				*baseWorkloadBuilder.DeepCopy(),
+				*baseWorkloadBuilder.Clone().
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Obj(),
 			},
 			wantManagersWorkloads: []kueue.Workload{
 				*baseWorkloadBuilder.Clone().
@@ -768,7 +851,9 @@ func TestWlReconcile(t *testing.T) {
 					Obj(),
 			},
 			wantWorker2Workloads: []kueue.Workload{
-				*baseWorkloadBuilder.DeepCopy(),
+				*baseWorkloadBuilder.Clone().
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Obj(),
 			},
 		},
 		"handle workload evicted on worker cluster": {
@@ -811,7 +896,9 @@ func TestWlReconcile(t *testing.T) {
 			},
 			useSecondWorker: true,
 			worker2Workloads: []kueue.Workload{
-				*baseWorkloadBuilder.DeepCopy(),
+				*baseWorkloadBuilder.Clone().
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Obj(),
 			},
 			wantManagersWorkloads: []kueue.Workload{
 				*baseWorkloadBuilder.Clone().
@@ -848,7 +935,9 @@ func TestWlReconcile(t *testing.T) {
 					Obj(),
 			},
 			wantWorker2Workloads: []kueue.Workload{
-				*baseWorkloadBuilder.DeepCopy(),
+				*baseWorkloadBuilder.Clone().
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Obj(),
 			},
 			wantEvents: []utiltesting.EventRecord{
 				{
@@ -2095,6 +2184,110 @@ func TestWlReconcile(t *testing.T) {
 	for name, tc := range cases {
 		for _, useMergePatch := range []bool{false, true} {
 			t.Run(fmt.Sprintf("%s when the WorkloadRequestUseMergePatch feature is %t", name, useMergePatch), func(t *testing.T) {
+				managerUIDs := make(map[string]types.UID)
+				managerJobUIDs := make(map[string]types.UID)
+				setManagerUIDs := func(workloads []kueue.Workload) {
+					for i := range workloads {
+						if workloads[i].UID == "" {
+							workloads[i].UID = types.UID("manager-" + workloads[i].Name + "-uid")
+						}
+						managerUIDs[workloads[i].Name] = workloads[i].UID
+						if owner := metav1.GetControllerOf(&workloads[i]); owner != nil && owner.UID != "" {
+							managerJobUIDs[owner.Name] = owner.UID
+						}
+					}
+				}
+				setManagerUIDs(tc.managersWorkloads)
+				setManagerUIDs(tc.wantManagersWorkloads)
+				for _, workload := range tc.managersDeletedWorkloads {
+					if workload.UID == "" {
+						workload.UID = types.UID("manager-" + workload.Name + "-uid")
+					}
+					managerUIDs[workload.Name] = workload.UID
+					if owner := metav1.GetControllerOf(workload); owner != nil && owner.UID != "" {
+						managerJobUIDs[owner.Name] = owner.UID
+					}
+				}
+				setManagerJobUIDs := func(jobs []batchv1.Job) {
+					for i := range jobs {
+						if jobs[i].UID == "" {
+							jobs[i].UID = managerJobUIDs[jobs[i].Name]
+							if jobs[i].UID == "" {
+								jobs[i].UID = types.UID("manager-" + jobs[i].Name + "-uid")
+							}
+						}
+						managerJobUIDs[jobs[i].Name] = jobs[i].UID
+					}
+				}
+				setManagerJobUIDs(tc.managersJobs)
+				setManagerJobUIDs(tc.wantManagersJobs)
+				remoteWorkloadUIDs := make(map[string]map[string]types.UID)
+				setRemoteIdentities := func(workloads []kueue.Workload, worker string, recordInitial bool) {
+					if remoteWorkloadUIDs[worker] == nil {
+						remoteWorkloadUIDs[worker] = make(map[string]types.UID)
+					}
+					for i := range workloads {
+						if workloads[i].UID == "" {
+							if recordInitial {
+								workloads[i].UID = types.UID(worker + "-" + workloads[i].Name + "-uid")
+							} else {
+								workloads[i].UID = remoteWorkloadUIDs[worker][workloads[i].Name]
+							}
+						}
+						if recordInitial {
+							remoteWorkloadUIDs[worker][workloads[i].Name] = workloads[i].UID
+						}
+						if workloads[i].Labels[kueue.MultiKueueOriginLabel] != defaultOrigin || workloads[i].Annotations[kueue.MultiKueueOriginUIDAnnotation] != "" {
+							continue
+						}
+						if managerUID := managerUIDs[workloads[i].Name]; managerUID != "" {
+							if workloads[i].Annotations == nil {
+								workloads[i].Annotations = make(map[string]string, 1)
+							}
+							workloads[i].Annotations[kueue.MultiKueueOriginUIDAnnotation] = string(managerUID)
+						}
+					}
+				}
+				setRemoteIdentities(tc.worker1Workloads, "worker1", true)
+				setRemoteIdentities(tc.wantWorker1Workloads, "worker1", false)
+				setRemoteIdentities(tc.worker2Workloads, "worker2", true)
+				setRemoteIdentities(tc.wantWorker2Workloads, "worker2", false)
+				remoteJobUIDs := make(map[string]map[string]types.UID)
+				setRemoteJobIdentities := func(jobs []batchv1.Job, worker string, recordInitial bool) {
+					if remoteJobUIDs[worker] == nil {
+						remoteJobUIDs[worker] = make(map[string]types.UID)
+					}
+					for i := range jobs {
+						if jobs[i].UID == "" {
+							if recordInitial {
+								jobs[i].UID = types.UID(worker + "-" + jobs[i].Name + "-uid")
+							} else {
+								jobs[i].UID = remoteJobUIDs[worker][jobs[i].Name]
+							}
+						}
+						if recordInitial {
+							remoteJobUIDs[worker][jobs[i].Name] = jobs[i].UID
+						}
+						if jobs[i].Labels[kueue.MultiKueueOriginLabel] != defaultOrigin {
+							continue
+						}
+						managerJobUID := managerJobUIDs[jobs[i].Name]
+						if managerJobUID == "" {
+							continue
+						}
+						if jobs[i].Annotations == nil {
+							jobs[i].Annotations = make(map[string]string, 1)
+						}
+						if jobs[i].Annotations[kueue.MultiKueueOriginUIDAnnotation] == "" {
+							jobs[i].Annotations[kueue.MultiKueueOriginUIDAnnotation] = string(managerJobUID)
+						}
+					}
+				}
+				setRemoteJobIdentities(tc.worker1Jobs, "worker1", true)
+				setRemoteJobIdentities(tc.wantWorker1Jobs, "worker1", false)
+				setRemoteJobIdentities(tc.worker2Jobs, "worker2", true)
+				setRemoteJobIdentities(tc.wantWorker2Jobs, "worker2", false)
+
 				features.SetFeatureGateDuringTest(t, features.WorkloadRequestUseMergePatch, useMergePatch)
 				features.SetFeatureGatesDuringTest(t, tc.featureGates)
 
@@ -2119,7 +2312,7 @@ func TestWlReconcile(t *testing.T) {
 				managerClient := managerBuilder.Build()
 				adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("batch/job"))
 				recorder := &utiltesting.EventRecorder{}
-				cRec := newClustersReconciler(managerClient, TestNamespace, 0, defaultOrigin, nil, adapters, nil, nil, recorder)
+				cRec := newClustersReconciler(managerClient, managerClient, TestNamespace, 0, defaultOrigin, nil, adapters, nil, nil, recorder)
 
 				worker1Client := NewNeverCachingClient(getClientBuilder(ctx).
 					WithLists(&kueue.WorkloadList{Items: tc.worker1Workloads}, &batchv1.JobList{Items: tc.worker1Jobs}).
@@ -2127,7 +2320,7 @@ func TestWlReconcile(t *testing.T) {
 					WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge}).
 					Build())
 
-				w1remoteClient := newRemoteClient(managerClient, nil, nil, nil, defaultOrigin, "", adapters)
+				w1remoteClient := newRemoteClient(managerClient, managerClient, nil, nil, nil, defaultOrigin, "", adapters)
 				w1remoteClient.client = worker1Client
 				w1remoteClient.connState.connected = !tc.worker1Reconnecting
 				w1remoteClient.connState.disconnectedSince = tc.worker1DisconnectedSince
@@ -2159,7 +2352,7 @@ func TestWlReconcile(t *testing.T) {
 						},
 					})
 					worker2Client = NewNeverCachingClient(worker2Builder.Build())
-					w2remoteClient := newRemoteClient(managerClient, nil, nil, nil, defaultOrigin, "", adapters)
+					w2remoteClient := newRemoteClient(managerClient, managerClient, nil, nil, nil, defaultOrigin, "", adapters)
 					w2remoteClient.client = worker2Client
 					w2remoteClient.connState.connected = !tc.worker2Reconnecting
 					w2remoteClient.connState.disconnectedSince = tc.worker2DisconnectedSince
@@ -2177,7 +2370,11 @@ func TestWlReconcile(t *testing.T) {
 				}
 
 				gotResult, gotErr := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.reconcileFor, Namespace: TestNamespace}})
-				if diff := cmp.Diff(tc.wantError, gotErr, cmpopts.EquateErrors()); diff != "" {
+				if tc.wantAnyError {
+					if gotErr == nil {
+						t.Error("Reconcile() error = nil, want an ownership error")
+					}
+				} else if diff := cmp.Diff(tc.wantError, gotErr, cmpopts.EquateErrors()); diff != "" {
 					t.Errorf("unexpected error (-want/+got):\n%s", diff)
 				}
 				if tc.wantResult != nil {
@@ -2277,14 +2474,17 @@ func TestOrphanedRemoteWorkloadCleanedAfterReconnect(t *testing.T) {
 	ctx, _ := utiltesting.ContextWithLog(t)
 
 	baseWorkloadBuilder := utiltestingapi.MakeWorkload("wl1", TestNamespace)
-	baseJobBuilder := testingjob.MakeJob("job1", TestNamespace).Suspend(false).ManagedBy(kueue.MultiKueueControllerName)
+	baseJobBuilder := testingjob.MakeJob("job1", TestNamespace).UID("uid1").Suspend(false).ManagedBy(kueue.MultiKueueControllerName)
 
 	managerWl := *baseWorkloadBuilder.Clone().
+		UID("manager-wl-uid").
 		AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).
 		ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 		Obj()
 	remoteWl := *baseWorkloadBuilder.Clone().
+		UID("worker-wl-uid").
 		Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+		Annotation(kueue.MultiKueueOriginUIDAnnotation, "manager-wl-uid").
 		Obj()
 
 	managerBuilder := getClientBuilder(ctx).
@@ -2300,9 +2500,9 @@ func TestOrphanedRemoteWorkloadCleanedAfterReconnect(t *testing.T) {
 	managerClient := managerBuilder.Build()
 
 	adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("batch/job"))
-	cRec := newClustersReconciler(managerClient, TestNamespace, 0, defaultOrigin, nil, adapters, nil, nil, nil)
+	cRec := newClustersReconciler(managerClient, managerClient, TestNamespace, 0, defaultOrigin, nil, adapters, nil, nil, nil)
 
-	w1remoteClient := newRemoteClient(managerClient, nil, nil, nil, defaultOrigin, "", adapters)
+	w1remoteClient := newRemoteClient(managerClient, managerClient, nil, nil, nil, defaultOrigin, "", adapters)
 	w1remoteClient.client = NewNeverCachingClient(getClientBuilder(ctx).
 		WithStatusSubresource(&kueue.Workload{}).
 		WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge}).
@@ -2315,7 +2515,7 @@ func TestOrphanedRemoteWorkloadCleanedAfterReconnect(t *testing.T) {
 		WithStatusSubresource(&kueue.Workload{}).
 		WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge}).
 		Build())
-	w2remoteClient := newRemoteClient(managerClient, nil, nil, nil, defaultOrigin, "", adapters)
+	w2remoteClient := newRemoteClient(managerClient, managerClient, nil, nil, nil, defaultOrigin, "", adapters)
 	w2remoteClient.client = worker2Client
 	cRec.remoteClients["worker2"] = w2remoteClient
 
@@ -2371,6 +2571,280 @@ func TestOrphanedRemoteWorkloadCleanedAfterReconnect(t *testing.T) {
 	}
 }
 
+func TestRemoveRemoteObjectsPreservesReplacementWorkload(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	key := types.NamespacedName{Name: "wl1", Namespace: TestNamespace}
+	const origin = "origin1"
+	oldUID := types.UID("old-remote-workload-uid")
+	replacementUID := types.UID("replacement-remote-workload-uid")
+
+	localWorkload := utiltestingapi.MakeWorkload(key.Name, key.Namespace).
+		UID("manager-workload-uid").
+		ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "manager-job-uid").
+		Obj()
+	remoteWorkload := utiltestingapi.MakeWorkload(key.Name, key.Namespace).
+		UID(oldUID).
+		Label(kueue.MultiKueueOriginLabel, origin).
+		Annotation(kueue.MultiKueueOriginUIDAnnotation, string(localWorkload.UID)).
+		Obj()
+	remoteJob := testingjob.MakeJob("job1", key.Namespace).
+		UID("remote-job-uid").
+		PrebuiltWorkloadLabel(key.Name).
+		Label(kueue.MultiKueueOriginLabel, origin).
+		SetAnnotation(kueue.MultiKueueOriginUIDAnnotation, "manager-job-uid").
+		Obj()
+
+	managerClient := getClientBuilder(ctx).WithObjects(localWorkload).Build()
+	baseWorkerClient := getClientBuilder(ctx).WithObjects(remoteWorkload, remoteJob).Build()
+	replaced := false
+	workerClient := interceptor.NewClient(baseWorkerClient, interceptor.Funcs{
+		Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			if _, isWorkload := obj.(*kueue.Workload); !isWorkload {
+				return c.Delete(ctx, obj, opts...)
+			}
+			deleteOptions := (&client.DeleteOptions{}).ApplyOptions(opts)
+			if deleteOptions.Preconditions == nil || deleteOptions.Preconditions.UID == nil || *deleteOptions.Preconditions.UID != oldUID {
+				t.Fatalf("delete precondition = %#v, want UID %q", deleteOptions.Preconditions, oldUID)
+			}
+			if err := c.Delete(ctx, obj); err != nil {
+				return err
+			}
+			replacement := remoteWorkload.DeepCopy()
+			replacement.UID = replacementUID
+			replacement.ResourceVersion = ""
+			if err := c.Create(ctx, replacement); err != nil {
+				return err
+			}
+			replaced = true
+			return apierrors.NewConflict(schema.GroupResource{Group: kueue.SchemeGroupVersion.Group, Resource: "workloads"}, key.Name, errors.New("UID precondition failed"))
+		},
+	})
+
+	adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("batch/job"))
+	adapter := adapters[schema.FromAPIVersionAndKind(batchv1.SchemeGroupVersion.String(), "Job").String()]
+	remote := newRemoteClient(managerClient, managerClient, nil, nil, nil, origin, "worker1", adapters)
+	remote.client = NewNeverCachingClient(workerClient)
+	group := &wlGroup{
+		local:         localWorkload,
+		localClient:   managerClient,
+		remotes:       map[string]*kueue.Workload{"worker1": remoteWorkload.DeepCopy()},
+		remoteClients: map[string]*remoteClient{"worker1": remote},
+		jobAdapter:    adapter,
+		controllerKey: types.NamespacedName{Name: "job1", Namespace: key.Namespace},
+	}
+
+	err := group.RemoveRemoteObjects(ctx, "worker1")
+	if !apierrors.IsConflict(err) {
+		t.Fatalf("RemoveRemoteObjects() error = %v, want Conflict", err)
+	}
+	if !replaced {
+		t.Fatal("replacement race was not exercised")
+	}
+	got := &kueue.Workload{}
+	if err := baseWorkerClient.Get(ctx, key, got); err != nil {
+		t.Fatalf("getting replacement Workload: %v", err)
+	}
+	if got.UID != replacementUID {
+		t.Fatalf("replacement Workload UID = %q, want %q", got.UID, replacementUID)
+	}
+}
+
+func TestSyncJobCleansUpWhenManagerWorkloadDeletionStartsDuringCreate(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	const (
+		origin      = "origin1"
+		clusterName = "worker1"
+		workloadUID = "manager-workload-uid"
+		managerUID  = "manager-job-uid"
+	)
+	workloadKey := types.NamespacedName{Name: "wl1", Namespace: TestNamespace}
+	jobKey := types.NamespacedName{Name: "job1", Namespace: TestNamespace}
+	localWorkload := utiltestingapi.MakeWorkload(workloadKey.Name, workloadKey.Namespace).
+		UID(workloadUID).
+		ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), jobKey.Name, managerUID).
+		Obj()
+	localJob := testingjob.MakeJob(jobKey.Name, jobKey.Namespace).UID(managerUID).Suspend(false).Obj()
+	remoteWorkload := utiltestingapi.MakeWorkload(workloadKey.Name, workloadKey.Namespace).
+		UID("remote-workload-uid").
+		Label(kueue.MultiKueueOriginLabel, origin).
+		Annotation(kueue.MultiKueueOriginUIDAnnotation, workloadUID).
+		Obj()
+
+	managerClient := getClientBuilder(ctx).WithObjects(localWorkload, localJob).Build()
+	var workloadReads atomic.Int32
+	freshReader := interceptor.NewClient(managerClient, interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if workload, ok := obj.(*kueue.Workload); ok && key == workloadKey && workloadReads.Add(1) > 1 {
+				*workload = *localWorkload.DeepCopy()
+				workload.DeletionTimestamp = new(metav1.Now())
+				return nil
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+	})
+
+	createStarted := make(chan struct{})
+	releaseCreate := make(chan struct{})
+	baseWorkerClient := getClientBuilder(ctx).WithObjects(remoteWorkload).Build()
+	workerClient := interceptor.NewClient(baseWorkerClient, interceptor.Funcs{
+		Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			if _, isJob := obj.(*batchv1.Job); isJob {
+				close(createStarted)
+				<-releaseCreate
+			}
+			return c.Create(ctx, obj, opts...)
+		},
+	})
+
+	adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("batch/job"))
+	adapter := adapters[schema.FromAPIVersionAndKind(batchv1.SchemeGroupVersion.String(), "Job").String()]
+	remote := newRemoteClient(managerClient, freshReader, nil, nil, nil, origin, clusterName, adapters)
+	remote.client = NewNeverCachingClient(workerClient)
+	group := &wlGroup{
+		local:         localWorkload,
+		localClient:   managerClient,
+		remotes:       map[string]*kueue.Workload{clusterName: remoteWorkload},
+		remoteClients: map[string]*remoteClient{clusterName: remote},
+		jobAdapter:    adapter,
+		controllerKey: jobKey,
+	}
+
+	syncResult := make(chan error, 1)
+	go func() {
+		_, err := group.syncJob(ctx, clusterName)
+		syncResult <- err
+	}()
+	select {
+	case <-createStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for remote Job creation")
+	}
+	close(releaseCreate)
+	select {
+	case err := <-syncResult:
+		if err == nil {
+			t.Fatal("syncJob() error = nil, want manager lifecycle error")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for sync cleanup")
+	}
+
+	if err := baseWorkerClient.Get(ctx, jobKey, &batchv1.Job{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("remote Job Get() error = %v, want NotFound", err)
+	}
+	if err := baseWorkerClient.Get(ctx, workloadKey, &kueue.Workload{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("remote Workload Get() error = %v, want NotFound", err)
+	}
+}
+
+func TestSyncJobWaitsForGCAndDoesNotRecreateExecutionObject(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	const (
+		origin       = "origin1"
+		clusterName  = "worker1"
+		workloadUID  = "manager-workload-uid"
+		managerUID   = "manager-job-uid"
+		remoteJobUID = "remote-job-uid"
+	)
+	workloadKey := types.NamespacedName{Name: "wl1", Namespace: TestNamespace}
+	jobKey := types.NamespacedName{Name: "job1", Namespace: TestNamespace}
+	localWorkload := utiltestingapi.MakeWorkload(workloadKey.Name, workloadKey.Namespace).
+		UID(workloadUID).
+		ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), jobKey.Name, managerUID).
+		Obj()
+	localWorkload.DeletionTimestamp = new(metav1.Now())
+	localWorkload.Finalizers = []string{kueue.ResourceInUseFinalizerName}
+	localJob := testingjob.MakeJob(jobKey.Name, jobKey.Namespace).UID(managerUID).Suspend(false).Obj()
+	remoteWorkload := utiltestingapi.MakeWorkload(workloadKey.Name, workloadKey.Namespace).
+		UID("remote-workload-uid").
+		Label(kueue.MultiKueueOriginLabel, origin).
+		Annotation(kueue.MultiKueueOriginUIDAnnotation, workloadUID).
+		ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), jobKey.Name, remoteJobUID).
+		Obj()
+	remoteJob := testingjob.MakeJob(jobKey.Name, jobKey.Namespace).
+		UID(remoteJobUID).
+		PrebuiltWorkloadLabel(workloadKey.Name).
+		Label(kueue.MultiKueueOriginLabel, origin).
+		SetAnnotation(kueue.MultiKueueOriginUIDAnnotation, managerUID).
+		Obj()
+
+	managerClient := getClientBuilder(ctx).WithObjects(localWorkload, localJob).Build()
+	workloadDeleteStarted := make(chan struct{})
+	releaseWorkloadDelete := make(chan struct{})
+	var jobCreates atomic.Int32
+	baseWorkerClient := getClientBuilder(ctx).WithObjects(remoteWorkload, remoteJob).Build()
+	workerClient := interceptor.NewClient(baseWorkerClient, interceptor.Funcs{
+		Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			if _, isJob := obj.(*batchv1.Job); isJob {
+				jobCreates.Add(1)
+			}
+			return c.Create(ctx, obj, opts...)
+		},
+		Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			if _, isWorkload := obj.(*kueue.Workload); isWorkload {
+				close(workloadDeleteStarted)
+				<-releaseWorkloadDelete
+			}
+			return c.Delete(ctx, obj, opts...)
+		},
+	})
+
+	adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("batch/job"))
+	adapter := adapters[schema.FromAPIVersionAndKind(batchv1.SchemeGroupVersion.String(), "Job").String()]
+	remote := newRemoteClient(managerClient, managerClient, nil, nil, nil, origin, clusterName, adapters)
+	remote.client = NewNeverCachingClient(workerClient)
+	remote.connState.markConnected()
+	group := &wlGroup{
+		local:         localWorkload.DeepCopy(),
+		localClient:   managerClient,
+		remotes:       map[string]*kueue.Workload{clusterName: remoteWorkload.DeepCopy()},
+		remoteClients: map[string]*remoteClient{clusterName: remote},
+		jobAdapter:    adapter,
+		controllerKey: jobKey,
+	}
+
+	gcDone := make(chan struct{})
+	go func() {
+		defer close(gcDone)
+		remote.runGC(ctx)
+	}()
+	select {
+	case <-workloadDeleteStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for GC remote Workload deletion")
+	}
+
+	syncResult := make(chan error, 1)
+	go func() {
+		_, err := group.syncJob(ctx, clusterName)
+		syncResult <- err
+	}()
+	close(releaseWorkloadDelete)
+	select {
+	case <-gcDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for GC")
+	}
+	select {
+	case err := <-syncResult:
+		if err == nil {
+			t.Fatal("syncJob() error = nil, want inactive manager Workload error")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for stale sync")
+	}
+
+	if got := jobCreates.Load(); got != 0 {
+		t.Fatalf("remote Job Create() calls = %d, want 0", got)
+	}
+	if err := baseWorkerClient.Get(ctx, jobKey, &batchv1.Job{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("remote Job Get() error = %v, want NotFound", err)
+	}
+	if err := baseWorkerClient.Get(ctx, workloadKey, &kueue.Workload{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("remote Workload Get() error = %v, want NotFound", err)
+	}
+}
+
 // setupAdmittedMetricTest builds a reconciler with a manager workload whose
 // admission check starts in acState and a worker1 remote workload that is
 // already admitted, so reconciliation reaches the admitted-metric code path.
@@ -2381,15 +2855,18 @@ func setupAdmittedMetricTest(ctx context.Context, t *testing.T, acState kueue.Ch
 	fakeClock := testingclock.NewFakeClock(now)
 
 	baseWorkloadBuilder := utiltestingapi.MakeWorkload("wl1", TestNamespace)
-	baseJobBuilder := testingjob.MakeJob("job1", TestNamespace).Suspend(false).ManagedBy(kueue.MultiKueueControllerName)
+	baseJobBuilder := testingjob.MakeJob("job1", TestNamespace).UID("uid1").Suspend(false).ManagedBy(kueue.MultiKueueControllerName)
 
 	managerWl := *baseWorkloadBuilder.Clone().
+		UID("manager-wl-uid").
 		AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: acState}).
 		ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 		ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
 		Obj()
 	remoteWl := *baseWorkloadBuilder.Clone().
+		UID("worker-wl-uid").
 		Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+		Annotation(kueue.MultiKueueOriginUIDAnnotation, "manager-wl-uid").
 		ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
 		Condition(metav1.Condition{
 			Type:   kueue.WorkloadAdmitted,
@@ -2411,9 +2888,9 @@ func setupAdmittedMetricTest(ctx context.Context, t *testing.T, acState kueue.Ch
 		Build()
 
 	adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("batch/job"))
-	cRec := newClustersReconciler(managerClient, TestNamespace, 0, defaultOrigin, nil, adapters, nil, nil, nil)
+	cRec := newClustersReconciler(managerClient, managerClient, TestNamespace, 0, defaultOrigin, nil, adapters, nil, nil, nil)
 
-	w1remoteClient := newRemoteClient(managerClient, nil, nil, nil, defaultOrigin, "", adapters)
+	w1remoteClient := newRemoteClient(managerClient, managerClient, nil, nil, nil, defaultOrigin, "", adapters)
 	w1remoteClient.client = NewNeverCachingClient(getClientBuilder(ctx).
 		WithLists(&kueue.WorkloadList{Items: []kueue.Workload{remoteWl}}).
 		WithStatusSubresource(&kueue.Workload{}).
@@ -2594,7 +3071,7 @@ func TestNominateAndSynchronizeWorkers_MoreCases(t *testing.T) {
 			fakeClock := testingclock.NewFakeClock(now)
 
 			local := &kueue.Workload{
-				ObjectMeta: metav1.ObjectMeta{Name: "wl", Namespace: "ns"},
+				ObjectMeta: metav1.ObjectMeta{Name: "wl", Namespace: "ns", UID: "manager-workload-uid"},
 				Status: kueue.WorkloadStatus{
 					Conditions:            make([]metav1.Condition, 0, 1),
 					NominatedClusterNames: tt.nominatedWorkers,
@@ -2619,6 +3096,7 @@ func TestNominateAndSynchronizeWorkers_MoreCases(t *testing.T) {
 					return utiltesting.TreatSSAAsStrategicMerge(ctx, client, subResourceName, obj, patch, opts...)
 				},
 			}).WithObjects(objs...).WithStatusSubresource(objs...)
+			managerClient := wlClientBuilder.Build()
 
 			remoteClientBuilders := make(map[string]*fake.ClientBuilder, len(tt.remotes))
 			for remote := range tt.remotes {
@@ -2629,7 +3107,7 @@ func TestNominateAndSynchronizeWorkers_MoreCases(t *testing.T) {
 			}
 			remoteClients := make(map[string]*remoteClient, len(tt.remotes))
 			for remote, builder := range remoteClientBuilders {
-				rc := &remoteClient{client: NewNeverCachingClient(builder.Build()), origin: remote}
+				rc := &remoteClient{client: NewNeverCachingClient(builder.Build()), localClient: managerClient, localReader: managerClient, origin: remote}
 				rc.connState.markDisconnected(time.Now())
 				remoteClients[remote] = rc
 			}
@@ -2639,6 +3117,7 @@ func TestNominateAndSynchronizeWorkers_MoreCases(t *testing.T) {
 			}
 			group := &wlGroup{
 				local:         local,
+				localClient:   managerClient,
 				remotes:       tt.remotes,
 				remoteClients: remoteClients,
 				acName:        "ac1",
@@ -2647,7 +3126,7 @@ func TestNominateAndSynchronizeWorkers_MoreCases(t *testing.T) {
 			wlRec := &wlReconciler{
 				clock:          fakeClock,
 				dispatcherName: tt.dispatcherMode,
-				client:         wlClientBuilder.Build(),
+				client:         managerClient,
 			}
 
 			ctx, _ := utiltesting.ContextWithLog(t)
@@ -3161,6 +3640,8 @@ func TestReconcileGroup_SyncDeferred_ShortRequeue(t *testing.T) {
 
 	// Local manager workload: admitted on worker1, AC=Ready, no Evicted condition.
 	local := utiltestingapi.MakeWorkload("wl1", TestNamespace).
+		UID("manager-workload-uid").
+		ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "manager-job-uid").
 		ReserveQuotaAt(utiltestingapi.MakeAdmission("cq1").Obj(), now).
 		AdmittedAt(true, now).
 		AdmissionCheck(kueue.AdmissionCheckState{
@@ -3173,6 +3654,9 @@ func TestReconcileGroup_SyncDeferred_ShortRequeue(t *testing.T) {
 
 	// Remote workload on worker1: WorkloadAdmitted=True.
 	remote := utiltestingapi.MakeWorkload("wl1", TestNamespace).
+		UID("remote-workload-uid").
+		Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+		Annotation(kueue.MultiKueueOriginUIDAnnotation, "manager-workload-uid").
 		Condition(metav1.Condition{
 			Type:               kueue.WorkloadAdmitted,
 			Status:             metav1.ConditionTrue,
@@ -3194,7 +3678,7 @@ func TestReconcileGroup_SyncDeferred_ShortRequeue(t *testing.T) {
 		localClient: managerClient,
 		remotes:     map[string]*kueue.Workload{workerName: remote},
 		remoteClients: map[string]*remoteClient{
-			workerName: {client: workerClient, origin: defaultOrigin},
+			workerName: {client: workerClient, localClient: managerClient, localReader: managerClient, origin: defaultOrigin},
 		},
 		acName:        acName,
 		jobAdapter:    &deferredSyncStubAdapter{deferred: true},

--- a/pkg/controller/jobframework/multikueue.go
+++ b/pkg/controller/jobframework/multikueue.go
@@ -27,9 +27,19 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 )
 
-// MultiKueueAdapter interface needed for MultiKueue job delegation.
+// MultiKueueAdapter is the interface used for MultiKueue job delegation.
+//
+// In production SyncJob and DeleteRemoteObject receive an identity-guarded
+// remote client. That client only permits objects of GVK(), validates the
+// MultiKueue origin, manager-object UID, and Workload association, and rejects
+// operations that cannot carry an enforceable identity check. In particular,
+// cross-GVK access, subresource reads, apply operations, and alternate
+// subresource bodies are unsupported. Updates and patches require the checked
+// UID and resourceVersion; deletes use UID preconditions. Custom adapters must
+// use only this restricted client contract.
 type MultiKueueAdapter interface {
-	// SyncJob creates the Job object in the worker cluster using remote client, if not already created.
+	// SyncJob creates the Job object in the worker cluster using the guarded
+	// remote client, if not already created.
 	// Copy the status from the remote job if already exists.
 	//
 	// The returned deferred flag reports that the adapter intentionally skipped
@@ -43,7 +53,7 @@ type MultiKueueAdapter interface {
 	// discussion see
 	// https://github.com/kubernetes-sigs/kueue/pull/11730#issuecomment-4566063844.
 	SyncJob(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) (deferred bool, err error)
-	// DeleteRemoteObject deletes the Job in the worker cluster.
+	// DeleteRemoteObject deletes the Job using the same guarded-client contract.
 	DeleteRemoteObject(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName) error
 	// IsJobManagedByKueue returns:
 	// - a bool indicating if the job object identified by key is managed by kueue and can be delegated.
@@ -57,19 +67,21 @@ type MultiKueueAdapter interface {
 // MultiKueueObjectAssociation identifies the origin and remote Workload that
 // mutable MultiKueue metadata associates with an object.
 type MultiKueueObjectAssociation struct {
-	Origin       string
-	WorkloadName string
+	Origin           string
+	WorkloadName     string
+	ManagerObjectUID types.UID
 }
 
 // MultiKueueRemoteObjectCleanupContext carries the expected remote object
 // identity and the Workload metadata needed for adapter-specific cleanup.
-// WorkloadAnnotations must be a copy so later API mutations cannot change the
-// cleanup decision.
+// WorkloadAnnotations and ManagerObjectUIDs must be copies so later API
+// mutations cannot change the cleanup decision.
 type MultiKueueRemoteObjectCleanupContext struct {
 	RemoteObjectUID     types.UID
 	Association         MultiKueueObjectAssociation
 	WorkloadKey         types.NamespacedName
 	WorkloadAnnotations map[string]string
+	ManagerObjectUIDs   map[string]types.UID
 }
 
 // MultiKueueAdapterWithRemoteObjectCleanup is an optional extension for adapters
@@ -77,7 +89,22 @@ type MultiKueueRemoteObjectCleanupContext struct {
 // Multi-object cleanup is one use case.
 type MultiKueueAdapterWithRemoteObjectCleanup interface {
 	MultiKueueAdapter
-	DeleteRemoteObjectWithCleanupContext(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, cleanupContext MultiKueueRemoteObjectCleanupContext) error
+	DeleteRemoteObjectWithCleanupContext(
+		ctx context.Context,
+		localClient client.Client,
+		remoteClient client.Client,
+		key types.NamespacedName,
+		cleanupContext MultiKueueRemoteObjectCleanupContext,
+	) error
+}
+
+// MultiKueueAdapterWithWorkloadReassignment marks adapters that can intentionally
+// move one stable remote controller object between Workload slices. The adapter
+// must authorize the specific manager object, and the remote object must carry
+// that object's exact UID before reassignment is allowed.
+type MultiKueueAdapterWithWorkloadReassignment interface {
+	MultiKueueAdapter
+	CanReassignWorkload(ctx context.Context, localClient client.Client, key types.NamespacedName) (bool, error)
 }
 
 // MultiKueueWatcher optional interface that can be implemented by a MultiKueueAdapter

--- a/pkg/controller/jobframework/multikueue.go
+++ b/pkg/controller/jobframework/multikueue.go
@@ -54,6 +54,32 @@ type MultiKueueAdapter interface {
 	GVK() schema.GroupVersionKind
 }
 
+// MultiKueueObjectAssociation identifies the origin and remote Workload that
+// mutable MultiKueue metadata associates with an object.
+type MultiKueueObjectAssociation struct {
+	Origin       string
+	WorkloadName string
+}
+
+// MultiKueueRemoteObjectCleanupContext carries the expected remote object
+// identity and the Workload metadata needed for adapter-specific cleanup.
+// WorkloadAnnotations must be a copy so later API mutations cannot change the
+// cleanup decision.
+type MultiKueueRemoteObjectCleanupContext struct {
+	RemoteObjectUID     types.UID
+	Association         MultiKueueObjectAssociation
+	WorkloadKey         types.NamespacedName
+	WorkloadAnnotations map[string]string
+}
+
+// MultiKueueAdapterWithRemoteObjectCleanup is an optional extension for adapters
+// whose cleanup must remain bound to an exact remote controller-object instance.
+// Multi-object cleanup is one use case.
+type MultiKueueAdapterWithRemoteObjectCleanup interface {
+	MultiKueueAdapter
+	DeleteRemoteObjectWithCleanupContext(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, cleanupContext MultiKueueRemoteObjectCleanupContext) error
+}
+
 // MultiKueueWatcher optional interface that can be implemented by a MultiKueueAdapter
 // to receive job related watch events from the worker cluster.
 // If not implemented, MultiKueue will only receive events related to the job's workload.

--- a/pkg/controller/jobframework/multikueue.go
+++ b/pkg/controller/jobframework/multikueue.go
@@ -77,7 +77,13 @@ type MultiKueueRemoteObjectCleanupContext struct {
 // Multi-object cleanup is one use case.
 type MultiKueueAdapterWithRemoteObjectCleanup interface {
 	MultiKueueAdapter
-	DeleteRemoteObjectWithCleanupContext(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, cleanupContext MultiKueueRemoteObjectCleanupContext) error
+	DeleteRemoteObjectWithCleanupContext(
+		ctx context.Context,
+		localClient client.Client,
+		remoteClient client.Client,
+		key types.NamespacedName,
+		cleanupContext MultiKueueRemoteObjectCleanupContext,
+	) error
 }
 
 // MultiKueueWatcher optional interface that can be implemented by a MultiKueueAdapter

--- a/pkg/controller/jobframework/multikueue_remote_client.go
+++ b/pkg/controller/jobframework/multikueue_remote_client.go
@@ -1,0 +1,619 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jobframework
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
+)
+
+var ErrRemoteObjectAccessUnsupported = errors.New("remote object access cannot be identity-guarded")
+var ErrRemoteObjectWriteUnsupported = errors.New("remote object write cannot be identity-guarded")
+
+// MultiKueueManagerObjectUIDsForWorkload returns the manager execution-object
+// identities persisted in a Workload's owner references for adapterGVK.
+func MultiKueueManagerObjectUIDsForWorkload(workload *kueue.Workload, adapterGVK schema.GroupVersionKind) (map[string]types.UID, error) {
+	if workload == nil {
+		return nil, ErrMultiKueueWorkloadNameEmpty
+	}
+	uids := make(map[string]types.UID)
+	for _, owner := range workload.OwnerReferences {
+		if schema.FromAPIVersionAndKind(owner.APIVersion, owner.Kind) != adapterGVK || owner.UID == "" {
+			continue
+		}
+		if existing := uids[owner.Name]; existing != "" && existing != owner.UID {
+			return nil, fmt.Errorf(
+				"%w: manager Workload %q has conflicting UIDs %q and %q for %s %q",
+				ErrRemoteObjectNotOwnedByMultiKueue,
+				client.ObjectKeyFromObject(workload),
+				existing,
+				owner.UID,
+				adapterGVK.Kind,
+				owner.Name,
+			)
+		}
+		uids[owner.Name] = owner.UID
+	}
+	return uids, nil
+}
+
+func managerObjectUIDForWorkload(workload *kueue.Workload, adapterGVK schema.GroupVersionKind, key types.NamespacedName) (types.UID, map[string]types.UID, error) {
+	managerObjectUIDs, err := MultiKueueManagerObjectUIDsForWorkload(workload, adapterGVK)
+	if err != nil {
+		return "", nil, err
+	}
+	referenceUID := managerObjectUIDs[key.Name]
+	labelUID := types.UID(workload.Labels[controllerconstants.JobUIDLabel])
+	ownerUID := types.UID("")
+	if owner := metav1.GetControllerOf(workload); owner != nil {
+		ownerUID = owner.UID
+	}
+	for _, candidate := range []types.UID{referenceUID, labelUID, ownerUID} {
+		if candidate == "" {
+			continue
+		}
+		if referenceUID != "" && candidate != referenceUID {
+			return "", nil, fmt.Errorf(
+				"%w: manager Workload %q has conflicting controller UIDs %q and %q",
+				ErrRemoteObjectNotOwnedByMultiKueue,
+				client.ObjectKeyFromObject(workload),
+				referenceUID,
+				candidate,
+			)
+		}
+		referenceUID = candidate
+	}
+	if referenceUID != "" {
+		managerObjectUIDs[key.Name] = referenceUID
+		return referenceUID, managerObjectUIDs, nil
+	}
+	return "", nil, fmt.Errorf("%w: manager Workload %q has no UID for %s %q", ErrRemoteObjectNotOwnedByMultiKueue, client.ObjectKeyFromObject(workload), adapterGVK.Kind, key.Name)
+}
+
+func validateRemoteObjectManagerUID(obj client.Object, expected types.UID) error {
+	actual := types.UID(obj.GetAnnotations()[kueue.MultiKueueOriginUIDAnnotation])
+	if expected == "" || actual != expected {
+		return fmt.Errorf("%w: expected %q=%q on %T %q, got %q", ErrRemoteObjectNotOwnedByMultiKueue, kueue.MultiKueueOriginUIDAnnotation, expected, obj, client.ObjectKeyFromObject(obj), actual)
+	}
+	return nil
+}
+
+type remoteObjectOwnershipClient struct {
+	delegate                client.Client
+	localClient             client.Client
+	localReader             client.Reader
+	gvk                     schema.GroupVersionKind
+	controllerKey           types.NamespacedName
+	association             MultiKueueObjectAssociation
+	managerObjectUIDs       map[string]types.UID
+	expectedRemoteObjectUID types.UID
+	multiWorkload           bool
+	workloadReassignment    MultiKueueAdapterWithWorkloadReassignment
+	allowCreate             bool
+}
+
+var _ client.Client = (*remoteObjectOwnershipClient)(nil)
+
+func (c *remoteObjectOwnershipClient) isAdapterObject(obj client.Object) (bool, error) {
+	gvk, err := apiutil.GVKForObject(obj, c.Scheme())
+	if err != nil {
+		return false, err
+	}
+	return gvk == c.gvk, nil
+}
+
+func (c *remoteObjectOwnershipClient) expectedManagerUID(ctx context.Context, key client.ObjectKey) (types.UID, error) {
+	expected := c.managerObjectUIDs[key.Name]
+	if c.localReader == nil {
+		if expected == "" && key == c.controllerKey {
+			expected = c.association.ManagerObjectUID
+		}
+		if expected == "" {
+			return "", fmt.Errorf("%w: no trusted manager UID for remote object %q", ErrRemoteObjectNotOwnedByMultiKueue, key)
+		}
+		return expected, nil
+	}
+	if expected == "" {
+		return "", fmt.Errorf("%w: manager Workload has no trusted UID for remote object %q", ErrRemoteObjectNotOwnedByMultiKueue, key)
+	}
+	localObject := &metav1.PartialObjectMetadata{}
+	localObject.SetGroupVersionKind(c.gvk)
+	if err := c.localReader.Get(ctx, key, localObject); err != nil {
+		return "", fmt.Errorf("%w: reading manager object %q: %v", ErrRemoteObjectNotOwnedByMultiKueue, key, err)
+	}
+	if localObject.UID != expected {
+		return "", fmt.Errorf("%w: manager object %q UID %q does not match Workload-bound UID %q", ErrRemoteObjectNotOwnedByMultiKueue, key, localObject.UID, expected)
+	}
+	return expected, nil
+}
+
+func (c *remoteObjectOwnershipClient) validateAdapterObject(ctx context.Context, obj client.Object, allowReassignment bool) error {
+	key := client.ObjectKeyFromObject(obj)
+	if key.Namespace != c.controllerKey.Namespace {
+		return fmt.Errorf("%w: expected Namespace %q on %T %q, got %q", ErrRemoteObjectNotOwnedByMultiKueue, c.controllerKey.Namespace, obj, key, key.Namespace)
+	}
+	if obj.GetLabels()[kueue.MultiKueueOriginLabel] != c.association.Origin {
+		return fmt.Errorf("%w: unexpected MultiKueue origin on %T %q", ErrRemoteObjectNotOwnedByMultiKueue, obj, key)
+	}
+	expectedManagerUID, err := c.expectedManagerUID(ctx, key)
+	if err != nil {
+		return err
+	}
+	if err := validateRemoteObjectManagerUID(obj, expectedManagerUID); err != nil {
+		return err
+	}
+	if c.multiWorkload {
+		return nil
+	}
+	objectWorkload, err := MultiKueueWorkloadNameFor(obj)
+	if err != nil {
+		return err
+	}
+	if objectWorkload == c.association.WorkloadName {
+		return nil
+	}
+	if allowReassignment && c.workloadReassignment != nil && key == c.controllerKey {
+		allowed, err := c.workloadReassignment.CanReassignWorkload(ctx, c.localClient, key)
+		if err != nil {
+			return err
+		}
+		if allowed {
+			return nil
+		}
+	}
+	return fmt.Errorf("%w: %T %q belongs to Workload %q, expected %q", ErrRemoteObjectNotOwnedByMultiKueue, obj, key, objectWorkload, c.association.WorkloadName)
+}
+
+func (c *remoteObjectOwnershipClient) getAndValidateAdapterObject(ctx context.Context, key client.ObjectKey, allowReassignment bool) (*metav1.PartialObjectMetadata, error) {
+	remoteObject := &metav1.PartialObjectMetadata{}
+	remoteObject.SetGroupVersionKind(c.gvk)
+	if err := c.delegate.Get(ctx, key, remoteObject); err != nil {
+		return nil, err
+	}
+	if err := c.validateAdapterObject(ctx, remoteObject, allowReassignment); err != nil {
+		return nil, err
+	}
+	if key == c.controllerKey && c.expectedRemoteObjectUID != "" && remoteObject.UID != c.expectedRemoteObjectUID {
+		return nil, fmt.Errorf("%w: expected remote UID %q on %T %q, got %q", ErrRemoteObjectNotOwnedByMultiKueue, c.expectedRemoteObjectUID, remoteObject, key, remoteObject.UID)
+	}
+	return remoteObject, nil
+}
+
+func (c *remoteObjectOwnershipClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	isAdapterObject, err := c.isAdapterObject(obj)
+	if err != nil {
+		return err
+	}
+	if !isAdapterObject {
+		return fmt.Errorf("%w: Get on %T %q", ErrRemoteObjectAccessUnsupported, obj, key)
+	}
+	if err := c.delegate.Get(ctx, key, obj, opts...); err != nil {
+		return err
+	}
+	return c.validateAdapterObject(ctx, obj, true)
+}
+
+func (c *remoteObjectOwnershipClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	gvk, err := apiutil.GVKForObject(list, c.Scheme())
+	if err != nil {
+		return err
+	}
+	if gvk.GroupVersion() != c.gvk.GroupVersion() || gvk.Kind != c.gvk.Kind+"List" {
+		return fmt.Errorf("%w: List on %T", ErrRemoteObjectAccessUnsupported, list)
+	}
+	if err := c.delegate.List(ctx, list, opts...); err != nil {
+		return err
+	}
+	items, err := apimeta.ExtractList(list)
+	if err != nil {
+		return err
+	}
+	filtered := make([]runtime.Object, 0, len(items))
+	for _, item := range items {
+		obj, ok := item.(client.Object)
+		if !ok {
+			return fmt.Errorf("validating remote list item %T: object metadata is unavailable", item)
+		}
+		isAdapterObject, err := c.isAdapterObject(obj)
+		if err != nil {
+			return err
+		}
+		if !isAdapterObject {
+			return fmt.Errorf("%w: List returned unexpected %T", ErrRemoteObjectAccessUnsupported, obj)
+		}
+		if err := c.validateAdapterObject(ctx, obj, false); err != nil {
+			if errors.Is(err, ErrRemoteObjectNotOwnedByMultiKueue) {
+				continue
+			}
+			return err
+		}
+		filtered = append(filtered, item)
+	}
+	return apimeta.SetList(list, filtered)
+}
+
+func (c *remoteObjectOwnershipClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	isAdapterObject, err := c.isAdapterObject(obj)
+	if err != nil {
+		return err
+	}
+	if !isAdapterObject {
+		return fmt.Errorf("%w: Create on %T %q", ErrRemoteObjectWriteUnsupported, obj, client.ObjectKeyFromObject(obj))
+	}
+	if !c.allowCreate {
+		return fmt.Errorf("%w: Create on %T %q", ErrRemoteObjectWriteUnsupported, obj, client.ObjectKeyFromObject(obj))
+	}
+	expectedManagerUID, err := c.expectedManagerUID(ctx, client.ObjectKeyFromObject(obj))
+	if err != nil {
+		return err
+	}
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string, 1)
+	}
+	if actual := types.UID(annotations[kueue.MultiKueueOriginUIDAnnotation]); actual != "" && actual != expectedManagerUID {
+		return fmt.Errorf("%w: refusing to replace manager UID %q on %T %q", ErrRemoteObjectNotOwnedByMultiKueue, actual, obj, client.ObjectKeyFromObject(obj))
+	}
+	annotations[kueue.MultiKueueOriginUIDAnnotation] = string(expectedManagerUID)
+	obj.SetAnnotations(annotations)
+	if err := c.validateAdapterObject(ctx, obj, false); err != nil {
+		return err
+	}
+	err = c.delegate.Create(ctx, obj, opts...)
+	if !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+
+	// Some multi-Workload adapters intentionally ignore AlreadyExists because
+	// several Workloads can race to create the same controller object. Do not
+	// let that compatibility behavior turn a foreign pre-created object into a
+	// successful sync: authenticate the object that won the create race before
+	// returning the error to the adapter.
+	remoteObject := &metav1.PartialObjectMetadata{}
+	remoteObject.SetGroupVersionKind(c.gvk)
+	if getErr := c.delegate.Get(ctx, client.ObjectKeyFromObject(obj), remoteObject); getErr != nil {
+		return getErr
+	}
+	if validateErr := c.validateAdapterObject(ctx, remoteObject, false); validateErr != nil {
+		return validateErr
+	}
+	return err
+}
+
+func (c *remoteObjectOwnershipClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	isAdapterObject, err := c.isAdapterObject(obj)
+	if err != nil {
+		return err
+	}
+	if !isAdapterObject {
+		return fmt.Errorf("%w: Delete on %T %q", ErrRemoteObjectWriteUnsupported, obj, client.ObjectKeyFromObject(obj))
+	}
+	remoteObject, err := c.getAndValidateAdapterObject(ctx, client.ObjectKeyFromObject(obj), false)
+	if err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			return nil
+		}
+		return err
+	}
+	uid := remoteObject.UID
+	return c.delegate.Delete(ctx, obj, append(opts, client.Preconditions{UID: &uid})...)
+}
+
+func (c *remoteObjectOwnershipClient) validateAdapterWrite(ctx context.Context, obj client.Object) error {
+	if err := c.validateAdapterObject(ctx, obj, true); err != nil {
+		return err
+	}
+	remoteObject, err := c.getAndValidateAdapterObject(ctx, client.ObjectKeyFromObject(obj), true)
+	if err != nil {
+		return err
+	}
+	if obj.GetUID() == "" || obj.GetUID() != remoteObject.UID {
+		return fmt.Errorf("%w: expected UID %q on %T %q, got %q", ErrRemoteObjectNotOwnedByMultiKueue, remoteObject.UID, obj, client.ObjectKeyFromObject(obj), obj.GetUID())
+	}
+	if obj.GetResourceVersion() == "" || obj.GetResourceVersion() != remoteObject.ResourceVersion {
+		return fmt.Errorf(
+			"%w: expected resourceVersion %q on %T %q, got %q",
+			ErrRemoteObjectNotOwnedByMultiKueue,
+			remoteObject.ResourceVersion,
+			obj,
+			client.ObjectKeyFromObject(obj),
+			obj.GetResourceVersion(),
+		)
+	}
+	return nil
+}
+
+func (c *remoteObjectOwnershipClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	isAdapterObject, err := c.isAdapterObject(obj)
+	if err != nil {
+		return err
+	}
+	if !isAdapterObject {
+		return fmt.Errorf("%w: Update on %T %q", ErrRemoteObjectWriteUnsupported, obj, client.ObjectKeyFromObject(obj))
+	}
+	if err := c.validateAdapterWrite(ctx, obj); err != nil {
+		return err
+	}
+	return c.delegate.Update(ctx, obj, opts...)
+}
+
+func patchResourceVersion(obj client.Object, patch client.Patch) (string, error) {
+	data, err := patch.Data(obj)
+	if err != nil {
+		return "", err
+	}
+	var document map[string]any
+	if err := json.Unmarshal(data, &document); err != nil {
+		return "", fmt.Errorf("patch has no enforceable resourceVersion: %w", err)
+	}
+	metadata, ok := document["metadata"].(map[string]any)
+	if !ok {
+		return "", errors.New("patch has no enforceable metadata.resourceVersion")
+	}
+	resourceVersion, ok := metadata["resourceVersion"].(string)
+	if !ok || resourceVersion == "" {
+		return "", errors.New("patch has no enforceable metadata.resourceVersion")
+	}
+	return resourceVersion, nil
+}
+
+func (c *remoteObjectOwnershipClient) validateAdapterPatch(ctx context.Context, obj client.Object, patch client.Patch) error {
+	if err := c.validateAdapterWrite(ctx, obj); err != nil {
+		return err
+	}
+	resourceVersion, err := patchResourceVersion(obj, patch)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrRemoteObjectWriteUnsupported, err)
+	}
+	if resourceVersion != obj.GetResourceVersion() {
+		return fmt.Errorf("%w: patch resourceVersion %q does not match object resourceVersion %q", ErrRemoteObjectNotOwnedByMultiKueue, resourceVersion, obj.GetResourceVersion())
+	}
+	return nil
+}
+
+func (c *remoteObjectOwnershipClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	isAdapterObject, err := c.isAdapterObject(obj)
+	if err != nil {
+		return err
+	}
+	if !isAdapterObject {
+		return fmt.Errorf("%w: Patch on %T %q", ErrRemoteObjectWriteUnsupported, obj, client.ObjectKeyFromObject(obj))
+	}
+	if err := c.validateAdapterPatch(ctx, obj, patch); err != nil {
+		return err
+	}
+	return c.delegate.Patch(ctx, obj, patch, opts...)
+}
+
+func (c *remoteObjectOwnershipClient) Apply(_ context.Context, obj runtime.ApplyConfiguration, _ ...client.ApplyOption) error {
+	return fmt.Errorf("%w: Apply on %T", ErrRemoteObjectWriteUnsupported, obj)
+}
+
+func (c *remoteObjectOwnershipClient) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
+	isAdapterObject, err := c.isAdapterObject(obj)
+	if err != nil {
+		return err
+	}
+	if !isAdapterObject {
+		return fmt.Errorf("%w: DeleteAllOf on %T", ErrRemoteObjectWriteUnsupported, obj)
+	}
+	deleteOptions := (&client.DeleteAllOfOptions{}).ApplyOptions(opts)
+	if deleteOptions.Namespace != c.controllerKey.Namespace {
+		return fmt.Errorf("%w: expected Namespace %q when deleting all %T, got %q", ErrRemoteObjectNotOwnedByMultiKueue, c.controllerKey.Namespace, obj, deleteOptions.Namespace)
+	}
+	list := &metav1.PartialObjectMetadataList{}
+	list.SetGroupVersionKind(c.gvk.GroupVersion().WithKind(c.gvk.Kind + "List"))
+	if err := c.List(ctx, list, &deleteOptions.ListOptions); err != nil {
+		return err
+	}
+	return apimeta.EachListItem(list, func(item runtime.Object) error {
+		remoteObject, ok := item.(client.Object)
+		if !ok {
+			return fmt.Errorf("deleting remote list item %T: object metadata is unavailable", item)
+		}
+		return c.Delete(ctx, remoteObject, &deleteOptions.DeleteOptions)
+	})
+}
+
+type remoteObjectOwnershipSubResourceClient struct {
+	delegate client.SubResourceClient
+	parent   *remoteObjectOwnershipClient
+}
+
+var _ client.SubResourceClient = (*remoteObjectOwnershipSubResourceClient)(nil)
+
+func (c *remoteObjectOwnershipSubResourceClient) isAdapterObject(obj client.Object) (bool, error) {
+	return c.parent.isAdapterObject(obj)
+}
+
+func (c *remoteObjectOwnershipSubResourceClient) Get(ctx context.Context, obj client.Object, subResource client.Object, opts ...client.SubResourceGetOption) error {
+	isAdapterObject, err := c.isAdapterObject(obj)
+	if err != nil {
+		return err
+	}
+	if !isAdapterObject {
+		return fmt.Errorf("%w: subresource Get on %T %q", ErrRemoteObjectAccessUnsupported, obj, client.ObjectKeyFromObject(obj))
+	}
+	return fmt.Errorf("%w: subresource Get on %T %q has no atomic identity check", ErrRemoteObjectAccessUnsupported, obj, client.ObjectKeyFromObject(obj))
+}
+
+func (c *remoteObjectOwnershipSubResourceClient) Create(ctx context.Context, obj client.Object, subResource client.Object, opts ...client.SubResourceCreateOption) error {
+	if _, err := c.isAdapterObject(obj); err != nil {
+		return err
+	}
+	return fmt.Errorf("%w: subresource Create on %T %q", ErrRemoteObjectWriteUnsupported, obj, client.ObjectKeyFromObject(obj))
+}
+
+func (c *remoteObjectOwnershipSubResourceClient) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	isAdapterObject, err := c.isAdapterObject(obj)
+	if err != nil {
+		return err
+	}
+	if !isAdapterObject {
+		return fmt.Errorf("%w: subresource Update on %T %q", ErrRemoteObjectWriteUnsupported, obj, client.ObjectKeyFromObject(obj))
+	}
+	updateOptions := (&client.SubResourceUpdateOptions{}).ApplyOptions(opts)
+	if updateOptions.SubResourceBody != nil {
+		return fmt.Errorf("%w: subresource Update on %T %q uses an alternate unvalidated body", ErrRemoteObjectWriteUnsupported, obj, client.ObjectKeyFromObject(obj))
+	}
+	if err := c.parent.validateAdapterWrite(ctx, obj); err != nil {
+		return err
+	}
+	return c.delegate.Update(ctx, obj, opts...)
+}
+
+func (c *remoteObjectOwnershipSubResourceClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+	isAdapterObject, err := c.isAdapterObject(obj)
+	if err != nil {
+		return err
+	}
+	if !isAdapterObject {
+		return fmt.Errorf("%w: subresource Patch on %T %q", ErrRemoteObjectWriteUnsupported, obj, client.ObjectKeyFromObject(obj))
+	}
+	patchOptions := (&client.SubResourcePatchOptions{}).ApplyOptions(opts)
+	if patchOptions.SubResourceBody != nil {
+		return fmt.Errorf("%w: subresource Patch on %T %q uses an alternate unvalidated body", ErrRemoteObjectWriteUnsupported, obj, client.ObjectKeyFromObject(obj))
+	}
+	if err := c.parent.validateAdapterPatch(ctx, obj, patch); err != nil {
+		return err
+	}
+	return c.delegate.Patch(ctx, obj, patch, opts...)
+}
+
+func (c *remoteObjectOwnershipSubResourceClient) Apply(_ context.Context, obj runtime.ApplyConfiguration, _ ...client.SubResourceApplyOption) error {
+	return fmt.Errorf("%w: subresource Apply on %T", ErrRemoteObjectWriteUnsupported, obj)
+}
+
+func (c *remoteObjectOwnershipClient) Status() client.SubResourceWriter {
+	return c.SubResource("status")
+}
+
+func (c *remoteObjectOwnershipClient) SubResource(subResource string) client.SubResourceClient {
+	return &remoteObjectOwnershipSubResourceClient{delegate: c.delegate.SubResource(subResource), parent: c}
+}
+
+func (c *remoteObjectOwnershipClient) Scheme() *runtime.Scheme {
+	return c.delegate.Scheme()
+}
+
+func (c *remoteObjectOwnershipClient) RESTMapper() apimeta.RESTMapper {
+	return c.delegate.RESTMapper()
+}
+
+func (c *remoteObjectOwnershipClient) GroupVersionKindFor(obj runtime.Object) (schema.GroupVersionKind, error) {
+	return c.delegate.GroupVersionKindFor(obj)
+}
+
+func (c *remoteObjectOwnershipClient) IsObjectNamespaced(obj runtime.Object) (bool, error) {
+	return c.delegate.IsObjectNamespaced(obj)
+}
+
+func newRemoteObjectOwnershipClientForSync(
+	localClient client.Client,
+	localReader client.Reader,
+	remoteClient client.Client,
+	adapter MultiKueueAdapter,
+	key types.NamespacedName,
+	localWorkload *kueue.Workload,
+	origin string,
+) (*remoteObjectOwnershipClient, error) {
+	if origin == "" {
+		return nil, ErrMultiKueueOriginEmpty
+	}
+	if localWorkload == nil || localWorkload.Name == "" {
+		return nil, ErrMultiKueueWorkloadNameEmpty
+	}
+	if localReader == nil {
+		return nil, fmt.Errorf("%w: manager object API reader is unavailable", ErrRemoteObjectAccessUnsupported)
+	}
+	managerObjectUID, managerObjectUIDs, err := managerObjectUIDForWorkload(localWorkload, adapter.GVK(), key)
+	if err != nil {
+		return nil, err
+	}
+	reassignmentAdapter, _ := adapter.(MultiKueueAdapterWithWorkloadReassignment)
+	_, multiWorkload := adapter.(MultiKueueMultiWorkloadAdapter)
+	return &remoteObjectOwnershipClient{
+		delegate:             remoteClient,
+		localClient:          localClient,
+		localReader:          localReader,
+		gvk:                  adapter.GVK(),
+		controllerKey:        key,
+		association:          MultiKueueObjectAssociation{Origin: origin, WorkloadName: localWorkload.Name, ManagerObjectUID: managerObjectUID},
+		managerObjectUIDs:    managerObjectUIDs,
+		multiWorkload:        multiWorkload,
+		workloadReassignment: reassignmentAdapter,
+		allowCreate:          true,
+	}, nil
+}
+
+func newRemoteObjectOwnershipClientForCleanup(
+	remoteClient client.Client,
+	adapter MultiKueueAdapter,
+	key types.NamespacedName,
+	cleanupContext MultiKueueRemoteObjectCleanupContext,
+) (*remoteObjectOwnershipClient, error) {
+	if cleanupContext.Association.Origin == "" {
+		return nil, ErrMultiKueueOriginEmpty
+	}
+	if cleanupContext.Association.WorkloadName == "" {
+		return nil, ErrMultiKueueWorkloadNameEmpty
+	}
+	_, multiWorkload := adapter.(MultiKueueMultiWorkloadAdapter)
+	return &remoteObjectOwnershipClient{
+		delegate:                remoteClient,
+		gvk:                     adapter.GVK(),
+		controllerKey:           key,
+		association:             cleanupContext.Association,
+		managerObjectUIDs:       maps.Clone(cleanupContext.ManagerObjectUIDs),
+		expectedRemoteObjectUID: cleanupContext.RemoteObjectUID,
+		multiWorkload:           multiWorkload,
+	}, nil
+}
+
+// SyncJobWithRemoteObjectOwnership runs the adapter with a remote client that
+// authenticates every adapter object at the read and write boundary.
+func SyncJobWithRemoteObjectOwnership(
+	ctx context.Context,
+	localClient client.Client,
+	localReader client.Reader,
+	remoteClient client.Client,
+	adapter MultiKueueAdapter,
+	key types.NamespacedName,
+	localWorkload *kueue.Workload,
+	origin string,
+) (bool, error) {
+	validatingClient, err := newRemoteObjectOwnershipClientForSync(localClient, localReader, remoteClient, adapter, key, localWorkload, origin)
+	if err != nil {
+		return false, err
+	}
+	return adapter.SyncJob(ctx, localClient, validatingClient, key, localWorkload.Name, origin)
+}

--- a/pkg/controller/jobframework/multikueue_remote_client_test.go
+++ b/pkg/controller/jobframework/multikueue_remote_client_test.go
@@ -1,0 +1,371 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jobframework
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/controller/constants"
+	clientutil "sigs.k8s.io/kueue/pkg/util/client"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+)
+
+type createRaceAdapter struct{}
+
+func jobBoundWorkload(name string, key types.NamespacedName, managerUID types.UID) *kueue.Workload {
+	return &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+		Name:      name,
+		Namespace: key.Namespace,
+		UID:       types.UID("manager-" + name + "-uid"),
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: batchv1.SchemeGroupVersion.String(),
+			Kind:       "Job",
+			Name:       key.Name,
+			UID:        managerUID,
+			Controller: new(true),
+		}},
+	}}
+}
+
+func (*createRaceAdapter) SyncJob(ctx context.Context, _ client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) (bool, error) {
+	remoteJob := &batchv1.Job{}
+	err := remoteClient.Get(ctx, key, remoteJob)
+	if client.IgnoreNotFound(err) != nil {
+		return false, err
+	}
+	if err == nil {
+		return false, nil
+	}
+	remoteJob = &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name:      key.Name,
+		Namespace: key.Namespace,
+		Labels: map[string]string{
+			kueue.MultiKueueOriginLabel:     origin,
+			constants.PrebuiltWorkloadLabel: workloadName,
+		},
+	}}
+	return false, client.IgnoreAlreadyExists(remoteClient.Create(ctx, remoteJob))
+}
+
+func (*createRaceAdapter) DeleteRemoteObject(context.Context, client.Client, client.Client, types.NamespacedName) error {
+	return nil
+}
+
+func (*createRaceAdapter) IsJobManagedByKueue(context.Context, client.Client, types.NamespacedName) (bool, string, error) {
+	return true, "", nil
+}
+
+func (*createRaceAdapter) GVK() schema.GroupVersionKind {
+	return batchv1.SchemeGroupVersion.WithKind("Job")
+}
+
+func TestRemoteObjectOwnershipClientAuthenticatesCreateRace(t *testing.T) {
+	const (
+		origin       = "origin"
+		workloadName = "workload"
+		managerUID   = types.UID("manager-job-uid")
+	)
+	key := types.NamespacedName{Namespace: "ns", Name: "job"}
+	managerJob := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace, UID: managerUID}}
+
+	tests := map[string]struct {
+		winnerOriginUID types.UID
+		wantErr         error
+	}{
+		"same manager object may win a concurrent multi-Workload create": {
+			winnerOriginUID: managerUID,
+		},
+		"foreign object cannot hide behind ignored AlreadyExists": {
+			winnerOriginUID: "foreign-manager-uid",
+			wantErr:         ErrRemoteObjectNotOwnedByMultiKueue,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			if err := batchv1.AddToScheme(scheme); err != nil {
+				t.Fatalf("adding batch scheme: %v", err)
+			}
+			managerClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(managerJob.DeepCopy()).Build()
+			baseWorkerClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+			winner := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+				Name:      key.Name,
+				Namespace: key.Namespace,
+				Labels: map[string]string{
+					kueue.MultiKueueOriginLabel:     origin,
+					constants.PrebuiltWorkloadLabel: workloadName,
+				},
+				Annotations: map[string]string{kueue.MultiKueueOriginUIDAnnotation: string(tc.winnerOriginUID)},
+			}}
+			workerClient := fake.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+				Create: func(ctx context.Context, _ client.WithWatch, _ client.Object, _ ...client.CreateOption) error {
+					if err := baseWorkerClient.Create(ctx, winner.DeepCopy()); err != nil {
+						return err
+					}
+					return apierrors.NewAlreadyExists(schema.GroupResource{Group: batchv1.GroupName, Resource: "jobs"}, key.Name)
+				},
+				Get: func(ctx context.Context, _ client.WithWatch, getKey client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					return baseWorkerClient.Get(ctx, getKey, obj, opts...)
+				},
+			}).Build()
+
+			ctx, _ := utiltesting.ContextWithLog(t)
+			_, err := SyncJobWithRemoteObjectOwnership(ctx, managerClient, managerClient, workerClient, &createRaceAdapter{}, key, jobBoundWorkload(workloadName, key, managerUID), origin)
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("SyncJobWithRemoteObjectOwnership() error = %v, want %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestRemoteObjectOwnershipClientRejectsSameNameManagerReplacement(t *testing.T) {
+	const (
+		origin         = "origin"
+		workloadName   = "workload"
+		originalUID    = types.UID("original-manager-job-uid")
+		replacementUID = types.UID("replacement-manager-job-uid")
+	)
+	key := types.NamespacedName{Namespace: "ns", Name: "job"}
+	scheme := runtime.NewScheme()
+	if err := batchv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("adding batch scheme: %v", err)
+	}
+	managerOriginal := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name: key.Name, Namespace: key.Namespace, UID: originalUID,
+	}}
+	managerReplacement := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name: key.Name, Namespace: key.Namespace, UID: replacementUID,
+	}}
+	managerClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(managerOriginal).Build()
+	managerReader := fake.NewClientBuilder().WithScheme(scheme).WithObjects(managerReplacement).Build()
+	workerClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	ctx, _ := utiltesting.ContextWithLog(t)
+	_, err := SyncJobWithRemoteObjectOwnership(
+		ctx,
+		managerClient,
+		managerReader,
+		workerClient,
+		&createRaceAdapter{},
+		key,
+		jobBoundWorkload(workloadName, key, originalUID),
+		origin,
+	)
+	if !errors.Is(err, ErrRemoteObjectNotOwnedByMultiKueue) {
+		t.Fatalf("SyncJobWithRemoteObjectOwnership() error = %v, want %v", err, ErrRemoteObjectNotOwnedByMultiKueue)
+	}
+	remoteJob := &batchv1.Job{}
+	if err := workerClient.Get(ctx, key, remoteJob); !apierrors.IsNotFound(err) {
+		t.Fatalf("worker Job Get() error = %v, want NotFound", err)
+	}
+}
+
+func TestRemoteObjectOwnershipClientWriteBoundaries(t *testing.T) {
+	const (
+		origin       = "origin"
+		workloadName = "workload"
+		managerUID   = types.UID("manager-job-uid")
+	)
+	key := types.NamespacedName{Namespace: "ns", Name: "job"}
+	scheme := runtime.NewScheme()
+	if err := batchv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("adding batch scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("adding core scheme: %v", err)
+	}
+	managerJob := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace, UID: managerUID}}
+	managerClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(managerJob).Build()
+	workerClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&batchv1.Job{}).Build()
+	guarded, err := newRemoteObjectOwnershipClientForSync(managerClient, managerClient, workerClient, &createRaceAdapter{}, key, jobBoundWorkload(workloadName, key, managerUID), origin)
+	if err != nil {
+		t.Fatalf("newRemoteObjectOwnershipClientForSync() error = %v", err)
+	}
+	ctx, _ := utiltesting.ContextWithLog(t)
+	remoteJob := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name:      key.Name,
+		Namespace: key.Namespace,
+		UID:       "remote-job-uid",
+		Labels: map[string]string{
+			kueue.MultiKueueOriginLabel:     origin,
+			constants.PrebuiltWorkloadLabel: workloadName,
+		},
+	}}
+	if err := guarded.Create(ctx, remoteJob); err != nil {
+		t.Fatalf("guarded Create() error = %v", err)
+	}
+	if got := remoteJob.Annotations[kueue.MultiKueueOriginUIDAnnotation]; got != string(managerUID) {
+		t.Fatalf("origin UID annotation = %q, want %q", got, managerUID)
+	}
+	configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "secondary", Namespace: key.Namespace}}
+	if err := guarded.Get(ctx, client.ObjectKeyFromObject(configMap), configMap); !errors.Is(err, ErrRemoteObjectAccessUnsupported) {
+		t.Fatalf("secondary-GVK Get() error = %v, want %v", err, ErrRemoteObjectAccessUnsupported)
+	}
+	if err := guarded.Create(ctx, configMap); !errors.Is(err, ErrRemoteObjectWriteUnsupported) {
+		t.Fatalf("secondary-GVK Create() error = %v, want %v", err, ErrRemoteObjectWriteUnsupported)
+	}
+
+	if err := guarded.Get(ctx, key, remoteJob); err != nil {
+		t.Fatalf("guarded Get() error = %v", err)
+	}
+	if err := clientutil.Patch(ctx, guarded, remoteJob, func() (bool, error) {
+		remoteJob.Labels["patched"] = "true"
+		return true, nil
+	}); err != nil {
+		t.Fatalf("strict guarded Patch() error = %v", err)
+	}
+	if err := guarded.Get(ctx, key, remoteJob); err != nil {
+		t.Fatalf("guarded Get() after patch error = %v", err)
+	}
+	remoteJob.Labels["updated"] = "true"
+	if err := guarded.Update(ctx, remoteJob); err != nil {
+		t.Fatalf("guarded Update() error = %v", err)
+	}
+	if err := guarded.Get(ctx, key, remoteJob); err != nil {
+		t.Fatalf("guarded Get() after update error = %v", err)
+	}
+	remoteJob.Status.Active = 1
+	if err := guarded.Status().Update(ctx, remoteJob); err != nil {
+		t.Fatalf("guarded Status().Update() error = %v", err)
+	}
+	if err := guarded.Get(ctx, key, remoteJob); err != nil {
+		t.Fatalf("guarded Get() after status update error = %v", err)
+	}
+	if remoteJob.Status.Active != 1 {
+		t.Fatalf("remote Job active status = %d, want 1", remoteJob.Status.Active)
+	}
+	loosePatch := client.RawPatch(types.MergePatchType, []byte(`{"metadata":{"labels":{"loose":"true"}}}`))
+	if err := guarded.Patch(ctx, remoteJob, loosePatch); !errors.Is(err, ErrRemoteObjectWriteUnsupported) {
+		t.Fatalf("unguarded Patch() error = %v, want %v", err, ErrRemoteObjectWriteUnsupported)
+	}
+	if err := guarded.Status().Patch(ctx, remoteJob, loosePatch); !errors.Is(err, ErrRemoteObjectWriteUnsupported) {
+		t.Fatalf("unguarded Status().Patch() error = %v, want %v", err, ErrRemoteObjectWriteUnsupported)
+	}
+	alternateBody := remoteJob.DeepCopy()
+	alternateBody.Annotations[kueue.MultiKueueOriginUIDAnnotation] = "foreign-manager-uid"
+	if err := guarded.Status().Update(ctx, remoteJob, client.WithSubResourceBody(alternateBody)); !errors.Is(err, ErrRemoteObjectWriteUnsupported) {
+		t.Fatalf("Status().Update() with alternate body error = %v, want %v", err, ErrRemoteObjectWriteUnsupported)
+	}
+	patchBase := remoteJob.DeepCopy()
+	remoteJob.Labels["strict-patch"] = "true"
+	strictPatch := client.MergeFromWithOptions(patchBase, client.MergeFromWithOptimisticLock{})
+	if err := guarded.Status().Patch(ctx, remoteJob, strictPatch, client.WithSubResourceBody(alternateBody)); !errors.Is(err, ErrRemoteObjectWriteUnsupported) {
+		t.Fatalf("Status().Patch() with alternate body error = %v, want %v", err, ErrRemoteObjectWriteUnsupported)
+	}
+	if err := guarded.SubResource("scale").Get(ctx, remoteJob, &metav1.PartialObjectMetadata{}); !errors.Is(err, ErrRemoteObjectAccessUnsupported) {
+		t.Fatalf("SubResource().Get() error = %v, want %v", err, ErrRemoteObjectAccessUnsupported)
+	}
+	if err := guarded.SubResource("scale").Create(ctx, remoteJob, &metav1.PartialObjectMetadata{}); !errors.Is(err, ErrRemoteObjectWriteUnsupported) {
+		t.Fatalf("SubResource().Create() error = %v, want %v", err, ErrRemoteObjectWriteUnsupported)
+	}
+	if err := guarded.Apply(ctx, nil); !errors.Is(err, ErrRemoteObjectWriteUnsupported) {
+		t.Fatalf("Apply() error = %v, want %v", err, ErrRemoteObjectWriteUnsupported)
+	}
+	if err := guarded.Status().Apply(ctx, nil); !errors.Is(err, ErrRemoteObjectWriteUnsupported) {
+		t.Fatalf("Status().Apply() error = %v, want %v", err, ErrRemoteObjectWriteUnsupported)
+	}
+}
+
+func TestRemoteObjectOwnershipClientFiltersListAndDeleteAllOf(t *testing.T) {
+	const (
+		origin       = "origin"
+		workloadName = "workload"
+	)
+	scheme := runtime.NewScheme()
+	if err := batchv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("adding batch scheme: %v", err)
+	}
+	makeManagerJob := func(name string, uid types.UID) *batchv1.Job {
+		return &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "ns", UID: uid}}
+	}
+	makeRemoteJob := func(name, workload string, managerUID types.UID) *batchv1.Job {
+		return &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "ns",
+			UID:       types.UID("remote-" + name + "-uid"),
+			Labels: map[string]string{
+				kueue.MultiKueueOriginLabel:     origin,
+				constants.PrebuiltWorkloadLabel: workload,
+			},
+			Annotations: map[string]string{kueue.MultiKueueOriginUIDAnnotation: string(managerUID)},
+		}}
+	}
+	associatedManager := makeManagerJob("associated", "manager-associated-uid")
+	otherWorkloadManager := makeManagerJob("other-workload", "manager-other-workload-uid")
+	foreignManager := makeManagerJob("foreign", "manager-foreign-uid")
+	associated := makeRemoteJob(associatedManager.Name, workloadName, associatedManager.UID)
+	otherWorkload := makeRemoteJob(otherWorkloadManager.Name, "another-workload", otherWorkloadManager.UID)
+	foreign := makeRemoteJob(foreignManager.Name, workloadName, "different-manager-uid")
+
+	managerClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(associatedManager, otherWorkloadManager, foreignManager).Build()
+	workerClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(associated, otherWorkload, foreign).Build()
+	guarded, err := newRemoteObjectOwnershipClientForSync(
+		managerClient,
+		managerClient,
+		workerClient,
+		&createRaceAdapter{},
+		client.ObjectKeyFromObject(associatedManager),
+		jobBoundWorkload(workloadName, client.ObjectKeyFromObject(associatedManager), associatedManager.UID),
+		origin,
+	)
+	if err != nil {
+		t.Fatalf("newRemoteObjectOwnershipClientForSync() error = %v", err)
+	}
+	ctx, _ := utiltesting.ContextWithLog(t)
+	jobs := &batchv1.JobList{}
+	if err := guarded.List(ctx, jobs, client.InNamespace("ns")); err != nil {
+		t.Fatalf("guarded List() error = %v", err)
+	}
+	if len(jobs.Items) != 1 || jobs.Items[0].Name != associated.Name {
+		t.Fatalf("guarded List() jobs = %v, want only %q", jobNames(jobs.Items), associated.Name)
+	}
+
+	if err := guarded.DeleteAllOf(ctx, &batchv1.Job{}, client.InNamespace("ns")); err != nil {
+		t.Fatalf("guarded DeleteAllOf() error = %v", err)
+	}
+	if err := workerClient.Get(ctx, client.ObjectKeyFromObject(associated), &batchv1.Job{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("associated Job Get() after DeleteAllOf error = %v, want NotFound", err)
+	}
+	for _, preserved := range []*batchv1.Job{otherWorkload, foreign} {
+		if err := workerClient.Get(ctx, client.ObjectKeyFromObject(preserved), &batchv1.Job{}); err != nil {
+			t.Fatalf("preserved Job %q Get() error = %v", preserved.Name, err)
+		}
+	}
+}
+
+func jobNames(jobs []batchv1.Job) []string {
+	names := make([]string, len(jobs))
+	for i := range jobs {
+		names[i] = jobs[i].Name
+	}
+	return names
+}

--- a/pkg/controller/jobframework/multikueue_test.go
+++ b/pkg/controller/jobframework/multikueue_test.go
@@ -28,15 +28,29 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/component-base/featuregate"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	mocks "sigs.k8s.io/kueue/internal/mocks/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 )
+
+type cleanupTrackingAdapter struct {
+	jobframework.MultiKueueAdapter
+	cleanupContext *jobframework.MultiKueueRemoteObjectCleanupContext
+}
+
+func (a *cleanupTrackingAdapter) DeleteRemoteObjectWithCleanupContext(_ context.Context, _, _ client.Client, _ types.NamespacedName, cleanupContext jobframework.MultiKueueRemoteObjectCleanupContext) error {
+	a.cleanupContext = &cleanupContext
+	cleanupContext.WorkloadAnnotations["mutated-by-adapter"] = "true"
+	return nil
+}
 
 func TestValidateRemoteObjectOwnership(t *testing.T) {
 	key := types.NamespacedName{Name: "test", Namespace: "default"}
@@ -112,6 +126,97 @@ func TestValidateRemoteObjectOwnership(t *testing.T) {
 	}
 }
 
+func TestValidateMultiKueueObjectAssociation(t *testing.T) {
+	const (
+		origin       = "origin-1"
+		workloadName = "workload-1"
+	)
+	longWorkloadName := "workload-name-that-is-longer-than-the-sixty-three-character-label-limit"
+
+	tests := map[string]struct {
+		featureGate bool
+		labels      map[string]string
+		annotations map[string]string
+		wantErr     error
+		workload    string
+	}{
+		"label survives gate enable": {
+			featureGate: true,
+			labels: map[string]string{
+				kueue.MultiKueueOriginLabel:     origin,
+				constants.PrebuiltWorkloadLabel: workloadName,
+			},
+		},
+		"annotation survives gate disable": {
+			featureGate: false,
+			labels:      map[string]string{kueue.MultiKueueOriginLabel: origin},
+			annotations: map[string]string{constants.PrebuiltWorkloadAnnotation: workloadName},
+		},
+		"matching label and annotation are accepted": {
+			featureGate: true,
+			labels: map[string]string{
+				kueue.MultiKueueOriginLabel:     origin,
+				constants.PrebuiltWorkloadLabel: workloadName,
+			},
+			annotations: map[string]string{constants.PrebuiltWorkloadAnnotation: workloadName},
+		},
+		"conflicting label and annotation are rejected": {
+			featureGate: false,
+			labels: map[string]string{
+				kueue.MultiKueueOriginLabel:     origin,
+				constants.PrebuiltWorkloadLabel: workloadName,
+			},
+			annotations: map[string]string{constants.PrebuiltWorkloadAnnotation: "another-workload"},
+			wantErr:     jobframework.ErrRemoteObjectNotOwnedByMultiKueue,
+		},
+		"long annotation survives gate disable": {
+			featureGate: false,
+			labels:      map[string]string{kueue.MultiKueueOriginLabel: origin},
+			annotations: map[string]string{constants.PrebuiltWorkloadAnnotation: longWorkloadName},
+			workload:    longWorkloadName,
+		},
+		"wrong origin is rejected": {
+			featureGate: true,
+			labels: map[string]string{
+				kueue.MultiKueueOriginLabel:     "another-origin",
+				constants.PrebuiltWorkloadLabel: workloadName,
+			},
+			wantErr: jobframework.ErrRemoteObjectNotOwnedByMultiKueue,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: tc.featureGate})
+			job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+				Name:        "job",
+				Namespace:   "default",
+				Labels:      tc.labels,
+				Annotations: tc.annotations,
+			}}
+			expectedWorkload := tc.workload
+			if expectedWorkload == "" {
+				expectedWorkload = workloadName
+			}
+			err := jobframework.ValidateMultiKueueObjectAssociation(job, jobframework.MultiKueueObjectAssociation{
+				Origin:       origin,
+				WorkloadName: expectedWorkload,
+			})
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Fatalf("ValidateMultiKueueObjectAssociation() error (-want,+got):\n%s", diff)
+			}
+		})
+	}
+
+	t.Run("empty origin is rejected", func(t *testing.T) {
+		job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "job", Namespace: "default"}}
+		err := jobframework.ValidateMultiKueueObjectAssociation(job, jobframework.MultiKueueObjectAssociation{WorkloadName: workloadName})
+		if !errors.Is(err, jobframework.ErrMultiKueueOriginEmpty) {
+			t.Fatalf("ValidateMultiKueueObjectAssociation() error = %v, want %v", err, jobframework.ErrMultiKueueOriginEmpty)
+		}
+	})
+}
+
 func TestDeleteRemoteObjectIfOwned(t *testing.T) {
 	makeJob := func(key types.NamespacedName, labels map[string]string) *batchv1.Job {
 		return &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace, Labels: labels}}
@@ -185,4 +290,127 @@ func TestDeleteRemoteObjectIfOwned(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDeleteRemoteObjectForWorkloadIfOwned(t *testing.T) {
+	key := types.NamespacedName{Name: "test-job", Namespace: "default"}
+	const (
+		origin       = "origin-1"
+		workloadName = "workload-1"
+	)
+	makeRemoteJob := func(remoteWorkloadName string) *batchv1.Job {
+		return &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+			Name:      key.Name,
+			Namespace: key.Namespace,
+			UID:       "remote-uid",
+			Labels: map[string]string{
+				kueue.MultiKueueOriginLabel:     origin,
+				constants.PrebuiltWorkloadLabel: remoteWorkloadName,
+			},
+		}}
+	}
+	makeClients := func(t *testing.T, remoteObjects ...client.Object) (client.Client, client.Client) {
+		t.Helper()
+		scheme := runtime.NewScheme()
+		if err := batchv1.AddToScheme(scheme); err != nil {
+			t.Fatalf("adding batch scheme: %v", err)
+		}
+		return fake.NewClientBuilder().WithScheme(scheme).Build(), fake.NewClientBuilder().WithScheme(scheme).WithObjects(remoteObjects...).Build()
+	}
+
+	t.Run("cleanup-aware adapter receives exact identity and copied Workload context", func(t *testing.T) {
+		localClient, remoteClient := makeClients(t, makeRemoteJob(workloadName))
+		mockCtrl := gomock.NewController(t)
+		baseAdapter := mocks.NewMockMultiKueueAdapter(mockCtrl)
+		baseAdapter.EXPECT().GVK().Return(batchv1.SchemeGroupVersion.WithKind("Job")).AnyTimes()
+		adapter := &cleanupTrackingAdapter{MultiKueueAdapter: baseAdapter}
+		localWorkload := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+			Name:        workloadName,
+			Namespace:   key.Namespace,
+			Annotations: map[string]string{"context": "manager"},
+		}}
+
+		ctx, _ := utiltesting.ContextWithLog(t)
+		if err := jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, localClient, remoteClient, adapter, key, localWorkload, origin); err != nil {
+			t.Fatalf("DeleteRemoteObjectForWorkloadIfOwned() error = %v", err)
+		}
+		if adapter.cleanupContext == nil {
+			t.Fatal("cleanup-aware adapter was not called")
+		}
+		if adapter.cleanupContext.RemoteObjectUID != "remote-uid" {
+			t.Fatalf("RemoteObjectUID = %q, want remote-uid", adapter.cleanupContext.RemoteObjectUID)
+		}
+		if adapter.cleanupContext.WorkloadKey != (types.NamespacedName{Name: workloadName, Namespace: key.Namespace}) {
+			t.Fatalf("WorkloadKey = %q", adapter.cleanupContext.WorkloadKey)
+		}
+		if _, mutated := localWorkload.Annotations["mutated-by-adapter"]; mutated {
+			t.Fatal("adapter mutation changed the manager Workload annotations")
+		}
+	})
+
+	t.Run("cleanup-aware adapter rejects another Workload association", func(t *testing.T) {
+		localClient, remoteClient := makeClients(t, makeRemoteJob("another-workload"))
+		mockCtrl := gomock.NewController(t)
+		baseAdapter := mocks.NewMockMultiKueueAdapter(mockCtrl)
+		baseAdapter.EXPECT().GVK().Return(batchv1.SchemeGroupVersion.WithKind("Job")).AnyTimes()
+		adapter := &cleanupTrackingAdapter{MultiKueueAdapter: baseAdapter}
+		localWorkload := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{Name: workloadName, Namespace: key.Namespace}}
+
+		ctx, _ := utiltesting.ContextWithLog(t)
+		if err := jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, localClient, remoteClient, adapter, key, localWorkload, origin); err != nil {
+			t.Fatalf("DeleteRemoteObjectForWorkloadIfOwned() error = %v", err)
+		}
+		if adapter.cleanupContext != nil {
+			t.Fatal("cleanup-aware adapter was called for another Workload")
+		}
+	})
+
+	t.Run("cleanup-aware adapter rejects an unexpected remote UID", func(t *testing.T) {
+		localClient, remoteClient := makeClients(t, makeRemoteJob(workloadName))
+		mockCtrl := gomock.NewController(t)
+		baseAdapter := mocks.NewMockMultiKueueAdapter(mockCtrl)
+		baseAdapter.EXPECT().GVK().Return(batchv1.SchemeGroupVersion.WithKind("Job")).AnyTimes()
+		adapter := &cleanupTrackingAdapter{MultiKueueAdapter: baseAdapter}
+
+		ctx, _ := utiltesting.ContextWithLog(t)
+		err := jobframework.DeleteRemoteObjectWithCleanupContextIfOwned(ctx, localClient, remoteClient, adapter, key, jobframework.MultiKueueRemoteObjectCleanupContext{
+			RemoteObjectUID: "another-uid",
+			Association: jobframework.MultiKueueObjectAssociation{
+				Origin:       origin,
+				WorkloadName: workloadName,
+			},
+			WorkloadKey: types.NamespacedName{Name: workloadName, Namespace: key.Namespace},
+		})
+		if err != nil {
+			t.Fatalf("DeleteRemoteObjectWithCleanupContextIfOwned() error = %v", err)
+		}
+		if adapter.cleanupContext != nil {
+			t.Fatal("cleanup-aware adapter was called for an unexpected remote UID")
+		}
+	})
+
+	t.Run("legacy adapter retains origin-only fallback", func(t *testing.T) {
+		localClient, remoteClient := makeClients(t, makeRemoteJob("another-workload"))
+		mockCtrl := gomock.NewController(t)
+		adapter := mocks.NewMockMultiKueueAdapter(mockCtrl)
+		adapter.EXPECT().GVK().Return(batchv1.SchemeGroupVersion.WithKind("Job")).AnyTimes()
+		adapter.EXPECT().DeleteRemoteObject(gomock.Any(), gomock.Any(), gomock.Any(), key).Return(nil)
+		localWorkload := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{Name: workloadName, Namespace: key.Namespace}}
+
+		ctx, _ := utiltesting.ContextWithLog(t)
+		if err := jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, localClient, remoteClient, adapter, key, localWorkload, origin); err != nil {
+			t.Fatalf("DeleteRemoteObjectForWorkloadIfOwned() error = %v", err)
+		}
+	})
+
+	t.Run("nil Workload is rejected", func(t *testing.T) {
+		localClient, remoteClient := makeClients(t)
+		mockCtrl := gomock.NewController(t)
+		adapter := mocks.NewMockMultiKueueAdapter(mockCtrl)
+		ctx, _ := utiltesting.ContextWithLog(t)
+		err := jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, localClient, remoteClient, adapter, key, nil, origin)
+		if !errors.Is(err, jobframework.ErrMultiKueueWorkloadNameEmpty) {
+			t.Fatalf("DeleteRemoteObjectForWorkloadIfOwned() error = %v, want %v", err, jobframework.ErrMultiKueueWorkloadNameEmpty)
+		}
+	})
 }

--- a/pkg/controller/jobframework/multikueue_test.go
+++ b/pkg/controller/jobframework/multikueue_test.go
@@ -46,7 +46,12 @@ type cleanupTrackingAdapter struct {
 	cleanupContext *jobframework.MultiKueueRemoteObjectCleanupContext
 }
 
-func (a *cleanupTrackingAdapter) DeleteRemoteObjectWithCleanupContext(_ context.Context, _, _ client.Client, _ types.NamespacedName, cleanupContext jobframework.MultiKueueRemoteObjectCleanupContext) error {
+func (a *cleanupTrackingAdapter) DeleteRemoteObjectWithCleanupContext(
+	_ context.Context,
+	_, _ client.Client,
+	_ types.NamespacedName,
+	cleanupContext jobframework.MultiKueueRemoteObjectCleanupContext,
+) error {
 	a.cleanupContext = &cleanupContext
 	cleanupContext.WorkloadAnnotations["mutated-by-adapter"] = "true"
 	return nil
@@ -217,6 +222,51 @@ func TestValidateMultiKueueObjectAssociation(t *testing.T) {
 	})
 }
 
+func TestSetPrebuiltWorkloadNameReconcilesFeatureGateRepresentations(t *testing.T) {
+	const (
+		oldWorkload = "old-workload"
+		newWorkload = "new-workload"
+	)
+	for _, tc := range []struct {
+		name           string
+		featureGate    bool
+		labels         map[string]string
+		annotations    map[string]string
+		wantLabel      string
+		wantAnnotation string
+	}{
+		{
+			name:           "gate enabled updates an existing label and writes the annotation",
+			featureGate:    true,
+			labels:         map[string]string{constants.PrebuiltWorkloadLabel: oldWorkload},
+			wantLabel:      newWorkload,
+			wantAnnotation: newWorkload,
+		},
+		{
+			name:           "gate disabled updates an existing annotation and writes the label",
+			featureGate:    false,
+			annotations:    map[string]string{constants.PrebuiltWorkloadAnnotation: oldWorkload},
+			wantLabel:      newWorkload,
+			wantAnnotation: newWorkload,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: tc.featureGate})
+			job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Labels: tc.labels, Annotations: tc.annotations}}
+			jobframework.SetPrebuiltWorkloadName(job, newWorkload)
+			if got := job.Labels[constants.PrebuiltWorkloadLabel]; got != tc.wantLabel {
+				t.Fatalf("prebuilt Workload label = %q, want %q", got, tc.wantLabel)
+			}
+			if got := job.Annotations[constants.PrebuiltWorkloadAnnotation]; got != tc.wantAnnotation {
+				t.Fatalf("prebuilt Workload annotation = %q, want %q", got, tc.wantAnnotation)
+			}
+			if got, err := jobframework.MultiKueueWorkloadNameFor(job); err != nil || got != newWorkload {
+				t.Fatalf("MultiKueueWorkloadNameFor() = %q, %v, want %q, nil", got, err, newWorkload)
+			}
+		})
+	}
+}
+
 func TestDeleteRemoteObjectIfOwned(t *testing.T) {
 	makeJob := func(key types.NamespacedName, labels map[string]string) *batchv1.Job {
 		return &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace, Labels: labels}}
@@ -297,6 +347,7 @@ func TestDeleteRemoteObjectForWorkloadIfOwned(t *testing.T) {
 	const (
 		origin       = "origin-1"
 		workloadName = "workload-1"
+		managerUID   = types.UID("manager-uid")
 	)
 	makeRemoteJob := func(remoteWorkloadName string) *batchv1.Job {
 		return &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
@@ -307,6 +358,21 @@ func TestDeleteRemoteObjectForWorkloadIfOwned(t *testing.T) {
 				kueue.MultiKueueOriginLabel:     origin,
 				constants.PrebuiltWorkloadLabel: remoteWorkloadName,
 			},
+			Annotations: map[string]string{kueue.MultiKueueOriginUIDAnnotation: string(managerUID)},
+		}}
+	}
+	makeLocalWorkload := func() *kueue.Workload {
+		controller := true
+		return &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+			Name:      workloadName,
+			Namespace: key.Namespace,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: batchv1.SchemeGroupVersion.String(),
+				Kind:       "Job",
+				Name:       key.Name,
+				UID:        managerUID,
+				Controller: &controller,
+			}},
 		}}
 	}
 	makeClients := func(t *testing.T, remoteObjects ...client.Object) (client.Client, client.Client) {
@@ -324,11 +390,8 @@ func TestDeleteRemoteObjectForWorkloadIfOwned(t *testing.T) {
 		baseAdapter := mocks.NewMockMultiKueueAdapter(mockCtrl)
 		baseAdapter.EXPECT().GVK().Return(batchv1.SchemeGroupVersion.WithKind("Job")).AnyTimes()
 		adapter := &cleanupTrackingAdapter{MultiKueueAdapter: baseAdapter}
-		localWorkload := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
-			Name:        workloadName,
-			Namespace:   key.Namespace,
-			Annotations: map[string]string{"context": "manager"},
-		}}
+		localWorkload := makeLocalWorkload()
+		localWorkload.Annotations = map[string]string{"context": "manager"}
 
 		ctx, _ := utiltesting.ContextWithLog(t)
 		if err := jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, localClient, remoteClient, adapter, key, localWorkload, origin); err != nil {
@@ -354,11 +417,12 @@ func TestDeleteRemoteObjectForWorkloadIfOwned(t *testing.T) {
 		baseAdapter := mocks.NewMockMultiKueueAdapter(mockCtrl)
 		baseAdapter.EXPECT().GVK().Return(batchv1.SchemeGroupVersion.WithKind("Job")).AnyTimes()
 		adapter := &cleanupTrackingAdapter{MultiKueueAdapter: baseAdapter}
-		localWorkload := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{Name: workloadName, Namespace: key.Namespace}}
+		localWorkload := makeLocalWorkload()
 
 		ctx, _ := utiltesting.ContextWithLog(t)
-		if err := jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, localClient, remoteClient, adapter, key, localWorkload, origin); err != nil {
-			t.Fatalf("DeleteRemoteObjectForWorkloadIfOwned() error = %v", err)
+		err := jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, localClient, remoteClient, adapter, key, localWorkload, origin)
+		if !errors.Is(err, jobframework.ErrRemoteObjectNotOwnedByMultiKueue) {
+			t.Fatalf("DeleteRemoteObjectForWorkloadIfOwned() error = %v, want %v", err, jobframework.ErrRemoteObjectNotOwnedByMultiKueue)
 		}
 		if adapter.cleanupContext != nil {
 			t.Fatal("cleanup-aware adapter was called for another Workload")
@@ -376,30 +440,31 @@ func TestDeleteRemoteObjectForWorkloadIfOwned(t *testing.T) {
 		err := jobframework.DeleteRemoteObjectWithCleanupContextIfOwned(ctx, localClient, remoteClient, adapter, key, jobframework.MultiKueueRemoteObjectCleanupContext{
 			RemoteObjectUID: "another-uid",
 			Association: jobframework.MultiKueueObjectAssociation{
-				Origin:       origin,
-				WorkloadName: workloadName,
+				Origin:           origin,
+				WorkloadName:     workloadName,
+				ManagerObjectUID: managerUID,
 			},
 			WorkloadKey: types.NamespacedName{Name: workloadName, Namespace: key.Namespace},
 		})
-		if err != nil {
-			t.Fatalf("DeleteRemoteObjectWithCleanupContextIfOwned() error = %v", err)
+		if !errors.Is(err, jobframework.ErrRemoteObjectNotOwnedByMultiKueue) {
+			t.Fatalf("DeleteRemoteObjectWithCleanupContextIfOwned() error = %v, want %v", err, jobframework.ErrRemoteObjectNotOwnedByMultiKueue)
 		}
 		if adapter.cleanupContext != nil {
 			t.Fatal("cleanup-aware adapter was called for an unexpected remote UID")
 		}
 	})
 
-	t.Run("legacy adapter retains origin-only fallback", func(t *testing.T) {
+	t.Run("ordinary adapter also requires exact Workload association", func(t *testing.T) {
 		localClient, remoteClient := makeClients(t, makeRemoteJob("another-workload"))
 		mockCtrl := gomock.NewController(t)
 		adapter := mocks.NewMockMultiKueueAdapter(mockCtrl)
 		adapter.EXPECT().GVK().Return(batchv1.SchemeGroupVersion.WithKind("Job")).AnyTimes()
-		adapter.EXPECT().DeleteRemoteObject(gomock.Any(), gomock.Any(), gomock.Any(), key).Return(nil)
-		localWorkload := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{Name: workloadName, Namespace: key.Namespace}}
+		localWorkload := makeLocalWorkload()
 
 		ctx, _ := utiltesting.ContextWithLog(t)
-		if err := jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, localClient, remoteClient, adapter, key, localWorkload, origin); err != nil {
-			t.Fatalf("DeleteRemoteObjectForWorkloadIfOwned() error = %v", err)
+		err := jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, localClient, remoteClient, adapter, key, localWorkload, origin)
+		if !errors.Is(err, jobframework.ErrRemoteObjectNotOwnedByMultiKueue) {
+			t.Fatalf("DeleteRemoteObjectForWorkloadIfOwned() error = %v, want %v", err, jobframework.ErrRemoteObjectNotOwnedByMultiKueue)
 		}
 	})
 

--- a/pkg/controller/jobframework/multikueue_test.go
+++ b/pkg/controller/jobframework/multikueue_test.go
@@ -46,7 +46,12 @@ type cleanupTrackingAdapter struct {
 	cleanupContext *jobframework.MultiKueueRemoteObjectCleanupContext
 }
 
-func (a *cleanupTrackingAdapter) DeleteRemoteObjectWithCleanupContext(_ context.Context, _, _ client.Client, _ types.NamespacedName, cleanupContext jobframework.MultiKueueRemoteObjectCleanupContext) error {
+func (a *cleanupTrackingAdapter) DeleteRemoteObjectWithCleanupContext(
+	_ context.Context,
+	_, _ client.Client,
+	_ types.NamespacedName,
+	cleanupContext jobframework.MultiKueueRemoteObjectCleanupContext,
+) error {
 	a.cleanupContext = &cleanupContext
 	cleanupContext.WorkloadAnnotations["mutated-by-adapter"] = "true"
 	return nil

--- a/pkg/controller/jobframework/utils.go
+++ b/pkg/controller/jobframework/utils.go
@@ -236,6 +236,14 @@ func SetPrebuiltWorkloadName(obj client.Object, workloadName string) {
 		}
 		annotations[controllerconstants.PrebuiltWorkloadAnnotation] = workloadName
 		obj.SetAnnotations(annotations)
+		labels := obj.GetLabels()
+		if len(workloadName) > validation.LabelValueMaxLength {
+			delete(labels, controllerconstants.PrebuiltWorkloadLabel)
+			obj.SetLabels(labels)
+		} else if labels[controllerconstants.PrebuiltWorkloadLabel] != "" {
+			labels[controllerconstants.PrebuiltWorkloadLabel] = workloadName
+			obj.SetLabels(labels)
+		}
 	} else {
 		objLabels := obj.GetLabels()
 		if objLabels == nil {
@@ -243,6 +251,11 @@ func SetPrebuiltWorkloadName(obj client.Object, workloadName string) {
 		}
 		objLabels[controllerconstants.PrebuiltWorkloadLabel] = workloadName
 		obj.SetLabels(objLabels)
+		annotations := obj.GetAnnotations()
+		if annotations[controllerconstants.PrebuiltWorkloadAnnotation] != "" {
+			annotations[controllerconstants.PrebuiltWorkloadAnnotation] = workloadName
+			obj.SetAnnotations(annotations)
+		}
 	}
 }
 
@@ -343,6 +356,9 @@ func getRemoteObjectForOrigin(ctx context.Context, remoteClient client.Client, k
 // Returns (true, nil) if the object exists and is owned by this MultiKueue origin.
 // Returns (false, nil) if the object does not exist.
 // Returns (false, err) if there is a retrieval error or if the object is not owned by this MultiKueue origin.
+//
+// Deprecated: origin metadata alone is not an ownership boundary. Production
+// synchronization must use SyncJobWithRemoteObjectOwnership.
 func ValidateRemoteObjectOwnership(ctx context.Context, remoteClient client.Client, key types.NamespacedName, gvk schema.GroupVersionKind, origin string) (bool, error) {
 	log := ctrl.LoggerFrom(ctx).WithValues("remoteObject", key, "objectType", gvk, "origin", origin)
 
@@ -365,6 +381,9 @@ func ValidateRemoteObjectOwnership(ctx context.Context, remoteClient client.Clie
 // skips deletion if the object does not exist or is not owned by this MultiKueue origin,
 // and otherwise delegates to adapter.DeleteRemoteObject.
 // Returns ErrMultiKueueOriginEmpty if origin is empty.
+//
+// Deprecated: origin metadata alone is not an ownership boundary. Production
+// cleanup must use DeleteRemoteObjectWithCleanupContextIfOwned.
 func DeleteRemoteObjectIfOwned(ctx context.Context, localClient client.Client, remoteClient client.Client, adapter MultiKueueAdapter, key types.NamespacedName, origin string) error {
 	log := ctrl.LoggerFrom(ctx).WithValues("remoteObject", key, "adapterGVK", adapter.GVK().String(), "origin", origin)
 
@@ -390,11 +409,19 @@ func DeleteRemoteObjectIfOwned(ctx context.Context, localClient client.Client, r
 }
 
 // DeleteRemoteObjectWithCleanupContextIfOwned validates the remote controller
-// object's association and identity before delegating to a cleanup-aware adapter.
+// object's association and identity before delegating to the adapter.
 // When RemoteObjectUID is empty, the helper binds the context to the exact UID it
 // observes. A non-empty UID is treated as an expected identity and must match.
-func DeleteRemoteObjectWithCleanupContextIfOwned(ctx context.Context, localClient client.Client, remoteClient client.Client, adapter MultiKueueAdapterWithRemoteObjectCleanup, key types.NamespacedName, cleanupContext MultiKueueRemoteObjectCleanupContext) error {
-	log := ctrl.LoggerFrom(ctx).WithValues("remoteObject", key, "adapterGVK", adapter.GVK().String(), "origin", cleanupContext.Association.Origin, "workload", cleanupContext.Association.WorkloadName, "remoteObjectUID", cleanupContext.RemoteObjectUID)
+func DeleteRemoteObjectWithCleanupContextIfOwned(
+	ctx context.Context,
+	localClient client.Client,
+	remoteClient client.Client,
+	adapter MultiKueueAdapter,
+	key types.NamespacedName,
+	cleanupContext MultiKueueRemoteObjectCleanupContext,
+) error {
+	log := ctrl.LoggerFrom(ctx).
+		WithValues("remoteObject", key, "adapterGVK", adapter.GVK().String(), "origin", cleanupContext.Association.Origin, "workload", cleanupContext.Association.WorkloadName, "remoteObjectUID", cleanupContext.RemoteObjectUID)
 	if cleanupContext.Association.Origin == "" {
 		log.Error(ErrMultiKueueOriginEmpty, "Skipping remote object deletion because origin is empty")
 		return ErrMultiKueueOriginEmpty
@@ -404,7 +431,13 @@ func DeleteRemoteObjectWithCleanupContextIfOwned(ctx context.Context, localClien
 		return ErrMultiKueueWorkloadNameEmpty
 	}
 	if cleanupContext.WorkloadKey.Name != cleanupContext.Association.WorkloadName || cleanupContext.WorkloadKey.Namespace != key.Namespace {
-		return fmt.Errorf("%w: cleanup Workload %q does not match association %q in namespace %q", ErrRemoteObjectNotOwnedByMultiKueue, cleanupContext.WorkloadKey, cleanupContext.Association.WorkloadName, key.Namespace)
+		return fmt.Errorf(
+			"%w: cleanup Workload %q does not match association %q in namespace %q",
+			ErrRemoteObjectNotOwnedByMultiKueue,
+			cleanupContext.WorkloadKey,
+			cleanupContext.Association.WorkloadName,
+			key.Namespace,
+		)
 	}
 
 	remoteObject, err := getRemoteObjectForOrigin(ctx, remoteClient, key, adapter.GVK(), cleanupContext.Association.Origin)
@@ -414,47 +447,61 @@ func DeleteRemoteObjectWithCleanupContextIfOwned(ctx context.Context, localClien
 			return nil
 		}
 		if errors.Is(err, ErrRemoteObjectNotOwnedByMultiKueue) {
-			log.V(2).Info("Skipping remote object deletion because object is not associated with this MultiKueue origin")
-			return nil
+			return err
 		}
 		return err
 	}
-	if err := ValidateMultiKueueObjectAssociation(remoteObject, cleanupContext.Association); err != nil {
-		if errors.Is(err, ErrRemoteObjectNotOwnedByMultiKueue) {
-			log.V(2).Info("Skipping remote object deletion because object is not associated with the expected Workload")
-			return nil
+	if _, multiWorkload := adapter.(MultiKueueMultiWorkloadAdapter); !multiWorkload {
+		if err := ValidateMultiKueueObjectAssociation(remoteObject, cleanupContext.Association); err != nil {
+			return err
 		}
+	}
+	if err := validateRemoteObjectManagerUID(remoteObject, cleanupContext.Association.ManagerObjectUID); err != nil {
 		return err
 	}
 	if cleanupContext.RemoteObjectUID != "" && remoteObject.UID != cleanupContext.RemoteObjectUID {
-		log.V(2).Info("Skipping remote object deletion because its UID does not match the expected identity", "observedRemoteObjectUID", remoteObject.UID)
-		return nil
+		return fmt.Errorf("%w: expected remote UID %q on %T %q, got %q", ErrRemoteObjectNotOwnedByMultiKueue, cleanupContext.RemoteObjectUID, remoteObject, key, remoteObject.UID)
 	}
 	cleanupContext.RemoteObjectUID = remoteObject.UID
-	return adapter.DeleteRemoteObjectWithCleanupContext(ctx, localClient, remoteClient, key, cleanupContext)
+	if cleanupAdapter, ok := adapter.(MultiKueueAdapterWithRemoteObjectCleanup); ok {
+		return cleanupAdapter.DeleteRemoteObjectWithCleanupContext(ctx, localClient, remoteClient, key, cleanupContext)
+	}
+	validatingClient, err := newRemoteObjectOwnershipClientForCleanup(remoteClient, adapter, key, cleanupContext)
+	if err != nil {
+		return err
+	}
+	return adapter.DeleteRemoteObject(ctx, localClient, validatingClient, key)
 }
 
 // DeleteRemoteObjectForWorkloadIfOwned uses manager-side Workload metadata to
-// validate cleanup for adapters implementing MultiKueueAdapterWithRemoteObjectCleanup.
-// Other adapters intentionally retain the legacy origin-only deletion behavior
-// for compatibility and must not treat this helper as a Workload-binding check.
-func DeleteRemoteObjectForWorkloadIfOwned(ctx context.Context, localClient client.Client, remoteClient client.Client, adapter MultiKueueAdapter, key types.NamespacedName, localWorkload *kueue.Workload, origin string) error {
+// validate cleanup for every adapter.
+func DeleteRemoteObjectForWorkloadIfOwned(
+	ctx context.Context,
+	localClient client.Client,
+	remoteClient client.Client,
+	adapter MultiKueueAdapter,
+	key types.NamespacedName,
+	localWorkload *kueue.Workload,
+	origin string,
+) error {
 	if localWorkload == nil {
 		return ErrMultiKueueWorkloadNameEmpty
 	}
-	cleanupAdapter, ok := adapter.(MultiKueueAdapterWithRemoteObjectCleanup)
-	if !ok {
-		return DeleteRemoteObjectIfOwned(ctx, localClient, remoteClient, adapter, key, origin)
+	managerObjectUID, managerObjectUIDs, err := managerObjectUIDForWorkload(localWorkload, adapter.GVK(), key)
+	if err != nil {
+		return err
 	}
 
 	workloadAnnotations := map[string]string(nil)
 	maps.Copy(&workloadAnnotations, localWorkload.Annotations)
-	return DeleteRemoteObjectWithCleanupContextIfOwned(ctx, localClient, remoteClient, cleanupAdapter, key, MultiKueueRemoteObjectCleanupContext{
+	return DeleteRemoteObjectWithCleanupContextIfOwned(ctx, localClient, remoteClient, adapter, key, MultiKueueRemoteObjectCleanupContext{
 		Association: MultiKueueObjectAssociation{
-			Origin:       origin,
-			WorkloadName: localWorkload.Name,
+			Origin:           origin,
+			WorkloadName:     localWorkload.Name,
+			ManagerObjectUID: managerObjectUID,
 		},
 		WorkloadKey:         client.ObjectKeyFromObject(localWorkload),
 		WorkloadAnnotations: workloadAnnotations,
+		ManagerObjectUIDs:   managerObjectUIDs,
 	})
 }

--- a/pkg/controller/jobframework/utils.go
+++ b/pkg/controller/jobframework/utils.go
@@ -283,6 +283,60 @@ func NewWorkload(name string, obj client.Object, podSets []kueue.PodSet, labelKe
 
 var ErrRemoteObjectNotOwnedByMultiKueue = errors.New("remote object is not owned by MultiKueue")
 var ErrMultiKueueOriginEmpty = errors.New("multikueue origin is empty")
+var ErrMultiKueueWorkloadNameEmpty = errors.New("multikueue workload name is empty")
+
+// MultiKueueWorkloadNameFor returns the prebuilt Workload identifier carried by
+// obj. It reads both supported metadata representations independently of the
+// current feature-gate state so rolling upgrades and rollbacks remain safe.
+func MultiKueueWorkloadNameFor(obj client.Object) (string, error) {
+	labelValue := obj.GetLabels()[controllerconstants.PrebuiltWorkloadLabel]
+	annotationValue := obj.GetAnnotations()[controllerconstants.PrebuiltWorkloadAnnotation]
+	if labelValue != "" && annotationValue != "" && labelValue != annotationValue {
+		return "", fmt.Errorf("%w: conflicting prebuilt Workload identifiers on %T %q", ErrRemoteObjectNotOwnedByMultiKueue, obj, client.ObjectKeyFromObject(obj))
+	}
+	if annotationValue != "" {
+		return annotationValue, nil
+	}
+	if labelValue != "" {
+		return labelValue, nil
+	}
+	return "", fmt.Errorf("%w: missing prebuilt Workload identifier on %T %q", ErrRemoteObjectNotOwnedByMultiKueue, obj, client.ObjectKeyFromObject(obj))
+}
+
+// ValidateMultiKueueObjectAssociation checks that obj carries metadata for the
+// expected MultiKueue origin and remote Workload. This is an association check,
+// not proof that the object was created by MultiKueue.
+func ValidateMultiKueueObjectAssociation(obj client.Object, association MultiKueueObjectAssociation) error {
+	if association.Origin == "" {
+		return ErrMultiKueueOriginEmpty
+	}
+	if association.WorkloadName == "" {
+		return ErrMultiKueueWorkloadNameEmpty
+	}
+	if obj.GetLabels()[kueue.MultiKueueOriginLabel] != association.Origin {
+		return fmt.Errorf("%w: unexpected MultiKueue origin on %T %q", ErrRemoteObjectNotOwnedByMultiKueue, obj, client.ObjectKeyFromObject(obj))
+	}
+	objWorkloadName, err := MultiKueueWorkloadNameFor(obj)
+	if err != nil {
+		return err
+	}
+	if objWorkloadName != association.WorkloadName {
+		return fmt.Errorf("%w: %T %q belongs to Workload %q, expected %q", ErrRemoteObjectNotOwnedByMultiKueue, obj, client.ObjectKeyFromObject(obj), objWorkloadName, association.WorkloadName)
+	}
+	return nil
+}
+
+func getRemoteObjectForOrigin(ctx context.Context, remoteClient client.Client, key types.NamespacedName, gvk schema.GroupVersionKind, origin string) (*metav1.PartialObjectMetadata, error) {
+	remoteObject := &metav1.PartialObjectMetadata{}
+	remoteObject.SetGroupVersionKind(gvk)
+	if err := remoteClient.Get(ctx, key, remoteObject); err != nil {
+		return nil, err
+	}
+	if objOrigin, owned := remoteObject.GetLabels()[kueue.MultiKueueOriginLabel]; !owned || objOrigin != origin {
+		return nil, fmt.Errorf("%w: expected %q=%q on %T %q", ErrRemoteObjectNotOwnedByMultiKueue, kueue.MultiKueueOriginLabel, origin, remoteObject, client.ObjectKeyFromObject(remoteObject))
+	}
+	return remoteObject, nil
+}
 
 // ValidateRemoteObjectOwnership retrieves the remote object and validates it is owned by this MultiKueue origin.
 // Returns (false, ErrMultiKueueOriginEmpty) if origin is empty.
@@ -297,17 +351,11 @@ func ValidateRemoteObjectOwnership(ctx context.Context, remoteClient client.Clie
 		return false, ErrMultiKueueOriginEmpty
 	}
 
-	remoteObject := &metav1.PartialObjectMetadata{}
-	remoteObject.SetGroupVersionKind(gvk)
-	if err := remoteClient.Get(ctx, key, remoteObject); err != nil {
+	if _, err := getRemoteObjectForOrigin(ctx, remoteClient, key, gvk, origin); err != nil {
 		if client.IgnoreNotFound(err) == nil {
 			return false, nil
 		}
 		return false, err
-	}
-
-	if objOrigin, owned := remoteObject.GetLabels()[kueue.MultiKueueOriginLabel]; !owned || objOrigin != origin {
-		return false, fmt.Errorf("%w: expected %q=%q on %T %q", ErrRemoteObjectNotOwnedByMultiKueue, kueue.MultiKueueOriginLabel, origin, remoteObject, client.ObjectKeyFromObject(remoteObject))
 	}
 
 	return true, nil
@@ -325,18 +373,88 @@ func DeleteRemoteObjectIfOwned(ctx context.Context, localClient client.Client, r
 		return ErrMultiKueueOriginEmpty
 	}
 
-	found, err := ValidateRemoteObjectOwnership(ctx, remoteClient, key, adapter.GVK(), origin)
+	_, err := getRemoteObjectForOrigin(ctx, remoteClient, key, adapter.GVK(), origin)
 	if err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			log.V(2).Info("Skipping remote object deletion because object was not found")
+			return nil
+		}
 		if errors.Is(err, ErrRemoteObjectNotOwnedByMultiKueue) {
 			log.V(2).Info("Skipping remote object deletion because object is not owned by this MultiKueue origin")
 			return nil
 		}
 		return err
 	}
-	if !found {
-		log.V(2).Info("Skipping remote object deletion because object was not found")
-		return nil
-	}
 
 	return adapter.DeleteRemoteObject(ctx, localClient, remoteClient, key)
+}
+
+// DeleteRemoteObjectWithCleanupContextIfOwned validates the remote controller
+// object's association and identity before delegating to a cleanup-aware adapter.
+// When RemoteObjectUID is empty, the helper binds the context to the exact UID it
+// observes. A non-empty UID is treated as an expected identity and must match.
+func DeleteRemoteObjectWithCleanupContextIfOwned(ctx context.Context, localClient client.Client, remoteClient client.Client, adapter MultiKueueAdapterWithRemoteObjectCleanup, key types.NamespacedName, cleanupContext MultiKueueRemoteObjectCleanupContext) error {
+	log := ctrl.LoggerFrom(ctx).WithValues("remoteObject", key, "adapterGVK", adapter.GVK().String(), "origin", cleanupContext.Association.Origin, "workload", cleanupContext.Association.WorkloadName, "remoteObjectUID", cleanupContext.RemoteObjectUID)
+	if cleanupContext.Association.Origin == "" {
+		log.Error(ErrMultiKueueOriginEmpty, "Skipping remote object deletion because origin is empty")
+		return ErrMultiKueueOriginEmpty
+	}
+	if cleanupContext.Association.WorkloadName == "" {
+		log.Error(ErrMultiKueueWorkloadNameEmpty, "Skipping remote object deletion because Workload name is empty")
+		return ErrMultiKueueWorkloadNameEmpty
+	}
+	if cleanupContext.WorkloadKey.Name != cleanupContext.Association.WorkloadName || cleanupContext.WorkloadKey.Namespace != key.Namespace {
+		return fmt.Errorf("%w: cleanup Workload %q does not match association %q in namespace %q", ErrRemoteObjectNotOwnedByMultiKueue, cleanupContext.WorkloadKey, cleanupContext.Association.WorkloadName, key.Namespace)
+	}
+
+	remoteObject, err := getRemoteObjectForOrigin(ctx, remoteClient, key, adapter.GVK(), cleanupContext.Association.Origin)
+	if err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			log.V(2).Info("Skipping remote object deletion because object was not found")
+			return nil
+		}
+		if errors.Is(err, ErrRemoteObjectNotOwnedByMultiKueue) {
+			log.V(2).Info("Skipping remote object deletion because object is not associated with this MultiKueue origin")
+			return nil
+		}
+		return err
+	}
+	if err := ValidateMultiKueueObjectAssociation(remoteObject, cleanupContext.Association); err != nil {
+		if errors.Is(err, ErrRemoteObjectNotOwnedByMultiKueue) {
+			log.V(2).Info("Skipping remote object deletion because object is not associated with the expected Workload")
+			return nil
+		}
+		return err
+	}
+	if cleanupContext.RemoteObjectUID != "" && remoteObject.UID != cleanupContext.RemoteObjectUID {
+		log.V(2).Info("Skipping remote object deletion because its UID does not match the expected identity", "observedRemoteObjectUID", remoteObject.UID)
+		return nil
+	}
+	cleanupContext.RemoteObjectUID = remoteObject.UID
+	return adapter.DeleteRemoteObjectWithCleanupContext(ctx, localClient, remoteClient, key, cleanupContext)
+}
+
+// DeleteRemoteObjectForWorkloadIfOwned uses manager-side Workload metadata to
+// validate cleanup for adapters implementing MultiKueueAdapterWithRemoteObjectCleanup.
+// Other adapters intentionally retain the legacy origin-only deletion behavior
+// for compatibility and must not treat this helper as a Workload-binding check.
+func DeleteRemoteObjectForWorkloadIfOwned(ctx context.Context, localClient client.Client, remoteClient client.Client, adapter MultiKueueAdapter, key types.NamespacedName, localWorkload *kueue.Workload, origin string) error {
+	if localWorkload == nil {
+		return ErrMultiKueueWorkloadNameEmpty
+	}
+	cleanupAdapter, ok := adapter.(MultiKueueAdapterWithRemoteObjectCleanup)
+	if !ok {
+		return DeleteRemoteObjectIfOwned(ctx, localClient, remoteClient, adapter, key, origin)
+	}
+
+	workloadAnnotations := map[string]string(nil)
+	maps.Copy(&workloadAnnotations, localWorkload.Annotations)
+	return DeleteRemoteObjectWithCleanupContextIfOwned(ctx, localClient, remoteClient, cleanupAdapter, key, MultiKueueRemoteObjectCleanupContext{
+		Association: MultiKueueObjectAssociation{
+			Origin:       origin,
+			WorkloadName: localWorkload.Name,
+		},
+		WorkloadKey:         client.ObjectKeyFromObject(localWorkload),
+		WorkloadAnnotations: workloadAnnotations,
+	})
 }

--- a/pkg/controller/jobframework/utils.go
+++ b/pkg/controller/jobframework/utils.go
@@ -393,7 +393,14 @@ func DeleteRemoteObjectIfOwned(ctx context.Context, localClient client.Client, r
 // object's association and identity before delegating to a cleanup-aware adapter.
 // When RemoteObjectUID is empty, the helper binds the context to the exact UID it
 // observes. A non-empty UID is treated as an expected identity and must match.
-func DeleteRemoteObjectWithCleanupContextIfOwned(ctx context.Context, localClient client.Client, remoteClient client.Client, adapter MultiKueueAdapterWithRemoteObjectCleanup, key types.NamespacedName, cleanupContext MultiKueueRemoteObjectCleanupContext) error {
+func DeleteRemoteObjectWithCleanupContextIfOwned(
+	ctx context.Context,
+	localClient client.Client,
+	remoteClient client.Client,
+	adapter MultiKueueAdapterWithRemoteObjectCleanup,
+	key types.NamespacedName,
+	cleanupContext MultiKueueRemoteObjectCleanupContext,
+) error {
 	log := ctrl.LoggerFrom(ctx).WithValues("remoteObject", key, "adapterGVK", adapter.GVK().String(), "origin", cleanupContext.Association.Origin, "workload", cleanupContext.Association.WorkloadName, "remoteObjectUID", cleanupContext.RemoteObjectUID)
 	if cleanupContext.Association.Origin == "" {
 		log.Error(ErrMultiKueueOriginEmpty, "Skipping remote object deletion because origin is empty")

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -45,6 +45,15 @@ import (
 type multiKueueAdapter struct{}
 
 var _ jobframework.MultiKueueAdapter = (*multiKueueAdapter)(nil)
+var _ jobframework.MultiKueueAdapterWithWorkloadReassignment = (*multiKueueAdapter)(nil)
+
+func (*multiKueueAdapter) CanReassignWorkload(ctx context.Context, localClient client.Client, key types.NamespacedName) (bool, error) {
+	localJob := &batchv1.Job{}
+	if err := localClient.Get(ctx, key, localJob); err != nil {
+		return false, err
+	}
+	return workloadslicing.Enabled(localJob), nil
+}
 
 func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)

--- a/pkg/controller/jobs/job/job_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter_test.go
@@ -48,6 +48,19 @@ const (
 	TestNamespace = "ns"
 )
 
+func makeJobBoundWorkload(name string, key types.NamespacedName, managerUID types.UID) *kueue.Workload {
+	return &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+		Name:      name,
+		Namespace: key.Namespace,
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: batchv1.SchemeGroupVersion.String(),
+			Kind:       "Job",
+			Name:       key.Name,
+			UID:        managerUID,
+		}},
+	}}
+}
+
 func TestMultiKueueAdapter(t *testing.T) {
 	objCheckOpts := cmp.Options{
 		cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion"),
@@ -569,7 +582,7 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 				remoteJob: newJob().
 					ResourceVersion("2").
 					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
-					PrebuiltWorkloadLabel("test-workload").
+					PrebuiltWorkloadLabel("job-test-f53b2").
 					SetAnnotation(constants.PrebuiltWorkloadAnnotation, "job-test-f53b2").
 					Parallelism(22).
 					Condition(runningJobCondition).
@@ -717,6 +730,150 @@ func Test_multiKueueAdapter_SyncJob(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestMultiKueueOwnershipWrapperAllowsUIDBoundElasticReassignment(t *testing.T) {
+	const (
+		origin     = "origin1"
+		managerUID = "manager-job-uid"
+		oldWL      = "old-workload"
+		newWL      = "new-workload"
+	)
+	for _, tc := range []struct {
+		name           string
+		annotationsOn  bool
+		setOldIdentity func(*utiltestingjob.JobWrapper)
+	}{
+		{
+			name:          "label to annotation",
+			annotationsOn: true,
+			setOldIdentity: func(job *utiltestingjob.JobWrapper) {
+				job.PrebuiltWorkloadLabel(oldWL)
+			},
+		},
+		{
+			name:          "annotation to label",
+			annotationsOn: false,
+			setOldIdentity: func(job *utiltestingjob.JobWrapper) {
+				job.SetAnnotation(constants.PrebuiltWorkloadAnnotation, oldWL)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, map[featuregate.Feature]bool{
+				features.ElasticJobsViaWorkloadSlices:  true,
+				features.WorkloadIdentifierAnnotations: tc.annotationsOn,
+			})
+			key := types.NamespacedName{Name: "elastic", Namespace: TestNamespace}
+			localJob := utiltestingjob.MakeJob(key.Name, key.Namespace).
+				UID(managerUID).
+				ResourceVersion("1").
+				SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+				Parallelism(1).
+				Obj()
+			remoteJobBuilder := utiltestingjob.MakeJob(key.Name, key.Namespace).
+				UID("remote-job-uid").
+				ResourceVersion("1").
+				SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+				SetAnnotation(kueue.MultiKueueOriginUIDAnnotation, managerUID).
+				Label(kueue.MultiKueueOriginLabel, origin).
+				Parallelism(3)
+			tc.setOldIdentity(remoteJobBuilder)
+			remoteJob := remoteJobBuilder.Obj()
+
+			managerClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(localJob).WithStatusSubresource(localJob).Build()
+			workerClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(remoteJob).Build()
+			ctx, _ := utiltesting.ContextWithLog(t)
+			if _, err := jobframework.SyncJobWithRemoteObjectOwnership(
+				ctx,
+				managerClient,
+				managerClient,
+				workerClient,
+				&multiKueueAdapter{},
+				key,
+				makeJobBoundWorkload(newWL, key, managerUID),
+				origin,
+			); err != nil {
+				t.Fatalf("SyncJobWithRemoteObjectOwnership() error = %v", err)
+			}
+
+			got := &batchv1.Job{}
+			if err := workerClient.Get(ctx, key, got); err != nil {
+				t.Fatalf("getting remote Job: %v", err)
+			}
+			if got.Spec.Parallelism == nil || *got.Spec.Parallelism != 1 {
+				t.Fatalf("remote parallelism = %v, want 1", got.Spec.Parallelism)
+			}
+			if gotWorkload := jobframework.PrebuiltWorkloadNameFor(got); gotWorkload != newWL {
+				t.Fatalf("remote Workload association = %q, want %q", gotWorkload, newWL)
+			}
+			if got.Labels[constants.PrebuiltWorkloadLabel] != newWL || got.Annotations[constants.PrebuiltWorkloadAnnotation] != newWL {
+				t.Fatalf(
+					"transitioned Workload metadata label=%q annotation=%q, want both %q",
+					got.Labels[constants.PrebuiltWorkloadLabel],
+					got.Annotations[constants.PrebuiltWorkloadAnnotation],
+					newWL,
+				)
+			}
+		})
+	}
+}
+
+func TestMultiKueueOwnershipWrapperRejectsWorkloadReassignmentForNonElasticJob(t *testing.T) {
+	features.SetFeatureGatesDuringTest(t, map[featuregate.Feature]bool{
+		features.ElasticJobsViaWorkloadSlices:  true,
+		features.WorkloadIdentifierAnnotations: false,
+	})
+	const (
+		origin     = "origin1"
+		managerUID = "manager-job-uid"
+		oldWL      = "old-workload"
+		newWL      = "new-workload"
+	)
+	key := types.NamespacedName{Name: "ordinary", Namespace: TestNamespace}
+	localJob := utiltestingjob.MakeJob(key.Name, key.Namespace).
+		UID(managerUID).
+		ResourceVersion("1").
+		Parallelism(1).
+		Obj()
+	remoteJob := utiltestingjob.MakeJob(key.Name, key.Namespace).
+		UID("remote-job-uid").
+		ResourceVersion("1").
+		SetAnnotation(kueue.MultiKueueOriginUIDAnnotation, managerUID).
+		PrebuiltWorkloadLabel(oldWL).
+		Label(kueue.MultiKueueOriginLabel, origin).
+		Parallelism(3).
+		Obj()
+
+	managerClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(localJob).WithStatusSubresource(localJob).Build()
+	workerClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(remoteJob).Build()
+	ctx, _ := utiltesting.ContextWithLog(t)
+	if _, err := jobframework.SyncJobWithRemoteObjectOwnership(
+		ctx,
+		managerClient,
+		managerClient,
+		workerClient,
+		&multiKueueAdapter{},
+		key,
+		makeJobBoundWorkload(newWL, key, managerUID),
+		origin,
+	); !errors.Is(
+		err,
+		jobframework.ErrRemoteObjectNotOwnedByMultiKueue,
+	) {
+		t.Fatalf("SyncJobWithRemoteObjectOwnership() error = %v, want %v", err, jobframework.ErrRemoteObjectNotOwnedByMultiKueue)
+	}
+
+	got := &batchv1.Job{}
+	if err := workerClient.Get(ctx, key, got); err != nil {
+		t.Fatalf("getting remote Job: %v", err)
+	}
+	if got.Spec.Parallelism == nil || *got.Spec.Parallelism != 3 {
+		t.Fatalf("remote parallelism = %v, want unchanged value 3", got.Spec.Parallelism)
+	}
+	if gotWorkload := jobframework.PrebuiltWorkloadNameFor(got); gotWorkload != oldWL {
+		t.Fatalf("remote Workload association = %q, want unchanged value %q", gotWorkload, oldWL)
 	}
 }
 

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_multikueue_adapter_test.go
@@ -18,10 +18,12 @@ package leaderworkerset
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/component-base/featuregate"
@@ -40,6 +42,19 @@ import (
 const (
 	TestNamespace = "ns"
 )
+
+func makeLWSBoundWorkload(name string, key types.NamespacedName, managerUID types.UID) *kueue.Workload {
+	return &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+		Name:      name,
+		Namespace: key.Namespace,
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: gvk.GroupVersion().String(),
+			Kind:       gvk.Kind,
+			Name:       key.Name,
+			UID:        managerUID,
+		}},
+	}}
+}
 
 func TestMultiKueueAdapter(t *testing.T) {
 	objCheckOpts := cmp.Options{
@@ -279,6 +294,127 @@ func TestMultiKueueAdapter(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMultiKueueOwnershipWrapperUsesManagerObjectUID(t *testing.T) {
+	const (
+		origin       = "origin1"
+		workloadName = "wl1"
+		managerUID   = "manager-uid-123"
+	)
+	key := types.NamespacedName{Name: "lws1", Namespace: TestNamespace}
+
+	makeManagerClient := func() client.Client {
+		return utiltesting.NewClientBuilder(leaderworkersetv1.AddToScheme).
+			WithObjects(utiltestingleaderworkerset.MakeLeaderWorkerSet(key.Name, key.Namespace).UID(managerUID).Obj()).
+			WithStatusSubresource(&leaderworkersetv1.LeaderWorkerSet{}).
+			Build()
+	}
+	makeWorkerClient := func(originUID string) client.Client {
+		return utiltesting.NewClientBuilder(leaderworkersetv1.AddToScheme).
+			WithObjects(utiltestingleaderworkerset.MakeLeaderWorkerSet(key.Name, key.Namespace).
+				UID("worker-uid").
+				Label(kueue.MultiKueueOriginLabel, origin).
+				Annotation(kueue.MultiKueueOriginUIDAnnotation, originUID).
+				ReadyReplicas(3).
+				Obj()).
+			Build()
+	}
+
+	t.Run("matching UID permits synchronization", func(t *testing.T) {
+		managerClient := makeManagerClient()
+		workerClient := makeWorkerClient(managerUID)
+		ctx, _ := utiltesting.ContextWithLog(t)
+
+		if _, err := jobframework.SyncJobWithRemoteObjectOwnership(
+			ctx,
+			managerClient,
+			managerClient,
+			workerClient,
+			&multiKueueAdapter{},
+			key,
+			makeLWSBoundWorkload(workloadName, key, managerUID),
+			origin,
+		); err != nil {
+			t.Fatalf("SyncJobWithRemoteObjectOwnership() error = %v", err)
+		}
+		local := &leaderworkersetv1.LeaderWorkerSet{}
+		if err := managerClient.Get(ctx, key, local); err != nil {
+			t.Fatalf("getting manager LeaderWorkerSet: %v", err)
+		}
+		if local.Status.ReadyReplicas != 0 {
+			t.Fatalf("manager ready replicas = %d, want 0 because LWS intentionally skips status copying", local.Status.ReadyReplicas)
+		}
+	})
+
+	t.Run("different UID blocks status synchronization", func(t *testing.T) {
+		managerClient := makeManagerClient()
+		workerClient := makeWorkerClient("other-manager-uid")
+		ctx, _ := utiltesting.ContextWithLog(t)
+
+		_, err := jobframework.SyncJobWithRemoteObjectOwnership(ctx, managerClient, managerClient, workerClient, &multiKueueAdapter{}, key, makeLWSBoundWorkload(workloadName, key, managerUID), origin)
+		if !errors.Is(err, jobframework.ErrRemoteObjectNotOwnedByMultiKueue) {
+			t.Fatalf("SyncJobWithRemoteObjectOwnership() error = %v, want %v", err, jobframework.ErrRemoteObjectNotOwnedByMultiKueue)
+		}
+		local := &leaderworkersetv1.LeaderWorkerSet{}
+		if err := managerClient.Get(ctx, key, local); err != nil {
+			t.Fatalf("getting manager LeaderWorkerSet: %v", err)
+		}
+		if local.Status.ReadyReplicas != 0 {
+			t.Fatalf("manager ready replicas = %d, want 0", local.Status.ReadyReplicas)
+		}
+	})
+
+	t.Run("matching UID permits deletion", func(t *testing.T) {
+		managerClient := utiltesting.NewClientBuilder(leaderworkersetv1.AddToScheme).Build()
+		workerClient := makeWorkerClient(managerUID)
+		ctx, _ := utiltesting.ContextWithLog(t)
+		managerWorkload := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+			Name:      workloadName,
+			Namespace: key.Namespace,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: leaderworkersetv1.GroupVersion.String(),
+				Kind:       "LeaderWorkerSet",
+				Name:       key.Name,
+				UID:        managerUID,
+				Controller: new(bool),
+			}},
+		}}
+		*managerWorkload.OwnerReferences[0].Controller = true
+
+		if err := jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, managerClient, workerClient, &multiKueueAdapter{}, key, managerWorkload, origin); err != nil {
+			t.Fatalf("DeleteRemoteObjectForWorkloadIfOwned() error = %v", err)
+		}
+		if err := workerClient.Get(ctx, key, &leaderworkersetv1.LeaderWorkerSet{}); !apierrors.IsNotFound(err) {
+			t.Fatalf("getting worker LeaderWorkerSet error = %v, want NotFound", err)
+		}
+	})
+
+	t.Run("different UID preserves object during deletion", func(t *testing.T) {
+		managerClient := utiltesting.NewClientBuilder(leaderworkersetv1.AddToScheme).Build()
+		workerClient := makeWorkerClient("other-manager-uid")
+		ctx, _ := utiltesting.ContextWithLog(t)
+		managerWorkload := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+			Name:      workloadName,
+			Namespace: key.Namespace,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: leaderworkersetv1.GroupVersion.String(),
+				Kind:       "LeaderWorkerSet",
+				Name:       key.Name,
+				UID:        managerUID,
+				Controller: new(bool),
+			}},
+		}}
+		*managerWorkload.OwnerReferences[0].Controller = true
+
+		err := jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, managerClient, workerClient, &multiKueueAdapter{}, key, managerWorkload, origin)
+		if !errors.Is(err, jobframework.ErrRemoteObjectNotOwnedByMultiKueue) {
+			t.Fatalf("DeleteRemoteObjectForWorkloadIfOwned() error = %v, want %v", err, jobframework.ErrRemoteObjectNotOwnedByMultiKueue)
+		}
+		if err := workerClient.Get(ctx, key, &leaderworkersetv1.LeaderWorkerSet{}); err != nil {
+			t.Fatalf("getting worker LeaderWorkerSet: %v", err)
+		}
+	})
 }
 
 func TestGetWorkloadIndex(t *testing.T) {

--- a/pkg/controller/jobs/pod/indexer.go
+++ b/pkg/controller/jobs/pod/indexer.go
@@ -18,13 +18,16 @@ package pod
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
 	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
 )
 
 const (
-	PodGroupNameCacheKey = "PodGroupNameCacheKey"
+	PodGroupNameCacheKey           = "PodGroupNameCacheKey"
+	multiKueuePodGroupNameCacheKey = "MultiKueuePodGroupNameCacheKey"
 )
 
 func IndexPodGroupName(o client.Object) []string {
@@ -37,4 +40,25 @@ func IndexPodGroupName(o client.Object) []string {
 		return []string{groupName}
 	}
 	return nil
+}
+
+// indexMultiKueuePodGroupName indexes both supported group-name representations
+// so MultiKueue can finish an in-flight dispatch across feature-gate changes.
+func indexMultiKueuePodGroupName(o client.Object) []string {
+	pod, ok := o.(*corev1.Pod)
+	if !ok {
+		return nil
+	}
+
+	groupNames := sets.New[string]()
+	if groupName := pod.Labels[podconstants.GroupNameLabel]; groupName != "" {
+		groupNames.Insert(groupName)
+	}
+	if groupName := pod.Annotations[podconstants.GroupNameAnnotation]; groupName != "" {
+		groupNames.Insert(groupName)
+	}
+	if groupNames.Len() == 0 {
+		return nil
+	}
+	return groupNames.UnsortedList()
 }

--- a/pkg/controller/jobs/pod/indexer_test.go
+++ b/pkg/controller/jobs/pod/indexer_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
@@ -50,6 +51,55 @@ func TestIndexPodGroupName(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			got := IndexPodGroupName(tc.object)
 			if diff := cmp.Diff(tc.wantKeys, got); diff != "" {
+				t.Errorf("Unexpected keys (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestIndexMultiKueuePodGroupName(t *testing.T) {
+	cases := map[string]struct {
+		object   client.Object
+		wantKeys []string
+	}{
+		"non-pod object": {
+			object: testingnode.MakeNode("node").Label(podconstants.GroupNameLabel, "group-1").Obj(),
+		},
+		"pod without group name": {
+			object: testingpod.MakePod("pod", "ns").Obj(),
+		},
+		"pod with label group name": {
+			object: testingpod.MakePod("pod", "ns").
+				GroupNameLabel("group-1").
+				Obj(),
+			wantKeys: []string{"group-1"},
+		},
+		"pod with annotation group name": {
+			object: testingpod.MakePod("pod", "ns").
+				GroupNameAnnotation("group-1").
+				Obj(),
+			wantKeys: []string{"group-1"},
+		},
+		"pod with matching label and annotation group names": {
+			object: testingpod.MakePod("pod", "ns").
+				GroupNameLabel("group-1").
+				GroupNameAnnotation("group-1").
+				Obj(),
+			wantKeys: []string{"group-1"},
+		},
+		"pod with distinct label and annotation group names": {
+			object: testingpod.MakePod("pod", "ns").
+				GroupNameLabel("group-1").
+				GroupNameAnnotation("group-2").
+				Obj(),
+			wantKeys: []string{"group-1", "group-2"},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := indexMultiKueuePodGroupName(tc.object)
+			if diff := cmp.Diff(tc.wantKeys, got, cmpopts.SortSlices(func(a, b string) bool { return a < b })); diff != "" {
 				t.Errorf("Unexpected keys (-want,+got):\n%s", diff)
 			}
 		})

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -589,6 +589,9 @@ func SetupIndexes(ctx context.Context, indexer client.FieldIndexer) error {
 	if err := indexer.IndexField(ctx, &corev1.Pod{}, PodGroupNameCacheKey, IndexPodGroupName); err != nil {
 		return err
 	}
+	if err := indexer.IndexField(ctx, &corev1.Pod{}, multiKueuePodGroupNameCacheKey, indexMultiKueuePodGroupName); err != nil {
+		return err
+	}
 	if err := jobframework.SetupWorkloadOwnerIndex(ctx, indexer, gvk); err != nil {
 		return err
 	}

--- a/pkg/controller/jobs/pod/pod_multikueue_adapter.go
+++ b/pkg/controller/jobs/pod/pod_multikueue_adapter.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -28,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -67,6 +67,13 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 }
 
 func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName) error {
+	localPod := corev1.Pod{}
+	if err := localClient.Get(ctx, key, &localPod); err != nil {
+		return err
+	}
+	if localPod.UID == "" {
+		return fmt.Errorf("%w: manager Pod %q has no UID", jobframework.ErrRemoteObjectNotOwnedByMultiKueue, klog.KObj(&localPod))
+	}
 	pod := corev1.Pod{}
 	err := remoteClient.Get(ctx, key, &pod)
 	if err != nil {
@@ -84,26 +91,39 @@ func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, localClient 
 	if groupName != "" {
 		workloadAnnotations = map[string]string{podconstants.IsGroupWorkloadAnnotationKey: podconstants.IsGroupWorkloadAnnotationValue}
 	}
-	return b.deleteRemoteObjectWithCleanupContext(ctx, remoteClient, key, jobframework.MultiKueueRemoteObjectCleanupContext{
+	return b.deleteRemoteObjectWithCleanupContext(ctx, localClient, remoteClient, key, jobframework.MultiKueueRemoteObjectCleanupContext{
 		RemoteObjectUID: pod.UID,
 		Association: jobframework.MultiKueueObjectAssociation{
-			Origin:       pod.Labels[kueue.MultiKueueOriginLabel],
-			WorkloadName: workloadName,
+			Origin:           pod.Labels[kueue.MultiKueueOriginLabel],
+			WorkloadName:     workloadName,
+			ManagerObjectUID: localPod.UID,
 		},
 		WorkloadKey:         types.NamespacedName{Name: workloadName, Namespace: pod.Namespace},
 		WorkloadAnnotations: workloadAnnotations,
 	}, groupName)
 }
 
-func (b *multiKueueAdapter) DeleteRemoteObjectWithCleanupContext(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, cleanupContext jobframework.MultiKueueRemoteObjectCleanupContext) error {
+func (b *multiKueueAdapter) DeleteRemoteObjectWithCleanupContext(
+	ctx context.Context,
+	localClient client.Client,
+	remoteClient client.Client,
+	key types.NamespacedName,
+	cleanupContext jobframework.MultiKueueRemoteObjectCleanupContext,
+) error {
 	groupName, err := expectedMultiKueuePodGroupName(ctx, localClient, key, cleanupContext)
 	if err != nil {
 		return err
 	}
-	return b.deleteRemoteObjectWithCleanupContext(ctx, remoteClient, key, cleanupContext, groupName)
+	return b.deleteRemoteObjectWithCleanupContext(ctx, localClient, remoteClient, key, cleanupContext, groupName)
 }
 
-func (b *multiKueueAdapter) deleteRemoteObjectWithCleanupContext(ctx context.Context, remoteClient client.Client, key types.NamespacedName, cleanupContext jobframework.MultiKueueRemoteObjectCleanupContext, groupName string) error {
+func (b *multiKueueAdapter) deleteRemoteObjectWithCleanupContext(
+	ctx context.Context,
+	localClient, remoteClient client.Client,
+	key types.NamespacedName,
+	cleanupContext jobframework.MultiKueueRemoteObjectCleanupContext,
+	groupName string,
+) error {
 	log := ctrl.LoggerFrom(ctx)
 
 	pod := corev1.Pod{}
@@ -116,9 +136,49 @@ func (b *multiKueueAdapter) deleteRemoteObjectWithCleanupContext(ctx context.Con
 	if err := validateRemotePodAssociation(&pod, cleanupContext.Association, groupName); err != nil {
 		return err
 	}
+	if err := validateRemotePodManagerUID(&pod, cleanupContext.Association.ManagerObjectUID); err != nil {
+		return err
+	}
 
 	if groupName == "" {
-		return deleteRemotePodIfAssociated(ctx, remoteClient, &pod, cleanupContext.Association, groupName, &log)
+		return deleteRemotePodIfAssociated(ctx, remoteClient, &pod, cleanupContext.Association, cleanupContext.Association.ManagerObjectUID, groupName, &log)
+	}
+
+	workloadBoundManagerUIDs := cleanupContext.ManagerObjectUIDs != nil
+	managerPodUIDs := maps.Clone(cleanupContext.ManagerObjectUIDs)
+	if managerPodUIDs == nil {
+		managerPodUIDs = make(map[string]types.UID)
+	}
+	if recorded := managerPodUIDs[key.Name]; recorded != "" && recorded != cleanupContext.Association.ManagerObjectUID {
+		return fmt.Errorf("%w: cleanup context has conflicting manager UIDs for Pod %q", jobframework.ErrRemoteObjectNotOwnedByMultiKueue, key)
+	}
+	managerPodUIDs[key.Name] = cleanupContext.Association.ManagerObjectUID
+	managerPods := &corev1.PodList{}
+	if err := localClient.List(ctx, managerPods, client.InNamespace(key.Namespace)); err != nil {
+		return err
+	}
+	for i := range managerPods.Items {
+		managerPod := &managerPods.Items[i]
+		managerGroupName, err := multiKueuePodGroupName(managerPod)
+		if err != nil {
+			return err
+		}
+		if managerGroupName != groupName {
+			continue
+		}
+		if managerPod.UID == "" {
+			return fmt.Errorf("%w: manager Pod %q has no UID", jobframework.ErrRemoteObjectNotOwnedByMultiKueue, klog.KObj(managerPod))
+		}
+		if recorded := managerPodUIDs[managerPod.Name]; recorded != "" {
+			if recorded != managerPod.UID {
+				return fmt.Errorf("%w: manager Pod %q UID %q conflicts with Workload identity %q", jobframework.ErrRemoteObjectNotOwnedByMultiKueue, klog.KObj(managerPod), managerPod.UID, recorded)
+			}
+			continue
+		}
+		if workloadBoundManagerUIDs {
+			continue
+		}
+		managerPodUIDs[managerPod.Name] = managerPod.UID
 	}
 
 	listOptions := &client.ListOptions{
@@ -126,6 +186,7 @@ func (b *multiKueueAdapter) deleteRemoteObjectWithCleanupContext(ctx context.Con
 		LabelSelector: labels.SelectorFromSet(labels.Set{kueue.MultiKueueOriginLabel: cleanupContext.Association.Origin}),
 		Limit:         remotePodCleanupPageSize,
 	}
+	remotePodsToDelete := make([]*corev1.Pod, 0)
 	for {
 		remotePodGroup := corev1.PodList{}
 		if err := remoteClient.List(ctx, &remotePodGroup, listOptions); err != nil {
@@ -141,6 +202,9 @@ func (b *multiKueueAdapter) deleteRemoteObjectWithCleanupContext(ctx context.Con
 		if err := validateRemotePodAssociation(&currentAnchor, cleanupContext.Association, groupName); err != nil {
 			return err
 		}
+		if err := validateRemotePodManagerUID(&currentAnchor, cleanupContext.Association.ManagerObjectUID); err != nil {
+			return err
+		}
 		for i := range remotePodGroup.Items {
 			remotePod := &remotePodGroup.Items[i]
 			podKey := client.ObjectKeyFromObject(remotePod)
@@ -150,19 +214,36 @@ func (b *multiKueueAdapter) deleteRemoteObjectWithCleanupContext(ctx context.Con
 				}
 				continue
 			}
-			if err := deleteRemotePodIfAssociated(ctx, remoteClient, remotePod, cleanupContext.Association, groupName, &log); err != nil {
+			if err := validateRemotePodAssociation(remotePod, cleanupContext.Association, groupName); err != nil {
+				if errors.Is(err, jobframework.ErrRemoteObjectNotOwnedByMultiKueue) {
+					log.V(4).Info("Preserving remote Pod that is not associated with this MultiKueue dispatch", "pod", klog.KObj(remotePod))
+					continue
+				}
 				return err
 			}
+			expectedManagerUID, found := managerPodUIDs[remotePod.Name]
+			if !found {
+				return fmt.Errorf("%w: no trusted manager UID for remote Pod %q", jobframework.ErrRemoteObjectNotOwnedByMultiKueue, klog.KObj(remotePod))
+			}
+			if err := validateRemotePodManagerUID(remotePod, expectedManagerUID); err != nil {
+				return err
+			}
+			remotePodsToDelete = append(remotePodsToDelete, remotePod.DeepCopy())
 		}
 		if remotePodGroup.Continue == "" {
 			break
 		}
 		listOptions.Continue = remotePodGroup.Continue
 	}
+	for _, remotePod := range remotePodsToDelete {
+		if err := client.IgnoreNotFound(remoteClient.Delete(ctx, remotePod, client.Preconditions{UID: &remotePod.UID})); err != nil {
+			return err
+		}
+	}
 
 	// Keep the anchor until all pages and member deletions succeed so a retry can
 	// still recover after a transient list or delete failure.
-	return deleteRemotePodIfAssociated(ctx, remoteClient, &pod, cleanupContext.Association, groupName, &log)
+	return deleteRemotePodIfAssociated(ctx, remoteClient, &pod, cleanupContext.Association, cleanupContext.Association.ManagerObjectUID, groupName, &log)
 }
 
 func expectedMultiKueuePodGroupName(ctx context.Context, localClient client.Client, key types.NamespacedName, cleanupContext jobframework.MultiKueueRemoteObjectCleanupContext) (string, error) {
@@ -180,7 +261,7 @@ func expectedMultiKueuePodGroupName(ctx context.Context, localClient client.Clie
 
 	if cleanupContext.WorkloadKey.Name != "" {
 		if cleanupContext.WorkloadKey.Name != cleanupContext.Association.WorkloadName || cleanupContext.WorkloadKey.Namespace != key.Namespace {
-			return "", fmt.Errorf("Workload %q does not match cleanup association %q", cleanupContext.WorkloadKey, cleanupContext.Association.WorkloadName)
+			return "", fmt.Errorf("workload %q does not match cleanup association %q", cleanupContext.WorkloadKey, cleanupContext.Association.WorkloadName)
 		}
 		workloadGroupName := ""
 		if cleanupContext.WorkloadAnnotations[podconstants.IsGroupWorkloadAnnotationKey] == podconstants.IsGroupWorkloadAnnotationValue {
@@ -364,11 +445,20 @@ func validateRemotePodAssociation(pod *corev1.Pod, association jobframework.Mult
 	return nil
 }
 
+func validateRemotePodManagerUID(pod *corev1.Pod, expected types.UID) error {
+	actual := types.UID(pod.Annotations[kueue.MultiKueueOriginUIDAnnotation])
+	if expected == "" || actual != expected {
+		return fmt.Errorf("%w: expected %q=%q on Pod %q, got %q", jobframework.ErrRemoteObjectNotOwnedByMultiKueue, kueue.MultiKueueOriginUIDAnnotation, expected, klog.KObj(pod), actual)
+	}
+	return nil
+}
+
 func deleteRemotePodIfAssociated(
 	ctx context.Context,
 	remoteClient client.Client,
 	pod *corev1.Pod,
 	association jobframework.MultiKueueObjectAssociation,
+	expectedManagerUID types.UID,
 	groupName string,
 	log *logr.Logger,
 ) error {
@@ -379,7 +469,10 @@ func deleteRemotePodIfAssociated(
 		}
 		return err
 	}
-	return client.IgnoreNotFound(remoteClient.Delete(ctx, pod, client.Preconditions{UID: ptr.To(pod.UID)}))
+	if err := validateRemotePodManagerUID(pod, expectedManagerUID); err != nil {
+		return err
+	}
+	return client.IgnoreNotFound(remoteClient.Delete(ctx, pod, client.Preconditions{UID: &pod.UID}))
 }
 
 // findPodCondition returns a pointer to the condition of the given type, or nil

--- a/pkg/controller/jobs/pod/pod_multikueue_adapter.go
+++ b/pkg/controller/jobs/pod/pod_multikueue_adapter.go
@@ -23,22 +23,28 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
 	"sigs.k8s.io/kueue/pkg/util/api"
 	clientutil "sigs.k8s.io/kueue/pkg/util/client"
-	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
 )
 
 type multiKueueAdapter struct{}
 
+const remotePodCleanupPageSize int64 = 100
+
 var _ jobframework.MultiKueueAdapter = (*multiKueueAdapter)(nil)
+var _ jobframework.MultiKueueAdapterWithRemoteObjectCleanup = (*multiKueueAdapter)(nil)
 
 func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
@@ -49,9 +55,12 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 		return false, err
 	}
 
-	groupName := utilpod.GetPodGroupName(&localPod)
+	groupName, err := multiKueuePodGroupName(&localPod)
+	if err != nil {
+		return false, err
+	}
 	if groupName == "" {
-		return false, syncLocalPodWithRemote(ctx, localClient, remoteClient, &localPod, workloadName, origin, &log)
+		return false, syncLocalPodWithRemote(ctx, localClient, remoteClient, &localPod, workloadName, origin, groupName, &log)
 	}
 
 	return false, syncPodGroup(ctx, localClient, remoteClient, key, workloadName, origin, groupName)
@@ -63,24 +72,130 @@ func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, localClient 
 	if err != nil {
 		return client.IgnoreNotFound(err)
 	}
-
-	groupName := utilpod.GetPodGroupName(&pod)
-	if groupName == "" {
-		return client.IgnoreNotFound(remoteClient.Delete(ctx, &pod))
-	}
-
-	localPodGroup, err := listLocalPods(ctx, localClient, key.Namespace, groupName)
+	workloadName, err := jobframework.MultiKueueWorkloadNameFor(&pod)
 	if err != nil {
 		return err
 	}
+	groupName, err := multiKueuePodGroupName(&pod)
+	if err != nil {
+		return err
+	}
+	workloadAnnotations := map[string]string(nil)
+	if groupName != "" {
+		workloadAnnotations = map[string]string{podconstants.IsGroupWorkloadAnnotationKey: podconstants.IsGroupWorkloadAnnotationValue}
+	}
+	return b.deleteRemoteObjectWithCleanupContext(ctx, remoteClient, key, jobframework.MultiKueueRemoteObjectCleanupContext{
+		RemoteObjectUID: pod.UID,
+		Association: jobframework.MultiKueueObjectAssociation{
+			Origin:       pod.Labels[kueue.MultiKueueOriginLabel],
+			WorkloadName: workloadName,
+		},
+		WorkloadKey:         types.NamespacedName{Name: workloadName, Namespace: pod.Namespace},
+		WorkloadAnnotations: workloadAnnotations,
+	}, groupName)
+}
 
-	for _, localPod := range localPodGroup.Items {
-		if err = client.IgnoreNotFound(remoteClient.Delete(ctx, &localPod)); err != nil {
-			return err
-		}
+func (b *multiKueueAdapter) DeleteRemoteObjectWithCleanupContext(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, cleanupContext jobframework.MultiKueueRemoteObjectCleanupContext) error {
+	groupName, err := expectedMultiKueuePodGroupName(ctx, localClient, key, cleanupContext)
+	if err != nil {
+		return err
+	}
+	return b.deleteRemoteObjectWithCleanupContext(ctx, remoteClient, key, cleanupContext, groupName)
+}
+
+func (b *multiKueueAdapter) deleteRemoteObjectWithCleanupContext(ctx context.Context, remoteClient client.Client, key types.NamespacedName, cleanupContext jobframework.MultiKueueRemoteObjectCleanupContext, groupName string) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	pod := corev1.Pod{}
+	if err := remoteClient.Get(ctx, key, &pod); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	if pod.UID != cleanupContext.RemoteObjectUID {
+		return fmt.Errorf("%w: remote Pod %q was replaced before cleanup", jobframework.ErrRemoteObjectNotOwnedByMultiKueue, klog.KObj(&pod))
+	}
+	if err := validateRemotePodAssociation(&pod, cleanupContext.Association, groupName); err != nil {
+		return err
 	}
 
-	return nil
+	if groupName == "" {
+		return deleteRemotePodIfAssociated(ctx, remoteClient, &pod, cleanupContext.Association, groupName, &log)
+	}
+
+	listOptions := &client.ListOptions{
+		Namespace:     key.Namespace,
+		LabelSelector: labels.SelectorFromSet(labels.Set{kueue.MultiKueueOriginLabel: cleanupContext.Association.Origin}),
+		Limit:         remotePodCleanupPageSize,
+	}
+	for {
+		remotePodGroup := corev1.PodList{}
+		if err := remoteClient.List(ctx, &remotePodGroup, listOptions); err != nil {
+			return err
+		}
+		currentAnchor := corev1.Pod{}
+		if err := remoteClient.Get(ctx, key, &currentAnchor); err != nil {
+			return err
+		}
+		if currentAnchor.UID != cleanupContext.RemoteObjectUID {
+			return fmt.Errorf("%w: remote Pod %q was replaced during PodGroup cleanup", jobframework.ErrRemoteObjectNotOwnedByMultiKueue, klog.KObj(&currentAnchor))
+		}
+		if err := validateRemotePodAssociation(&currentAnchor, cleanupContext.Association, groupName); err != nil {
+			return err
+		}
+		for i := range remotePodGroup.Items {
+			remotePod := &remotePodGroup.Items[i]
+			podKey := client.ObjectKeyFromObject(remotePod)
+			if podKey == key {
+				if remotePod.UID != cleanupContext.RemoteObjectUID {
+					return fmt.Errorf("%w: remote Pod %q was replaced during PodGroup cleanup", jobframework.ErrRemoteObjectNotOwnedByMultiKueue, klog.KObj(remotePod))
+				}
+				continue
+			}
+			if err := deleteRemotePodIfAssociated(ctx, remoteClient, remotePod, cleanupContext.Association, groupName, &log); err != nil {
+				return err
+			}
+		}
+		if remotePodGroup.Continue == "" {
+			break
+		}
+		listOptions.Continue = remotePodGroup.Continue
+	}
+
+	// Keep the anchor until all pages and member deletions succeed so a retry can
+	// still recover after a transient list or delete failure.
+	return deleteRemotePodIfAssociated(ctx, remoteClient, &pod, cleanupContext.Association, groupName, &log)
+}
+
+func expectedMultiKueuePodGroupName(ctx context.Context, localClient client.Client, key types.NamespacedName, cleanupContext jobframework.MultiKueueRemoteObjectCleanupContext) (string, error) {
+	var podGroupName string
+	localPod := corev1.Pod{}
+	if err := localClient.Get(ctx, key, &localPod); err == nil {
+		var groupErr error
+		podGroupName, groupErr = multiKueuePodGroupName(&localPod)
+		if groupErr != nil {
+			return "", groupErr
+		}
+	} else if client.IgnoreNotFound(err) != nil {
+		return "", err
+	}
+
+	if cleanupContext.WorkloadKey.Name != "" {
+		if cleanupContext.WorkloadKey.Name != cleanupContext.Association.WorkloadName || cleanupContext.WorkloadKey.Namespace != key.Namespace {
+			return "", fmt.Errorf("Workload %q does not match cleanup association %q", cleanupContext.WorkloadKey, cleanupContext.Association.WorkloadName)
+		}
+		workloadGroupName := ""
+		if cleanupContext.WorkloadAnnotations[podconstants.IsGroupWorkloadAnnotationKey] == podconstants.IsGroupWorkloadAnnotationValue {
+			workloadGroupName = cleanupContext.WorkloadKey.Name
+		}
+		if podGroupName != "" && podGroupName != workloadGroupName {
+			return "", fmt.Errorf("manager PodGroup %q does not match Workload group %q", podGroupName, workloadGroupName)
+		}
+		return workloadGroupName, nil
+	}
+
+	// The local Pod can still provide group context to direct adapter callers that
+	// do not have Workload context. Production Workload cleanup and GC always reach
+	// the branch above even after the manager Pods are finalized.
+	return podGroupName, nil
 }
 
 func (b *multiKueueAdapter) IsJobManagedByKueue(ctx context.Context, c client.Client, key types.NamespacedName) (bool, string, error) {
@@ -103,9 +218,9 @@ func (*multiKueueAdapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedN
 		return nil, errors.New("not a pod")
 	}
 
-	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(pod)
-	if prebuiltWorkload == "" {
-		return nil, fmt.Errorf("no prebuilt workload found for pod: %s", klog.KObj(pod))
+	prebuiltWorkload, err := jobframework.MultiKueueWorkloadNameFor(pod)
+	if err != nil {
+		return nil, fmt.Errorf("getting prebuilt Workload for Pod %q: %w", klog.KObj(pod), err)
 	}
 
 	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: pod.Namespace}}, nil
@@ -120,7 +235,14 @@ func syncPodGroup(ctx context.Context, localClient client.Client, remoteClient c
 	}
 
 	for _, localPod := range localPodGroup.Items {
-		if err = syncLocalPodWithRemote(ctx, localClient, remoteClient, &localPod, workloadName, origin, &log); err != nil {
+		localGroupName, err := multiKueuePodGroupName(&localPod)
+		if err != nil {
+			return err
+		}
+		if localGroupName != groupName {
+			return fmt.Errorf("Pod %q belongs to PodGroup %q, expected %q", klog.KObj(&localPod), localGroupName, groupName)
+		}
+		if err = syncLocalPodWithRemote(ctx, localClient, remoteClient, &localPod, workloadName, origin, groupName, &log); err != nil {
 			return err
 		}
 	}
@@ -130,7 +252,7 @@ func syncPodGroup(ctx context.Context, localClient client.Client, remoteClient c
 
 func listLocalPods(ctx context.Context, localClient client.Client, namespace, groupName string) (*corev1.PodList, error) {
 	pods := &corev1.PodList{}
-	if err := localClient.List(ctx, pods, client.InNamespace(namespace), client.MatchingFields{PodGroupNameCacheKey: groupName}); err != nil {
+	if err := localClient.List(ctx, pods, client.InNamespace(namespace), client.MatchingFields{multiKueuePodGroupNameCacheKey: groupName}); err != nil {
 		return nil, err
 	}
 	return pods, nil
@@ -141,7 +263,7 @@ func syncLocalPodWithRemote(
 	localClient client.Client,
 	remoteClient client.Client,
 	localPod *corev1.Pod,
-	workloadName, origin string,
+	workloadName, origin, groupName string,
 	log *logr.Logger,
 ) error {
 	key := types.NamespacedName{Name: localPod.Name, Namespace: localPod.Namespace}
@@ -155,6 +277,10 @@ func syncLocalPodWithRemote(
 
 	// If the remote pod exists
 	if err == nil {
+		if err := validateRemotePodAssociation(&remotePod, jobframework.MultiKueueObjectAssociation{Origin: origin, WorkloadName: workloadName}, groupName); err != nil {
+			return err
+		}
+
 		// Skip syncing if the local pod is terminating
 		if !localPod.DeletionTimestamp.IsZero() {
 			log.V(2).Info("Skipping sync since the local pod is terminating", "podName", localPod.Name)
@@ -210,6 +336,50 @@ func syncLocalPodWithRemote(
 	}
 
 	return nil
+}
+
+func multiKueuePodGroupName(pod *corev1.Pod) (string, error) {
+	labelValue := pod.Labels[podconstants.GroupNameLabel]
+	annotationValue := pod.Annotations[podconstants.GroupNameAnnotation]
+	if labelValue != "" && annotationValue != "" && labelValue != annotationValue {
+		return "", fmt.Errorf("%w: conflicting PodGroup identifiers on Pod %q", jobframework.ErrRemoteObjectNotOwnedByMultiKueue, klog.KObj(pod))
+	}
+	if annotationValue != "" {
+		return annotationValue, nil
+	}
+	return labelValue, nil
+}
+
+func validateRemotePodAssociation(pod *corev1.Pod, association jobframework.MultiKueueObjectAssociation, groupName string) error {
+	if err := jobframework.ValidateMultiKueueObjectAssociation(pod, association); err != nil {
+		return err
+	}
+	podGroupName, err := multiKueuePodGroupName(pod)
+	if err != nil {
+		return err
+	}
+	if podGroupName != groupName {
+		return fmt.Errorf("%w: Pod %q belongs to PodGroup %q, expected %q", jobframework.ErrRemoteObjectNotOwnedByMultiKueue, klog.KObj(pod), podGroupName, groupName)
+	}
+	return nil
+}
+
+func deleteRemotePodIfAssociated(
+	ctx context.Context,
+	remoteClient client.Client,
+	pod *corev1.Pod,
+	association jobframework.MultiKueueObjectAssociation,
+	groupName string,
+	log *logr.Logger,
+) error {
+	if err := validateRemotePodAssociation(pod, association, groupName); err != nil {
+		if errors.Is(err, jobframework.ErrRemoteObjectNotOwnedByMultiKueue) {
+			log.V(4).Info("Preserving remote Pod that is not associated with this MultiKueue dispatch", "pod", klog.KObj(pod))
+			return nil
+		}
+		return err
+	}
+	return client.IgnoreNotFound(remoteClient.Delete(ctx, pod, client.Preconditions{UID: ptr.To(pod.UID)}))
 }
 
 // findPodCondition returns a pointer to the condition of the given type, or nil

--- a/pkg/controller/jobs/pod/pod_multikueue_adapter.go
+++ b/pkg/controller/jobs/pod/pod_multikueue_adapter.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -95,7 +94,13 @@ func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, localClient 
 	}, groupName)
 }
 
-func (b *multiKueueAdapter) DeleteRemoteObjectWithCleanupContext(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, cleanupContext jobframework.MultiKueueRemoteObjectCleanupContext) error {
+func (b *multiKueueAdapter) DeleteRemoteObjectWithCleanupContext(
+	ctx context.Context,
+	localClient client.Client,
+	remoteClient client.Client,
+	key types.NamespacedName,
+	cleanupContext jobframework.MultiKueueRemoteObjectCleanupContext,
+) error {
 	groupName, err := expectedMultiKueuePodGroupName(ctx, localClient, key, cleanupContext)
 	if err != nil {
 		return err
@@ -180,7 +185,7 @@ func expectedMultiKueuePodGroupName(ctx context.Context, localClient client.Clie
 
 	if cleanupContext.WorkloadKey.Name != "" {
 		if cleanupContext.WorkloadKey.Name != cleanupContext.Association.WorkloadName || cleanupContext.WorkloadKey.Namespace != key.Namespace {
-			return "", fmt.Errorf("Workload %q does not match cleanup association %q", cleanupContext.WorkloadKey, cleanupContext.Association.WorkloadName)
+			return "", fmt.Errorf("workload %q does not match cleanup association %q", cleanupContext.WorkloadKey, cleanupContext.Association.WorkloadName)
 		}
 		workloadGroupName := ""
 		if cleanupContext.WorkloadAnnotations[podconstants.IsGroupWorkloadAnnotationKey] == podconstants.IsGroupWorkloadAnnotationValue {
@@ -379,7 +384,7 @@ func deleteRemotePodIfAssociated(
 		}
 		return err
 	}
-	return client.IgnoreNotFound(remoteClient.Delete(ctx, pod, client.Preconditions{UID: ptr.To(pod.UID)}))
+	return client.IgnoreNotFound(remoteClient.Delete(ctx, pod, client.Preconditions{UID: &pod.UID}))
 }
 
 // findPodCondition returns a pointer to the condition of the given type, or nil

--- a/pkg/controller/jobs/pod/pod_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/pod/pod_multikueue_adapter_test.go
@@ -19,18 +19,23 @@ package pod
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/component-base/featuregate"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -47,7 +52,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 		cmpopts.EquateEmpty(),
 	}
 
-	basePodName := "test-pod"
+	basePodName := "wl1"
 	basePodBuilder := utiltestingpod.MakePod(basePodName, TestNamespace)
 
 	groupSize := 3
@@ -60,6 +65,9 @@ func TestMultiKueueAdapter(t *testing.T) {
 		PrebuiltWorkloadLabel("wl1").
 		Label(kueue.MultiKueueOriginLabel, "origin1").
 		MakePodGroupWrappers(groupSize)
+	for i := range podGroupWithWl {
+		podGroupWithWl[i].UID(fmt.Sprintf("worker-pod-%d", i))
+	}
 
 	podGroupWithWlAnnotations := basePodBuilder.
 		Clone().
@@ -70,6 +78,16 @@ func TestMultiKueueAdapter(t *testing.T) {
 		PrebuiltWorkloadAnnotation("wl1").
 		Label(kueue.MultiKueueOriginLabel, "origin1").
 		MakePodGroupWrappersWithWorkloadAnnotations(groupSize)
+	for i := range workerPodGroupWithAnnotations {
+		workerPodGroupWithAnnotations[i].UID(fmt.Sprintf("worker-pod-%d", i))
+	}
+	groupWorkload := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+		Name:      "wl1",
+		Namespace: TestNamespace,
+		Annotations: map[string]string{
+			podconstants.IsGroupWorkloadAnnotationKey: podconstants.IsGroupWorkloadAnnotationValue,
+		},
+	}}
 
 	cases := map[string]struct {
 		managersPods []corev1.Pod
@@ -81,6 +99,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 		wantManagersPods []corev1.Pod
 		wantWorkerPods   []corev1.Pod
 		featureGates     map[featuregate.Feature]bool
+		ignoreWorkerUIDs bool
 	}{
 		"sync creates missing remote pod": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
@@ -103,7 +122,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync status from remote pod": {
-			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
 			managersPods: []corev1.Pod{
 				*basePodBuilder.DeepCopy(),
 			},
@@ -276,7 +295,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync creates missing remote pods of the group": {
-			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			featureGates:     map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			ignoreWorkerUIDs: true,
 			managersPods: []corev1.Pod{
 				*podGroup[0].DeepCopy(),
 				*podGroup[1].DeepCopy(),
@@ -333,7 +353,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 		},
-		"remote pod group is deleted": {
+		"sync rejects remote pod group member from another workload": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersPods: []corev1.Pod{
 				*podGroup[0].DeepCopy(),
@@ -343,15 +363,339 @@ func TestMultiKueueAdapter(t *testing.T) {
 			workerPods: []corev1.Pod{
 				*podGroupWithWl[0].DeepCopy(),
 				*podGroupWithWl[1].DeepCopy(),
+				*podGroupWithWl[2].Clone().
+					PrebuiltWorkloadLabel("another-workload").
+					StatusPhase(corev1.PodRunning).
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, "wl1", "origin1")
+				return err
+			},
+			wantError: jobframework.ErrRemoteObjectNotOwnedByMultiKueue,
+			wantManagersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].DeepCopy(),
+			},
+			wantWorkerPods: []corev1.Pod{
+				*podGroupWithWl[0].DeepCopy(),
+				*podGroupWithWl[1].DeepCopy(),
+				*podGroupWithWl[2].Clone().
+					PrebuiltWorkloadLabel("another-workload").
+					StatusPhase(corev1.PodRunning).
+					Obj(),
+			},
+		},
+		"sync rejects remote pod with another group identity": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			managersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].DeepCopy(),
+			},
+			workerPods: []corev1.Pod{
+				*podGroupWithWl[0].DeepCopy(),
+				*podGroupWithWl[1].DeepCopy(),
+				*podGroupWithWl[2].Clone().
+					GroupNameLabel("another-group").
+					StatusPhase(corev1.PodRunning).
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, "wl1", "origin1")
+				return err
+			},
+			wantError: jobframework.ErrRemoteObjectNotOwnedByMultiKueue,
+			wantManagersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].DeepCopy(),
+			},
+			wantWorkerPods: []corev1.Pod{
+				*podGroupWithWl[0].DeepCopy(),
+				*podGroupWithWl[1].DeepCopy(),
+				*podGroupWithWl[2].Clone().
+					GroupNameLabel("another-group").
+					StatusPhase(corev1.PodRunning).
+					Obj(),
+			},
+		},
+		"sync status from annotation pod group after gate disable": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			managersPods: []corev1.Pod{
+				*podGroupWithWlAnnotations[0].DeepCopy(),
+				*podGroupWithWlAnnotations[1].DeepCopy(),
+				*podGroupWithWlAnnotations[2].DeepCopy(),
+			},
+			workerPods: []corev1.Pod{
+				*workerPodGroupWithAnnotations[0].DeepCopy(),
+				*workerPodGroupWithAnnotations[1].DeepCopy(),
+				*workerPodGroupWithAnnotations[2].Clone().
+					StatusPhase(corev1.PodRunning).
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, "wl1", "origin1")
+				return err
+			},
+			wantManagersPods: []corev1.Pod{
+				*podGroupWithWlAnnotations[0].DeepCopy(),
+				*podGroupWithWlAnnotations[1].DeepCopy(),
+				*podGroupWithWlAnnotations[2].Clone().
+					StatusPhase(corev1.PodRunning).
+					Obj(),
+			},
+			wantWorkerPods: []corev1.Pod{
+				*workerPodGroupWithAnnotations[0].DeepCopy(),
+				*workerPodGroupWithAnnotations[1].DeepCopy(),
+				*workerPodGroupWithAnnotations[2].Clone().
+					StatusPhase(corev1.PodRunning).
+					Obj(),
+			},
+		},
+		"sync status from label pod group after gate enable": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+			managersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].DeepCopy(),
+			},
+			workerPods: []corev1.Pod{
+				*podGroupWithWl[0].DeepCopy(),
+				*podGroupWithWl[1].DeepCopy(),
+				*podGroupWithWl[2].Clone().
+					StatusPhase(corev1.PodRunning).
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, "wl1", "origin1")
+				return err
+			},
+			wantManagersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].Clone().
+					StatusPhase(corev1.PodRunning).
+					Obj(),
+			},
+			wantWorkerPods: []corev1.Pod{
+				*podGroupWithWl[0].DeepCopy(),
+				*podGroupWithWl[1].DeepCopy(),
+				*podGroupWithWl[2].Clone().
+					StatusPhase(corev1.PodRunning).
+					Obj(),
+			},
+		},
+		"sync rejects conflicting remote anchor group identities": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			managersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].DeepCopy(),
+			},
+			workerPods: []corev1.Pod{
+				*podGroupWithWl[0].Clone().GroupNameAnnotation("another-group").Obj(),
+				*podGroupWithWl[1].DeepCopy(),
 				*podGroupWithWl[2].DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return adapter.DeleteRemoteObject(ctx, managerClient, workerClient, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace})
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, "wl1", "origin1")
+				return err
+			},
+			wantError: jobframework.ErrRemoteObjectNotOwnedByMultiKueue,
+			wantManagersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].DeepCopy(),
+			},
+			wantWorkerPods: []corev1.Pod{
+				*podGroupWithWl[0].Clone().GroupNameAnnotation("another-group").Obj(),
+				*podGroupWithWl[1].DeepCopy(),
+				*podGroupWithWl[2].DeepCopy(),
+			},
+		},
+		"sync rejects conflicting remote member group identities": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			managersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].DeepCopy(),
+			},
+			workerPods: []corev1.Pod{
+				*podGroupWithWl[0].DeepCopy(),
+				*podGroupWithWl[1].DeepCopy(),
+				*podGroupWithWl[2].Clone().GroupNameAnnotation("another-group").Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, "wl1", "origin1")
+				return err
+			},
+			wantError: jobframework.ErrRemoteObjectNotOwnedByMultiKueue,
+			wantManagersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].DeepCopy(),
+			},
+			wantWorkerPods: []corev1.Pod{
+				*podGroupWithWl[0].DeepCopy(),
+				*podGroupWithWl[1].DeepCopy(),
+				*podGroupWithWl[2].Clone().GroupNameAnnotation("another-group").Obj(),
+			},
+		},
+		"sync rejects unlabelled remote pod group member": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			managersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].DeepCopy(),
+			},
+			workerPods: []corev1.Pod{
+				*podGroupWithWl[0].DeepCopy(),
+				*podGroupWithWl[1].DeepCopy(),
+				*utiltestingpod.MakePod(podGroup[2].Obj().Name, TestNamespace).
+					UID("victim-uid").
+					StatusPhase(corev1.PodRunning).
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, "wl1", "origin1")
+				return err
+			},
+			wantError: jobframework.ErrRemoteObjectNotOwnedByMultiKueue,
+			wantManagersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].DeepCopy(),
+			},
+			wantWorkerPods: []corev1.Pod{
+				*podGroupWithWl[0].DeepCopy(),
+				*podGroupWithWl[1].DeepCopy(),
+				*utiltestingpod.MakePod(podGroup[2].Obj().Name, TestNamespace).
+					UID("victim-uid").
+					StatusPhase(corev1.PodRunning).
+					Obj(),
+			},
+		},
+		"remote pod group is deleted": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			managersPods: []corev1.Pod{
+				*podGroupWithWlAnnotations[0].DeepCopy(),
+				*podGroupWithWlAnnotations[1].DeepCopy(),
+				*podGroupWithWlAnnotations[2].DeepCopy(),
+			},
+			workerPods: []corev1.Pod{
+				*workerPodGroupWithAnnotations[0].DeepCopy(),
+				*workerPodGroupWithAnnotations[1].DeepCopy(),
+				*workerPodGroupWithAnnotations[2].DeepCopy(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				return jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, managerClient, workerClient, adapter, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, groupWorkload, "origin1")
+			},
+			wantManagersPods: []corev1.Pod{
+				*podGroupWithWlAnnotations[0].DeepCopy(),
+				*podGroupWithWlAnnotations[1].DeepCopy(),
+				*podGroupWithWlAnnotations[2].DeepCopy(),
+			},
+		},
+		"remote pod group cleanup preserves unlabelled member": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			managersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].DeepCopy(),
+			},
+			workerPods: []corev1.Pod{
+				*podGroupWithWl[0].DeepCopy(),
+				*podGroupWithWl[1].DeepCopy(),
+				*utiltestingpod.MakePod(podGroup[2].Obj().Name, TestNamespace).
+					UID("victim-uid").
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				return jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, managerClient, workerClient, adapter, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, groupWorkload, "origin1")
 			},
 			wantManagersPods: []corev1.Pod{
 				*podGroup[0].DeepCopy(),
 				*podGroup[1].DeepCopy(),
 				*podGroup[2].DeepCopy(),
+			},
+			wantWorkerPods: []corev1.Pod{
+				*utiltestingpod.MakePod(podGroup[2].Obj().Name, TestNamespace).
+					UID("victim-uid").
+					Obj(),
+			},
+		},
+		"remote pod group cleanup uses Workload context after manager Pods are finalized": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			workerPods: []corev1.Pod{
+				*podGroupWithWl[0].DeepCopy(),
+				*podGroupWithWl[1].DeepCopy(),
+				*utiltestingpod.MakePod(podGroup[2].Obj().Name, TestNamespace).
+					UID("victim-uid").
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				return jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, managerClient, workerClient, adapter, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, groupWorkload, "origin1")
+			},
+			wantWorkerPods: []corev1.Pod{
+				*utiltestingpod.MakePod(podGroup[2].Obj().Name, TestNamespace).
+					UID("victim-uid").
+					Obj(),
+			},
+		},
+		"remote pod group cleanup preserves member from another workload": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			managersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].DeepCopy(),
+			},
+			workerPods: []corev1.Pod{
+				*podGroupWithWl[0].DeepCopy(),
+				*podGroupWithWl[1].DeepCopy(),
+				*podGroupWithWl[2].Clone().
+					PrebuiltWorkloadLabel("another-workload").
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				return jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, managerClient, workerClient, adapter, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, groupWorkload, "origin1")
+			},
+			wantManagersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].DeepCopy(),
+			},
+			wantWorkerPods: []corev1.Pod{
+				*podGroupWithWl[2].Clone().
+					PrebuiltWorkloadLabel("another-workload").
+					Obj(),
+			},
+		},
+		"remote pod group cleanup preserves foreign anchor": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			managersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].DeepCopy(),
+			},
+			workerPods: []corev1.Pod{
+				*podGroupWithWl[0].Clone().PrebuiltWorkloadLabel("another-workload").Obj(),
+				*podGroupWithWl[1].Clone().PrebuiltWorkloadLabel("another-workload").Obj(),
+				*podGroupWithWl[2].Clone().PrebuiltWorkloadLabel("another-workload").Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				return jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, managerClient, workerClient, adapter, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, groupWorkload, "origin1")
+			},
+			wantManagersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].DeepCopy(),
+			},
+			wantWorkerPods: []corev1.Pod{
+				*podGroupWithWl[0].Clone().PrebuiltWorkloadLabel("another-workload").Obj(),
+				*podGroupWithWl[1].Clone().PrebuiltWorkloadLabel("another-workload").Obj(),
+				*podGroupWithWl[2].Clone().PrebuiltWorkloadLabel("another-workload").Obj(),
 			},
 		},
 		"sync creates missing remote pod, WorkloadIdentifierAnnotations enabled": {
@@ -374,7 +718,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync creates missing remote pods of the group, WorkloadIdentifierAnnotations enabled": {
-			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+			featureGates:     map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+			ignoreWorkerUIDs: true,
 			managersPods: []corev1.Pod{
 				*podGroupWithWlAnnotations[0].DeepCopy(),
 				*podGroupWithWlAnnotations[1].DeepCopy(),
@@ -401,14 +746,14 @@ func TestMultiKueueAdapter(t *testing.T) {
 			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			managerBuilder := utiltesting.NewClientBuilder().
 				WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge}).
-				WithIndex(&corev1.Pod{}, PodGroupNameCacheKey, IndexPodGroupName)
+				WithIndex(&corev1.Pod{}, multiKueuePodGroupNameCacheKey, indexMultiKueuePodGroupName)
 			managerBuilder = managerBuilder.WithLists(&corev1.PodList{Items: tc.managersPods})
 			managerBuilder = managerBuilder.WithStatusSubresource(slices.Map(tc.managersPods, func(w *corev1.Pod) client.Object { return w })...)
 			managerClient := managerBuilder.Build()
 
 			workerBuilder := utiltesting.NewClientBuilder().
 				WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge}).
-				WithIndex(&corev1.Pod{}, PodGroupNameCacheKey, IndexPodGroupName)
+				WithIndex(&corev1.Pod{}, multiKueuePodGroupNameCacheKey, indexMultiKueuePodGroupName)
 			workerBuilder = workerBuilder.WithLists(&corev1.PodList{Items: tc.workerPods})
 			workerClient := workerBuilder.Build()
 
@@ -435,10 +780,325 @@ func TestMultiKueueAdapter(t *testing.T) {
 			if err := workerClient.List(ctx, gotWorkerPods); err != nil {
 				t.Errorf("unexpected list worker's pod error %s", err)
 			} else {
-				if diff := cmp.Diff(tc.wantWorkerPods, gotWorkerPods.Items, objCheckOpts...); diff != "" {
+				workerCheckOpts := append(cmp.Options{}, objCheckOpts...)
+				if tc.ignoreWorkerUIDs {
+					workerCheckOpts = append(workerCheckOpts, cmpopts.IgnoreFields(metav1.ObjectMeta{}, "UID"))
+				}
+				if diff := cmp.Diff(tc.wantWorkerPods, gotWorkerPods.Items, workerCheckOpts...); diff != "" {
 					t.Errorf("unexpected worker's pod (-want/+got):\n%s", diff)
 				}
 			}
 		})
+	}
+}
+
+func TestMultiKueueWorkloadKeysForSurvivesFeatureGateChanges(t *testing.T) {
+	features.SetFeatureGatesDuringTest(t, map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false})
+	pod := utiltestingpod.MakePod("pod", TestNamespace).
+		PrebuiltWorkloadAnnotation("workload").
+		Obj()
+
+	got, err := (&multiKueueAdapter{}).WorkloadKeysFor(pod)
+	if err != nil {
+		t.Fatalf("WorkloadKeysFor() error = %v", err)
+	}
+	want := []types.NamespacedName{{Name: "workload", Namespace: TestNamespace}}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("WorkloadKeysFor() (-want,+got):\n%s", diff)
+	}
+}
+
+func TestDeleteRemotePodGroupPaginationKeepsAnchorForRetry(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	const (
+		groupName = "workload"
+		origin    = "origin"
+	)
+	anchor := utiltestingpod.MakePod("anchor", TestNamespace).
+		UID("anchor-uid").
+		GroupNameLabel(groupName).
+		PrebuiltWorkloadLabel(groupName).
+		Label(kueue.MultiKueueOriginLabel, origin).
+		Obj()
+	member1 := utiltestingpod.MakePod("member-1", TestNamespace).
+		UID("member-1-uid").
+		GroupNameLabel(groupName).
+		PrebuiltWorkloadLabel(groupName).
+		Label(kueue.MultiKueueOriginLabel, origin).
+		Obj()
+	member2 := utiltestingpod.MakePod("member-2", TestNamespace).
+		UID("member-2-uid").
+		GroupNameLabel(groupName).
+		PrebuiltWorkloadLabel(groupName).
+		Label(kueue.MultiKueueOriginLabel, origin).
+		Obj()
+	collision := utiltestingpod.MakePod("collision", TestNamespace).
+		UID("collision-uid").
+		GroupNameLabel(groupName).
+		PrebuiltWorkloadLabel("another-workload").
+		Label(kueue.MultiKueueOriginLabel, origin).
+		Obj()
+	foreignOrigin := utiltestingpod.MakePod("foreign-origin", TestNamespace).
+		UID("foreign-origin-uid").
+		GroupNameLabel(groupName).
+		PrebuiltWorkloadLabel(groupName).
+		Label(kueue.MultiKueueOriginLabel, "another-origin").
+		Obj()
+
+	baseClient := utiltesting.NewClientBuilder().WithObjects(anchor, member1, member2, collision, foreignOrigin).Build()
+	listCall := 0
+	pageErr := errors.New("second page unavailable")
+	workerClient := interceptor.NewClient(baseClient, interceptor.Funcs{
+		List: func(_ context.Context, _ client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+			listCall++
+			listOptions := &client.ListOptions{}
+			for _, opt := range opts {
+				opt.ApplyToList(listOptions)
+			}
+			if listOptions.Namespace != TestNamespace {
+				t.Errorf("List() namespace = %q, want %q", listOptions.Namespace, TestNamespace)
+			}
+			if listOptions.Limit != remotePodCleanupPageSize {
+				t.Errorf("List() limit = %d, want %d", listOptions.Limit, remotePodCleanupPageSize)
+			}
+			wantSelector := kueue.MultiKueueOriginLabel + "=" + origin
+			if listOptions.LabelSelector == nil || listOptions.LabelSelector.String() != wantSelector {
+				t.Errorf("List() selector = %v, want %q", listOptions.LabelSelector, wantSelector)
+			}
+			podList, ok := list.(*corev1.PodList)
+			if !ok {
+				t.Fatalf("List() object = %T, want *corev1.PodList", list)
+			}
+			switch listCall {
+			case 1:
+				*podList = corev1.PodList{
+					ListMeta: metav1.ListMeta{Continue: "page-2"},
+					Items:    []corev1.Pod{*anchor.DeepCopy(), *member1.DeepCopy()},
+				}
+			case 2:
+				if listOptions.Continue != "page-2" {
+					t.Errorf("second List() continue = %q, want page-2", listOptions.Continue)
+				}
+				return pageErr
+			case 3:
+				*podList = corev1.PodList{
+					ListMeta: metav1.ListMeta{Continue: "page-2"},
+					Items:    []corev1.Pod{*anchor.DeepCopy()},
+				}
+			case 4:
+				if listOptions.Continue != "page-2" {
+					t.Errorf("retry second List() continue = %q, want page-2", listOptions.Continue)
+				}
+				*podList = corev1.PodList{Items: []corev1.Pod{*member2.DeepCopy(), *collision.DeepCopy()}}
+			default:
+				t.Fatalf("unexpected List() call %d", listCall)
+			}
+			return nil
+		},
+	})
+
+	managerClient := utiltesting.NewClientBuilder().Build()
+	localWorkload := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+		Name:      groupName,
+		Namespace: TestNamespace,
+		Annotations: map[string]string{
+			podconstants.IsGroupWorkloadAnnotationKey: podconstants.IsGroupWorkloadAnnotationValue,
+		},
+	}}
+	adapter := &multiKueueAdapter{}
+	key := client.ObjectKeyFromObject(anchor)
+
+	err := jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, managerClient, workerClient, adapter, key, localWorkload, origin)
+	if !errors.Is(err, pageErr) {
+		t.Fatalf("first cleanup error = %v, want %v", err, pageErr)
+	}
+	if err := workerClient.Get(ctx, key, &corev1.Pod{}); err != nil {
+		t.Fatalf("anchor was deleted before all pages succeeded: %v", err)
+	}
+	if err := workerClient.Get(ctx, client.ObjectKeyFromObject(member1), &corev1.Pod{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("first-page member Get() error = %v, want NotFound", err)
+	}
+
+	if err := jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, managerClient, workerClient, adapter, key, localWorkload, origin); err != nil {
+		t.Fatalf("retry cleanup error = %v", err)
+	}
+	for _, deletedPod := range []*corev1.Pod{anchor, member1, member2} {
+		if err := workerClient.Get(ctx, client.ObjectKeyFromObject(deletedPod), &corev1.Pod{}); !apierrors.IsNotFound(err) {
+			t.Errorf("deleted Pod %q Get() error = %v, want NotFound", deletedPod.Name, err)
+		}
+	}
+	for _, preservedPod := range []*corev1.Pod{collision, foreignOrigin} {
+		got := &corev1.Pod{}
+		if err := workerClient.Get(ctx, client.ObjectKeyFromObject(preservedPod), got); err != nil {
+			t.Errorf("preserved Pod %q Get() error = %v", preservedPod.Name, err)
+		} else if got.UID != preservedPod.UID {
+			t.Errorf("preserved Pod %q UID = %q, want %q", preservedPod.Name, got.UID, preservedPod.UID)
+		}
+	}
+}
+
+func TestDeleteRemotePodGroupRejectsReplacementBeforePageDeletion(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	const (
+		groupName = "workload"
+		origin    = "origin"
+	)
+	makePod := func(name string, uid types.UID) *corev1.Pod {
+		return utiltestingpod.MakePod(name, TestNamespace).
+			UID(string(uid)).
+			GroupNameLabel(groupName).
+			PrebuiltWorkloadLabel(groupName).
+			Label(kueue.MultiKueueOriginLabel, origin).
+			Obj()
+	}
+	anchor := makePod("anchor", "anchor-uid")
+	member := makePod("member", "member-uid")
+	replacementAnchor := makePod(anchor.Name, "replacement-anchor-uid")
+	replacementMember := makePod(member.Name, "replacement-member-uid")
+
+	baseClient := utiltesting.NewClientBuilder().WithObjects(anchor, member).Build()
+	listCalled := false
+	workerClient := interceptor.NewClient(baseClient, interceptor.Funcs{
+		List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, _ ...client.ListOption) error {
+			if listCalled {
+				t.Fatal("unexpected second List() call")
+			}
+			listCalled = true
+			if err := c.Delete(ctx, anchor); err != nil {
+				return err
+			}
+			if err := c.Delete(ctx, member); err != nil {
+				return err
+			}
+			if err := c.Create(ctx, replacementAnchor); err != nil {
+				return err
+			}
+			if err := c.Create(ctx, replacementMember); err != nil {
+				return err
+			}
+			podList := list.(*corev1.PodList)
+			// Put the replacement member first to prove no page item is deleted
+			// before the anchor is revalidated.
+			podList.Items = []corev1.Pod{*replacementMember.DeepCopy(), *replacementAnchor.DeepCopy()}
+			return nil
+		},
+	})
+	localWorkload := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+		Name:      groupName,
+		Namespace: TestNamespace,
+		Annotations: map[string]string{
+			podconstants.IsGroupWorkloadAnnotationKey: podconstants.IsGroupWorkloadAnnotationValue,
+		},
+	}}
+
+	err := jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, utiltesting.NewClientBuilder().Build(), workerClient, &multiKueueAdapter{}, client.ObjectKeyFromObject(anchor), localWorkload, origin)
+	if !errors.Is(err, jobframework.ErrRemoteObjectNotOwnedByMultiKueue) {
+		t.Fatalf("cleanup error = %v, want %v", err, jobframework.ErrRemoteObjectNotOwnedByMultiKueue)
+	}
+	for _, replacement := range []*corev1.Pod{replacementAnchor, replacementMember} {
+		got := &corev1.Pod{}
+		if err := workerClient.Get(ctx, client.ObjectKeyFromObject(replacement), got); err != nil {
+			t.Fatalf("replacement Pod %q Get() error = %v", replacement.Name, err)
+		}
+		if got.UID != replacement.UID {
+			t.Fatalf("replacement Pod %q UID = %q, want %q", replacement.Name, got.UID, replacement.UID)
+		}
+	}
+}
+
+func TestDeleteRemotePodUsesUIDPrecondition(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	key := types.NamespacedName{Name: "pod", Namespace: TestNamespace}
+	original := utiltestingpod.MakePod(key.Name, key.Namespace).
+		UID("original-uid").
+		PrebuiltWorkloadLabel("workload").
+		Label(kueue.MultiKueueOriginLabel, "origin").
+		Obj()
+	replacement := original.DeepCopy()
+	replacement.UID = "replacement-uid"
+
+	baseClient := utiltesting.NewClientBuilder().WithObjects(original).Build()
+	workerClient := interceptor.NewClient(baseClient, interceptor.Funcs{
+		Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			deleteOptions := &client.DeleteOptions{}
+			for _, opt := range opts {
+				opt.ApplyToDelete(deleteOptions)
+			}
+			if deleteOptions.Preconditions == nil || deleteOptions.Preconditions.UID == nil || *deleteOptions.Preconditions.UID != original.UID {
+				t.Errorf("Delete() UID precondition = %v, want %q", deleteOptions.Preconditions, original.UID)
+			}
+			if err := c.Delete(ctx, obj); err != nil {
+				return err
+			}
+			if err := c.Create(ctx, replacement); err != nil {
+				return err
+			}
+			return apierrors.NewConflict(schema.GroupResource{Resource: "pods"}, key.Name, errors.New("UID precondition failed"))
+		},
+	})
+
+	adapter := &multiKueueAdapter{}
+	managerClient := utiltesting.NewClientBuilder().WithObjects(utiltestingpod.MakePod(key.Name, key.Namespace).Obj()).Build()
+	err := adapter.DeleteRemoteObject(ctx, managerClient, workerClient, key)
+	if !apierrors.IsConflict(err) {
+		t.Fatalf("DeleteRemoteObject() error = %v, want conflict", err)
+	}
+	got := &corev1.Pod{}
+	if err := workerClient.Get(ctx, key, got); err != nil {
+		t.Fatalf("Get() replacement Pod: %v", err)
+	}
+	if got.UID != replacement.UID {
+		t.Fatalf("replacement Pod UID = %q, want %q", got.UID, replacement.UID)
+	}
+}
+
+func TestDeleteRemotePodRejectsReplacementBeforeAdapterCleanup(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	key := types.NamespacedName{Name: "pod", Namespace: TestNamespace}
+	original := utiltestingpod.MakePod(key.Name, key.Namespace).
+		UID("original-uid").
+		PrebuiltWorkloadLabel("workload").
+		Label(kueue.MultiKueueOriginLabel, "origin").
+		Obj()
+	replacement := original.DeepCopy()
+	replacement.UID = "replacement-uid"
+
+	getCount := 0
+	deleteCalled := false
+	baseClient := utiltesting.NewClientBuilder().WithObjects(original).Build()
+	workerClient := interceptor.NewClient(baseClient, interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			getCount++
+			if getCount == 2 {
+				if err := c.Delete(ctx, original); err != nil {
+					return err
+				}
+				if err := c.Create(ctx, replacement); err != nil {
+					return err
+				}
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+		Delete: func(context.Context, client.WithWatch, client.Object, ...client.DeleteOption) error {
+			deleteCalled = true
+			return nil
+		},
+	})
+
+	managerClient := utiltesting.NewClientBuilder().WithObjects(utiltestingpod.MakePod(key.Name, key.Namespace).Obj()).Build()
+	adapter := &multiKueueAdapter{}
+	err := adapter.DeleteRemoteObject(ctx, managerClient, workerClient, key)
+	if !errors.Is(err, jobframework.ErrRemoteObjectNotOwnedByMultiKueue) {
+		t.Fatalf("DeleteRemoteObject() error = %v, want %v", err, jobframework.ErrRemoteObjectNotOwnedByMultiKueue)
+	}
+	if deleteCalled {
+		t.Fatal("Delete() called for a replacement Pod")
+	}
+	got := &corev1.Pod{}
+	if err := workerClient.Get(ctx, key, got); err != nil {
+		t.Fatalf("Get() replacement Pod: %v", err)
+	}
+	if got.UID != replacement.UID {
+		t.Fatalf("replacement Pod UID = %q, want %q", got.UID, replacement.UID)
 	}
 }

--- a/pkg/controller/jobs/pod/pod_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/pod/pod_multikueue_adapter_test.go
@@ -87,6 +87,27 @@ func TestMultiKueueAdapter(t *testing.T) {
 		Annotations: map[string]string{
 			podconstants.IsGroupWorkloadAnnotationKey: podconstants.IsGroupWorkloadAnnotationValue,
 		},
+		OwnerReferences: []metav1.OwnerReference{
+			{
+				APIVersion: corev1.SchemeGroupVersion.String(),
+				Kind:       "Pod",
+				Name:       podGroup[0].Obj().Name,
+				UID:        "manager-anchor-uid",
+				Controller: new(true),
+			},
+			{
+				APIVersion: corev1.SchemeGroupVersion.String(),
+				Kind:       "Pod",
+				Name:       podGroup[1].Obj().Name,
+				UID:        types.UID("manager-" + podGroup[1].Obj().Name + "-uid"),
+			},
+			{
+				APIVersion: corev1.SchemeGroupVersion.String(),
+				Kind:       "Pod",
+				Name:       podGroup[2].Obj().Name,
+				UID:        types.UID("manager-" + podGroup[2].Obj().Name + "-uid"),
+			},
+		},
 	}}
 
 	cases := map[string]struct {
@@ -269,6 +290,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 		},
 		"remote pod is deleted": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			managersPods: []corev1.Pod{*basePodBuilder.DeepCopy()},
 			workerPods: []corev1.Pod{
 				*basePodBuilder.Clone().
 					PrebuiltWorkloadLabel("wl1").
@@ -278,6 +300,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
 				return adapter.DeleteRemoteObject(ctx, managerClient, workerClient, types.NamespacedName{Name: basePodName, Namespace: TestNamespace})
 			},
+			wantManagersPods: []corev1.Pod{*basePodBuilder.DeepCopy()},
 		},
 		"pod managedBy multikueue": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
@@ -585,12 +608,20 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*podGroupWithWlAnnotations[2].DeepCopy(),
 			},
 			workerPods: []corev1.Pod{
-				*workerPodGroupWithAnnotations[0].DeepCopy(),
+				*workerPodGroupWithAnnotations[0].Clone().Annotation(kueue.MultiKueueOriginUIDAnnotation, "manager-anchor-uid").Obj(),
 				*workerPodGroupWithAnnotations[1].DeepCopy(),
 				*workerPodGroupWithAnnotations[2].DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, managerClient, workerClient, adapter, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, groupWorkload, "origin1")
+				return jobframework.DeleteRemoteObjectForWorkloadIfOwned(
+					ctx,
+					managerClient,
+					workerClient,
+					adapter,
+					types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace},
+					groupWorkload,
+					"origin1",
+				)
 			},
 			wantManagersPods: []corev1.Pod{
 				*podGroupWithWlAnnotations[0].DeepCopy(),
@@ -606,14 +637,22 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*podGroup[2].DeepCopy(),
 			},
 			workerPods: []corev1.Pod{
-				*podGroupWithWl[0].DeepCopy(),
+				*podGroupWithWl[0].Clone().Annotation(kueue.MultiKueueOriginUIDAnnotation, "manager-anchor-uid").Obj(),
 				*podGroupWithWl[1].DeepCopy(),
 				*utiltestingpod.MakePod(podGroup[2].Obj().Name, TestNamespace).
 					UID("victim-uid").
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, managerClient, workerClient, adapter, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, groupWorkload, "origin1")
+				return jobframework.DeleteRemoteObjectForWorkloadIfOwned(
+					ctx,
+					managerClient,
+					workerClient,
+					adapter,
+					types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace},
+					groupWorkload,
+					"origin1",
+				)
 			},
 			wantManagersPods: []corev1.Pod{
 				*podGroup[0].DeepCopy(),
@@ -629,19 +668,62 @@ func TestMultiKueueAdapter(t *testing.T) {
 		"remote pod group cleanup uses Workload context after manager Pods are finalized": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			workerPods: []corev1.Pod{
-				*podGroupWithWl[0].DeepCopy(),
-				*podGroupWithWl[1].DeepCopy(),
+				*podGroupWithWl[0].Clone().Annotation(kueue.MultiKueueOriginUIDAnnotation, "manager-anchor-uid").Obj(),
+				*podGroupWithWl[1].Clone().Annotation(kueue.MultiKueueOriginUIDAnnotation, "manager-"+podGroupWithWl[1].Obj().Name+"-uid").Obj(),
 				*utiltestingpod.MakePod(podGroup[2].Obj().Name, TestNamespace).
 					UID("victim-uid").
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, managerClient, workerClient, adapter, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, groupWorkload, "origin1")
+				return jobframework.DeleteRemoteObjectForWorkloadIfOwned(
+					ctx,
+					managerClient,
+					workerClient,
+					adapter,
+					types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace},
+					groupWorkload,
+					"origin1",
+				)
 			},
 			wantWorkerPods: []corev1.Pod{
 				*utiltestingpod.MakePod(podGroup[2].Obj().Name, TestNamespace).
 					UID("victim-uid").
 					Obj(),
+			},
+		},
+		"remote pod group cleanup does not trust a live manager member absent from the Workload": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			managersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].DeepCopy(),
+			},
+			workerPods: []corev1.Pod{
+				*podGroupWithWl[0].DeepCopy(),
+				*podGroupWithWl[1].DeepCopy(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				workloadWithoutMember := groupWorkload.DeepCopy()
+				workloadWithoutMember.OwnerReferences = workloadWithoutMember.OwnerReferences[:1]
+				return jobframework.DeleteRemoteObjectForWorkloadIfOwned(
+					ctx,
+					managerClient,
+					workerClient,
+					adapter,
+					types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace},
+					workloadWithoutMember,
+					"origin1",
+				)
+			},
+			wantError: jobframework.ErrRemoteObjectNotOwnedByMultiKueue,
+			wantManagersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].DeepCopy(),
+			},
+			wantWorkerPods: []corev1.Pod{
+				*podGroupWithWl[0].DeepCopy(),
+				*podGroupWithWl[1].DeepCopy(),
 			},
 		},
 		"remote pod group cleanup preserves member from another workload": {
@@ -652,14 +734,22 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*podGroup[2].DeepCopy(),
 			},
 			workerPods: []corev1.Pod{
-				*podGroupWithWl[0].DeepCopy(),
+				*podGroupWithWl[0].Clone().Annotation(kueue.MultiKueueOriginUIDAnnotation, "manager-anchor-uid").Obj(),
 				*podGroupWithWl[1].DeepCopy(),
 				*podGroupWithWl[2].Clone().
 					PrebuiltWorkloadLabel("another-workload").
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, managerClient, workerClient, adapter, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, groupWorkload, "origin1")
+				return jobframework.DeleteRemoteObjectForWorkloadIfOwned(
+					ctx,
+					managerClient,
+					workerClient,
+					adapter,
+					types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace},
+					groupWorkload,
+					"origin1",
+				)
 			},
 			wantManagersPods: []corev1.Pod{
 				*podGroup[0].DeepCopy(),
@@ -672,6 +762,41 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 		},
+		"remote pod group cleanup rejects a member with another manager UID": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			managersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].DeepCopy(),
+			},
+			workerPods: []corev1.Pod{
+				*podGroupWithWl[0].Clone().Annotation(kueue.MultiKueueOriginUIDAnnotation, "manager-anchor-uid").Obj(),
+				*podGroupWithWl[1].Clone().Annotation(kueue.MultiKueueOriginUIDAnnotation, "foreign-manager-pod-uid").Obj(),
+				*podGroupWithWl[2].DeepCopy(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				return jobframework.DeleteRemoteObjectForWorkloadIfOwned(
+					ctx,
+					managerClient,
+					workerClient,
+					adapter,
+					types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace},
+					groupWorkload,
+					"origin1",
+				)
+			},
+			wantError: jobframework.ErrRemoteObjectNotOwnedByMultiKueue,
+			wantManagersPods: []corev1.Pod{
+				*podGroup[0].DeepCopy(),
+				*podGroup[1].DeepCopy(),
+				*podGroup[2].DeepCopy(),
+			},
+			wantWorkerPods: []corev1.Pod{
+				*podGroupWithWl[0].Clone().Annotation(kueue.MultiKueueOriginUIDAnnotation, "manager-anchor-uid").Obj(),
+				*podGroupWithWl[1].Clone().Annotation(kueue.MultiKueueOriginUIDAnnotation, "foreign-manager-pod-uid").Obj(),
+				*podGroupWithWl[2].DeepCopy(),
+			},
+		},
 		"remote pod group cleanup preserves foreign anchor": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersPods: []corev1.Pod{
@@ -680,20 +805,29 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*podGroup[2].DeepCopy(),
 			},
 			workerPods: []corev1.Pod{
-				*podGroupWithWl[0].Clone().PrebuiltWorkloadLabel("another-workload").Obj(),
+				*podGroupWithWl[0].Clone().PrebuiltWorkloadLabel("another-workload").Annotation(kueue.MultiKueueOriginUIDAnnotation, "manager-anchor-uid").Obj(),
 				*podGroupWithWl[1].Clone().PrebuiltWorkloadLabel("another-workload").Obj(),
 				*podGroupWithWl[2].Clone().PrebuiltWorkloadLabel("another-workload").Obj(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, managerClient, workerClient, adapter, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, groupWorkload, "origin1")
+				return jobframework.DeleteRemoteObjectForWorkloadIfOwned(
+					ctx,
+					managerClient,
+					workerClient,
+					adapter,
+					types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace},
+					groupWorkload,
+					"origin1",
+				)
 			},
+			wantError: jobframework.ErrRemoteObjectNotOwnedByMultiKueue,
 			wantManagersPods: []corev1.Pod{
 				*podGroup[0].DeepCopy(),
 				*podGroup[1].DeepCopy(),
 				*podGroup[2].DeepCopy(),
 			},
 			wantWorkerPods: []corev1.Pod{
-				*podGroupWithWl[0].Clone().PrebuiltWorkloadLabel("another-workload").Obj(),
+				*podGroupWithWl[0].Clone().PrebuiltWorkloadLabel("another-workload").Annotation(kueue.MultiKueueOriginUIDAnnotation, "manager-anchor-uid").Obj(),
 				*podGroupWithWl[1].Clone().PrebuiltWorkloadLabel("another-workload").Obj(),
 				*podGroupWithWl[2].Clone().PrebuiltWorkloadLabel("another-workload").Obj(),
 			},
@@ -743,6 +877,44 @@ func TestMultiKueueAdapter(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			managerPodUIDs := make(map[string]types.UID, len(tc.managersPods))
+			setManagerPodUIDs := func(pods []corev1.Pod) {
+				for i := range pods {
+					if pods[i].UID == "" {
+						if pods[i].Name == podGroup[0].Obj().Name {
+							pods[i].UID = "manager-anchor-uid"
+						} else {
+							pods[i].UID = types.UID("manager-" + pods[i].Name + "-uid")
+						}
+					}
+					managerPodUIDs[pods[i].Name] = pods[i].UID
+				}
+			}
+			setManagerPodUIDs(tc.managersPods)
+			setManagerPodUIDs(tc.wantManagersPods)
+			initialWorkerNames := make(map[string]struct{}, len(tc.workerPods))
+			setRemotePodUIDs := func(pods []corev1.Pod, recordInitial bool) {
+				for i := range pods {
+					if recordInitial {
+						initialWorkerNames[pods[i].Name] = struct{}{}
+					} else if _, existed := initialWorkerNames[pods[i].Name]; !existed {
+						continue
+					}
+					managerUID := managerPodUIDs[pods[i].Name]
+					if managerUID == "" || pods[i].Labels[kueue.MultiKueueOriginLabel] != "origin1" {
+						continue
+					}
+					if pods[i].Annotations == nil {
+						pods[i].Annotations = make(map[string]string, 1)
+					}
+					if pods[i].Annotations[kueue.MultiKueueOriginUIDAnnotation] == "" {
+						pods[i].Annotations[kueue.MultiKueueOriginUIDAnnotation] = string(managerUID)
+					}
+				}
+			}
+			setRemotePodUIDs(tc.workerPods, true)
+			setRemotePodUIDs(tc.wantWorkerPods, false)
+
 			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			managerBuilder := utiltesting.NewClientBuilder().
 				WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge}).
@@ -792,6 +964,73 @@ func TestMultiKueueAdapter(t *testing.T) {
 	}
 }
 
+func TestSyncPodGroupRejectsSameNameManagerReplacement(t *testing.T) {
+	features.SetFeatureGatesDuringTest(t, map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false})
+	const (
+		origin       = "origin"
+		workloadName = "workload"
+	)
+	pods := utiltestingpod.MakePod(workloadName, TestNamespace).MakePodGroupWrappers(2)
+	anchor := pods[0].UID("original-anchor-uid").Obj()
+	replacementMember := pods[1].UID("replacement-member-uid").Obj()
+	originalMemberUID := types.UID("original-member-uid")
+	key := client.ObjectKeyFromObject(anchor)
+
+	managerWorkload := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+		Name:      workloadName,
+		Namespace: TestNamespace,
+		UID:       "manager-workload-uid",
+		Annotations: map[string]string{
+			podconstants.IsGroupWorkloadAnnotationKey: podconstants.IsGroupWorkloadAnnotationValue,
+		},
+		OwnerReferences: []metav1.OwnerReference{
+			{
+				APIVersion: corev1.SchemeGroupVersion.String(),
+				Kind:       "Pod",
+				Name:       anchor.Name,
+				UID:        anchor.UID,
+				Controller: new(true),
+			},
+			{
+				APIVersion: corev1.SchemeGroupVersion.String(),
+				Kind:       "Pod",
+				Name:       replacementMember.Name,
+				UID:        originalMemberUID,
+			},
+		},
+	}}
+	remoteAnchor := anchor.DeepCopy()
+	remoteAnchor.UID = "worker-anchor-uid"
+	jobframework.SetMultiKueueMeta(remoteAnchor, workloadName, origin)
+	remoteAnchor.Annotations[kueue.MultiKueueOriginUIDAnnotation] = string(anchor.UID)
+
+	managerClient := utiltesting.NewClientBuilder().
+		WithObjects(anchor, replacementMember).
+		WithStatusSubresource(anchor, replacementMember).
+		WithIndex(&corev1.Pod{}, multiKueuePodGroupNameCacheKey, indexMultiKueuePodGroupName).
+		Build()
+	workerClient := utiltesting.NewClientBuilder().WithObjects(remoteAnchor).Build()
+	ctx, _ := utiltesting.ContextWithLog(t)
+
+	_, err := jobframework.SyncJobWithRemoteObjectOwnership(
+		ctx,
+		managerClient,
+		managerClient,
+		workerClient,
+		&multiKueueAdapter{},
+		key,
+		managerWorkload,
+		origin,
+	)
+	if !errors.Is(err, jobframework.ErrRemoteObjectNotOwnedByMultiKueue) {
+		t.Fatalf("SyncJobWithRemoteObjectOwnership() error = %v, want %v", err, jobframework.ErrRemoteObjectNotOwnedByMultiKueue)
+	}
+	remoteMember := &corev1.Pod{}
+	if err := workerClient.Get(ctx, client.ObjectKeyFromObject(replacementMember), remoteMember); !apierrors.IsNotFound(err) {
+		t.Fatalf("worker replacement-member Pod Get() error = %v, want NotFound", err)
+	}
+}
+
 func TestMultiKueueWorkloadKeysForSurvivesFeatureGateChanges(t *testing.T) {
 	features.SetFeatureGatesDuringTest(t, map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false})
 	pod := utiltestingpod.MakePod("pod", TestNamespace).
@@ -819,18 +1058,21 @@ func TestDeleteRemotePodGroupPaginationKeepsAnchorForRetry(t *testing.T) {
 		GroupNameLabel(groupName).
 		PrebuiltWorkloadLabel(groupName).
 		Label(kueue.MultiKueueOriginLabel, origin).
+		Annotation(kueue.MultiKueueOriginUIDAnnotation, "manager-anchor-uid").
 		Obj()
 	member1 := utiltestingpod.MakePod("member-1", TestNamespace).
 		UID("member-1-uid").
 		GroupNameLabel(groupName).
 		PrebuiltWorkloadLabel(groupName).
 		Label(kueue.MultiKueueOriginLabel, origin).
+		Annotation(kueue.MultiKueueOriginUIDAnnotation, "manager-member-1-uid").
 		Obj()
 	member2 := utiltestingpod.MakePod("member-2", TestNamespace).
 		UID("member-2-uid").
 		GroupNameLabel(groupName).
 		PrebuiltWorkloadLabel(groupName).
 		Label(kueue.MultiKueueOriginLabel, origin).
+		Annotation(kueue.MultiKueueOriginUIDAnnotation, "manager-member-2-uid").
 		Obj()
 	collision := utiltestingpod.MakePod("collision", TestNamespace).
 		UID("collision-uid").
@@ -883,7 +1125,7 @@ func TestDeleteRemotePodGroupPaginationKeepsAnchorForRetry(t *testing.T) {
 			case 3:
 				*podList = corev1.PodList{
 					ListMeta: metav1.ListMeta{Continue: "page-2"},
-					Items:    []corev1.Pod{*anchor.DeepCopy()},
+					Items:    []corev1.Pod{*anchor.DeepCopy(), *member1.DeepCopy()},
 				}
 			case 4:
 				if listOptions.Continue != "page-2" {
@@ -897,12 +1139,39 @@ func TestDeleteRemotePodGroupPaginationKeepsAnchorForRetry(t *testing.T) {
 		},
 	})
 
-	managerClient := utiltesting.NewClientBuilder().Build()
+	managerAnchor := anchor.DeepCopy()
+	managerAnchor.UID = "manager-anchor-uid"
+	managerMember1 := member1.DeepCopy()
+	managerMember1.UID = "manager-member-1-uid"
+	managerMember2 := member2.DeepCopy()
+	managerMember2.UID = "manager-member-2-uid"
+	managerClient := utiltesting.NewClientBuilder().WithObjects(managerAnchor, managerMember1, managerMember2).Build()
 	localWorkload := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
 		Name:      groupName,
 		Namespace: TestNamespace,
 		Annotations: map[string]string{
 			podconstants.IsGroupWorkloadAnnotationKey: podconstants.IsGroupWorkloadAnnotationValue,
+		},
+		OwnerReferences: []metav1.OwnerReference{
+			{
+				APIVersion: corev1.SchemeGroupVersion.String(),
+				Kind:       "Pod",
+				Name:       anchor.Name,
+				UID:        "manager-anchor-uid",
+				Controller: new(true),
+			},
+			{
+				APIVersion: corev1.SchemeGroupVersion.String(),
+				Kind:       "Pod",
+				Name:       member1.Name,
+				UID:        "manager-member-1-uid",
+			},
+			{
+				APIVersion: corev1.SchemeGroupVersion.String(),
+				Kind:       "Pod",
+				Name:       member2.Name,
+				UID:        "manager-member-2-uid",
+			},
 		},
 	}}
 	adapter := &multiKueueAdapter{}
@@ -915,8 +1184,8 @@ func TestDeleteRemotePodGroupPaginationKeepsAnchorForRetry(t *testing.T) {
 	if err := workerClient.Get(ctx, key, &corev1.Pod{}); err != nil {
 		t.Fatalf("anchor was deleted before all pages succeeded: %v", err)
 	}
-	if err := workerClient.Get(ctx, client.ObjectKeyFromObject(member1), &corev1.Pod{}); !apierrors.IsNotFound(err) {
-		t.Fatalf("first-page member Get() error = %v, want NotFound", err)
+	if err := workerClient.Get(ctx, client.ObjectKeyFromObject(member1), &corev1.Pod{}); err != nil {
+		t.Fatalf("first-page member was deleted before all pages were authenticated: %v", err)
 	}
 
 	if err := jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, managerClient, workerClient, adapter, key, localWorkload, origin); err != nil {
@@ -952,6 +1221,7 @@ func TestDeleteRemotePodGroupRejectsReplacementBeforePageDeletion(t *testing.T) 
 			Obj()
 	}
 	anchor := makePod("anchor", "anchor-uid")
+	anchor.Annotations = map[string]string{kueue.MultiKueueOriginUIDAnnotation: "manager-anchor-uid"}
 	member := makePod("member", "member-uid")
 	replacementAnchor := makePod(anchor.Name, "replacement-anchor-uid")
 	replacementMember := makePod(member.Name, "replacement-member-uid")
@@ -989,6 +1259,13 @@ func TestDeleteRemotePodGroupRejectsReplacementBeforePageDeletion(t *testing.T) 
 		Annotations: map[string]string{
 			podconstants.IsGroupWorkloadAnnotationKey: podconstants.IsGroupWorkloadAnnotationValue,
 		},
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "Pod",
+			Name:       anchor.Name,
+			UID:        "manager-anchor-uid",
+			Controller: new(true),
+		}},
 	}}
 
 	err := jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, utiltesting.NewClientBuilder().Build(), workerClient, &multiKueueAdapter{}, client.ObjectKeyFromObject(anchor), localWorkload, origin)
@@ -1013,6 +1290,7 @@ func TestDeleteRemotePodUsesUIDPrecondition(t *testing.T) {
 		UID("original-uid").
 		PrebuiltWorkloadLabel("workload").
 		Label(kueue.MultiKueueOriginLabel, "origin").
+		Annotation(kueue.MultiKueueOriginUIDAnnotation, "manager-pod-uid").
 		Obj()
 	replacement := original.DeepCopy()
 	replacement.UID = "replacement-uid"
@@ -1038,7 +1316,7 @@ func TestDeleteRemotePodUsesUIDPrecondition(t *testing.T) {
 	})
 
 	adapter := &multiKueueAdapter{}
-	managerClient := utiltesting.NewClientBuilder().WithObjects(utiltestingpod.MakePod(key.Name, key.Namespace).Obj()).Build()
+	managerClient := utiltesting.NewClientBuilder().WithObjects(utiltestingpod.MakePod(key.Name, key.Namespace).UID("manager-pod-uid").Obj()).Build()
 	err := adapter.DeleteRemoteObject(ctx, managerClient, workerClient, key)
 	if !apierrors.IsConflict(err) {
 		t.Fatalf("DeleteRemoteObject() error = %v, want conflict", err)
@@ -1059,6 +1337,7 @@ func TestDeleteRemotePodRejectsReplacementBeforeAdapterCleanup(t *testing.T) {
 		UID("original-uid").
 		PrebuiltWorkloadLabel("workload").
 		Label(kueue.MultiKueueOriginLabel, "origin").
+		Annotation(kueue.MultiKueueOriginUIDAnnotation, "manager-pod-uid").
 		Obj()
 	replacement := original.DeepCopy()
 	replacement.UID = "replacement-uid"
@@ -1085,7 +1364,7 @@ func TestDeleteRemotePodRejectsReplacementBeforeAdapterCleanup(t *testing.T) {
 		},
 	})
 
-	managerClient := utiltesting.NewClientBuilder().WithObjects(utiltestingpod.MakePod(key.Name, key.Namespace).Obj()).Build()
+	managerClient := utiltesting.NewClientBuilder().WithObjects(utiltestingpod.MakePod(key.Name, key.Namespace).UID("manager-pod-uid").Obj()).Build()
 	adapter := &multiKueueAdapter{}
 	err := adapter.DeleteRemoteObject(ctx, managerClient, workerClient, key)
 	if !errors.Is(err, jobframework.ErrRemoteObjectNotOwnedByMultiKueue) {

--- a/pkg/controller/jobs/pod/pod_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/pod/pod_multikueue_adapter_test.go
@@ -590,7 +590,15 @@ func TestMultiKueueAdapter(t *testing.T) {
 				*workerPodGroupWithAnnotations[2].DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
-				return jobframework.DeleteRemoteObjectForWorkloadIfOwned(ctx, managerClient, workerClient, adapter, types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace}, groupWorkload, "origin1")
+				return jobframework.DeleteRemoteObjectForWorkloadIfOwned(
+					ctx,
+					managerClient,
+					workerClient,
+					adapter,
+					types.NamespacedName{Name: podGroup[0].Obj().Name, Namespace: TestNamespace},
+					groupWorkload,
+					"origin1",
+				)
 			},
 			wantManagersPods: []corev1.Pod{
 				*podGroupWithWlAnnotations[0].DeepCopy(),

--- a/pkg/controller/jobs/ray/ray_multikueue_adapter.go
+++ b/pkg/controller/jobs/ray/ray_multikueue_adapter.go
@@ -61,6 +61,17 @@ type adapter[PtrT objAsPtr[T], T any] struct {
 	remoteSpecSync RemoteSpecSyncer[PtrT]
 }
 
+func (a *adapter[PtrT, T]) CanReassignWorkload(ctx context.Context, localClient client.Client, key types.NamespacedName) (bool, error) {
+	if a.elastic == nil {
+		return false, nil
+	}
+	localJob := PtrT(new(T))
+	if err := localClient.Get(ctx, key, localJob); err != nil {
+		return false, err
+	}
+	return workloadslicing.Enabled(localJob), nil
+}
+
 // RemoteSpecSyncer lets a job type forward selected spec changes from the manager
 // copy to its worker copy after the job is admitted, via an in-place patch of the
 // remote. Each job type decides which fields to forward and when a sync is needed.

--- a/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter_test.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/ray"
 	"sigs.k8s.io/kueue/pkg/features"
@@ -44,6 +45,19 @@ import (
 const (
 	TestNamespace = "ns"
 )
+
+func makeRayBoundWorkload(name string, key types.NamespacedName, managerUID types.UID) *kueue.Workload {
+	return &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+		Name:      name,
+		Namespace: key.Namespace,
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: gvk.GroupVersion().String(),
+			Kind:       gvk.Kind,
+			Name:       key.Name,
+			UID:        managerUID,
+		}},
+	}}
+}
 
 func TestMultiKueueAdapter(t *testing.T) {
 	objCheckOpts := cmp.Options{
@@ -419,6 +433,86 @@ func TestMultiKueueAdapter(t *testing.T) {
 				if diff := cmp.Diff(tc.wantWorkerRayClusters, gotWorkerRayClusters.Items, objCheckOpts...); diff != "" {
 					t.Errorf("unexpected worker's rayclusters (-want/+got):\n%s", diff)
 				}
+			}
+		})
+	}
+}
+
+func TestMultiKueueOwnershipWrapperAllowsUIDBoundElasticReassignment(t *testing.T) {
+	const (
+		origin     = "origin1"
+		managerUID = "manager-raycluster-uid"
+		oldWL      = "old-workload"
+		newWL      = "new-workload"
+	)
+	for _, tc := range []struct {
+		name          string
+		annotationsOn bool
+		oldAsLabel    bool
+	}{
+		{name: "label to annotation", annotationsOn: true, oldAsLabel: true},
+		{name: "annotation to label", annotationsOn: false, oldAsLabel: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, map[featuregate.Feature]bool{
+				features.ElasticJobsViaWorkloadSlices:  true,
+				features.WorkloadIdentifierAnnotations: tc.annotationsOn,
+			})
+			key := types.NamespacedName{Name: "raycluster1", Namespace: TestNamespace}
+			base := utiltestingraycluster.MakeCluster(key.Name, key.Namespace).
+				Suspend(false).
+				SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue)
+			localRayCluster := base.Clone().ScaleFirstWorkerGroup(1).Obj()
+			localRayCluster.UID = types.UID(managerUID)
+			localRayCluster.ResourceVersion = "1"
+			remoteBuilder := base.Clone().
+				ScaleFirstWorkerGroup(3).
+				Label(kueue.MultiKueueOriginLabel, origin).
+				SetAnnotation(kueue.MultiKueueOriginUIDAnnotation, managerUID)
+			if tc.oldAsLabel {
+				remoteBuilder.PrebuiltWorkloadLabel(oldWL)
+			} else {
+				remoteBuilder.SetAnnotation(constants.PrebuiltWorkloadAnnotation, oldWL)
+			}
+			remoteRayCluster := remoteBuilder.Obj()
+			remoteRayCluster.UID = "remote-raycluster-uid"
+			remoteRayCluster.ResourceVersion = "1"
+
+			managerClient := utiltesting.NewClientBuilder(rayv1.AddToScheme).WithObjects(localRayCluster).WithStatusSubresource(localRayCluster).Build()
+			workerClient := utiltesting.NewClientBuilder(rayv1.AddToScheme).WithObjects(remoteRayCluster).Build()
+			adapter := ray.NewMKAdapter(copyJobSpec, copyJobStatus, getEmptyList, gvk, getManagedBy, setManagedBy,
+				ray.WithElasticReplicaSync(elasticReplicaSync()))
+			ctx, _ := utiltesting.ContextWithLog(t)
+			if _, err := jobframework.SyncJobWithRemoteObjectOwnership(
+				ctx,
+				managerClient,
+				managerClient,
+				workerClient,
+				adapter,
+				key,
+				makeRayBoundWorkload(newWL, key, types.UID(managerUID)),
+				origin,
+			); err != nil {
+				t.Fatalf("SyncJobWithRemoteObjectOwnership() error = %v", err)
+			}
+
+			got := &rayv1.RayCluster{}
+			if err := workerClient.Get(ctx, key, got); err != nil {
+				t.Fatalf("getting remote RayCluster: %v", err)
+			}
+			if replicas := got.Spec.WorkerGroupSpecs[0].Replicas; replicas == nil || *replicas != 1 {
+				t.Fatalf("remote worker replicas = %v, want 1", replicas)
+			}
+			if gotWorkload := jobframework.PrebuiltWorkloadNameFor(got); gotWorkload != newWL {
+				t.Fatalf("remote Workload association = %q, want %q", gotWorkload, newWL)
+			}
+			if got.Labels[constants.PrebuiltWorkloadLabel] != newWL || got.Annotations[constants.PrebuiltWorkloadAnnotation] != newWL {
+				t.Fatalf(
+					"transitioned Workload metadata label=%q annotation=%q, want both %q",
+					got.Labels[constants.PrebuiltWorkloadLabel],
+					got.Annotations[constants.PrebuiltWorkloadAnnotation],
+					newWL,
+				)
 			}
 		})
 	}

--- a/site/content/en/docs/concepts/multikueue.md
+++ b/site/content/en/docs/concepts/multikueue.md
@@ -218,6 +218,76 @@ For production deployments, use `ClusterProfile` or `Secret` instead of `Path`.
 See [Setup a MultiKueue environment](/docs/tasks/manage/setup_multikueue/) for
 configuration details.
 
+### Remote object identity and cleanup
+
+MultiKueue validates every adapter-declared worker execution object against the
+expected MultiKueue origin, exact manager object UID, and—when the object belongs
+to one Workload—the remote Workload name before reading its status or mutating or
+deleting it. Each such remote execution object
+carries its corresponding manager object UID in the
+`kueue.x-k8s.io/multikueue-origin-uid` annotation; for a PodGroup, each remote
+Pod carries the UID of its same-name manager Pod. Remote Workloads carry the UID
+of their same-name manager Workload. Worker-object deletions use UID
+preconditions, so an object replaced after validation is preserved.
+The admitted manager Workload is the authority for execution-object UIDs: its
+owner references retain the original same-name manager object identities, and
+MultiKueue cross-checks each live manager object directly from the API server
+against that controller-recorded mapping before creating or consuming the
+worker object. Recreating a manager Job or Pod with the same name therefore
+cannot inherit the old Workload's admission.
+
+Shared execution objects for multi-Workload integrations, such as
+LeaderWorkerSet, are intentionally not bound to one Workload name. They remain
+bound to the MultiKueue origin and exact manager object UID, while each of their
+remote Workloads is independently bound to its same-name manager Workload UID.
+
+The guarded worker client only permits the adapter's declared object kind.
+Cross-kind secondary-object access, subresource reads, apply operations, and
+writes that cannot be bound to a checked UID and resource version fail closed.
+Adapters that create multiple objects of their declared kind must implement the
+cleanup extension; PodGroup cleanup, for example, uses the member UID map
+retained in the manager Workload even after the manager Pods are gone.
+
+The garbage collector deletes a remote Workload only when the corresponding
+manager Workload is awaiting deletion and the recorded manager UID matches.
+If the manager Workload is missing or the identity does not match, the remote
+Workload and its owner are preserved for administrator review. This can leave
+orphaned objects that require manual cleanup, but it prevents a same-name,
+unrelated object from turning the manager into a deletion deputy.
+
+Within a running leader, reconciliation and garbage collection serialize each
+remote Workload lifecycle and re-read the manager Workload directly from the API
+before and after remote creation. If manager deletion starts during a remote
+write, MultiKueue performs authenticated cleanup before releasing that
+lifecycle, so an in-process stale reconcile does not recreate an execution
+object after concurrent cleanup. A leader crash or handoff after the worker API
+commits a write but before the post-write check can still leave an orphan, as
+can an ambiguous worker API error. If the manager Workload is then unavailable,
+the next leader preserves that object for administrator review rather than
+risk deleting an unrelated same-name object.
+
+These labels and annotations express association; they are not cryptographic
+proof of provenance. Treat principals that can read and mutate MultiKueue
+objects in worker Namespaces, including by patching or replacing them, as
+trusted until authenticated remote-object provenance is available.
+Principals that can patch or replace UID-bearing owner references on manager
+Workloads are also trusted. The standard batch-user role does not grant this
+mutation, but the Workload editor role does.
+
+#### Upgrade note
+
+Remote Workloads and execution objects created by older Kueue versions do not
+consistently contain the manager UID annotation. Live migration is not
+supported: adapters can create multiple execution objects, and custom adapters
+can define their own manager-to-worker mapping. Before any upgraded manager
+replica can become leader, stop new MultiKueue submissions and let every active
+MultiKueue dispatch finish and clean up its worker objects.
+
+Do not run old and new manager leaders concurrently during this upgrade. An
+older leader can create an unbound object that a new leader must reject. If an
+unbound legacy object remains, the upgraded manager fails closed and preserves
+it for administrator review; it does not adopt, mutate, or delete it.
+
 ## Limitations
 
 - We do not currently support running the manager cluster as one of the workers for itself.

--- a/site/content/en/docs/tasks/manage/setup_multikueue.md
+++ b/site/content/en/docs/tasks/manage/setup_multikueue.md
@@ -421,3 +421,38 @@ spec:
     clusterProfileRef:
       name: worker1-cluster
 ```
+
+## Upgrade installations with active remote objects
+
+New Kueue versions bind every worker Workload and execution object to the UID
+of its exact manager-side counterpart. Older versions did not consistently add
+this identity to Jobs, Pods, and other execution objects. Annotating only the
+remote Workload is therefore insufficient.
+
+Live migration of active dispatches is not supported. PodGroups and some other
+integrations create multiple worker objects, and custom integrations can define
+their own object mapping.
+
+Before upgrading, audit every custom `MultiKueueAdapter`. The worker client
+passed to adapters is now restricted to the adapter's declared GVK and to
+operations that can enforce the MultiKueue origin, manager-object UID, Workload
+association, worker UID, and resource version. Cross-GVK access, subresource
+reads, apply operations, and alternate subresource bodies fail closed. Update
+an incompatible adapter before re-enabling submissions; draining active work
+does not make those operations compatible.
+
+Use this upgrade sequence:
+
+1. Stop new MultiKueue submissions and prevent old and new manager replicas
+   from becoming leader concurrently.
+2. Let every active MultiKueue Workload finish and verify that its remote
+   Workload and execution objects have been cleaned up on every worker.
+3. Upgrade all manager replicas.
+4. Re-enable submissions only after an upgraded replica is leader.
+
+If a legacy object remains, the upgraded manager rejects and preserves it for
+administrator review because it has no verifiable manager-object UID. Remove
+such an object manually only after confirming that it is not part of a live
+dispatch. Do not add the annotation as a generic migration step: each remote
+execution object needs the UID of its specific manager object, which is not
+necessarily the manager Workload UID.

--- a/site/data/labels_and_annotations.yaml
+++ b/site/data/labels_and_annotations.yaml
@@ -150,9 +150,10 @@
   used_on: |
     [MultiKueue](/docs/concepts/multikueue/).
   description: |
-    The annotation stores the UID of the original object from the management cluster on remote objects
-    in worker clusters. Used by job types (e.g., LeaderWorkerSet) that generate workload names based on
-    their UID, ensuring workload names match between management and worker clusters.
+    The annotation stores the UID of the exact original object from the management cluster on corresponding
+    remote objects in worker clusters. Remote Workloads record the manager Workload UID; adapter-declared
+    execution objects record their manager execution-object UID. For a PodGroup, each remote Pod records the
+    UID of its same-name manager Pod. MultiKueue requires this binding for synchronization and cleanup.
 
 - key: kueue.x-k8s.io/pod-group-fast-admission
   type: Annotation

--- a/test/integration/multikueue/pod_test.go
+++ b/test/integration/multikueue/pod_test.go
@@ -33,8 +33,10 @@ import (
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	workloadpod "sigs.k8s.io/kueue/pkg/controller/jobs/pod"
 	"sigs.k8s.io/kueue/pkg/util/admissioncheck"
+	utilapi "sigs.k8s.io/kueue/pkg/util/api"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
@@ -275,6 +277,96 @@ var _ = ginkgo.Describe("MultiKueue Pod", ginkgo.Label("area:multikueue", "featu
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			}
 			waitForWorkloadToFinishAndRemoteWorkloadToBeDeleted(wlLookupKey, "Pods succeeded: 3/3.")
+		})
+	})
+
+	ginkgo.It("Should preserve a colliding worker PodGroup member", func() {
+		groupName := "collision-group"
+		podGroup := testingpod.MakePod(groupName, f.managerNs.Name).
+			Queue(f.managerLq.Name).
+			ManagedByKueueLabel().
+			KueueFinalizer().
+			KueueSchedulingGate().
+			MakeGroup(3)
+		for _, pod := range podGroup {
+			util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, pod)
+		}
+
+		wlKey := types.NamespacedName{Name: groupName, Namespace: f.managerNs.Name}
+		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).
+			PodSets(utiltestingapi.MakePodSetAssignment("bf90803c").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Count(3).Obj()).
+			Obj()
+
+		ginkgo.By("dispatching the Workload before the worker admits it", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlKey, &kueue.Workload{})).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			util.SetQuotaReservation(managerTestCluster.ctx, managerTestCluster.client, wlKey, admission)
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, wlKey, &kueue.Workload{})).To(gomega.Succeed())
+				g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, wlKey, &kueue.Workload{})).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		victimKey := client.ObjectKeyFromObject(podGroup[2])
+		victim := testingpod.MakePod(victimKey.Name, victimKey.Namespace).Obj()
+		util.MustCreate(worker1TestCluster.ctx, worker1TestCluster.client, victim)
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, victimKey, victim)).To(gomega.Succeed())
+			victim.Status.Phase = corev1.PodRunning
+			g.Expect(worker1TestCluster.client.Status().Update(worker1TestCluster.ctx, victim)).To(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		victimUID := victim.UID
+		for i := range 2 {
+			remotePod := &corev1.Pod{
+				ObjectMeta: utilapi.CloneObjectMetaForCreation(&podGroup[i].ObjectMeta),
+				Spec:       *podGroup[i].Spec.DeepCopy(),
+			}
+			jobframework.SetMultiKueueMeta(remotePod, groupName, "multikueue")
+			util.MustCreate(worker1TestCluster.ctx, worker1TestCluster.client, remotePod)
+		}
+
+		ginkgo.By("admitting the worker Workload and rejecting the colliding member", func() {
+			util.SetQuotaReservation(worker1TestCluster.ctx, worker1TestCluster.client, wlKey, admission)
+			gomega.Eventually(func(g gomega.Gomega) {
+				remoteAnchor := &corev1.Pod{}
+				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, client.ObjectKeyFromObject(podGroup[0]), remoteAnchor)).To(gomega.Succeed())
+				remoteAnchor.Status.Phase = corev1.PodRunning
+				g.Expect(worker1TestCluster.client.Status().Update(worker1TestCluster.ctx, remoteAnchor)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			gomega.Eventually(func(g gomega.Gomega) {
+				managerAnchor := &corev1.Pod{}
+				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, client.ObjectKeyFromObject(podGroup[0]), managerAnchor)).To(gomega.Succeed())
+				g.Expect(managerAnchor.Status.Phase).To(gomega.Equal(corev1.PodRunning))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			gomega.Consistently(func(g gomega.Gomega) {
+				managerPod := &corev1.Pod{}
+				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, victimKey, managerPod)).To(gomega.Succeed())
+				g.Expect(managerPod.Status.Phase).NotTo(gomega.Equal(corev1.PodRunning))
+				workerPod := &corev1.Pod{}
+				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, victimKey, workerPod)).To(gomega.Succeed())
+				g.Expect(workerPod.UID).To(gomega.Equal(victimUID))
+			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("cleaning up legitimate remote objects without deleting the victim", func() {
+			util.SetQuotaReservation(managerTestCluster.ctx, managerTestCluster.client, wlKey, nil)
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, wlKey, &kueue.Workload{})).To(utiltesting.BeNotFoundError())
+				anchor := &corev1.Pod{}
+				if err := worker1TestCluster.client.Get(worker1TestCluster.ctx, client.ObjectKeyFromObject(podGroup[0]), anchor); err == nil {
+					// The worker Pod controller can keep a malformed group's Pods in
+					// Terminating while it reports that the group has too few runnable
+					// members. A deletion timestamp is sufficient to prove MultiKueue
+					// targeted the legitimate anchor for cleanup.
+					g.Expect(anchor.DeletionTimestamp.IsZero()).To(gomega.BeFalse())
+				} else {
+					g.Expect(err).To(utiltesting.BeNotFoundError())
+				}
+				workerPod := &corev1.Pod{}
+				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, victimKey, workerPod)).To(gomega.Succeed())
+				g.Expect(workerPod.UID).To(gomega.Equal(victimUID))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})
 

--- a/test/integration/multikueue/pod_test.go
+++ b/test/integration/multikueue/pod_test.go
@@ -323,6 +323,10 @@ var _ = ginkgo.Describe("MultiKueue Pod", ginkgo.Label("area:multikueue", "featu
 				Spec:       *podGroup[i].Spec.DeepCopy(),
 			}
 			jobframework.SetMultiKueueMeta(remotePod, groupName, "multikueue")
+			if remotePod.Annotations == nil {
+				remotePod.Annotations = make(map[string]string, 1)
+			}
+			remotePod.Annotations[kueue.MultiKueueOriginUIDAnnotation] = string(podGroup[i].UID)
 			util.MustCreate(worker1TestCluster.ctx, worker1TestCluster.client, remotePod)
 		}
 

--- a/test/integration/singlecluster/controller/core/multikueue_remote_identity_test.go
+++ b/test/integration/singlecluster/controller/core/multikueue_remote_identity_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"context"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+type deletingConfigMapAdapter struct{}
+
+func (*deletingConfigMapAdapter) SyncJob(context.Context, client.Client, client.Client, types.NamespacedName, string, string) (bool, error) {
+	return false, nil
+}
+
+func (*deletingConfigMapAdapter) DeleteRemoteObject(ctx context.Context, _ client.Client, remoteClient client.Client, key types.NamespacedName) error {
+	return remoteClient.Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace}})
+}
+
+func (*deletingConfigMapAdapter) IsJobManagedByKueue(context.Context, client.Client, types.NamespacedName) (bool, string, error) {
+	return true, "", nil
+}
+
+func (*deletingConfigMapAdapter) GVK() schema.GroupVersionKind {
+	return corev1.SchemeGroupVersion.WithKind("ConfigMap")
+}
+
+var _ = ginkgo.Describe("MultiKueue remote object identity", ginkgo.Label("area:multikueue", "feature:multikueue"), func() {
+	var namespace *corev1.Namespace
+
+	ginkgo.BeforeEach(func() {
+		namespace = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "multikueue-identity-")
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, namespace)).To(gomega.Succeed())
+	})
+
+	ginkgo.It("preserves a replacement when deletion races after identity validation", func() {
+		baseClient, err := client.NewWithWatch(cfg, client.Options{Scheme: k8sClient.Scheme(), Mapper: k8sClient.RESTMapper()})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		const (
+			origin       = "manager-origin"
+			workloadName = "manager-workload"
+			managerUID   = "manager-job-uid"
+		)
+		key := types.NamespacedName{Name: "delete-race", Namespace: namespace.Name}
+		makeConfigMap := func() *corev1.ConfigMap {
+			return &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      key.Name,
+					Namespace: key.Namespace,
+					Labels: map[string]string{
+						kueue.MultiKueueOriginLabel:               origin,
+						controllerconstants.PrebuiltWorkloadLabel: workloadName,
+					},
+					Annotations: map[string]string{kueue.MultiKueueOriginUIDAnnotation: managerUID},
+				},
+			}
+		}
+
+		original := makeConfigMap()
+		gomega.Expect(baseClient.Create(ctx, original)).To(gomega.Succeed())
+		originalUID := original.UID
+		gomega.Expect(originalUID).NotTo(gomega.BeEmpty())
+
+		replaced := false
+		racingClient := interceptor.NewClient(baseClient, interceptor.Funcs{
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				if client.ObjectKeyFromObject(obj) != key || replaced {
+					return c.Delete(ctx, obj, opts...)
+				}
+				replaced = true
+				current := &corev1.ConfigMap{}
+				if err := c.Get(ctx, key, current); err != nil {
+					return err
+				}
+				if err := c.Delete(ctx, current, client.GracePeriodSeconds(0)); err != nil {
+					return err
+				}
+				if err := wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+					err := c.Get(ctx, key, &corev1.ConfigMap{})
+					return apierrors.IsNotFound(err), client.IgnoreNotFound(err)
+				}); err != nil {
+					return err
+				}
+				if err := c.Create(ctx, makeConfigMap()); err != nil {
+					return err
+				}
+				return c.Delete(ctx, obj, opts...)
+			},
+		})
+
+		err = jobframework.DeleteRemoteObjectWithCleanupContextIfOwned(
+			ctx,
+			baseClient,
+			racingClient,
+			&deletingConfigMapAdapter{},
+			key,
+			jobframework.MultiKueueRemoteObjectCleanupContext{
+				RemoteObjectUID: originalUID,
+				Association: jobframework.MultiKueueObjectAssociation{
+					Origin:           origin,
+					WorkloadName:     workloadName,
+					ManagerObjectUID: managerUID,
+				},
+				WorkloadKey: types.NamespacedName{Name: workloadName, Namespace: key.Namespace},
+			},
+		)
+		gomega.Expect(err).To(gomega.MatchError(apierrors.IsConflict, "API-server UID precondition conflict"))
+
+		replacement := &corev1.ConfigMap{}
+		gomega.Expect(baseClient.Get(ctx, key, replacement)).To(gomega.Succeed())
+		gomega.Expect(replacement.UID).NotTo(gomega.Equal(originalUID))
+	})
+})


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area multikueue

#### What this PR does / why we need it:

This change prevents MultiKueue from adopting, reading, mutating, or deleting a same-name worker object based only on public origin metadata.

It:

- binds every remote Workload to the exact manager Workload UID;
- binds each adapter execution object, including every PodGroup member, to the manager object UID retained by the admitted Workload;
- cross-checks live manager identities with the uncached API reader;
- runs adapters through an identity-guarded worker client with worker UID and resource-version checks;
- makes garbage collection fail closed on missing, conflicting, or replaced identities and uses UID delete preconditions;
- serializes in-process reconcile and garbage-collection lifecycle work and rechecks manager Workload liveness around worker writes;
- documents the custom-adapter contract, drained upgrade sequence, and residual trust boundary.

This PR is stacked on #14753. The current diff includes that draft PR because its head branch exists only in the contributor fork; after #14753 merges, this PR can be rebased onto `main` and the PodGroup-only commits will disappear from the diff.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

Security-sensitive paths have malicious and legitimate regression pairs for remote Workloads, Jobs, external unstructured adapters, LeaderWorkerSet, RayCluster, PodGroups, create races, replacement races, cleanup, and garbage collection.

Verification completed on the exact pushed commit:

- focused unit suites for jobframework, MultiKueue, external adapters, Job, LeaderWorkerSet, Pod, and RayCluster;
- the same security-sensitive packages under the race detector;
- focused `go vet` and repository-pinned golangci-lint with zero issues;
- compile-only checks for MultiKueue integration and e2e packages;
- a live API-server UID-precondition replacement race;
- the live three-cluster PodGroup collision regression;
- `git diff --check upstream/main`.

Three independent read-only reviews of the exact commit found no remaining security, structural/API, or test-strategy shipping blocker.

This change was developed with assistance from OpenAI Codex. I reviewed the implementation, tests, generated diff, and published commit.

#### Does this PR introduce a user-facing change?

```release-note
action required: Before upgrading MultiKueue, drain active remote dispatches and do not run old and new manager leaders concurrently. Custom MultiKueue adapters must use only identity-guardable operations on their declared GVK; cross-GVK access, apply operations, subresource reads, and unguardable writes now fail closed.
```