### PR TITLE
Exclude PodSet name from the scheduling equivalence hash behind a feature gate

### DIFF
--- a/keps/9694-scheduling-equivalence-hashing/README.md
+++ b/keps/9694-scheduling-equivalence-hashing/README.md
@@ -362,7 +362,8 @@ listed under Risks and Mitigations.
 The scheduling shape includes the effective Workload priority and an ordered
 description of every PodSet. Each PodSet description includes:
 
-- `name` and effective `count`
+- effective `count`
+- `name` only when `SchedulingEquivalenceHashingIgnorePodSetName` is disabled
 - `minCount`
 - effective `requests` after Kueue-side processing
 - scheduling-relevant fields from `template.spec`, including
@@ -379,10 +380,19 @@ shape. The Pod group integration uses the same shape when calculating the
 Pod integration, such as StatefulSet and LeaderWorkerSet, also use it when
 validating `PodTemplateSpec` identity.
 
-PodSet name is included conservatively even though the current flavor-assignment
-path does not use it. This can split otherwise equivalent Workloads into
-different classes, reducing optimization opportunities, but it cannot merge
-different scheduling shapes incorrectly.
+PodSet name was included conservatively even though the flavor-assignment path
+does not use it. That split otherwise equivalent Workloads into different
+classes and reduced optimization opportunities without improving correctness,
+which is most visible for clients that set a distinct
+`kueue.x-k8s.io/role-hash` per Workload. The
+`SchedulingEquivalenceHashingIgnorePodSetName` gate excludes the name from the
+shape.
+
+PodSet descriptions retain their order, so Workloads with different ordered
+descriptions stay in different classes. PodSets that differ only by name
+serialize identically once the name is excluded, so their order stops mattering.
+The Pod group integration sorts PodSets by name, so a multi-PodSet group whose
+descriptions differ can order them differently per Workload and stay split.
 
 Effective resource requests are included separately from the original Pod
 shape. They can differ after reclaimable Pod accounting, resource
@@ -471,6 +481,7 @@ move an entire class without evaluating its remaining Workloads.
 | v0.19.0 | Failed-class records began retaining the representative's high-level reason for bypassed Workloads | observability |
 | v0.19.0 | Equivalence identifier corrected to include Pod-level resource requests when the field is set | bugfix |
 | v0.20.0 | Added the `kueue_pending_scheduling_hashes` gauge, reporting unique active and inadmissible classes per ClusterQueue | observability |
+| v0.20.0 | PodSet name excluded from the scheduling shape, behind the Beta `SchedulingEquivalenceHashingIgnorePodSetName` gate, enabled by default | gate |
 
 ### Test Plan
 
