### PR TITLE
Clamp workload recovery time to non-negative values

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1207,12 +1207,12 @@ func ReportPendingWorkloads(cqName kueue.ClusterQueueReference, pendingStatus st
 
 func ReportWorkloadRecoveryWaitTime(cqName kueue.ClusterQueueReference, priorityClass string, waitTime time.Duration, customLabelValues []string, tracker *roletracker.RoleTracker) {
 	labels := append([]string{string(cqName), priorityClass, roletracker.GetRole(tracker)}, customLabelValues...)
-	WorkloadRecoveryWaitTime.WithLabelValues(labels...).Observe(waitTime.Seconds())
+	WorkloadRecoveryWaitTime.WithLabelValues(labels...).Observe(max(0, waitTime.Seconds()))
 }
 
 func ReportLocalQueueWorkloadRecoveryWaitTime(lq LocalQueueReference, priorityClass string, waitTime time.Duration, customLabelValues []string, tracker *roletracker.RoleTracker) {
 	labels := append([]string{string(lq.Name), lq.Namespace, priorityClass, roletracker.GetRole(tracker)}, customLabelValues...)
-	LocalQueueWorkloadRecoveryWaitTime.WithLabelValues(labels...).Observe(waitTime.Seconds())
+	LocalQueueWorkloadRecoveryWaitTime.WithLabelValues(labels...).Observe(max(0, waitTime.Seconds()))
 }
 
 func ReportPendingSchedulingHashes(cqName kueue.ClusterQueueReference, active, inadmissible int, customLabelValues []string, tracker *roletracker.RoleTracker) {

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
@@ -41,6 +42,27 @@ func expectFilteredMetricsCount(t *testing.T, vec prometheus.Collector, count in
 	if len(all) != count {
 		t.Helper()
 		t.Errorf("Expecting %d metrics got %d, matching labels %v", count, len(all), kvs)
+	}
+}
+
+func expectHistogramSampleSum(t *testing.T, vec *prometheus.HistogramVec, expected float64, labels ...string) {
+	t.Helper()
+	observer, err := vec.GetMetricWithLabelValues(labels...)
+	if err != nil {
+		t.Fatalf("Error getting metric for labels %v: %v", labels, err)
+	}
+	var dto dto.Metric
+
+	if err := observer.(prometheus.Metric).Write(&dto); err != nil {
+		t.Fatalf("Error writing metric: %v", err)
+	}
+
+	if dto.Histogram == nil {
+		t.Fatalf("Expected histogram metric for labels %v", labels)
+	}
+
+	if got := dto.GetHistogram().GetSampleSum(); got != expected {
+		t.Errorf("got %v want %v", got, expected)
 	}
 }
 
@@ -642,11 +664,19 @@ func TestWorkloadRecoveryWaitTimeMetrics(t *testing.T) {
 	cqName := kueue.ClusterQueueReference("cq-recovery-test")
 	lqRef := LocalQueueReference{Name: "lq-recovery-test", Namespace: "default"}
 
+	// Positive wait times
 	ReportWorkloadRecoveryWaitTime(cqName, "default", 5*time.Second, nil, nil)
-	expectFilteredMetricsCount(t, WorkloadRecoveryWaitTime, 1, "cluster_queue", "cq-recovery-test")
+	expectHistogramSampleSum(t, WorkloadRecoveryWaitTime, 5.0, "cq-recovery-test", "default", roletracker.RoleStandalone)
 
 	ReportLocalQueueWorkloadRecoveryWaitTime(lqRef, "default", 5*time.Second, nil, nil)
-	expectFilteredMetricsCount(t, LocalQueueWorkloadRecoveryWaitTime, 1, "name", "lq-recovery-test", "namespace", "default")
+	expectHistogramSampleSum(t, LocalQueueWorkloadRecoveryWaitTime, 5.0, "lq-recovery-test", "default", "default", roletracker.RoleStandalone)
+
+	// Negative wait times
+	ReportWorkloadRecoveryWaitTime(cqName, "default", -5*time.Second, nil, nil)
+	expectHistogramSampleSum(t, WorkloadRecoveryWaitTime, 5.0, "cq-recovery-test", "default", roletracker.RoleStandalone)
+
+	ReportLocalQueueWorkloadRecoveryWaitTime(lqRef, "default", -5*time.Second, nil, nil)
+	expectHistogramSampleSum(t, LocalQueueWorkloadRecoveryWaitTime, 5.0, "lq-recovery-test", "default", "default", roletracker.RoleStandalone)
 
 	ClearClusterQueueMetrics(cqName)
 	expectFilteredMetricsCount(t, WorkloadRecoveryWaitTime, 0, "cluster_queue", "cq-recovery-test")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

Clamps recovery wait time metric to `>=0` to prevent recording negative durations to Prometheus.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14797 

#### Special notes for your reviewer:
Follow-up to #14766.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Recovery wait time metrics no longer record negative values; negative durations are reported as zero.
  - Applies to both workload and local-queue recovery metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->