### PR TITLE
Upgrade to go v1.27

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # defaulted ARGs need to be declared first
-ARG BUILDER_IMAGE=public.ecr.aws/docker/library/golang:1.26
+ARG BUILDER_IMAGE=public.ecr.aws/docker/library/golang:1.27
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
 # compilation stage for the manager binary
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} AS builder

--- a/cmd/experimental/kueue-populator/Dockerfile
+++ b/cmd/experimental/kueue-populator/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDER_IMAGE=public.ecr.aws/docker/library/golang:1.26
+ARG BUILDER_IMAGE=public.ecr.aws/docker/library/golang:1.27
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
 
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} AS builder

--- a/cmd/experimental/kueue-priority-booster/Dockerfile
+++ b/cmd/experimental/kueue-priority-booster/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDER_IMAGE=public.ecr.aws/docker/library/golang:1.26
+ARG BUILDER_IMAGE=public.ecr.aws/docker/library/golang:1.27
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
 
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} AS builder

--- a/cmd/experimental/webhook-conversion-repro/Dockerfile
+++ b/cmd/experimental/webhook-conversion-repro/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.0 AS build
+FROM golang:1.27.0 AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download

--- a/cmd/experimental/webhook-conversion-repro/go.mod
+++ b/cmd/experimental/webhook-conversion-repro/go.mod
@@ -1,6 +1,6 @@
 module populator
 
-go 1.26.0
+go 1.27.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/cmd/importer/Dockerfile
+++ b/cmd/importer/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDER_IMAGE=public.ecr.aws/docker/library/golang:1.26
+ARG BUILDER_IMAGE=public.ecr.aws/docker/library/golang:1.27
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
 # Build the manager binary
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} AS builder

--- a/cmd/kueueviz/backend/Dockerfile
+++ b/cmd/kueueviz/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-ARG BUILDER_IMAGE=public.ecr.aws/docker/library/golang:1.26
+ARG BUILDER_IMAGE=public.ecr.aws/docker/library/golang:1.27
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} AS builder
 

--- a/cmd/kueueviz/backend/go.mod
+++ b/cmd/kueueviz/backend/go.mod
@@ -1,25 +1,40 @@
 module kueueviz
 