@@ -577,3 +588,7 @@ Graduation to stable requires:
 - 2026-08-07: Metrics and the KEP were added.
   - [#12520: Pending scheduling hashes metric](https://github.com/kubernetes-sigs/kueue/pull/12520)
   - [#13973: KEP](https://github.com/kubernetes-sigs/kueue/pull/13973)
+- 2026-08-24: PodSet name was excluded from the scheduling shape behind a new
+  feature gate, so Workloads that differ only by PodSet name share a class.
+  - [#14780: Scenario tests for the prior behaviour](https://github.com/kubernetes-sigs/kueue/pull/14780)
+  - [#14784: SchedulingEquivalenceHashingIgnorePodSetName](https://github.com/kubernetes-sigs/kueue/pull/14784)

--- a/keps/9694-scheduling-equivalence-hashing/kep.yaml
+++ b/keps/9694-scheduling-equivalence-hashing/kep.yaml
@@ -24,6 +24,7 @@ milestone:
 
 feature-gates:
   - name: SchedulingEquivalenceHashing
+  - name: SchedulingEquivalenceHashingIgnorePodSetName
 disable-supported: true
 
 metrics:

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -290,6 +290,13 @@ const (
 	// Skip equivalent inadmissible workloads in BestEffortFIFO scheduling.
 	SchedulingEquivalenceHashing featuregate.Feature = "SchedulingEquivalenceHashing"
 
+	// owner: @venuchitta
+	//
+	// issue: https://github.com/kubernetes-sigs/kueue/issues/14534
+	// Exclude the PodSet name from the scheduling equivalence hash. Flavor assignment
+	// does not use the name, so including it splits otherwise equivalent Workloads.
+	SchedulingEquivalenceHashingIgnorePodSetName featuregate.Feature = "SchedulingEquivalenceHashingIgnorePodSetName"
+
 	// owner: @IrvingMg
 	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/7066-custom-metric-labels
 	//
@@ -608,23 +615,24 @@ func init() {
 }
 
 var defaultFeatureGateDependencies = map[featuregate.Feature][]featuregate.Feature{
-	TASFailedNodeReplacement:                    {TopologyAwareScheduling},
-	TASFailedNodeReplacementFailFast:            {TopologyAwareScheduling, TASFailedNodeReplacement},
-	TASReplaceNodeOnPodTermination:              {TopologyAwareScheduling, TASFailedNodeReplacement},
-	TASReplaceNodeDueToNotReadyOverFixedTime:    {TopologyAwareScheduling, TASFailedNodeReplacement},
-	TASBalancedPlacement:                        {TopologyAwareScheduling},
-	TASReplaceNodeOnNodeTaints:                  {TopologyAwareScheduling},
-	TASMultiLayerTopology:                       {TopologyAwareScheduling},
-	TASRespectNodeAffinityPreferred:             {TopologyAwareScheduling},
-	UnadmittedWorkloadsExplicitStatus:           {UnadmittedWorkloadsObservability},
-	TASHandleOverlappingFlavors:                 {TopologyAwareScheduling},
-	TASProfileMixed:                             {TopologyAwareScheduling},
-	TASRecomputeAssignmentWithinSchedulingCycle: {TopologyAwareScheduling},
-	ElasticJobsViaWorkloadSlicesWithTAS:         {ElasticJobsViaWorkloadSlices, TopologyAwareScheduling},
-	KueueDRAIntegrationExtendedResource:         {KueueDRAIntegration},
-	KueueDRAIntegrationPartitionableDevices:     {KueueDRAIntegration},
-	KueueDRAIntegrationConsumableCapacity:       {KueueDRAIntegration},
-	FlavorFungibilityPreserveScanProgress:       {FlavorFungibility},
+	TASFailedNodeReplacement:                     {TopologyAwareScheduling},
+	TASFailedNodeReplacementFailFast:             {TopologyAwareScheduling, TASFailedNodeReplacement},
+	TASReplaceNodeOnPodTermination:               {TopologyAwareScheduling, TASFailedNodeReplacement},
+	TASReplaceNodeDueToNotReadyOverFixedTime:     {TopologyAwareScheduling, TASFailedNodeReplacement},
+	TASBalancedPlacement:                         {TopologyAwareScheduling},
+	TASReplaceNodeOnNodeTaints:                   {TopologyAwareScheduling},
+	TASMultiLayerTopology:                        {TopologyAwareScheduling},
+	TASRespectNodeAffinityPreferred:              {TopologyAwareScheduling},
+	UnadmittedWorkloadsExplicitStatus:            {UnadmittedWorkloadsObservability},
+	TASHandleOverlappingFlavors:                  {TopologyAwareScheduling},
+	TASProfileMixed:                              {TopologyAwareScheduling},
+	TASRecomputeAssignmentWithinSchedulingCycle:  {TopologyAwareScheduling},
+	ElasticJobsViaWorkloadSlicesWithTAS:          {ElasticJobsViaWorkloadSlices, TopologyAwareScheduling},
+	KueueDRAIntegrationExtendedResource:          {KueueDRAIntegration},
+	KueueDRAIntegrationPartitionableDevices:      {KueueDRAIntegration},
+	KueueDRAIntegrationConsumableCapacity:        {KueueDRAIntegration},
+	FlavorFungibilityPreserveScanProgress:        {FlavorFungibility},
+	SchedulingEquivalenceHashingIgnorePodSetName: {SchedulingEquivalenceHashing},
 }
 
 // defaultVersionedFeatureGates consists of all known Kueue-specific feature keys.
@@ -778,6 +786,9 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	SchedulingEquivalenceHashing: {
 		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Beta},
 		{Version: version.MustParse("0.18"), Default: true, PreRelease: featuregate.Beta},
+	},
+	SchedulingEquivalenceHashingIgnorePodSetName: {
+		{Version: version.MustParse("0.20"), Default: true, PreRelease: featuregate.Beta},
 	},
 	CustomMetricLabels: {
 		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -6888,13 +6888,14 @@ func TestSchedule(t *testing.T) {
 			},
 		},
 		// Same as above, but each workload names its PodSets uniquely, as Pod-group clients
-		// do via the kueue.x-k8s.io/role-hash annotation. The name is part of the hash, so
-		// the bulk-move matches nothing and the siblings stay in the active heap.
-		"equivalent workloads with distinct PodSet names are not bulk-moved": {
+		// do via the kueue.x-k8s.io/role-hash annotation. With the name in the hash the
+		// bulk-move matches nothing and the siblings stay in the active heap.
+		"equivalent workloads with distinct PodSet names are not bulk-moved; SchedulingEquivalenceHashingIgnorePodSetName disabled": {
 			featureGates: map[featuregate.Feature]bool{
-				features.SchedulingEquivalenceHashing:          true,
-				features.FlavorFungibility:                     true,
-				features.FlavorFungibilityPreserveScanProgress: true,
+				features.SchedulingEquivalenceHashing:                 true,
+				features.SchedulingEquivalenceHashingIgnorePodSetName: false,
+				features.FlavorFungibility:                            true,
+				features.FlavorFungibilityPreserveScanProgress:        true,
 			},
 			additionalClusterQueues: []kueue.ClusterQueue{
 				*utiltestingapi.MakeClusterQueue("hash-cq").
@@ -6993,14 +6994,118 @@ func TestSchedule(t *testing.T) {
 				"hash-cq": {"default/wl-head"},
 			},
 		},
+		// The same distinct-name workloads once the name is out of the hash. They now
+		// share one class, so the siblings are bulk-moved after the head fails.
+		"equivalent workloads with distinct PodSet names are bulk-moved; SchedulingEquivalenceHashingIgnorePodSetName enabled": {
+			featureGates: map[featuregate.Feature]bool{
+				features.SchedulingEquivalenceHashing:                 true,
+				features.SchedulingEquivalenceHashingIgnorePodSetName: true,
+				features.FlavorFungibility:                            true,
+				features.FlavorFungibilityPreserveScanProgress:        true,
+			},
+			additionalClusterQueues: []kueue.ClusterQueue{
+				*utiltestingapi.MakeClusterQueue("hash-cq").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("on-demand").
+							Resource(corev1.ResourceCPU, "2").Obj(),
+						*utiltestingapi.MakeFlavorQuotas("spot").
+							Resource(corev1.ResourceCPU, "2").Obj(),
+					).
+					Obj(),
+			},
+			additionalLocalQueues: []kueue.LocalQueue{
+				*utiltestingapi.MakeLocalQueue("hash-queue", "default").ClusterQueue("hash-cq").Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-head", "default").
+					Queue("hash-queue").
+					PodSets(
+						*utiltestingapi.MakePodSet("4f7aac39", 1).Request(corev1.ResourceCPU, "3").Obj(),
+						*utiltestingapi.MakePodSet("12b10b3c", 1).Request(corev1.ResourceCPU, "1").Obj(),
+					).
+					Creation(now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-sibling-1", "default").
+					Queue("hash-queue").
+					PodSets(
+						*utiltestingapi.MakePodSet("f8172213", 1).Request(corev1.ResourceCPU, "3").Obj(),
+						*utiltestingapi.MakePodSet("a4586327", 1).Request(corev1.ResourceCPU, "1").Obj(),
+					).
+					Creation(now.Add(time.Second)).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-sibling-2", "default").
+					Queue("hash-queue").
+					PodSets(
+						*utiltestingapi.MakePodSet("8e163c4e", 1).Request(corev1.ResourceCPU, "3").Obj(),
+						*utiltestingapi.MakePodSet("4601f5b4", 1).Request(corev1.ResourceCPU, "1").Obj(),
+					).
+					Creation(now.Add(2 * time.Second)).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-head", "default").
+					Queue("hash-queue").
+					PodSets(
+						*utiltestingapi.MakePodSet("4f7aac39", 1).Request(corev1.ResourceCPU, "3").Obj(),
+						*utiltestingapi.MakePodSet("12b10b3c", 1).Request(corev1.ResourceCPU, "1").Obj(),
+					).
+					Creation(now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadQuotaReservedReasonExceedsMaxQuota,
+						Message:            "couldn't assign flavors to pod set 4f7aac39: insufficient quota for cpu in flavor on-demand, previously considered podsets requests (0) + current podset request (3) > maximum capacity (2), insufficient quota for cpu in flavor spot, previously considered podsets requests (0) + current podset request (3) > maximum capacity (2)",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadAdmittedReasonNoReservation,
+						Message:            "The workload has no reservation",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "4f7aac39",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("3"),
+						},
+					}, kueue.PodSetRequest{
+						Name: "12b10b3c",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1"),
+						},
+					}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-sibling-1", "default").
+					Queue("hash-queue").
+					PodSets(
+						*utiltestingapi.MakePodSet("f8172213", 1).Request(corev1.ResourceCPU, "3").Obj(),
+						*utiltestingapi.MakePodSet("a4586327", 1).Request(corev1.ResourceCPU, "1").Obj(),
+					).
+					Creation(now.Add(time.Second)).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-sibling-2", "default").
+					Queue("hash-queue").
+					PodSets(
+						*utiltestingapi.MakePodSet("8e163c4e", 1).Request(corev1.ResourceCPU, "3").Obj(),
+						*utiltestingapi.MakePodSet("4601f5b4", 1).Request(corev1.ResourceCPU, "1").Obj(),
+					).
+					Creation(now.Add(2 * time.Second)).
+					Obj(),
+			},
+			wantInadmissibleLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+				"hash-cq": {"default/wl-head", "default/wl-sibling-1", "default/wl-sibling-2"},
+			},
+		},
 		// ConcurrentAdmission puts the allowed-flavors annotation in the shape. That is
 		// independent of the PodSet name, so the siblings still get their own class.
-		"equivalent workloads with distinct PodSet names are not bulk-moved; ConcurrentAdmission enabled": {
+		"equivalent workloads with distinct PodSet names are not bulk-moved; ConcurrentAdmission enabled, SchedulingEquivalenceHashingIgnorePodSetName disabled": {
 			featureGates: map[featuregate.Feature]bool{
-				features.SchedulingEquivalenceHashing:          true,
-				features.FlavorFungibility:                     true,
-				features.FlavorFungibilityPreserveScanProgress: true,
-				features.ConcurrentAdmission:                   true,
+				features.SchedulingEquivalenceHashing:                 true,
+				features.SchedulingEquivalenceHashingIgnorePodSetName: false,
+				features.FlavorFungibility:                            true,
+				features.FlavorFungibilityPreserveScanProgress:        true,
+				features.ConcurrentAdmission:                          true,
 			},
 			additionalClusterQueues: []kueue.ClusterQueue{
 				*utiltestingapi.MakeClusterQueue("hash-cq").

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -399,14 +399,20 @@ func computeSchedulingHash(log logr.Logger, wl *kueue.Workload, totalRequests []
 			effectiveCount = totalRequests[i].Count
 			effectiveRequests = totalRequests[i].Requests
 		}
-		podSetShapes = append(podSetShapes, map[string]any{
-			"name":            ps.Name,
+		podSetShape := map[string]any{
 			"spec":            utilpod.SpecShape(&ps.Template.Spec),
 			"count":           effectiveCount,
 			"requests":        resources.ToMap(effectiveRequests),
 			"minCount":        ps.MinCount,
 			"topologyRequest": ps.TopologyRequest,
-		})
+		}
+		// The name identifies a PodSet but does not affect how it is assigned.
+		// Two readers depend on this shape: the queue's equivalence classes, and
+		// LastAssignment reuse through MatchesSchedulingShape.
+		if !features.Enabled(features.SchedulingEquivalenceHashingIgnorePodSetName) {
+			podSetShape["name"] = ps.Name
+		}
+		podSetShapes = append(podSetShapes, podSetShape)
 	}
 	shape := map[string]any{
 		"podSets":  podSetShapes,

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -3119,6 +3119,69 @@ func TestSchedulingHash(t *testing.T) {
 				features.ConcurrentAdmission:          true,
 			},
 		},
+		"different PodSet names when the name is part of the hash": {
+			wl1: utiltestingapi.MakeWorkload("wl1", "ns").
+				PodSets(*utiltestingapi.MakePodSet("4f7aac39", 1).
+					Request(corev1.ResourceCPU, "1").Obj()).Obj(),
+			wl2: utiltestingapi.MakeWorkload("wl2", "ns").
+				PodSets(*utiltestingapi.MakePodSet("f8172213", 1).
+					Request(corev1.ResourceCPU, "1").Obj()).Obj(),
+			wantSame: false,
+			featureGates: map[featuregate.Feature]bool{
+				features.SchedulingEquivalenceHashing:                 true,
+				features.SchedulingEquivalenceHashingIgnorePodSetName: false,
+			},
+		},
+		"different PodSet names when the name is ignored": {
+			wl1: utiltestingapi.MakeWorkload("wl1", "ns").
+				PodSets(*utiltestingapi.MakePodSet("4f7aac39", 1).
+					Request(corev1.ResourceCPU, "1").Obj()).Obj(),
+			wl2: utiltestingapi.MakeWorkload("wl2", "ns").
+				PodSets(*utiltestingapi.MakePodSet("f8172213", 1).
+					Request(corev1.ResourceCPU, "1").Obj()).Obj(),
+			wantSame: true,
+			featureGates: map[featuregate.Feature]bool{
+				features.SchedulingEquivalenceHashing:                 true,
+				features.SchedulingEquivalenceHashingIgnorePodSetName: true,
+			},
+		},
+		// Position still matters: requests are matched to PodSets by index.
+		"PodSet requests swapped between the same names when the name is ignored": {
+			wl1: utiltestingapi.MakeWorkload("wl1", "ns").
+				PodSets(
+					*utiltestingapi.MakePodSet("a", 1).Request(corev1.ResourceCPU, "1").Obj(),
+					*utiltestingapi.MakePodSet("b", 1).Request(corev1.ResourceCPU, "2").Obj(),
+				).Obj(),
+			wl2: utiltestingapi.MakeWorkload("wl2", "ns").
+				PodSets(
+					*utiltestingapi.MakePodSet("a", 1).Request(corev1.ResourceCPU, "2").Obj(),
+					*utiltestingapi.MakePodSet("b", 1).Request(corev1.ResourceCPU, "1").Obj(),
+				).Obj(),
+			wantSame: false,
+			featureGates: map[featuregate.Feature]bool{
+				features.SchedulingEquivalenceHashing:                 true,
+				features.SchedulingEquivalenceHashingIgnorePodSetName: true,
+			},
+		},
+		// The Pod group case: same two roles, distinct per-Workload names that sort
+		// into opposite positions, so the ordered descriptions differ.
+		"PodSets with distinct names sorting into a different order when the name is ignored": {
+			wl1: utiltestingapi.MakeWorkload("wl1", "ns").
+				PodSets(
+					*utiltestingapi.MakePodSet("4f7aac39", 1).Request(corev1.ResourceCPU, "1").Obj(),
+					*utiltestingapi.MakePodSet("f8172213", 1).Request(corev1.ResourceCPU, "2").Obj(),
+				).Obj(),
+			wl2: utiltestingapi.MakeWorkload("wl2", "ns").
+				PodSets(
+					*utiltestingapi.MakePodSet("12b10b3c", 1).Request(corev1.ResourceCPU, "2").Obj(),
+					*utiltestingapi.MakePodSet("a4586327", 1).Request(corev1.ResourceCPU, "1").Obj(),
+				).Obj(),
+			wantSame: false,
+			featureGates: map[featuregate.Feature]bool{
+				features.SchedulingEquivalenceHashing:                 true,
+				features.SchedulingEquivalenceHashingIgnorePodSetName: true,
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -361,6 +361,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.18"
+- name: SchedulingEquivalenceHashingIgnorePodSetName
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.20"
 - name: ShortWorkloadNames
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -361,6 +361,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.18"
+- name: SchedulingEquivalenceHashingIgnorePodSetName
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.20"
 - name: ShortWorkloadNames
   versionedSpecs:
   - default: false


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The scheduling equivalence hash includes each PodSet's `Name`, which flavor assignment does not use. A client that gives every Workload a unique PodSet name gets one class per Workload, so the bulk-move to inadmissible never matches and equivalent unschedulable Workloads are re-evaluated every cycle. The Pod group integration is one such client: `getRoleHash` returns the `kueue.x-k8s.io/role-hash` annotation as-is when it is already set, and that value becomes the PodSet name.

Task 2 from #14534. The name is now excluded behind `SchedulingEquivalenceHashingIgnorePodSetName`, Beta and on by default, depending on `SchedulingEquivalenceHashing`. KEP-9694 listed this as a known gap and is updated, including the ordering behaviour and the multi-PodSet caveat.

#### Which issue(s) this PR fixes:

Part of #14534

#### Special notes for your reviewer:

On the default: #14534 asks for beta here and alpha in the backports, so I read that as on by default on main. Happy to flip it.

`defaultFeatureGateDependencies` is reindented because the new key is the longest in it. No entries changed.

#### Does this PR introduce a user-facing change?

```release-note
Scheduling: Fixed a bug where Workloads differing only in PodSet names formed separate equivalence classes, so BestEffortFIFO queues re-evaluated each one individually and admission slowed on busy clusters. Controlled by the new SchedulingEquivalenceHashingIgnorePodSetName gate, enabled by default.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a beta scheduling option, enabled by default in version 0.20, that treats workloads with different PodSet names as scheduling-equivalent.
  * PodSet ordering and resource differences remain significant, preserving distinctions between meaningfully different workloads.
  * The option can be disabled when PodSet names must remain part of equivalence calculations.
  * Added beta validation for reserved resource names, enabled by default in version 0.20.

* **Documentation**
  * Documented feature availability, behavior, and PodSet ordering considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
