### PR TITLE
Reuse DRS zero-weight-borrows check in fair sharing preemption

### DIFF
--- a/pkg/cache/scheduler/fair_sharing.go
+++ b/pkg/cache/scheduler/fair_sharing.go
@@ -111,11 +111,11 @@ func (d DRS) PreciseWeightedShareSerialized() string {
 // a higher value preferred for preemption.
 func CompareDRS(a, b DRS) int {
 	switch {
-	case a.zeroWeightBorrows() && b.zeroWeightBorrows():
+	case a.ZeroWeightBorrows() && b.ZeroWeightBorrows():
 		return cmp.Compare(a.unweightedRatio, b.unweightedRatio)
-	case a.zeroWeightBorrows():
+	case a.ZeroWeightBorrows():
 		return 1
-	case b.zeroWeightBorrows():
+	case b.ZeroWeightBorrows():
 		return -1
 	default:
 		return cmp.Compare(a.PreciseWeightedShare(), b.PreciseWeightedShare())
@@ -132,7 +132,7 @@ func CompareDRS(a, b DRS) int {
 // or Cohort is borrowing, we return math.MaxInt.
 func (d DRS) roundedWeightedShare() (int64, corev1.ResourceName) {
 	var weightedShare int64
-	if d.zeroWeightBorrows() {
+	if d.ZeroWeightBorrows() {
 		weightedShare = math.MaxInt64
 	} else {
 		weightedShare = int64(math.Ceil(d.PreciseWeightedShare()))
@@ -140,9 +140,10 @@ func (d DRS) roundedWeightedShare() (int64, corev1.ResourceName) {
 	return weightedShare, d.dominantResource
 }
 
-// zeroWeightBorrows returns whether this DRS represents a
+// ZeroWeightBorrows returns whether this DRS represents a
 // borrowing state for a ClusterQueue/Cohort with a zero weight.
-func (d DRS) zeroWeightBorrows() bool {
+// This is equivalent to PreciseWeightedShare returning +Inf.
+func (d DRS) ZeroWeightBorrows() bool {
 	return d.isWeightZero() && !d.IsZero()
 }
 

--- a/pkg/cache/scheduler/fair_sharing_test.go
+++ b/pkg/cache/scheduler/fair_sharing_test.go
@@ -983,6 +983,33 @@ func TestIsBorrowingOn(t *testing.T) {
 	}
 }
 
+func TestZeroWeightBorrows(t *testing.T) {
+	cases := map[string]struct {
+		drs  DRS
+		want bool
+	}{
+		"zero weight and borrowing returns true": {
+			drs:  DRS{fairWeight: 0, unweightedRatio: 100},
+			want: true,
+		},
+		"zero weight and not borrowing returns false": {
+			drs:  DRS{fairWeight: 0, unweightedRatio: 0},
+			want: false,
+		},
+		"non-zero weight and borrowing returns false": {
+			drs:  DRS{fairWeight: 1, unweightedRatio: 100},
+			want: false,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := tc.drs.ZeroWeightBorrows(); got != tc.want {
+				t.Errorf("ZeroWeightBorrows() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestPreciseWeightedShareSerialized(t *testing.T) {
 	cases := map[string]struct {
 		drs  DRS

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -20,7 +20,6 @@ import (
 	"cmp"
 	"context"
 	"fmt"
-	"math"
 	"slices"
 	"strings"
 	"sync/atomic"
@@ -492,8 +491,8 @@ func runFirstFsStrategy(preemptionCtx *preemptionCtx, candidates []*workload.Inf
 //     is not +Inf before removal is therefore not +Inf after removal either,
 //     and CompareDRS returns 1 for it as well.
 func fsStrategyUnsatisfiable(preemptorNewShare fairsharing.PreemptorNewShare, targetOldShare fairsharing.TargetOldShare) bool {
-	return math.IsInf(schdcache.DRS(preemptorNewShare).PreciseWeightedShare(), 1) &&
-		!math.IsInf(schdcache.DRS(targetOldShare).PreciseWeightedShare(), 1)
+	return schdcache.DRS(preemptorNewShare).ZeroWeightBorrows() &&
+		!schdcache.DRS(targetOldShare).ZeroWeightBorrows()
 }
 
 // runSecondFsStrategy implements Fair Sharing Rule S2-b. It returns


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
fsStrategyUnsatisfiable used math.IsInf on PreciseWeightedShare to detect an infinite DominantResourceShare. The cache already has this logic as the unexported zeroWeightBorrows method, so export it and call it directly instead of recomputing through PreciseWeightedShare.

PreciseWeightedShare returns +Inf exactly when isWeightZero() and not IsZero(), the same condition zeroWeightBorrows checks. FairSharing preemption tests still pass unchanged, and a new ZeroWeightBorrows table test covers the borrowing, non-borrowing, and non-zero-weight cases.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14675 

#### Special notes for your reviewer:
This is a follow-up to the review comment on #14490. 
Also linking specific comment https://github.com/kubernetes-sigs/kueue/pull/14490#discussion_r3819570881.
I have also tested my code across the unit test suite and it passes.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
________
Disclosure : AI assistance was used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved detection of zero-weight borrowing in scheduling and preemption decisions.
  * Made zero-weight borrowing status available for broader internal use.

* **Tests**
  * Added coverage for zero-weight borrowing, non-borrowing, and non-zero-weight scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->