### PR TITLE
Follow up: Track the deferred cleanup items from pull request #14099.

### DIFF
--- a/pkg/controller/tas/topology_ungater.go
+++ b/pkg/controller/tas/topology_ungater.go
@@ -246,7 +246,7 @@ func (r *topologyUngater) Reconcile(ctx context.Context, req reconcile.Request) 
 	}
 	for _, psa := range wl.Status.Admission.PodSetAssignments {
 		if psa.TopologyAssignment != nil {
-			pods, err := r.podsForPodSet(ctx, wl.Namespace, workloadSliceName, psa.Name)
+			pods, err := r.filterPodsToUngate(ctx, wl.Namespace, workloadSliceName, psa.Name)
 			if err != nil {
 				log.Error(err, "failed to list Pods for PodSet", "podset", psa.Name, "count", psa.Count)
 				return reconcile.Result{}, err
@@ -355,21 +355,32 @@ func shouldReconcileWorkload(wl *kueue.Workload) bool {
 	return workload.IsAdmittedByTAS(wl)
 }
 
-func (r *topologyUngater) podsForPodSet(ctx context.Context, ns, workloadSliceName string, psName kueue.PodSetReference) ([]*corev1.Pod, error) {
-	pods, err := ListPodsForWorkloadSlice(ctx, r.client, ns, workloadSliceName,
-		client.MatchingLabels{constants.PodSetLabel: string(psName)})
+func (r *topologyUngater) filterPodsToUngate(
+	ctx context.Context,
+	ns, workloadSliceName string,
+	psName kueue.PodSetReference,
+) ([]*corev1.Pod, error) {
+	pods, err := ListPodsForWorkloadSlice(
+		ctx,
+		r.client,
+		ns,
+		workloadSliceName,
+		client.MatchingLabels{constants.PodSetLabel: string(psName)},
+	)
 	if err != nil {
 		return nil, err
 	}
+
 	result := make([]*corev1.Pod, 0, len(pods))
 	for _, pod := range pods {
 		if utilpod.IsTerminated(pod) {
-			// ignore failed or succeeded pods as they need to be replaced, and
-			// so we don't want to count them as already ungated Pods.
+			// Ignore failed or succeeded pods as they need to be replaced,
+			// and so we don't want to count them as already ungated Pods.
 			continue
 		}
 		result = append(result, pod)
 	}
+
 	return result, nil
 }
 

--- a/pkg/controller/tas/topology_ungater.go
+++ b/pkg/controller/tas/topology_ungater.go
@@ -246,7 +246,7 @@ func (r *topologyUngater) Reconcile(ctx context.Context, req reconcile.Request) 
 	}
 	for _, psa := range wl.Status.Admission.PodSetAssignments {
 		if psa.TopologyAssignment != nil {
-			pods, err := r.filterPodsToUngate(ctx, wl.Namespace, workloadSliceName, psa.Name)
+			pods, err := r.podsForPodSet(ctx, wl.Namespace, workloadSliceName, psa.Name)
 			if err != nil {
 				log.Error(err, "failed to list Pods for PodSet", "podset", psa.Name, "count", psa.Count)
 				return reconcile.Result{}, err
@@ -275,18 +275,8 @@ func (r *topologyUngater) Reconcile(ctx context.Context, req reconcile.Request) 
 			// terminates them with UnschedulableOnAssignedNode, so every recreated
 			// pod is killed again immediately. Leaving them gated lets them wait for
 			// the replacement domain and be ungated onto a healthy node instead.
-			if workload.HasUnhealthyNodes(wl) {
-				levels := psa.TopologyAssignment.Levels
-				gatedPodsToDomains = slices.DeleteFunc(gatedPodsToDomains, func(pd podWithDomain) bool {
-					nodeName, ok := utiltas.NodeNameFromDomainID(levels, pd.domainID)
-					if !ok || !workload.HasUnhealthyNode(wl, nodeName) {
-						return false
-					}
-					log.V(3).Info("skipping ungate; the assigned node is unhealthy and awaiting replacement",
-						"pod", klog.KObj(pd.pod), "domain", pd.domainID, "node", nodeName)
-					return true
-				})
-			}
+			gatedPodsToDomains = filterPodsToUngate(log, wl, &psa, gatedPodsToDomains)
+
 			if len(gatedPodsToDomains) > 0 {
 				toUngate := podsToUngateInfo(&psa, gatedPodsToDomains)
 				log.V(2).Info("identified pods to ungate for podset", "podset", psa.Name, "count", len(toUngate))
@@ -355,33 +345,41 @@ func shouldReconcileWorkload(wl *kueue.Workload) bool {
 	return workload.IsAdmittedByTAS(wl)
 }
 
-func (r *topologyUngater) filterPodsToUngate(
-	ctx context.Context,
-	ns, workloadSliceName string,
-	psName kueue.PodSetReference,
-) ([]*corev1.Pod, error) {
-	pods, err := ListPodsForWorkloadSlice(
-		ctx,
-		r.client,
-		ns,
-		workloadSliceName,
-		client.MatchingLabels{constants.PodSetLabel: string(psName)},
-	)
+func (r *topologyUngater) podsForPodSet(ctx context.Context, ns, workloadSliceName string, psName kueue.PodSetReference) ([]*corev1.Pod, error) {
+	pods, err := ListPodsForWorkloadSlice(ctx, r.client, ns, workloadSliceName,
+		client.MatchingLabels{constants.PodSetLabel: string(psName)})
 	if err != nil {
 		return nil, err
 	}
-
 	result := make([]*corev1.Pod, 0, len(pods))
 	for _, pod := range pods {
 		if utilpod.IsTerminated(pod) {
-			// Ignore failed or succeeded pods as they need to be replaced,
-			// and so we don't want to count them as already ungated Pods.
+			// ignore failed or succeeded pods as they need to be replaced, and
+			// so we don't want to count them as already ungated Pods.
 			continue
 		}
 		result = append(result, pod)
 	}
-
 	return result, nil
+}
+
+// filterPodsToUngate filters out pods assigned to unhealthy nodes that are awaiting replacement.
+// Pods on such nodes should remain gated to wait for a replacement domain instead of being
+// ungated onto a node that will never allow them to schedule.
+func filterPodsToUngate(log logr.Logger, wl *kueue.Workload, psa *kueue.PodSetAssignment, gatedPodsToDomains []podWithDomain) []podWithDomain {
+	if !workload.HasUnhealthyNodes(wl) {
+		return gatedPodsToDomains
+	}
+	levels := psa.TopologyAssignment.Levels
+	return slices.DeleteFunc(gatedPodsToDomains, func(pd podWithDomain) bool {
+		nodeName, ok := utiltas.NodeNameFromDomainID(levels, pd.domainID)
+		if !ok || !workload.HasUnhealthyNode(wl, nodeName) {
+			return false
+		}
+		log.V(3).Info("skipping ungate; the assigned node is unhealthy and awaiting replacement",
+			"pod", klog.KObj(pd.pod), "domain", pd.domainID, "node", nodeName)
+		return true
+	})
 }
 
 func podsToUngateInfo(

--- a/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
@@ -3513,7 +3513,9 @@ var _ = ginkgo.Describe("Pod controller with TASFailedNodeReplacementFailFast di
 			gomega.Expect(k8sClient.Get(ctx, wlKey, wl)).To(gomega.Succeed())
 			nodeNames := slices.Collect(tas.LowestLevelValues(wl.Status.Admission.PodSetAssignments[0].TopologyAssignment))
 			gomega.Expect(nodeNames).To(gomega.ConsistOf("x1", "x2"))
-			gomega.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
+			})
 		})
 
 		ginkgo.By("wait for pods to be ungated and bind each to its assigned node", func() {

--- a/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
@@ -3513,8 +3513,6 @@ var _ = ginkgo.Describe("Pod controller with TASFailedNodeReplacementFailFast di
 			// below uses as the lookup key.
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
-				g.Expect(wl.Spec.PodSets).To(gomega.HaveLen(1))
-				g.Expect(wl.Spec.PodSets[0].Count).To(gomega.Equal(int32(2)))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 

--- a/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
@@ -3508,19 +3508,12 @@ var _ = ginkgo.Describe("Pod controller with TASFailedNodeReplacementFailFast di
 		wlKey := types.NamespacedName{Namespace: ns.Name, Name: podGroupName}
 		wl := &kueue.Workload{}
 
-		ginkgo.By("checking that the workload is created", func() {
-			// Also populates wl, whose name/namespace ExpectWorkloadsToBeAdmitted
-			// below uses as the lookup key.
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-		})
-
 		ginkgo.By("verify the workload is admitted onto both nodes", func() {
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
 			gomega.Expect(k8sClient.Get(ctx, wlKey, wl)).To(gomega.Succeed())
 			nodeNames := slices.Collect(tas.LowestLevelValues(wl.Status.Admission.PodSetAssignments[0].TopologyAssignment))
 			gomega.Expect(nodeNames).To(gomega.ConsistOf("x1", "x2"))
+			gomega.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
 		})
 
 		ginkgo.By("wait for pods to be ungated and bind each to its assigned node", func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind feature
/area tas
/area testing



#### What this PR does / why we need it:
1. Extract the pod filtering logic from the main reconciliation loop into a focused helper, such as filterPodsToUngate, to improve readability.

Affected area: `pkg/controller/tas/topology_ungater.go`

2.Simplify the TAS integration test by removing redundant assertions that wl.Spec.PodSets has one entry and that its count is  when the existing verification already confirms admission on both nodes.

Affected area: `test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go`

3.Simplify the replacement-pod test verification so it focuses on the required behavior: the replacement pod remains topology-gated and is never pinned to the failed node.

Affected area: `test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go`

#### Which issue(s) this PR fixes:

Fixes #14161

#### Special notes for your reviewer:
also a small typo addition.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented terminated Pods, including failed and succeeded Pods, from being selected for ungating.
  * Preserved workload-slice and PodSet filtering when determining which Pods to ungate.

* **Tests**
  * Updated integration test expectations for TAS failed-node replacement behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->