### PR TITLE
Let a configuration naming pods defer the reserved-name refusal for one release

### DIFF
--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -560,8 +560,9 @@ const Replace ResourceTransformationStrategy = "Replace"
 
 type ResourceTransformation struct {
 	// Input is the name of the input resource.
-	// It must not be `pods`; that exact name is reserved for Kueue's internal
-	// Pod-count accounting. A qualified name such as `example.com/pods` is allowed.
+	// It must not be `pods` while ReservedResourceNameValidation is enabled; that
+	// exact name is reserved for Kueue's internal Pod-count accounting. A qualified
+	// name such as `example.com/pods` is allowed.
 	Input corev1.ResourceName `json:"input"`
 
 	// Strategy specifies if the input resource should be replaced or retained.
@@ -574,15 +575,16 @@ type ResourceTransformation struct {
 	// amount of the resource indicated by the "input" field when computing
 	// "outputs". It does not change the quantity retained under "input" when
 	// "strategy" is Retain.
-	// It must not be `pods`; that exact name is reserved for Kueue's internal
-	// Pod-count accounting. A qualified name such as `example.com/pods` is allowed.
+	// It must not be `pods` while ReservedResourceNameValidation is enabled; that
+	// exact name is reserved for Kueue's internal Pod-count accounting. A qualified
+	// name such as `example.com/pods` is allowed.
 	// +optional
 	MultiplyBy corev1.ResourceName `json:"multiplyBy,omitempty"`
 
 	// Outputs specifies the output resources and quantities per unit of input resource.
-	// An output resource name must not be `pods`; that exact name is reserved for
-	// Kueue's internal Pod-count accounting. A qualified name such as
-	// `example.com/pods` is allowed.
+	// An output resource name must not be `pods` while ReservedResourceNameValidation
+	// is enabled; that exact name is reserved for Kueue's internal Pod-count
+	// accounting. A qualified name such as `example.com/pods` is allowed.
 	// An empty Outputs combined with a `Replace` Strategy causes the Input resource to be ignored by Kueue.
 	Outputs corev1.ResourceList `json:"outputs,omitempty"`
 }
@@ -597,9 +599,9 @@ type DeviceClassMapping struct {
 	// and must start and end with an alphanumeric character.
 	// DNS subdomain prefixes follow the same rules as DNS labels but can contain periods.
 	// The total length must not exceed 253 characters.
-	// With KueueDRAIntegration enabled it must not be `pods`; that exact name is
-	// reserved for Kueue's internal Pod-count accounting. A qualified name such
-	// as `example.com/pods` is allowed.
+	// With KueueDRAIntegration and ReservedResourceNameValidation enabled it must not
+	// be `pods`; that exact name is reserved for Kueue's internal Pod-count
+	// accounting. A qualified name such as `example.com/pods` is allowed.
 	Name corev1.ResourceName `json:"name"`
 
 	// DeviceClassNames enumerates the DeviceClasses represented by this resource name.

--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -560,9 +560,11 @@ const Replace ResourceTransformationStrategy = "Replace"
 
 type ResourceTransformation struct {
 	// Input is the name of the input resource.
-	// It must not be `pods` while ReservedResourceNameValidation is enabled; that
-	// exact name is reserved for Kueue's internal Pod-count accounting. A qualified
-	// name such as `example.com/pods` is allowed.
+	// It must not be `pods`; that exact name is reserved for Kueue's internal
+	// Pod-count accounting. A qualified name such as `example.com/pods` is allowed.
+	// Disabling the ReservedResourceNameValidation feature gate lets such a
+	// configuration load for an upgrade; flavor assignment still overwrites the
+	// key with the PodSet count.
 	Input corev1.ResourceName `json:"input"`
 
 	// Strategy specifies if the input resource should be replaced or retained.
@@ -575,16 +577,21 @@ type ResourceTransformation struct {
 	// amount of the resource indicated by the "input" field when computing
 	// "outputs". It does not change the quantity retained under "input" when
 	// "strategy" is Retain.
-	// It must not be `pods` while ReservedResourceNameValidation is enabled; that
-	// exact name is reserved for Kueue's internal Pod-count accounting. A qualified
-	// name such as `example.com/pods` is allowed.
+	// It must not be `pods`; that exact name is reserved for Kueue's internal
+	// Pod-count accounting. A qualified name such as `example.com/pods` is allowed.
+	// Disabling the ReservedResourceNameValidation feature gate lets such a
+	// configuration load for an upgrade; flavor assignment still overwrites the
+	// key with the PodSet count.
 	// +optional
 	MultiplyBy corev1.ResourceName `json:"multiplyBy,omitempty"`
 
 	// Outputs specifies the output resources and quantities per unit of input resource.
-	// An output resource name must not be `pods` while ReservedResourceNameValidation
-	// is enabled; that exact name is reserved for Kueue's internal Pod-count
-	// accounting. A qualified name such as `example.com/pods` is allowed.
+	// An output resource name must not be `pods`; that exact name is reserved for
+	// Kueue's internal Pod-count accounting. A qualified name such as
+	// `example.com/pods` is allowed.
+	// Disabling the ReservedResourceNameValidation feature gate lets such a
+	// configuration load for an upgrade; flavor assignment still overwrites the
+	// key with the PodSet count.
 	// An empty Outputs combined with a `Replace` Strategy causes the Input resource to be ignored by Kueue.
 	Outputs corev1.ResourceList `json:"outputs,omitempty"`
 }
@@ -599,9 +606,12 @@ type DeviceClassMapping struct {
 	// and must start and end with an alphanumeric character.
 	// DNS subdomain prefixes follow the same rules as DNS labels but can contain periods.
 	// The total length must not exceed 253 characters.
-	// With KueueDRAIntegration and ReservedResourceNameValidation enabled it must not
-	// be `pods`; that exact name is reserved for Kueue's internal Pod-count
-	// accounting. A qualified name such as `example.com/pods` is allowed.
+	// With KueueDRAIntegration enabled it must not be `pods`; that exact name is
+	// reserved for Kueue's internal Pod-count accounting. A qualified name such
+	// as `example.com/pods` is allowed.
+	// Disabling the ReservedResourceNameValidation feature gate lets such a
+	// configuration load for an upgrade; flavor assignment still overwrites the
+	// key with the PodSet count.
 	Name corev1.ResourceName `json:"name"`
 
 	// DeviceClassNames enumerates the DeviceClasses represented by this resource name.

--- a/apis/config/v1beta2/configuration_types.go
+++ b/apis/config/v1beta2/configuration_types.go
@@ -612,9 +612,11 @@ const Replace ResourceTransformationStrategy = "Replace"
 
 type ResourceTransformation struct {
 	// Input is the name of the input resource.
-	// It must not be `pods` while ReservedResourceNameValidation is enabled; that
-	// exact name is reserved for Kueue's internal Pod-count accounting. A qualified
-	// name such as `example.com/pods` is allowed.
+	// It must not be `pods`; that exact name is reserved for Kueue's internal
+	// Pod-count accounting. A qualified name such as `example.com/pods` is allowed.
+	// Disabling the ReservedResourceNameValidation feature gate lets such a
+	// configuration load for an upgrade; flavor assignment still overwrites the
+	// key with the PodSet count.
 	Input corev1.ResourceName `json:"input"`
 
 	// Strategy specifies if the input resource should be replaced or retained.
@@ -627,16 +629,21 @@ type ResourceTransformation struct {
 	// amount of the resource indicated by the "input" field when computing
 	// "outputs". It does not change the quantity retained under "input" when
 	// "strategy" is Retain.
-	// It must not be `pods` while ReservedResourceNameValidation is enabled; that
-	// exact name is reserved for Kueue's internal Pod-count accounting. A qualified
-	// name such as `example.com/pods` is allowed.
+	// It must not be `pods`; that exact name is reserved for Kueue's internal
+	// Pod-count accounting. A qualified name such as `example.com/pods` is allowed.
+	// Disabling the ReservedResourceNameValidation feature gate lets such a
+	// configuration load for an upgrade; flavor assignment still overwrites the
+	// key with the PodSet count.
 	// +optional
 	MultiplyBy corev1.ResourceName `json:"multiplyBy,omitempty"`
 
 	// Outputs specifies the output resources and quantities per unit of input resource.
-	// An output resource name must not be `pods` while ReservedResourceNameValidation
-	// is enabled; that exact name is reserved for Kueue's internal Pod-count
-	// accounting. A qualified name such as `example.com/pods` is allowed.
+	// An output resource name must not be `pods`; that exact name is reserved for
+	// Kueue's internal Pod-count accounting. A qualified name such as
+	// `example.com/pods` is allowed.
+	// Disabling the ReservedResourceNameValidation feature gate lets such a
+	// configuration load for an upgrade; flavor assignment still overwrites the
+	// key with the PodSet count.
 	// An empty Outputs combined with a `Replace` Strategy causes the Input resource to be ignored by Kueue.
 	Outputs corev1.ResourceList `json:"outputs,omitempty"`
 }
@@ -651,9 +658,12 @@ type DeviceClassMapping struct {
 	// and must start and end with an alphanumeric character.
 	// DNS subdomain prefixes follow the same rules as DNS labels but can contain periods.
 	// The total length must not exceed 253 characters.
-	// With KueueDRAIntegration and ReservedResourceNameValidation enabled it must not
-	// be `pods`; that exact name is reserved for Kueue's internal Pod-count
-	// accounting. A qualified name such as `example.com/pods` is allowed.
+	// With KueueDRAIntegration enabled it must not be `pods`; that exact name is
+	// reserved for Kueue's internal Pod-count accounting. A qualified name such
+	// as `example.com/pods` is allowed.
+	// Disabling the ReservedResourceNameValidation feature gate lets such a
+	// configuration load for an upgrade; flavor assignment still overwrites the
+	// key with the PodSet count.
 	Name corev1.ResourceName `json:"name"`
 
 	// DeviceClassNames enumerates the DeviceClasses represented by this resource name.

--- a/apis/config/v1beta2/configuration_types.go
+++ b/apis/config/v1beta2/configuration_types.go
@@ -612,8 +612,9 @@ const Replace ResourceTransformationStrategy = "Replace"
 
 type ResourceTransformation struct {
 	// Input is the name of the input resource.
-	// It must not be `pods`; that exact name is reserved for Kueue's internal
-	// Pod-count accounting. A qualified name such as `example.com/pods` is allowed.
+	// It must not be `pods` while ReservedResourceNameValidation is enabled; that
+	// exact name is reserved for Kueue's internal Pod-count accounting. A qualified
+	// name such as `example.com/pods` is allowed.
 	Input corev1.ResourceName `json:"input"`
 
 	// Strategy specifies if the input resource should be replaced or retained.
@@ -626,15 +627,16 @@ type ResourceTransformation struct {
 	// amount of the resource indicated by the "input" field when computing
 	// "outputs". It does not change the quantity retained under "input" when
 	// "strategy" is Retain.
-	// It must not be `pods`; that exact name is reserved for Kueue's internal
-	// Pod-count accounting. A qualified name such as `example.com/pods` is allowed.
+	// It must not be `pods` while ReservedResourceNameValidation is enabled; that
+	// exact name is reserved for Kueue's internal Pod-count accounting. A qualified
+	// name such as `example.com/pods` is allowed.
 	// +optional
 	MultiplyBy corev1.ResourceName `json:"multiplyBy,omitempty"`
 
 	// Outputs specifies the output resources and quantities per unit of input resource.
-	// An output resource name must not be `pods`; that exact name is reserved for
-	// Kueue's internal Pod-count accounting. A qualified name such as
-	// `example.com/pods` is allowed.
+	// An output resource name must not be `pods` while ReservedResourceNameValidation
+	// is enabled; that exact name is reserved for Kueue's internal Pod-count
+	// accounting. A qualified name such as `example.com/pods` is allowed.
 	// An empty Outputs combined with a `Replace` Strategy causes the Input resource to be ignored by Kueue.
 	Outputs corev1.ResourceList `json:"outputs,omitempty"`
 }
@@ -649,9 +651,9 @@ type DeviceClassMapping struct {
 	// and must start and end with an alphanumeric character.
 	// DNS subdomain prefixes follow the same rules as DNS labels but can contain periods.
 	// The total length must not exceed 253 characters.
-	// With KueueDRAIntegration enabled it must not be `pods`; that exact name is
-	// reserved for Kueue's internal Pod-count accounting. A qualified name such
-	// as `example.com/pods` is allowed.
+	// With KueueDRAIntegration and ReservedResourceNameValidation enabled it must not
+	// be `pods`; that exact name is reserved for Kueue's internal Pod-count
+	// accounting. A qualified name such as `example.com/pods` is allowed.
 	Name corev1.ResourceName `json:"name"`
 
 	// DeviceClassNames enumerates the DeviceClasses represented by this resource name.

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -465,6 +465,7 @@ func validateResourceTransformations(c *configapi.Configuration) field.ErrorList
 	}
 	var allErrs field.ErrorList
 	seenKeys := make(sets.Set[corev1.ResourceName])
+	refuseReserved := features.Enabled(features.ReservedResourceNameValidation)
 	for idx, transform := range res.Transformations {
 		strategy := ptr.Deref(transform.Strategy, "")
 		if strategy != configapi.Retain && strategy != configapi.Replace {
@@ -477,21 +478,24 @@ func validateResourceTransformations(c *configapi.Configuration) field.ErrorList
 			seenKeys.Insert(transform.Input)
 		}
 		// pods is reserved for the request Kueue synthesizes from the PodSet
-		// count, so a transformation must not name it in any position.
-		if transform.Input == corev1.ResourcePods {
-			allErrs = append(allErrs, field.Invalid(
-				resourceTransformationPath.Index(idx).Child("input"),
-				transform.Input, reservedResourceNameMsg))
-		}
-		if _, ok := transform.Outputs[corev1.ResourcePods]; ok {
-			allErrs = append(allErrs, field.Invalid(
-				resourceTransformationPath.Index(idx).Child("outputs").Key(string(corev1.ResourcePods)),
-				corev1.ResourcePods, reservedResourceNameMsg))
-		}
-		if transform.MultiplyBy == corev1.ResourcePods {
-			allErrs = append(allErrs, field.Invalid(
-				resourceTransformationPath.Index(idx).Child("multiplyBy"),
-				transform.MultiplyBy, reservedResourceNameMsg))
+		// count, so a transformation must not name it in any position. Gated so
+		// a configuration that loaded before can defer the os.Exit for a release.
+		if refuseReserved {
+			if transform.Input == corev1.ResourcePods {
+				allErrs = append(allErrs, field.Invalid(
+					resourceTransformationPath.Index(idx).Child("input"),
+					transform.Input, reservedResourceNameMsg))
+			}
+			if _, ok := transform.Outputs[corev1.ResourcePods]; ok {
+				allErrs = append(allErrs, field.Invalid(
+					resourceTransformationPath.Index(idx).Child("outputs").Key(string(corev1.ResourcePods)),
+					corev1.ResourcePods, reservedResourceNameMsg))
+			}
+			if transform.MultiplyBy == corev1.ResourcePods {
+				allErrs = append(allErrs, field.Invalid(
+					resourceTransformationPath.Index(idx).Child("multiplyBy"),
+					transform.MultiplyBy, reservedResourceNameMsg))
+			}
 		}
 	}
 	return allErrs
@@ -509,6 +513,7 @@ func validateDeviceClassMappings(c *configapi.Configuration) field.ErrorList {
 		allErrs = append(allErrs, field.TooMany(dynamicResourceAllocationPath, len(mappings), 16))
 	}
 
+	refuseReserved := features.Enabled(features.ReservedResourceNameValidation)
 	seenResourceNames := make(sets.Set[corev1.ResourceName])
 	deviceClassToResource := make(map[corev1.ResourceName]corev1.ResourceName)
 	deviceClassCounterNames := make(map[corev1.ResourceName]sets.Set[string])
@@ -525,9 +530,9 @@ func validateDeviceClassMappings(c *configapi.Configuration) field.ErrorList {
 		}
 
 		// pods is reserved for the request Kueue synthesizes from the PodSet count.
-		// Only behind the gate: the mapper is built there, so until then the name
-		// is dormant and refusing it would fail an unrelated upgrade.
-		if features.Enabled(features.KueueDRAIntegration) && mapping.Name == corev1.ResourcePods {
+		// Dormant until KueueDRAIntegration builds the mapper, and deferred by the
+		// same gate as the transformation positions.
+		if refuseReserved && features.Enabled(features.KueueDRAIntegration) && mapping.Name == corev1.ResourcePods {
 			allErrs = append(allErrs, field.Invalid(mappingPath.Child("name"), mapping.Name, reservedResourceNameMsg))
 		}
 

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -478,8 +478,8 @@ func validateResourceTransformations(c *configapi.Configuration) field.ErrorList
 			seenKeys.Insert(transform.Input)
 		}
 		// pods is reserved for the request Kueue synthesizes from the PodSet
-		// count, so a transformation must not name it in any position. Gated so
-		// a configuration that loaded before can defer the os.Exit for a release.
+		// count, so a transformation must not name it in any position. Gated
+		// because the refusal exits the manager on a file that used to load.
 		if refuseReserved {
 			if transform.Input == corev1.ResourcePods {
 				allErrs = append(allErrs, field.Invalid(
@@ -530,8 +530,8 @@ func validateDeviceClassMappings(c *configapi.Configuration) field.ErrorList {
 		}
 
 		// pods is reserved for the request Kueue synthesizes from the PodSet count.
-		// Dormant until KueueDRAIntegration builds the mapper, and deferred by the
-		// same gate as the transformation positions.
+		// The mapper is only built with DRA on, so the name is inert until then,
+		// and refusing it exits the manager the same way.
 		if refuseReserved && features.Enabled(features.KueueDRAIntegration) && mapping.Name == corev1.ResourcePods {
 			allErrs = append(allErrs, field.Invalid(mappingPath.Child("name"), mapping.Name, reservedResourceNameMsg))
 		}

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -530,8 +530,8 @@ func validateDeviceClassMappings(c *configapi.Configuration) field.ErrorList {
 		}
 
 		// pods is reserved for the request Kueue synthesizes from the PodSet count.
-		// The mapper is only built with DRA on, so the name is inert until then,
-		// and refusing it exits the manager the same way.
+		// The mapper is only built with DRA on, so until then the name is dormant
+		// and refusing it would fail an upgrade over an entry that does nothing.
 		if refuseReserved && features.Enabled(features.KueueDRAIntegration) && mapping.Name == corev1.ResourcePods {
 			allErrs = append(allErrs, field.Invalid(mappingPath.Child("name"), mapping.Name, reservedResourceNameMsg))
 		}

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1376,7 +1376,7 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		"device class mapping named pods rejected when DRA is enabled": {
-			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegration: true},
+			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegration: true, features.ReservedResourceNameValidation: true},
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				Resources: &configapi.Resources{
@@ -1399,7 +1399,7 @@ func TestValidate(t *testing.T) {
 		// while it is off and refusing it would fail an upgrade about something
 		// else. It is refused the day the gate goes on, which is the case above.
 		"device class mapping named pods accepted when DRA is disabled": {
-			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegration: false},
+			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegration: false, features.ReservedResourceNameValidation: true},
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				Resources: &configapi.Resources{
@@ -1415,7 +1415,7 @@ func TestValidate(t *testing.T) {
 		// Transformations are installed whatever the DRA gate says, so the name is
 		// refused there whatever it says too.
 		"transformation output named pods rejected when DRA is disabled": {
-			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegration: false},
+			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegration: false, features.ReservedResourceNameValidation: true},
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				Resources: &configapi.Resources{
@@ -1436,6 +1436,7 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		"transformation output named pods rejected": {
+			featureGates: map[featuregate.Feature]bool{features.ReservedResourceNameValidation: true},
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				Resources: &configapi.Resources{
@@ -1456,6 +1457,7 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		"transformation taking pods as input rejected": {
+			featureGates: map[featuregate.Feature]bool{features.ReservedResourceNameValidation: true},
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				Resources: &configapi.Resources{
@@ -1476,6 +1478,7 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		"transformation multiplying by pods rejected": {
+			featureGates: map[featuregate.Feature]bool{features.ReservedResourceNameValidation: true},
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				Resources: &configapi.Resources{
@@ -1497,7 +1500,7 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		// The escape hatch: a configuration every released version accepted, loaded
-		// by a manager told to defer the refusal for one release.
+		// by a manager told not to refuse it.
 		"every position naming pods is accepted while the gate is off": {
 			featureGates: map[featuregate.Feature]bool{
 				features.ReservedResourceNameValidation: false,
@@ -1524,6 +1527,7 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		"transformation naming pods twice reports both": {
+			featureGates: map[featuregate.Feature]bool{features.ReservedResourceNameValidation: true},
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				Resources: &configapi.Resources{
@@ -1551,6 +1555,7 @@ func TestValidate(t *testing.T) {
 		// Reported per entry rather than once for the Configuration, and in the
 		// order the transformations are written.
 		"pods reported for each transformation naming it": {
+			featureGates: map[featuregate.Feature]bool{features.ReservedResourceNameValidation: true},
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				Resources: &configapi.Resources{

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1496,6 +1496,33 @@ func TestValidate(t *testing.T) {
 				},
 			},
 		},
+		// The escape hatch: a configuration every released version accepted, loaded
+		// by a manager told to defer the refusal for one release.
+		"every position naming pods is accepted while the gate is off": {
+			featureGates: map[featuregate.Feature]bool{
+				features.ReservedResourceNameValidation: false,
+				features.KueueDRAIntegration:            true,
+			},
+			cfg: &configapi.Configuration{
+				Integrations: defaultIntegrations,
+				Resources: &configapi.Resources{
+					Transformations: []configapi.ResourceTransformation{
+						{
+							Input:      corev1.ResourcePods,
+							Strategy:   new(configapi.Retain),
+							MultiplyBy: corev1.ResourcePods,
+							Outputs:    corev1.ResourceList{corev1.ResourcePods: resource.MustParse("1")},
+						},
+					},
+					DeviceClassMappings: []configapi.DeviceClassMapping{
+						{
+							Name:             corev1.ResourcePods,
+							DeviceClassNames: []corev1.ResourceName{"gpu.example.com"},
+						},
+					},
+				},
+			},
+		},
 		"transformation naming pods twice reports both": {
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1376,7 +1376,7 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		"device class mapping named pods rejected when DRA is enabled": {
-			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegration: true, features.ReservedResourceNameValidation: true},
+			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegration: true},
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				Resources: &configapi.Resources{
@@ -1399,7 +1399,7 @@ func TestValidate(t *testing.T) {
 		// while it is off and refusing it would fail an upgrade about something
 		// else. It is refused the day the gate goes on, which is the case above.
 		"device class mapping named pods accepted when DRA is disabled": {
-			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegration: false, features.ReservedResourceNameValidation: true},
+			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegration: false},
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				Resources: &configapi.Resources{
@@ -1415,7 +1415,7 @@ func TestValidate(t *testing.T) {
 		// Transformations are installed whatever the DRA gate says, so the name is
 		// refused there whatever it says too.
 		"transformation output named pods rejected when DRA is disabled": {
-			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegration: false, features.ReservedResourceNameValidation: true},
+			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegration: false},
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				Resources: &configapi.Resources{
@@ -1436,7 +1436,6 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		"transformation output named pods rejected": {
-			featureGates: map[featuregate.Feature]bool{features.ReservedResourceNameValidation: true},
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				Resources: &configapi.Resources{
@@ -1457,7 +1456,6 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		"transformation taking pods as input rejected": {
-			featureGates: map[featuregate.Feature]bool{features.ReservedResourceNameValidation: true},
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				Resources: &configapi.Resources{
@@ -1478,7 +1476,6 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		"transformation multiplying by pods rejected": {
-			featureGates: map[featuregate.Feature]bool{features.ReservedResourceNameValidation: true},
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				Resources: &configapi.Resources{
@@ -1527,7 +1524,6 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		"transformation naming pods twice reports both": {
-			featureGates: map[featuregate.Feature]bool{features.ReservedResourceNameValidation: true},
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				Resources: &configapi.Resources{
@@ -1555,7 +1551,6 @@ func TestValidate(t *testing.T) {
 		// Reported per entry rather than once for the Configuration, and in the
 		// order the transformations are written.
 		"pods reported for each transformation naming it": {
-			featureGates: map[featuregate.Feature]bool{features.ReservedResourceNameValidation: true},
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				Resources: &configapi.Resources{

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -182,12 +182,11 @@ const (
 	KueueDRAIntegrationExtendedResource featuregate.Feature = "KueueDRAIntegrationExtendedResource"
 
 	// owner: @thc1006
+	// issue: https://github.com/kubernetes-sigs/kueue/issues/14763
 	//
 	// Refuse `pods` as a deviceClassMappings name or in a resource transformation.
-	// Turning it off lets a configuration written before the refusal load for one
-	// more release instead of exiting the manager at startup.
-	//
-	// Deprecated: planned to be removed in 0.21.
+	// Off until an operator asks for it, since the refusal exits the manager on a
+	// file every released version accepted.
 	ReservedResourceNameValidation featuregate.Feature = "ReservedResourceNameValidation"
 
 	// owner: @MaysaMacedo
@@ -723,7 +722,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Beta},
 	},
 	ReservedResourceNameValidation: {
-		{Version: version.MustParse("0.20"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("0.20"), Default: false, PreRelease: featuregate.Alpha},
 	},
 
 	KueueDRARejectWorkloadsWhenDRADisabled: {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -184,9 +184,9 @@ const (
 	// owner: @thc1006
 	// issue: https://github.com/kubernetes-sigs/kueue/issues/14763
 	//
-	// Refuse `pods` as a deviceClassMappings name or in a resource transformation.
-	// Off until an operator asks for it, since the refusal exits the manager on a
-	// file every released version accepted.
+	// Refuse `pods` in a resource transformation, and as a deviceClassMappings name
+	// once KueueDRAIntegration builds the mapper. Off until asked for, since the
+	// refusal exits the manager on a configuration every released version accepted.
 	ReservedResourceNameValidation featuregate.Feature = "ReservedResourceNameValidation"
 
 	// owner: @MaysaMacedo

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -181,6 +181,15 @@ const (
 	// via standard resources.requests using DeviceClass extendedResourceName.
 	KueueDRAIntegrationExtendedResource featuregate.Feature = "KueueDRAIntegrationExtendedResource"
 
+	// owner: @thc1006
+	//
+	// Refuse `pods` as a deviceClassMappings name or in a resource transformation.
+	// Turning it off lets a configuration written before the refusal load for one
+	// more release instead of exiting the manager at startup.
+	//
+	// Deprecated: planned to be removed in 0.21.
+	ReservedResourceNameValidation featuregate.Feature = "ReservedResourceNameValidation"
+
 	// owner: @MaysaMacedo
 	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/7513-quota-check-strategy
 	//
@@ -712,6 +721,9 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	KueueDRAIntegrationExtendedResource: {
 		{Version: version.MustParse("0.18"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Beta},
+	},
+	ReservedResourceNameValidation: {
+		{Version: version.MustParse("0.20"), Default: true, PreRelease: featuregate.Beta},
 	},
 
 	KueueDRARejectWorkloadsWhenDRADisabled: {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -185,8 +185,8 @@ const (
 	// issue: https://github.com/kubernetes-sigs/kueue/issues/14763
 	//
 	// Refuse `pods` in a resource transformation, and as a deviceClassMappings name
-	// once KueueDRAIntegration builds the mapper. Off until asked for, since the
-	// refusal exits the manager on a configuration every released version accepted.
+	// once KueueDRAIntegration builds the mapper. With it off such a configuration
+	// loads, and flavor assignment then overwrites the key with the PodSet count.
 	ReservedResourceNameValidation featuregate.Feature = "ReservedResourceNameValidation"
 
 	// owner: @MaysaMacedo
@@ -722,7 +722,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Beta},
 	},
 	ReservedResourceNameValidation: {
-		{Version: version.MustParse("0.20"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("0.20"), Default: true, PreRelease: featuregate.Beta},
 	},
 
 	KueueDRARejectWorkloadsWhenDRADisabled: {

--- a/pkg/features/kube_features_test.go
+++ b/pkg/features/kube_features_test.go
@@ -32,6 +32,14 @@ func TestFeatureGate(t *testing.T) {
 	}
 }
 
+// The gate defers the refusal rather than withholding it, so it has to arrive
+// on. Turning it off is the escape hatch for a configuration written earlier.
+func TestReservedResourceNameValidationDefaultsOn(t *testing.T) {
+	if !utilfeature.DefaultFeatureGate.Enabled(ReservedResourceNameValidation) {
+		t.Error("ReservedResourceNameValidation is off by default; a configuration naming pods would load unrefused")
+	}
+}
+
 func TestSetFeatureGatesDuringTest(t *testing.T) {
 	cases := map[string]struct {
 		input     map[featuregate.Feature]bool

--- a/pkg/features/kube_features_test.go
+++ b/pkg/features/kube_features_test.go
@@ -32,11 +32,11 @@ func TestFeatureGate(t *testing.T) {
 	}
 }
 
-// The gate defers the refusal rather than withholding it, so it has to arrive
-// on. Turning it off is the escape hatch for a configuration written earlier.
-func TestReservedResourceNameValidationDefaultsOn(t *testing.T) {
-	if !utilfeature.DefaultFeatureGate.Enabled(ReservedResourceNameValidation) {
-		t.Error("ReservedResourceNameValidation is off by default; a configuration naming pods would load unrefused")
+// A configuration written before the refusal has to keep loading, so the default
+// is part of the contract here and not just a starting value.
+func TestReservedResourceNameValidationDefaultsOff(t *testing.T) {
+	if utilfeature.DefaultFeatureGate.Enabled(ReservedResourceNameValidation) {
+		t.Error("ReservedResourceNameValidation is on by default; a configuration naming pods would exit the manager")
 	}
 }
 

--- a/pkg/features/kube_features_test.go
+++ b/pkg/features/kube_features_test.go
@@ -32,14 +32,6 @@ func TestFeatureGate(t *testing.T) {
 	}
 }
 
-// A configuration written before the refusal has to keep loading, so the default
-// is part of the contract here and not just a starting value.
-func TestReservedResourceNameValidationDefaultsOff(t *testing.T) {
-	if utilfeature.DefaultFeatureGate.Enabled(ReservedResourceNameValidation) {
-		t.Error("ReservedResourceNameValidation is on by default; a configuration naming pods would exit the manager")
-	}
-}
-
 func TestSetFeatureGatesDuringTest(t *testing.T) {
 	cases := map[string]struct {
 		input     map[featuregate.Feature]bool

--- a/site/content/en/docs/reference/kueue-config.v1beta1.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta1.md
@@ -602,9 +602,12 @@ DNS labels consist of lower-case alphanumeric characters or hyphens,
 and must start and end with an alphanumeric character.
 DNS subdomain prefixes follow the same rules as DNS labels but can contain periods.
 The total length must not exceed 253 characters.
-With KueueDRAIntegration and ReservedResourceNameValidation enabled it must not
-be <code>pods</code>; that exact name is reserved for Kueue's internal Pod-count
-accounting. A qualified name such as <code>example.com/pods</code> is allowed.</p>
+With KueueDRAIntegration enabled it must not be <code>pods</code>; that exact name is
+reserved for Kueue's internal Pod-count accounting. A qualified name such
+as <code>example.com/pods</code> is allowed.
+Disabling the ReservedResourceNameValidation feature gate lets such a
+configuration load for an upgrade; flavor assignment still overwrites the
+key with the PodSet count.</p>
 </td>
 </tr>
 <tr><td><code>deviceClassNames</code> <B>[Required]</B><br/>
@@ -1143,9 +1146,11 @@ re-queuing an evicted workload.</p>
 </td>
 <td>
    <p>Input is the name of the input resource.
-It must not be <code>pods</code> while ReservedResourceNameValidation is enabled; that
-exact name is reserved for Kueue's internal Pod-count accounting. A qualified
-name such as <code>example.com/pods</code> is allowed.</p>
+It must not be <code>pods</code>; that exact name is reserved for Kueue's internal
+Pod-count accounting. A qualified name such as <code>example.com/pods</code> is allowed.
+Disabling the ReservedResourceNameValidation feature gate lets such a
+configuration load for an upgrade; flavor assignment still overwrites the
+key with the PodSet count.</p>
 </td>
 </tr>
 <tr><td><code>strategy</code> <B>[Required]</B><br/>
@@ -1166,9 +1171,11 @@ The requested amount of the resource is used to multiply the requested
 amount of the resource indicated by the &quot;input&quot; field when computing
 &quot;outputs&quot;. It does not change the quantity retained under &quot;input&quot; when
 &quot;strategy&quot; is Retain.
-It must not be <code>pods</code> while ReservedResourceNameValidation is enabled; that
-exact name is reserved for Kueue's internal Pod-count accounting. A qualified
-name such as <code>example.com/pods</code> is allowed.</p>
+It must not be <code>pods</code>; that exact name is reserved for Kueue's internal
+Pod-count accounting. A qualified name such as <code>example.com/pods</code> is allowed.
+Disabling the ReservedResourceNameValidation feature gate lets such a
+configuration load for an upgrade; flavor assignment still overwrites the
+key with the PodSet count.</p>
 </td>
 </tr>
 <tr><td><code>outputs</code> <B>[Required]</B><br/>
@@ -1176,9 +1183,12 @@ name such as <code>example.com/pods</code> is allowed.</p>
 </td>
 <td>
    <p>Outputs specifies the output resources and quantities per unit of input resource.
-An output resource name must not be <code>pods</code> while ReservedResourceNameValidation
-is enabled; that exact name is reserved for Kueue's internal Pod-count
-accounting. A qualified name such as <code>example.com/pods</code> is allowed.
+An output resource name must not be <code>pods</code>; that exact name is reserved for
+Kueue's internal Pod-count accounting. A qualified name such as
+<code>example.com/pods</code> is allowed.
+Disabling the ReservedResourceNameValidation feature gate lets such a
+configuration load for an upgrade; flavor assignment still overwrites the
+key with the PodSet count.
 An empty Outputs combined with a <code>Replace</code> Strategy causes the Input resource to be ignored by Kueue.</p>
 </td>
 </tr>

--- a/site/content/en/docs/reference/kueue-config.v1beta1.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta1.md
@@ -602,9 +602,9 @@ DNS labels consist of lower-case alphanumeric characters or hyphens,
 and must start and end with an alphanumeric character.
 DNS subdomain prefixes follow the same rules as DNS labels but can contain periods.
 The total length must not exceed 253 characters.
-With KueueDRAIntegration enabled it must not be <code>pods</code>; that exact name is
-reserved for Kueue's internal Pod-count accounting. A qualified name such
-as <code>example.com/pods</code> is allowed.</p>
+With KueueDRAIntegration and ReservedResourceNameValidation enabled it must not
+be <code>pods</code>; that exact name is reserved for Kueue's internal Pod-count
+accounting. A qualified name such as <code>example.com/pods</code> is allowed.</p>
 </td>
 </tr>
 <tr><td><code>deviceClassNames</code> <B>[Required]</B><br/>
@@ -1143,8 +1143,9 @@ re-queuing an evicted workload.</p>
 </td>
 <td>
    <p>Input is the name of the input resource.
-It must not be <code>pods</code>; that exact name is reserved for Kueue's internal
-Pod-count accounting. A qualified name such as <code>example.com/pods</code> is allowed.</p>
+It must not be <code>pods</code> while ReservedResourceNameValidation is enabled; that
+exact name is reserved for Kueue's internal Pod-count accounting. A qualified
+name such as <code>example.com/pods</code> is allowed.</p>
 </td>
 </tr>
 <tr><td><code>strategy</code> <B>[Required]</B><br/>
@@ -1165,8 +1166,9 @@ The requested amount of the resource is used to multiply the requested
 amount of the resource indicated by the &quot;input&quot; field when computing
 &quot;outputs&quot;. It does not change the quantity retained under &quot;input&quot; when
 &quot;strategy&quot; is Retain.
-It must not be <code>pods</code>; that exact name is reserved for Kueue's internal
-Pod-count accounting. A qualified name such as <code>example.com/pods</code> is allowed.</p>
+It must not be <code>pods</code> while ReservedResourceNameValidation is enabled; that
+exact name is reserved for Kueue's internal Pod-count accounting. A qualified
+name such as <code>example.com/pods</code> is allowed.</p>
 </td>
 </tr>
 <tr><td><code>outputs</code> <B>[Required]</B><br/>
@@ -1174,9 +1176,9 @@ Pod-count accounting. A qualified name such as <code>example.com/pods</code> is 
 </td>
 <td>
    <p>Outputs specifies the output resources and quantities per unit of input resource.
-An output resource name must not be <code>pods</code>; that exact name is reserved for
-Kueue's internal Pod-count accounting. A qualified name such as
-<code>example.com/pods</code> is allowed.
+An output resource name must not be <code>pods</code> while ReservedResourceNameValidation
+is enabled; that exact name is reserved for Kueue's internal Pod-count
+accounting. A qualified name such as <code>example.com/pods</code> is allowed.
 An empty Outputs combined with a <code>Replace</code> Strategy causes the Input resource to be ignored by Kueue.</p>
 </td>
 </tr>

--- a/site/content/en/docs/reference/kueue-config.v1beta2.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta2.md
@@ -770,9 +770,12 @@ DNS labels consist of lower-case alphanumeric characters or hyphens,
 and must start and end with an alphanumeric character.
 DNS subdomain prefixes follow the same rules as DNS labels but can contain periods.
 The total length must not exceed 253 characters.
-With KueueDRAIntegration and ReservedResourceNameValidation enabled it must not
-be <code>pods</code>; that exact name is reserved for Kueue's internal Pod-count
-accounting. A qualified name such as <code>example.com/pods</code> is allowed.</p>
+With KueueDRAIntegration enabled it must not be <code>pods</code>; that exact name is
+reserved for Kueue's internal Pod-count accounting. A qualified name such
+as <code>example.com/pods</code> is allowed.
+Disabling the ReservedResourceNameValidation feature gate lets such a
+configuration load for an upgrade; flavor assignment still overwrites the
+key with the PodSet count.</p>
 </td>
 </tr>
 <tr><td><code>deviceClassNames</code> <B>[Required]</B><br/>
@@ -1335,9 +1338,11 @@ re-queuing an evicted workload.</p>
 </td>
 <td>
    <p>Input is the name of the input resource.
-It must not be <code>pods</code> while ReservedResourceNameValidation is enabled; that
-exact name is reserved for Kueue's internal Pod-count accounting. A qualified
-name such as <code>example.com/pods</code> is allowed.</p>
+It must not be <code>pods</code>; that exact name is reserved for Kueue's internal
+Pod-count accounting. A qualified name such as <code>example.com/pods</code> is allowed.
+Disabling the ReservedResourceNameValidation feature gate lets such a
+configuration load for an upgrade; flavor assignment still overwrites the
+key with the PodSet count.</p>
 </td>
 </tr>
 <tr><td><code>strategy</code> <B>[Required]</B><br/>
@@ -1358,9 +1363,11 @@ The requested amount of the resource is used to multiply the requested
 amount of the resource indicated by the &quot;input&quot; field when computing
 &quot;outputs&quot;. It does not change the quantity retained under &quot;input&quot; when
 &quot;strategy&quot; is Retain.
-It must not be <code>pods</code> while ReservedResourceNameValidation is enabled; that
-exact name is reserved for Kueue's internal Pod-count accounting. A qualified
-name such as <code>example.com/pods</code> is allowed.</p>
+It must not be <code>pods</code>; that exact name is reserved for Kueue's internal
+Pod-count accounting. A qualified name such as <code>example.com/pods</code> is allowed.
+Disabling the ReservedResourceNameValidation feature gate lets such a
+configuration load for an upgrade; flavor assignment still overwrites the
+key with the PodSet count.</p>
 </td>
 </tr>
 <tr><td><code>outputs</code> <B>[Required]</B><br/>
@@ -1368,9 +1375,12 @@ name such as <code>example.com/pods</code> is allowed.</p>
 </td>
 <td>
    <p>Outputs specifies the output resources and quantities per unit of input resource.
-An output resource name must not be <code>pods</code> while ReservedResourceNameValidation
-is enabled; that exact name is reserved for Kueue's internal Pod-count
-accounting. A qualified name such as <code>example.com/pods</code> is allowed.
+An output resource name must not be <code>pods</code>; that exact name is reserved for
+Kueue's internal Pod-count accounting. A qualified name such as
+<code>example.com/pods</code> is allowed.
+Disabling the ReservedResourceNameValidation feature gate lets such a
+configuration load for an upgrade; flavor assignment still overwrites the
+key with the PodSet count.
 An empty Outputs combined with a <code>Replace</code> Strategy causes the Input resource to be ignored by Kueue.</p>
 </td>
 </tr>

--- a/site/content/en/docs/reference/kueue-config.v1beta2.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta2.md
@@ -770,9 +770,9 @@ DNS labels consist of lower-case alphanumeric characters or hyphens,
 and must start and end with an alphanumeric character.
 DNS subdomain prefixes follow the same rules as DNS labels but can contain periods.
 The total length must not exceed 253 characters.
-With KueueDRAIntegration enabled it must not be <code>pods</code>; that exact name is
-reserved for Kueue's internal Pod-count accounting. A qualified name such
-as <code>example.com/pods</code> is allowed.</p>
+With KueueDRAIntegration and ReservedResourceNameValidation enabled it must not
+be <code>pods</code>; that exact name is reserved for Kueue's internal Pod-count
+accounting. A qualified name such as <code>example.com/pods</code> is allowed.</p>
 </td>
 </tr>
 <tr><td><code>deviceClassNames</code> <B>[Required]</B><br/>
@@ -1335,8 +1335,9 @@ re-queuing an evicted workload.</p>
 </td>
 <td>
    <p>Input is the name of the input resource.
-It must not be <code>pods</code>; that exact name is reserved for Kueue's internal
-Pod-count accounting. A qualified name such as <code>example.com/pods</code> is allowed.</p>
+It must not be <code>pods</code> while ReservedResourceNameValidation is enabled; that
+exact name is reserved for Kueue's internal Pod-count accounting. A qualified
+name such as <code>example.com/pods</code> is allowed.</p>
 </td>
 </tr>
 <tr><td><code>strategy</code> <B>[Required]</B><br/>
@@ -1357,8 +1358,9 @@ The requested amount of the resource is used to multiply the requested
 amount of the resource indicated by the &quot;input&quot; field when computing
 &quot;outputs&quot;. It does not change the quantity retained under &quot;input&quot; when
 &quot;strategy&quot; is Retain.
-It must not be <code>pods</code>; that exact name is reserved for Kueue's internal
-Pod-count accounting. A qualified name such as <code>example.com/pods</code> is allowed.</p>
+It must not be <code>pods</code> while ReservedResourceNameValidation is enabled; that
+exact name is reserved for Kueue's internal Pod-count accounting. A qualified
+name such as <code>example.com/pods</code> is allowed.</p>
 </td>
 </tr>
 <tr><td><code>outputs</code> <B>[Required]</B><br/>
@@ -1366,9 +1368,9 @@ Pod-count accounting. A qualified name such as <code>example.com/pods</code> is 
 </td>
 <td>
    <p>Outputs specifies the output resources and quantities per unit of input resource.
-An output resource name must not be <code>pods</code>; that exact name is reserved for
-Kueue's internal Pod-count accounting. A qualified name such as
-<code>example.com/pods</code> is allowed.
+An output resource name must not be <code>pods</code> while ReservedResourceNameValidation
+is enabled; that exact name is reserved for Kueue's internal Pod-count
+accounting. A qualified name such as <code>example.com/pods</code> is allowed.
 An empty Outputs combined with a <code>Replace</code> Strategy causes the Input resource to be ignored by Kueue.</p>
 </td>
 </tr>

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -335,6 +335,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.17"
+- name: ReservedResourceNameValidation
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.20"
 - name: SchedulerLibraryIntegration
   versionedSpecs:
   - default: false

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -337,9 +337,9 @@
     version: "0.17"
 - name: ReservedResourceNameValidation
   versionedSpecs:
-  - default: true
+  - default: false
     lockToDefault: false
-    preRelease: Beta
+    preRelease: Alpha
     version: "0.20"
 - name: SchedulerLibraryIntegration
   versionedSpecs:

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -337,9 +337,9 @@
     version: "0.17"
 - name: ReservedResourceNameValidation
   versionedSpecs:
-  - default: false
+  - default: true
     lockToDefault: false
-    preRelease: Alpha
+    preRelease: Beta
     version: "0.20"
 - name: SchedulerLibraryIntegration
   versionedSpecs:

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -335,6 +335,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.17"
+- name: ReservedResourceNameValidation
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.20"
 - name: SchedulerLibraryIntegration
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -337,9 +337,9 @@
     version: "0.17"
 - name: ReservedResourceNameValidation
   versionedSpecs:
-  - default: true
+  - default: false
     lockToDefault: false
-    preRelease: Beta
+    preRelease: Alpha
     version: "0.20"
 - name: SchedulerLibraryIntegration
   versionedSpecs:

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -337,9 +337,9 @@
     version: "0.17"
 - name: ReservedResourceNameValidation
   versionedSpecs:
-  - default: false
+  - default: true
     lockToDefault: false
-    preRelease: Alpha
+    preRelease: Beta
     version: "0.20"
 - name: SchedulerLibraryIntegration
   versionedSpecs:


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

/kind bug
/area dra

#### What this PR does / why we need it:

#14773 and #14774 put `ReservedResourceNameValidation` on `release-0.18` and `release-0.19`. This is the `main` counterpart, registered from 0.20, beta and on, so 0.20 keeps refusing the name and the gate is the way through one upgrade for an operator who has not renamed the entry yet.

What the refusal is worth is `flavorassigner.go#L743-L748`: when the ClusterQueue covers `pods`, flavor assignment overwrites that key with the PodSet count. A `deviceClassMappings` entry named `pods` therefore loses its charge, and a Pod asking for eight devices is counted as one, with nothing said about it. Leaving the refusal off would defer that rather than warn anyone.

Two things make the gate worth having rather than leaving `main` alone.

Configuration validation calls `os.Exit`, and no released version refuses the name:

```
git grep reservedResourceNameMsg v0.18.6 -- pkg/config/validation.go   ->  nothing
git grep reservedResourceNameMsg v0.19.2 -- pkg/config/validation.go   ->  nothing
```

So every upgrade into 0.20 would be the first one where such a file stops the manager, with nothing to do about it at rollout time but edit the file and start again.

The second is what the gate name has to solve. An operator who follows the mitigation on 0.18 or 0.19 sets `ReservedResourceNameValidation` in `featureGates` or `--feature-gates` and carries that setting into 0.20. `Set` and `SetFromMap` return `unrecognized feature gate` for a name that is not registered, and `cmd/kueue/main.go` exits on it:

```go
if err := config.LoadAndValidateFeatureGates(featureGates, cfg.FeatureGates).ToAggregate(); err != nil {
	setupLog.Error(err, "conflicting feature gates detected")
	os.Exit(1)
}
```

Without the name on `main`, the branch mitigation becomes the next crashloop one release later.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #14763

#### Special notes for your reviewer:

The four positions sit in two functions, and each reads the gate once rather than once per position, so they cannot disagree about whether the name is refused.

One case carries the change: every position naming `pods` in one configuration, with the gate off, expected to load. The refusal cases run at the default rather than naming the gate, so they answer for it too. Measured by breaking each piece in turn:

| broken | what fails |
| --- | --- |
| `Default: true` -> `false` | all seven refusal cases |
| the transformation guard | the new case |
| the deviceClassMappings guard | the new case |

The field comments in `apis/config/v1beta{1,2}` said the name is refused outright, and the `DeviceClassMapping` one credited `KueueDRAIntegration` alone. Both read as the whole rule to anyone reading the configuration reference, so they name the gate now and the site reference is regenerated from them.

Not in this one: `validateResourceList` in `pkg/webhooks/workload_webhook.go` refuses the same name on a Workload. That path rejects an object rather than stopping the manager, so it has no upgrade to survive, and gating it belongs with #14373.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```

#### AI usage

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the beta `ReservedResourceNameValidation` feature gate, enabled by default starting in version 0.20.
  * Rejects the reserved `pods` resource name in resource transformations.
  * Applies device-class mapping validation when reserved-resource validation and device-resource integration are enabled.
  * Qualified names such as `example.com/pods` remain permitted.
  * Disabling the gate allows existing configurations to load during upgrades; flavor assignment may overwrite the reserved key.

* **Documentation**
  * Updated configuration references to describe validation behavior, feature-gate requirements, and supported resource-name formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->