### PR TITLE
[release-0.18] Gate the reserved pods name validation behind an alpha feature gate

### DIFF
--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -425,6 +425,7 @@ func validateResourceTransformations(c *configapi.Configuration) field.ErrorList
 	}
 	var allErrs field.ErrorList
 	seenKeys := make(sets.Set[corev1.ResourceName])
+	refuseReserved := features.Enabled(features.ReservedResourceNameValidation)
 	for idx, transform := range res.Transformations {
 		strategy := ptr.Deref(transform.Strategy, "")
 		if strategy != configapi.Retain && strategy != configapi.Replace {
@@ -437,21 +438,24 @@ func validateResourceTransformations(c *configapi.Configuration) field.ErrorList
 			seenKeys.Insert(transform.Input)
 		}
 		// pods is reserved for the request Kueue synthesizes from the PodSet
-		// count, so a transformation must not name it in any position.
-		if transform.Input == corev1.ResourcePods {
-			allErrs = append(allErrs, field.Invalid(
-				resourceTransformationPath.Index(idx).Child("input"),
-				transform.Input, reservedResourceNameMsg))
-		}
-		if _, ok := transform.Outputs[corev1.ResourcePods]; ok {
-			allErrs = append(allErrs, field.Invalid(
-				resourceTransformationPath.Index(idx).Child("outputs").Key(string(corev1.ResourcePods)),
-				corev1.ResourcePods, reservedResourceNameMsg))
-		}
-		if transform.MultiplyBy == corev1.ResourcePods {
-			allErrs = append(allErrs, field.Invalid(
-				resourceTransformationPath.Index(idx).Child("multiplyBy"),
-				transform.MultiplyBy, reservedResourceNameMsg))
+		// count, so a transformation must not name it in any position. Held
+		// behind the gate here, since a release before it accepted all three.
+		if refuseReserved {
+			if transform.Input == corev1.ResourcePods {
+				allErrs = append(allErrs, field.Invalid(
+					resourceTransformationPath.Index(idx).Child("input"),
+					transform.Input, reservedResourceNameMsg))
+			}
+			if _, ok := transform.Outputs[corev1.ResourcePods]; ok {
+				allErrs = append(allErrs, field.Invalid(
+					resourceTransformationPath.Index(idx).Child("outputs").Key(string(corev1.ResourcePods)),
+					corev1.ResourcePods, reservedResourceNameMsg))
+			}
+			if transform.MultiplyBy == corev1.ResourcePods {
+				allErrs = append(allErrs, field.Invalid(
+					resourceTransformationPath.Index(idx).Child("multiplyBy"),
+					transform.MultiplyBy, reservedResourceNameMsg))
+			}
 		}
 	}
 	return allErrs
@@ -469,6 +473,7 @@ func validateDeviceClassMappings(c *configapi.Configuration) field.ErrorList {
 		allErrs = append(allErrs, field.TooMany(dynamicResourceAllocationPath, len(mappings), 16))
 	}
 
+	refuseReserved := features.Enabled(features.ReservedResourceNameValidation)
 	seenResourceNames := make(sets.Set[corev1.ResourceName])
 	deviceClassToResource := make(map[corev1.ResourceName]corev1.ResourceName)
 
@@ -486,7 +491,7 @@ func validateDeviceClassMappings(c *configapi.Configuration) field.ErrorList {
 		// pods is reserved for the request Kueue synthesizes from the PodSet count.
 		// Only behind the gate: the mapper is built there, so until then the name
 		// is dormant and refusing it would fail an unrelated upgrade.
-		if features.Enabled(features.KueueDRAIntegration) && mapping.Name == corev1.ResourcePods {
+		if refuseReserved && features.Enabled(features.KueueDRAIntegration) && mapping.Name == corev1.ResourcePods {
 			allErrs = append(allErrs, field.Invalid(mappingPath.Child("name"), mapping.Name, reservedResourceNameMsg))
 		}
 

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1196,7 +1196,7 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		"device class mapping named pods rejected when DRA is enabled": {
-			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegration: true},
+			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegration: true, features.ReservedResourceNameValidation: true},
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				Resources: &configapi.Resources{
@@ -1235,7 +1235,7 @@ func TestValidate(t *testing.T) {
 		// Transformations are installed whatever the DRA gate says, so the name is
 		// refused there whatever it says too.
 		"transformation output named pods rejected when DRA is disabled": {
-			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegration: false},
+			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegration: false, features.ReservedResourceNameValidation: true},
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				Resources: &configapi.Resources{
@@ -1256,6 +1256,7 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		"transformation output named pods rejected": {
+			featureGates: map[featuregate.Feature]bool{features.ReservedResourceNameValidation: true},
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				Resources: &configapi.Resources{
@@ -1276,6 +1277,7 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		"transformation taking pods as input rejected": {
+			featureGates: map[featuregate.Feature]bool{features.ReservedResourceNameValidation: true},
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				Resources: &configapi.Resources{
@@ -1296,6 +1298,7 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		"transformation multiplying by pods rejected": {
+			featureGates: map[featuregate.Feature]bool{features.ReservedResourceNameValidation: true},
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				Resources: &configapi.Resources{
@@ -1316,7 +1319,35 @@ func TestValidate(t *testing.T) {
 				},
 			},
 		},
+		// The upgrade this branch has to survive: a configuration 0.18.0 through
+		// 0.18.6 accepted, loaded by a manager that refuses it only when asked to.
+		"every position naming pods is accepted while the gate is off": {
+			featureGates: map[featuregate.Feature]bool{
+				features.ReservedResourceNameValidation: false,
+				features.KueueDRAIntegration:            true,
+			},
+			cfg: &configapi.Configuration{
+				Integrations: defaultIntegrations,
+				Resources: &configapi.Resources{
+					Transformations: []configapi.ResourceTransformation{
+						{
+							Input:      corev1.ResourcePods,
+							Strategy:   new(configapi.Retain),
+							MultiplyBy: corev1.ResourcePods,
+							Outputs:    corev1.ResourceList{corev1.ResourcePods: resource.MustParse("1")},
+						},
+					},
+					DeviceClassMappings: []configapi.DeviceClassMapping{
+						{
+							Name:             corev1.ResourcePods,
+							DeviceClassNames: []corev1.ResourceName{"gpu.example.com"},
+						},
+					},
+				},
+			},
+		},
 		"transformation naming pods twice reports both": {
+			featureGates: map[featuregate.Feature]bool{features.ReservedResourceNameValidation: true},
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				Resources: &configapi.Resources{
@@ -1344,6 +1375,7 @@ func TestValidate(t *testing.T) {
 		// Reported per entry rather than once for the Configuration, and in the
 		// order the transformations are written.
 		"pods reported for each transformation naming it": {
+			featureGates: map[featuregate.Feature]bool{features.ReservedResourceNameValidation: true},
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				Resources: &configapi.Resources{

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -208,6 +208,13 @@ const (
 	// Deprecated: planned to be removed in 0.19. Use KueueDRAIntegrationExtendedResource instead.
 	DRAExtendedResources featuregate.Feature = "DRAExtendedResources"
 
+	// owner: @thc1006
+	//
+	// Refuse `pods` as a deviceClassMappings name or in a resource transformation.
+	// Releases through 0.18.6 accepted it, and refusing it calls os.Exit, so this
+	// branch holds the refusal until those entries are renamed.
+	ReservedResourceNameValidation featuregate.Feature = "ReservedResourceNameValidation"
+
 	// owner: @MaysaMacedo
 	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/7513-quota-check-strategy
 	//
@@ -746,6 +753,9 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	DRAExtendedResources: {
 		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("0.18"), Default: false, PreRelease: featuregate.Deprecated, LockToDefault: true}, // remove in 0.19
+	},
+	ReservedResourceNameValidation: {
+		{Version: version.MustParse("0.18"), Default: false, PreRelease: featuregate.Alpha},
 	},
 
 	KueueDRARejectWorkloadsWhenDRADisabled: {

--- a/pkg/features/kube_features_test.go
+++ b/pkg/features/kube_features_test.go
@@ -30,3 +30,11 @@ func TestFeatureGate(t *testing.T) {
 		t.Error("feature gate should be disabled")
 	}
 }
+
+// A cluster upgrading into this branch keeps a configuration that named the
+// reserved key, so the refusal has to stay off until it is asked for.
+func TestReservedResourceNameValidationDefaultsOff(t *testing.T) {
+	if utilfeature.DefaultFeatureGate.Enabled(ReservedResourceNameValidation) {
+		t.Error("ReservedResourceNameValidation is on by default; upgrading a configuration that names pods would exit the manager")
+	}
+}

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -401,6 +401,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.17"
+- name: ReservedResourceNameValidation
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.18"
 - name: SanitizePodSets
   versionedSpecs:
   - default: true

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -401,6 +401,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.17"
+- name: ReservedResourceNameValidation
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.18"
 - name: SanitizePodSets
   versionedSpecs:
   - default: true


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/area dra

#### What this PR does / why we need it:

#14758 backported the refusal of `pods` as a reserved resource name to this branch. Every release up to and including v0.18.6 accepted a configuration that names it:

- `resources.transformations[].input: pods`
- `resources.transformations[].multiplyBy: pods`
- `resources.transformations[].outputs: {pods: 1}`
- `resources.deviceClassMappings[].name: pods`

Configuration validation failure calls `os.Exit`, so a cluster carrying one of those and upgrading to the next patch release gets a crashlooping `kueue-controller-manager` for a file that was valid when it was written. The mapping case reaches operators who never opted in, since `KueueDRAIntegration` has defaulted on since 0.18.

This holds the refusal behind an alpha gate, `ReservedResourceNameValidation`, defaulted off. An operator turns it on once the entries are renamed. `main` keeps the refusal unconditional, so nothing here changes what a 0.20 cluster does.

#### Which issue(s) this PR fixes:

Fixes #14763

#### Special notes for your reviewer:

The four positions sit in two functions, and each reads the gate once rather than per position, so they cannot disagree about whether the name is refused on this branch.

Two cases carry it. One walks all four positions with the gate off and expects the configuration to load, which is the upgrade this branch has to survive. The other pins the default, because the first sets the value explicitly and would not notice the default moving. Flipping `Default` to `true` fails only the second.

The same change is on `release-0.19` as its own PR; the two are identical apart from the version the gate is registered from.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### AI usage

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.
