### PR TITLE
Fix(Flake): pull-kueue-test-e2e-tas-baseline-release-0-19

### DIFF
--- a/test/e2e/tas/baseline/job_test.go
+++ b/test/e2e/tas/baseline/job_test.go
@@ -18,6 +18,7 @@ package baseline
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -395,7 +396,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for Job", ginkgo.Label(util.Sha
 					g.Expect(tas.TotalDomainCount(
 						scaledWorkload.Status.Admission.PodSetAssignments[0].TopologyAssignment,
 					)).Should(gomega.Equal(int(scaledParallelism)))
-				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+				}, 2*time.Minute, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("verify both job pods are ready", func() {


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test
/kind flake
/area testing


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #14472

#### Special notes for your reviewer:

Gives the controller 30 more seconds to process everything
Most runs complete within 90 seconds, but occasionally (due to cluster load, network latency, etc.) it takes longer
120 seconds provides a safe buffer for these intermittent delays

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the elastic-job scale-up test to use a fixed two-minute timeout for more consistent test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->