### PR TITLE
Fix Scheduling Equivalence Hashing under UsageBasedAdmissionFairSharing

### DIFF
--- a/keps/9694-scheduling-equivalence-hashing/README.md
+++ b/keps/9694-scheduling-equivalence-hashing/README.md
@@ -161,7 +161,7 @@ diagnostics, or add overhead, but cannot admit a Workload incorrectly.
 | Risk | Worst case | Mitigation | Status |
 |---|---|---|---|
 | [ElasticJobsViaWorkloadSlices shape gap](#elasticjobsviaworkloadslices) | A schedulable replacement is repeatedly deferred | Model replacement state or exclude replacements | **Open** |
-| [UsageBasedAdmissionFairSharing timestamp gap](#usagebasedadmissionfairsharing) | A Workload that can preempt is repeatedly deferred | Include the timestamp or exclude the combination | **Open** |
+| [UsageBasedAdmissionFairSharing timestamp gap](#usagebasedadmissionfairsharing) | A Workload that can preempt is repeatedly deferred | Exclude PreemptionNoCandidates in ClusterQueues that order by LocalQueue usage | Mitigated |
 | [Overly broad failure classification](#overly-broad-failure-classification) | Valid class members are deferred | Allowlist class-wide requeue reasons | Mitigated |
 | [Stale failed-class records](#stale-failed-class-records) | A class remains deferred after conditions change | Clear failed records on retry or restart | Mitigated |
 | [Identifier collision](#identifier-collision) | A colliding shape is repeatedly delayed or starved | Use a 64-bit SHA-256 prefix | Accepted |
@@ -169,7 +169,7 @@ diagnostics, or add overhead, but cannot admit a Workload incorrectly.
 | [Reduced diagnostics for bypassed Workloads](#reduced-diagnostics-for-bypassed-workloads) | A bypassed Workload lacks a detailed diagnosis | Preserve the representative's reason | Mitigated |
 | [Additional memory and queue work](#additional-memory-and-queue-work) | Pending state and heap scans add overhead | Bound records to classes between retries | Accepted |
 
-Only the two scheduling-shape gaps are open. The subsections below provide the
+One scheduling-shape gap remains open. The subsections below provide the
 trigger, user impact, mitigation, and residual risk for each row.
 
 #### Incomplete scheduling shape
@@ -184,8 +184,9 @@ trigger, user impact, mitigation, and residual risk for each row.
 3. **Mitigation:** Every new scheduling input must either be represented in the
    shape or cause the affected outcome to be excluded from class-wide handling.
 4. **Residual risk:** The current shape includes Pod placement and effective
-   requests, but does not model every input used by all scheduling paths. Two
-   known cases remain.
+   requests, but does not model every input used by all scheduling paths. One
+   known case remains open; a second was resolved by excluding the affected
+   outcome from class-wide handling rather than extending the shape.
 
 ##### ElasticJobsViaWorkloadSlices
 
@@ -224,11 +225,32 @@ trigger, user impact, mitigation, and residual risk for each row.
    | V | t1 | admitted | preemption target |
    | B | t2 | pending, evaluated first because it belongs to a lower-usage LocalQueue | cannot preempt V because V is older than B |
 
-3. **Mitigation:** Before stable, either include the queue-order timestamp in
-   the scheduling shape or exclude this feature combination from class-wide
-   handling.
-4. **Residual risk:** Until then, B can record PreemptionNoCandidates and defer
-   A despite A being able to preempt V.
+3. **Mitigation:** When usage-based ordering is in effect for the ClusterQueue,
+   a `PreemptionNoCandidates` result no longer creates a failed-class record or
+   triggers bulk movement; the affected Workload is evaluated individually
+   instead. `NoFit` is unaffected, because quota fit does not depend on
+   queue-order timestamp. The exclusion is keyed on whether the ClusterQueue
+   actually pops by LocalQueue usage, which requires all three of
+   `AdmissionScope.AdmissionMode` set to `UsageBasedAdmissionFairSharing`, an
+   `admissionFairSharing` block in the Configuration, and the
+   `AdmissionFairSharing` feature gate. This is the same value the queue's
+   ordering comparator is built from, so the exclusion cannot disagree with the
+   pop order it protects. A narrower exclusion, limited to ClusterQueues that
+   also use the `LowerOrNewerEqualPriority` preemption policy, is possible: the
+   scheduler holds the ClusterQueue snapshot, and with it the preemption policy,
+   at the point it sets the requeue reason. The coarser form is a choice rather
+   than a constraint. The queue layer decides bulk movement from ordering state
+   it already owns, rather than reaching for an input the scheduler would have
+   to hand down. The wider coverage costs optimization, not safety.
+4. **Residual risk:** None for the triggering scenario. ClusterQueues that
+   actually order by LocalQueue usage but use a preemption policy other than
+   `LowerOrNewerEqualPriority` lose the `PreemptionNoCandidates` bulk-move
+   optimization even though they were never affected by the underlying gap.
+   ClusterQueues that set `AdmissionScope.AdmissionMode` without
+   `admissionFairSharing` enabled in the Configuration are a distinct case: they
+   still order by effective priority and then queue-order timestamp, so the gap
+   cannot arise, and they retain the optimization rather than paying for a
+   mitigation they do not need.
 
 #### Overly broad failure classification
 
@@ -482,13 +504,16 @@ move an entire class without evaluating its remaining Workloads.
 | v0.19.0 | Equivalence identifier corrected to include Pod-level resource requests when the field is set | bugfix |
 | v0.20.0 | Added the `kueue_pending_scheduling_hashes` gauge, reporting unique active and inadmissible classes per ClusterQueue | observability |
 | v0.20.0 | PodSet name excluded from the scheduling shape, behind the Beta `SchedulingEquivalenceHashingIgnorePodSetName` gate, enabled by default | gate |
+| v0.20.0 | PreemptionNoCandidates excluded from class-wide handling in ClusterQueues that order by LocalQueue usage | bugfix |
 
 ### Test Plan
 
 [x] The owners of the involved components understand that existing tests may
 need updates as scheduling inputs and feature interactions evolve.
 
-This retrospective KEP adds no product code. Existing tests cover the core hash,
+This KEP was originally retrospective and added no product code. Closing an
+open risk from Risks and Mitigations does add product code, as the
+`UsageBasedAdmissionFairSharing` gap did. Existing tests cover the core hash,
 queue transitions, failure-reason allowlist, retry invalidation, deep-queue
 progress, and bypass observability. The known input combinations described in
 Risks and Mitigations are not fully automated today. Future changes must
@@ -520,9 +545,18 @@ Integration coverage must exercise a deep BestEffortFIFO queue in which a large
 group of equivalent, unschedulable Workloads precedes a schedulable Workload.
 It must also verify that relevant cluster-state changes retry the deferred group
 and that namespace, preemption, and observability boundaries retain their
-existing behavior. Before stable, it must exercise the resolved behavior for
-Workload-slice replacement and LowerOrNewerEqualPriority under usage-based
-admission fair sharing.
+existing behavior. Before stable, it must additionally exercise the resolved
+behavior for Workload-slice replacement.
+
+The `UsageBasedAdmissionFairSharing` exclusion is covered at two levels.
+`TestRequeueHashTriggerByReason` in `pkg/cache/queue/cluster_queue_test.go`
+asserts the failed-class record directly at the queue level, including that a
+ClusterQueue setting `AdmissionScope.AdmissionMode` without
+`admissionFairSharing` enabled still bulk-moves on `PreemptionNoCandidates`.
+`TestScheduleForAFS` in `pkg/scheduler/scheduler_afs_test.go` runs the real
+scheduler, queue manager, and cache together to confirm an equivalent Workload
+under `UsageBasedAdmissionFairSharing` is evaluated individually rather than
+bulk-moved without evaluation.
 
 #### End-to-End Tests
 
@@ -552,10 +586,9 @@ Graduation to stable requires:
 - reevaluation of class-wide outcomes for ElasticJobsViaWorkloadSlices and a
   decision to either include the replacement target and relevant state in the
   scheduling shape or exclude affected Workloads from class-wide handling
-- reevaluation of PreemptionNoCandidates class-wide handling when
-  UsageBasedAdmissionFairSharing is combined with LowerOrNewerEqualPriority,
-  and a decision to either include the queue-order timestamp in the scheduling
-  shape or exclude this combination from class-wide handling
+- confirmation that excluding PreemptionNoCandidates in every ClusterQueue
+  that orders by LocalQueue usage is still the right boundary, or a decision to
+  narrow it to the LowerOrNewerEqualPriority preemption policy
 - validated retry triggers for quota, cohort, flavor, topology, admission
   checks, and relevant Pod-capacity changes
 - an explicit decision on whether the current digest size is sufficient for

--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -192,7 +192,12 @@ type ClusterQueue struct {
 
 	clock clock.Clock
 
-	AdmissionScope *kueue.AdmissionScope
+	// enableAdmissionFs reports whether this ClusterQueue actually pops pending
+	// workloads by LocalQueue usage rather than by the queue-order timestamp.
+	// Set once at construction from afs.ResourceWeights, the same value the heap
+	// comparator captured, so the two can never disagree. Immutable after
+	// construction, so it needs no synchronization of its own.
+	enableAdmissionFs bool
 
 	afsUsageLedger *queueafs.AfsUsageLedger
 
@@ -316,6 +321,7 @@ func newClusterQueueImpl(ctx context.Context, client client.Client, cl *metrics.
 		snapshotSort:           snapshotSort,
 		rwm:                    sync.RWMutex{},
 		clock:                  clock,
+		enableAdmissionFs:      options.enableAdmissionFs,
 		afsUsageLedger:         options.afsUsageLedger,
 		lqWeights:              lqWeights,
 		pw:                     &pw,
@@ -545,9 +551,10 @@ func resolveQuotaReservedReason(reason QuotaReservedReason) QuotaReservedReason 
 // or if there was a call to QueueInadmissibleWorkloads after a call to Pop,
 // the workload will be pushed back to heap directly. Otherwise, the workload
 // will be put into the inadmissibleWorkloads.
-// When SchedulingEquivalenceHashing is enabled and the reason is NoFit or
-// PreemptionNoCandidates, equivalent workloads in the heap are bulk-moved
-// to inadmissible.
+// When SchedulingEquivalenceHashing is enabled, equivalent workloads in the
+// heap are bulk-moved to inadmissible if the reason is NoFit, or if the reason
+// is PreemptionNoCandidates and this ClusterQueue does not order by LocalQueue
+// usage.
 func (c *ClusterQueue) requeueIfNotPresent(log logr.Logger, wInfo *workload.Info, immediate bool, reason RequeueReason, quotaReservedReason QuotaReservedReason) bool {
 	c.rwm.Lock()
 	defer c.rwm.Unlock()
@@ -593,8 +600,14 @@ func (c *ClusterQueue) requeueIfNotPresent(log logr.Logger, wInfo *workload.Info
 	}
 	log.V(2).Info(logMsg, "clusterQueue", c.name, "workload", key)
 
+	// PreemptionNoCandidates is excluded when this queue pops by LocalQueue usage:
+	// the scheduling-equivalence shape does not encode the queue-order timestamp,
+	// which under a LowerOrNewerEqualPriority preemption policy decides whether a
+	// workload may preempt an equal-priority victim. Two workloads can therefore
+	// share a hash but not a preemption verdict, so a class-wide conclusion would
+	// defer workloads that are in fact eligible. See Kueue#14231.
 	if features.Enabled(features.SchedulingEquivalenceHashing) && wInfo.SchedulingHash != workload.SchedulingHashUnknown &&
-		(reason == RequeueReasonNoFit || reason == RequeueReasonPreemptionNoCandidates) {
+		(reason == RequeueReasonNoFit || (reason == RequeueReasonPreemptionNoCandidates && !c.enableAdmissionFs)) {
 		if moved := c.handleInadmissibleHash(wInfo.SchedulingHash, resolveQuotaReservedReason(quotaReservedReason)); moved > 0 {
 			log.V(2).Info("Bulk-moved equivalent workloads to inadmissible", "hash", wInfo.SchedulingHash, "movedCount", moved)
 		}

--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -2107,9 +2107,15 @@ func TestQueueInadmissibleWorkloadsClearsHashes(t *testing.T) {
 }
 
 func TestRequeueHashTriggerByReason(t *testing.T) {
+	usageBasedAFS := &kueue.AdmissionScope{AdmissionMode: kueue.UsageBasedAdmissionFairSharing}
+
 	tests := map[string]struct {
-		reason   RequeueReason
-		wantHash bool
+		reason RequeueReason
+		// admissionScope and afsConfig must both be set for the ClusterQueue to
+		// actually order by LocalQueue usage; see afs.ResourceWeights.
+		admissionScope *kueue.AdmissionScope
+		afsConfig      *config.AdmissionFairSharing
+		wantHash       bool
 	}{
 		"nofit triggers hash": {
 			reason:   RequeueReasonNoFit,
@@ -2131,20 +2137,47 @@ func TestRequeueHashTriggerByReason(t *testing.T) {
 			reason:   RequeueReasonGeneric,
 			wantHash: false,
 		},
+		"nofit triggers hash under usage-based admission fair sharing": {
+			reason:         RequeueReasonNoFit,
+			admissionScope: usageBasedAFS,
+			afsConfig:      &config.AdmissionFairSharing{},
+			wantHash:       true,
+		},
+		"preempt no candidates does not trigger hash under usage-based admission fair sharing": {
+			// The scheduling shape omits the queue-order timestamp that
+			// UsageBasedAdmissionFairSharing's LocalQueue-usage-first pop order can
+			// reorder relative to LowerOrNewerEqualPriority preemption eligibility, so a
+			// class-wide PreemptionNoCandidates conclusion is unsafe here. See Kueue#14231.
+			reason:         RequeueReasonPreemptionNoCandidates,
+			admissionScope: usageBasedAFS,
+			afsConfig:      &config.AdmissionFairSharing{},
+			wantHash:       false,
+		},
+		"preempt no candidates triggers hash when admission mode is set but admission fair sharing is not configured": {
+			// Without admissionFairSharing in the Configuration the queue still pops
+			// oldest-first, so the queue-order timestamp gap does not apply and the
+			// optimization must be retained.
+			reason:         RequeueReasonPreemptionNoCandidates,
+			admissionScope: usageBasedAFS,
+			afsConfig:      nil,
+			wantHash:       true,
+		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			features.SetFeatureGateDuringTest(t, features.SchedulingEquivalenceHashing, true)
+			features.SetFeatureGateDuringTest(t, features.AdmissionFairSharing, true)
 			ctx, log := utiltesting.ContextWithLog(t)
 			cq, _ := newClusterQueue(ctx, nil,
 				&kueue.ClusterQueue{
 					Spec: kueue.ClusterQueueSpec{
 						QueueingStrategy: kueue.BestEffortFIFO,
+						AdmissionScope:   tc.admissionScope,
 					},
 				}, nil,
 				workload.Ordering{PodsReadyRequeuingTimestamp: config.EvictionTimestamp},
-				nil, nil)
+				tc.afsConfig, nil)
 
 			wl := utiltestingapi.MakeWorkload("workload-1", defaultNamespace).
 				Request(corev1.ResourceCPU, "1").Obj()

--- a/pkg/scheduler/scheduler_afs_test.go
+++ b/pkg/scheduler/scheduler_afs_test.go
@@ -621,14 +621,38 @@ func TestScheduleForAFS(t *testing.T) {
 							Obj(),
 					).
 					Obj(),
-				// wl-b2 has no Pending condition because SchedulingEquivalenceHashing
-				// bulk-moves it to inadmissible before individual evaluation.
+				// wl-b2 is individually evaluated even though it shares a scheduling
+				// hash with wl-a2's PreemptionNoCandidates failure: under
+				// UsageBasedAdmissionFairSharing, class-wide bulk movement on
+				// PreemptionNoCandidates is disabled because the scheduling shape
+				// doesn't capture the queue-order timestamp that determines
+				// preemption eligibility. See Kueue#14231.
 				*utiltestingapi.MakeWorkload("wl-b2", "default").
 					Queue("lq-b").
 					PodSets(*utiltestingapi.MakePodSet("one", 1).
 						Request(corev1.ResourceCPU, "4").
 						Obj()).
 					Creation(now.Add(3 * time.Second)).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
+						Message:            "couldn't assign flavors to pod set one: insufficient unused quota for cpu in flavor default, 4 more needed",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadAdmittedReasonNoReservation,
+						Message:            "The workload has no reservation",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "one",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("4"),
+						},
+					}).
 					Obj(),
 			},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
The scheduling-equivalence hash covers effective priority and pod spec, but not the queue-order timestamp. That timestamp is what UsageBasedAdmissionFairSharing uses to pop pending workloads in creation order, and under LowerOrNewerEqualPriority, it's also what decides whether a workload can preempt an equal-priority victim.

So two workloads can hash identically but carry different timestamps. If a class-wide PreemptionNoCandidates verdict fires under UsageBasedAdmissionFairSharing, it can sweep a workload to inadmissible without ever checking it individually. This is a high impact delay bug.

Fix: when a ClusterQueue's AdmissionScope.AdmissionMode is UsageBasedAdmissionFairSharing, PreemptionNoCandidates no longer applies class-wide. Instead, the workload gets evaluated on its own.

This is gated on whether the ClusterQueue effectively order by LocalQueue usage alone, not on the active preemption policy.

Also updating the Scheduling Equivalence Hashing KEP as requested.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14231

#### Special notes for your reviewer:
I performed a full validation run with `go build ./...`, `go vet ./...`, `gofmt -l` on
  changed files which were all clean. `go test ./pkg/...` also had 0 failures across 89
  packages. Additionally I also ran the real envtest-backed integration suites
  directly via `go test` which passed in all cases.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Scheduling: Fixed a bug where a Workload eligible to preempt could be deferred along with its equivalence class, in BestEffortFIFO ClusterQueues using UsageBasedAdmissionFairSharing with a LowerOrNewerEqualPriority preemption policy. Such Workloads are now evaluated individually.
```

______
Disclosure: AI assistance was used while drafting this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduling behavior when usage-based admission fair sharing is enabled and configured.
  * Workloads affected by preemption without candidates are now evaluated individually instead of moved in bulk.
  * Preserved bulk movement when fair-sharing configuration is not enabled.
  * Corrected quota-waiting outcomes, including cases where no reservation is created.

* **Documentation**
  * Updated scheduling guidance, risk information, version history, and validation coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->