-go 1.26.0
+go 1.27.0
 
 require (
 	github.com/bep/debounce v1.2.1
 	github.com/gin-contrib/cors v1.7.7
 	github.com/gin-gonic/gin v1.12.0
+	github.com/go-logr/logr v1.4.4
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
+	github.com/spf13/viper v1.21.0
+	golang.org/x/time v0.15.0
 	k8s.io/api v0.36.3
 	k8s.io/apimachinery v0.36.3
 	k8s.io/client-go v0.36.3
 	sigs.k8s.io/controller-runtime v0.24.1
 	sigs.k8s.io/kueue v0.19.1
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
+	github.com/bytedance/sonic v1.15.0 // indirect
+	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/cloudwego/base64x v0.1.6 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
+	github.com/fxamacker/cbor/v2 v2.9.1 // indirect
+	github.com/gabriel-vasile/mimetype v1.4.12 // indirect
+	github.com/gin-contrib/sse v1.1.0 // indirect
+	github.com/go-openapi/jsonpointer v0.23.1 // indirect
+	github.com/go-openapi/jsonreference v0.21.5 // indirect
+	github.com/go-openapi/swag v0.26.0 // indirect
 	github.com/go-openapi/swag/cmdutils v0.26.0 // indirect
 	github.com/go-openapi/swag/conv v0.26.0 // indirect
 	github.com/go-openapi/swag/fileutils v0.26.0 // indirect
@@ -31,8 +46,22 @@ require (
 	github.com/go-openapi/swag/stringutils v0.26.0 // indirect
 	github.com/go-openapi/swag/typeutils v0.26.0 // indirect
 	github.com/go-openapi/swag/yamlutils v0.26.0 // indirect
+	github.com/go-playground/locales v0.14.1 // indirect
+	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/go-playground/validator/v10 v10.30.1 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
+	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect
+	github.com/google/gnostic-models v0.7.1 // indirect
+	github.com/google/uuid v1.6.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
+	github.com/leodido/go-urn v1.4.0 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
@@ -44,63 +73,31 @@ require (
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
-	github.com/subosito/gotenv v1.6.0 // indirect
-	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
-	go.yaml.in/yaml/v2 v2.4.4 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/sync v0.22.0 // indirect
-	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect
-	k8s.io/apiextensions-apiserver v0.36.3 // indirect
-	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/structured-merge-diff/v6 v6.4.2 // indirect
-)
-
-require (
-	github.com/bytedance/sonic v1.15.0 // indirect
-	github.com/bytedance/sonic/loader v0.5.0 // indirect
-	github.com/cloudwego/base64x v0.1.6 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
-	github.com/fxamacker/cbor/v2 v2.9.1 // indirect
-	github.com/gabriel-vasile/mimetype v1.4.12 // indirect
-	github.com/gin-contrib/sse v1.1.0 // indirect
-	github.com/go-logr/logr v1.4.4
-	github.com/go-openapi/jsonpointer v0.23.1 // indirect
-	github.com/go-openapi/jsonreference v0.21.5 // indirect
-	github.com/go-openapi/swag v0.26.0 // indirect
-	github.com/go-playground/locales v0.14.1 // indirect
-	github.com/go-playground/universal-translator v0.18.1 // indirect
-	github.com/go-playground/validator/v10 v10.30.1 // indirect
-	github.com/goccy/go-json v0.10.5 // indirect
-	github.com/google/gnostic-models v0.7.1 // indirect
-	github.com/google/uuid v1.6.0 // indirect
-	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
-	github.com/leodido/go-urn v1.4.0 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
-	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
-	github.com/spf13/viper v1.21.0
+	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.1 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
+	go.yaml.in/yaml/v2 v2.4.4 // indirect
+	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/arch v0.23.0 // indirect
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
+	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
-	golang.org/x/time v0.15.0
+	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	k8s.io/apiextensions-apiserver v0.36.3 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260618221249-bc653b64f974 // indirect
 	k8s.io/utils v0.0.0-20260626114624-be93311217bd // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
-	sigs.k8s.io/yaml v1.6.0
+	sigs.k8s.io/randfill v1.0.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v6 v6.4.2 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/kueue
 
-go 1.26.0
+go 1.27.0
 
 require (
 	github.com/cert-manager/cert-manager v1.21.1

--- a/hack/images/golang/Dockerfile
+++ b/hack/images/golang/Dockerfile
@@ -1,1 +1,1 @@
-FROM public.ecr.aws/docker/library/golang:1.26@sha256:3aff6657219a4d9c14e27fb1d8976c49c29fddb70ba835014f477e1c70636647
+FROM public.ecr.aws/docker/library/golang:1.27@sha256:65b6f280bf050ec5af12716857e8ea8439d694dbba8f31ceeb7630670071f2bb

--- a/hack/make/test.mk
+++ b/hack/make/test.mk
@@ -111,8 +111,7 @@ test: gotestsum ## Run tests. Set UNIT_TOTAL_SHARDS and UNIT_SHARD_INDEX to run 
 	GORACE="log_path=$(ARTIFACTS)/race$(OPTIONAL_SHARD_SUFFIX)" TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) $(GOTESTSUM) --junitfile $(ARTIFACTS)/junit$(OPTIONAL_SHARD_SUFFIX).xml -- $(GOFLAGS) $(GO_TEST_FLAGS) $(UNIT_TEST_PACKAGES) -coverpkg=$(GO_TEST_TARGET)/... -coverprofile $(ARTIFACTS)/cover$(OPTIONAL_SHARD_SUFFIX).out
 
 # Time budget for fuzzing each individual fuzz target.
-# TODO: Change back to 5s when golang/go#75804 is fixed in Go 1.27
-FUZZTIME ?= 1000x
+FUZZTIME ?= 5s
 
 .PHONY: test-fuzz
 test-fuzz: ## Run all fuzz tests with fuzzing enabled, FUZZTIME per target.

--- a/hack/testing/secretreader/Dockerfile
+++ b/hack/testing/secretreader/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
+FROM golang:1.27-alpine@sha256:4c9fe60190a2a3350ddc51de80d0224b8a6698d12bdfc999fee45ea9d6c46dbc AS builder
 ARG PLUGIN_VERSION
 RUN go install sigs.k8s.io/cluster-inventory-api/plugins/secretreader/cmd/plugin@${PLUGIN_VERSION}
 

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/kueue/hack/tools
 
-go 1.26.0
+go 1.27.0
 
 tool (
 	github.com/gohugoio/hugo
@@ -37,7 +37,6 @@ require (
 	gotest.tools/gotestsum v1.13.0
 	helm.sh/helm/v4 v4.2.4
 	k8s.io/code-generator v0.36.3 // Used not only as code-generator but also for compatibility_lifecycle (feature-gates docs) tool versioning.
-	sigs.k8s.io/cluster-inventory-api v0.1.3 // indirect
 	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.24.1
 	sigs.k8s.io/controller-tools v0.20.1
 	sigs.k8s.io/dra-example-driver v0.4.0
@@ -524,6 +523,7 @@ require (
 	mvdan.cc/unparam v0.0.0-20251027182757-5beb8c8f8f15 // indirect
 	oras.land/oras-go/v2 v2.6.2 // indirect
 	rsc.io/qr v0.2.0 // indirect
+	sigs.k8s.io/cluster-inventory-api v0.1.3 // indirect
 	sigs.k8s.io/controller-runtime v0.24.1 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/kustomize/api v0.21.1 // indirect

--- a/pkg/resources/slice_requests.go
+++ b/pkg/resources/slice_requests.go
@@ -35,9 +35,9 @@ const emptyResourceName = corev1.ResourceName("")
 func hashResourceName(name corev1.ResourceName) uint64 {
 	h := fnv.New64a()
 	// Write cannot fail: this is guaranteed by the hash.Hash interface contract:
-	// https://github.com/golang/go/blob/go1.26.5/src/hash/hash.go#L26-L29
+	// https://github.com/golang/go/blob/go1.27.0/src/hash/hash.go#L26-L29
 	// and by the fnv.New64a implementation, which always returns len(data), nil.
-	// https://github.com/golang/go/blob/go1.26.5/src/hash/fnv/fnv.go#L56-L115
+	// https://github.com/golang/go/blob/go1.27.0/src/hash/fnv/fnv.go#L63-L138
 	_, _ = h.Write([]byte(name))
 	return h.Sum64()
 }

--- a/site/go.mod
+++ b/site/go.mod
@@ -1,5 +1,5 @@
 module sigs.k8s.io/kueue/site
 
-go 1.26.0
+go 1.27.0
 
 require github.com/google/docsy v0.11.0 // indirect

--- a/test/e2e/config/default/controller_manager_config.yaml
+++ b/test/e2e/config/default/controller_manager_config.yaml
@@ -43,7 +43,7 @@ featureGates:
   MultiKueueManagerQuotaAutomation: true
 tls:
   minVersion: "VersionTLS12"
-  # this is the default ciphersuite for golang 1.26
+  # this is the default ciphersuite for golang 1.27
   cipherSuites:
     - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
     - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256

--- a/test/e2e/config/extended/controller_manager_config.yaml
+++ b/test/e2e/config/extended/controller_manager_config.yaml
@@ -46,7 +46,7 @@ featureGates:
   MultiKueueManagerQuotaAutomation: true
 tls:
   minVersion: "VersionTLS12"
-  # this is the default ciphersuite for golang 1.26
+  # this is the default ciphersuite for golang 1.27
   cipherSuites:
     - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
     - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256

--- a/test/e2e/config/multikueue/extended-shard-0/controller_manager_config.yaml
+++ b/test/e2e/config/multikueue/extended-shard-0/controller_manager_config.yaml
@@ -47,7 +47,7 @@ featureGates:
   MultiKueueManagerQuotaAutomation: true
 tls:
   minVersion: "VersionTLS12"
-  # this is the default ciphersuite for golang 1.26
+  # this is the default ciphersuite for golang 1.27
   cipherSuites:
     - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
     - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256

--- a/test/e2e/config/multikueue/extended-shard-1/controller_manager_config.yaml
+++ b/test/e2e/config/multikueue/extended-shard-1/controller_manager_config.yaml
@@ -40,7 +40,7 @@ featureGates:
   MultiKueueManagerQuotaAutomation: true
 tls:
   minVersion: "VersionTLS12"
-  # this is the default ciphersuite for golang 1.26
+  # this is the default ciphersuite for golang 1.27
   cipherSuites:
     - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
     - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Updates Kueue to golang 1.27:
- Bumps the `go` directive to 1.27.0 in all five modules (root, `site`, `hack/tools`, `cmd/kueueviz/backend`, `cmd/experimental/webhook-conversion-repro`). 
- Bumps all golang builder images to 1.27, including fresh multi-arch index digests for the two digest-pinned images (`hack/images/golang/Dockerfile`, `hack/testing/secretreader/Dockerfile`).
- Regenerates `client-go/applyconfiguration` (60 files): the apply-configuration generator compiled with Go 1.27 emits an extra blank comment line for some field docs, and `verify` regenerates and diffs these files in CI.
- Restores `FUZZTIME` to `5s` in `hack/make/test.mk`, resolving the TODO left by #13580: the fuzz coordinator race golang/go#75804 is fixed in Go 1.27.0 (the corrected suppression check is present in the released `internal/fuzz` sources).

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
AI usage disclaimer: I used fable-5 to do the version upgrade and run the checks.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

