### PR TITLE
[release-0.19] Add SchedulingEquivalenceHashingIgnorePodSetName feature gate

### DIFF
--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -717,6 +717,9 @@ func LoadAndValidateFeatureGates(featureGateCLI string, featureGateMap map[strin
 	allErrs = append(allErrs, validateFeatureGateDependency(features.TASRecomputeAssignmentWithinSchedulingCycle, features.TopologyAwareScheduling)...)
 	allErrs = append(allErrs, validateFeatureGateDependency(features.UnadmittedWorkloadsExplicitStatus, features.UnadmittedWorkloadsObservability)...)
 
+	// Excluding the PodSet name only means something once the hash itself is computed.
+	allErrs = append(allErrs, validateFeatureGateDependency(features.SchedulingEquivalenceHashingIgnorePodSetName, features.SchedulingEquivalenceHashing)...)
+
 	if features.Enabled(features.ElasticJobsViaWorkloadSlicesWithTAS) {
 		if !features.Enabled(features.ElasticJobsViaWorkloadSlices) {
 			allErrs = append(allErrs, field.Invalid(featureGatesPath, "ElasticJobsViaWorkloadSlicesWithTAS", "ElasticJobsViaWorkloadSlicesWithTAS requires ElasticJobsViaWorkloadSlices to be enabled"))

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -2354,6 +2354,23 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				},
 			},
 		},
+		"SchedulingEquivalenceHashingIgnorePodSetName requires SchedulingEquivalenceHashing": {
+			featureGateMap: map[string]bool{
+				string(features.SchedulingEquivalenceHashingIgnorePodSetName): true,
+				string(features.SchedulingEquivalenceHashing):                 false,
+			},
+			gatesToRestore: map[featuregate.Feature]bool{
+				features.SchedulingEquivalenceHashingIgnorePodSetName: false,
+				features.SchedulingEquivalenceHashing:                 true,
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:   field.ErrorTypeInvalid,
+					Field:  "featureGates",
+					Detail: "SchedulingEquivalenceHashingIgnorePodSetName requires SchedulingEquivalenceHashing to be enabled",
+				},
+			},
+		},
 		"TASHandleOverlappingFlavors requires TopologyAwareScheduling": {
 			featureGateMap: map[string]bool{
 				string(features.TopologyAwareScheduling):                     false,

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -334,6 +334,13 @@ const (
 	// Skip equivalent inadmissible workloads in BestEffortFIFO scheduling.
 	SchedulingEquivalenceHashing featuregate.Feature = "SchedulingEquivalenceHashing"
 
+	// owner: @venuchitta
+	//
+	// issue: https://github.com/kubernetes-sigs/kueue/issues/14534
+	// Exclude the PodSet name from the scheduling equivalence hash. Flavor assignment
+	// does not use the name, so including it splits otherwise equivalent Workloads.
+	SchedulingEquivalenceHashingIgnorePodSetName featuregate.Feature = "SchedulingEquivalenceHashingIgnorePodSetName"
+
 	// owner: @mbobrovskyi
 	//
 	// issue: https://github.com/kubernetes-sigs/kueue/issues/9799
@@ -845,6 +852,9 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	SchedulingEquivalenceHashing: {
 		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Beta},
 		{Version: version.MustParse("0.18"), Default: true, PreRelease: featuregate.Beta},
+	},
+	SchedulingEquivalenceHashingIgnorePodSetName: {
+		{Version: version.MustParse("0.19"), Default: false, PreRelease: featuregate.Alpha},
 	},
 	SchedulerLongRequeueInterval: {
 		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Alpha}, // remove in 0.20

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -6871,13 +6871,14 @@ func TestSchedule(t *testing.T) {
 			},
 		},
 		// Same as above, but each workload names its PodSets uniquely, as Pod-group clients
-		// do via the kueue.x-k8s.io/role-hash annotation. The name is part of the hash, so
-		// the bulk-move matches nothing and the siblings stay in the active heap.
-		"equivalent workloads with distinct PodSet names are not bulk-moved": {
+		// do via the kueue.x-k8s.io/role-hash annotation. With the name in the hash the
+		// bulk-move matches nothing and the siblings stay in the active heap.
+		"equivalent workloads with distinct PodSet names are not bulk-moved; SchedulingEquivalenceHashingIgnorePodSetName disabled": {
 			featureGates: map[featuregate.Feature]bool{
-				features.SchedulingEquivalenceHashing:          true,
-				features.FlavorFungibility:                     true,
-				features.FlavorFungibilityPreserveScanProgress: true,
+				features.SchedulingEquivalenceHashing:                 true,
+				features.SchedulingEquivalenceHashingIgnorePodSetName: false,
+				features.FlavorFungibility:                            true,
+				features.FlavorFungibilityPreserveScanProgress:        true,
 			},
 			additionalClusterQueues: []kueue.ClusterQueue{
 				*utiltestingapi.MakeClusterQueue("hash-cq").
@@ -6976,14 +6977,118 @@ func TestSchedule(t *testing.T) {
 				"hash-cq": {"default/wl-head"},
 			},
 		},
+		// The same distinct-name workloads once the name is out of the hash. They now
+		// share one class, so the siblings are bulk-moved after the head fails.
+		"equivalent workloads with distinct PodSet names are bulk-moved; SchedulingEquivalenceHashingIgnorePodSetName enabled": {
+			featureGates: map[featuregate.Feature]bool{
+				features.SchedulingEquivalenceHashing:                 true,
+				features.SchedulingEquivalenceHashingIgnorePodSetName: true,
+				features.FlavorFungibility:                            true,
+				features.FlavorFungibilityPreserveScanProgress:        true,
+			},
+			additionalClusterQueues: []kueue.ClusterQueue{
+				*utiltestingapi.MakeClusterQueue("hash-cq").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("on-demand").
+							Resource(corev1.ResourceCPU, "2").Obj(),
+						*utiltestingapi.MakeFlavorQuotas("spot").
+							Resource(corev1.ResourceCPU, "2").Obj(),
+					).
+					Obj(),
+			},
+			additionalLocalQueues: []kueue.LocalQueue{
+				*utiltestingapi.MakeLocalQueue("hash-queue", "default").ClusterQueue("hash-cq").Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-head", "default").
+					Queue("hash-queue").
+					PodSets(
+						*utiltestingapi.MakePodSet("4f7aac39", 1).Request(corev1.ResourceCPU, "3").Obj(),
+						*utiltestingapi.MakePodSet("12b10b3c", 1).Request(corev1.ResourceCPU, "1").Obj(),
+					).
+					Creation(now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-sibling-1", "default").
+					Queue("hash-queue").
+					PodSets(
+						*utiltestingapi.MakePodSet("f8172213", 1).Request(corev1.ResourceCPU, "3").Obj(),
+						*utiltestingapi.MakePodSet("a4586327", 1).Request(corev1.ResourceCPU, "1").Obj(),
+					).
+					Creation(now.Add(time.Second)).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-sibling-2", "default").
+					Queue("hash-queue").
+					PodSets(
+						*utiltestingapi.MakePodSet("8e163c4e", 1).Request(corev1.ResourceCPU, "3").Obj(),
+						*utiltestingapi.MakePodSet("4601f5b4", 1).Request(corev1.ResourceCPU, "1").Obj(),
+					).
+					Creation(now.Add(2 * time.Second)).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-head", "default").
+					Queue("hash-queue").
+					PodSets(
+						*utiltestingapi.MakePodSet("4f7aac39", 1).Request(corev1.ResourceCPU, "3").Obj(),
+						*utiltestingapi.MakePodSet("12b10b3c", 1).Request(corev1.ResourceCPU, "1").Obj(),
+					).
+					Creation(now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadQuotaReservedReasonExceedsMaxQuota,
+						Message:            "couldn't assign flavors to pod set 4f7aac39: insufficient quota for cpu in flavor on-demand, previously considered podsets requests (0) + current podset request (3) > maximum capacity (2), insufficient quota for cpu in flavor spot, previously considered podsets requests (0) + current podset request (3) > maximum capacity (2)",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadAdmittedReasonNoReservation,
+						Message:            "The workload has no reservation",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "4f7aac39",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("3"),
+						},
+					}, kueue.PodSetRequest{
+						Name: "12b10b3c",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1"),
+						},
+					}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-sibling-1", "default").
+					Queue("hash-queue").
+					PodSets(
+						*utiltestingapi.MakePodSet("f8172213", 1).Request(corev1.ResourceCPU, "3").Obj(),
+						*utiltestingapi.MakePodSet("a4586327", 1).Request(corev1.ResourceCPU, "1").Obj(),
+					).
+					Creation(now.Add(time.Second)).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-sibling-2", "default").
+					Queue("hash-queue").
+					PodSets(
+						*utiltestingapi.MakePodSet("8e163c4e", 1).Request(corev1.ResourceCPU, "3").Obj(),
+						*utiltestingapi.MakePodSet("4601f5b4", 1).Request(corev1.ResourceCPU, "1").Obj(),
+					).
+					Creation(now.Add(2 * time.Second)).
+					Obj(),
+			},
+			wantInadmissibleLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+				"hash-cq": {"default/wl-head", "default/wl-sibling-1", "default/wl-sibling-2"},
+			},
+		},
 		// ConcurrentAdmission puts the allowed-flavors annotation in the shape. That is
 		// independent of the PodSet name, so the siblings still get their own class.
-		"equivalent workloads with distinct PodSet names are not bulk-moved; ConcurrentAdmission enabled": {
+		"equivalent workloads with distinct PodSet names are not bulk-moved; ConcurrentAdmission enabled, SchedulingEquivalenceHashingIgnorePodSetName disabled": {
 			featureGates: map[featuregate.Feature]bool{
-				features.SchedulingEquivalenceHashing:          true,
-				features.FlavorFungibility:                     true,
-				features.FlavorFungibilityPreserveScanProgress: true,
-				features.ConcurrentAdmission:                   true,
+				features.SchedulingEquivalenceHashing:                 true,
+				features.SchedulingEquivalenceHashingIgnorePodSetName: false,
+				features.FlavorFungibility:                            true,
+				features.FlavorFungibilityPreserveScanProgress:        true,
+				features.ConcurrentAdmission:                          true,
 			},
 			additionalClusterQueues: []kueue.ClusterQueue{
 				*utiltestingapi.MakeClusterQueue("hash-cq").

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -399,14 +399,20 @@ func computeSchedulingHash(log logr.Logger, wl *kueue.Workload, totalRequests []
 			effectiveCount = totalRequests[i].Count
 			effectiveRequests = totalRequests[i].Requests
 		}
-		podSetShapes = append(podSetShapes, map[string]any{
-			"name":            ps.Name,
+		podSetShape := map[string]any{
 			"spec":            utilpod.SpecShape(&ps.Template.Spec),
 			"count":           effectiveCount,
 			"requests":        resources.ToMap(effectiveRequests),
 			"minCount":        ps.MinCount,
 			"topologyRequest": ps.TopologyRequest,
-		})
+		}
+		// The name identifies a PodSet but does not affect how it is assigned.
+		// Two readers depend on this shape: the queue's equivalence classes, and
+		// LastAssignment reuse through MatchesSchedulingShape.
+		if !features.Enabled(features.SchedulingEquivalenceHashingIgnorePodSetName) {
+			podSetShape["name"] = ps.Name
+		}
+		podSetShapes = append(podSetShapes, podSetShape)
 	}
 	shape := map[string]any{
 		"podSets":  podSetShapes,

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -3107,6 +3107,69 @@ func TestSchedulingHash(t *testing.T) {
 				features.ConcurrentAdmission:          true,
 			},
 		},
+		"different PodSet names when the name is part of the hash": {
+			wl1: utiltestingapi.MakeWorkload("wl1", "ns").
+				PodSets(*utiltestingapi.MakePodSet("4f7aac39", 1).
+					Request(corev1.ResourceCPU, "1").Obj()).Obj(),
+			wl2: utiltestingapi.MakeWorkload("wl2", "ns").
+				PodSets(*utiltestingapi.MakePodSet("f8172213", 1).
+					Request(corev1.ResourceCPU, "1").Obj()).Obj(),
+			wantSame: false,
+			featureGates: map[featuregate.Feature]bool{
+				features.SchedulingEquivalenceHashing:                 true,
+				features.SchedulingEquivalenceHashingIgnorePodSetName: false,
+			},
+		},
+		"different PodSet names when the name is ignored": {
+			wl1: utiltestingapi.MakeWorkload("wl1", "ns").
+				PodSets(*utiltestingapi.MakePodSet("4f7aac39", 1).
+					Request(corev1.ResourceCPU, "1").Obj()).Obj(),
+			wl2: utiltestingapi.MakeWorkload("wl2", "ns").
+				PodSets(*utiltestingapi.MakePodSet("f8172213", 1).
+					Request(corev1.ResourceCPU, "1").Obj()).Obj(),
+			wantSame: true,
+			featureGates: map[featuregate.Feature]bool{
+				features.SchedulingEquivalenceHashing:                 true,
+				features.SchedulingEquivalenceHashingIgnorePodSetName: true,
+			},
+		},
+		// Position still matters: requests are matched to PodSets by index.
+		"PodSet requests swapped between the same names when the name is ignored": {
+			wl1: utiltestingapi.MakeWorkload("wl1", "ns").
+				PodSets(
+					*utiltestingapi.MakePodSet("a", 1).Request(corev1.ResourceCPU, "1").Obj(),
+					*utiltestingapi.MakePodSet("b", 1).Request(corev1.ResourceCPU, "2").Obj(),
+				).Obj(),
+			wl2: utiltestingapi.MakeWorkload("wl2", "ns").
+				PodSets(
+					*utiltestingapi.MakePodSet("a", 1).Request(corev1.ResourceCPU, "2").Obj(),
+					*utiltestingapi.MakePodSet("b", 1).Request(corev1.ResourceCPU, "1").Obj(),
+				).Obj(),
+			wantSame: false,
+			featureGates: map[featuregate.Feature]bool{
+				features.SchedulingEquivalenceHashing:                 true,
+				features.SchedulingEquivalenceHashingIgnorePodSetName: true,
+			},
+		},
+		// The Pod group case: same two roles, distinct per-Workload names that sort
+		// into opposite positions, so the ordered descriptions differ.
+		"PodSets with distinct names sorting into a different order when the name is ignored": {
+			wl1: utiltestingapi.MakeWorkload("wl1", "ns").
+				PodSets(
+					*utiltestingapi.MakePodSet("4f7aac39", 1).Request(corev1.ResourceCPU, "1").Obj(),
+					*utiltestingapi.MakePodSet("f8172213", 1).Request(corev1.ResourceCPU, "2").Obj(),
+				).Obj(),
+			wl2: utiltestingapi.MakeWorkload("wl2", "ns").
+				PodSets(
+					*utiltestingapi.MakePodSet("12b10b3c", 1).Request(corev1.ResourceCPU, "2").Obj(),
+					*utiltestingapi.MakePodSet("a4586327", 1).Request(corev1.ResourceCPU, "1").Obj(),
+				).Obj(),
+			wantSame: false,
+			featureGates: map[featuregate.Feature]bool{
+				features.SchedulingEquivalenceHashing:                 true,
+				features.SchedulingEquivalenceHashingIgnorePodSetName: true,
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -433,6 +433,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.18"
+- name: SchedulingEquivalenceHashingIgnorePodSetName
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.19"
 - name: ShortWorkloadNames
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -433,6 +433,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.18"
+- name: SchedulingEquivalenceHashingIgnorePodSetName
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.19"
 - name: ShortWorkloadNames
   versionedSpecs:
   - default: false


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Manual cherry pick of #14784 for release-0.19. Part 3 of #14534, which asks for the gate on release branches at alpha.

`SchedulingEquivalenceHashingIgnorePodSetName` registers at 0.19 as **Alpha, disabled by default**, so this branch keeps its current behaviour unless an operator opts in. On main it is Beta and on by default.

The hash change and both sets of tests are identical to #14784, verified by comparing the patches for `pkg/workload/workload.go`, `pkg/workload/workload_test.go`, and `pkg/scheduler/scheduler_test.go` against the merged commit.

#### Which issue(s) this PR fixes:

Part of #14534

#### Special notes for your reviewer:

Two deliberate differences from #14784.

The gate spec is rewritten, and it has to be. Kueue never sets an emulation version, so the effective version is Kubernetes' `DefaultKubeBinaryVersion`, currently 1.36. `featureSpecAtEmulationAndMinCompatVersion` picks the highest spec at or below that, so a spec written as `{0.20, Default: true, Beta}` would still be selected here and the gate would land enabled by default. It is `{0.19, Default: false, Alpha}` instead.

The dependency on `SchedulingEquivalenceHashing` goes through `validateFeatureGateDependency` in `pkg/config/validation.go`, per your comment, since that is how this branch tracks gate dependencies. Main uses the `defaultFeatureGateDependencies` map, which does not exist here. Added a `TestLoadAndValidateFeatureGates` case alongside the existing dependency cases, and confirmed it fails if the validation line is removed.

KEP-9694 does not exist on this branch, so the KEP updates from #14784 stay on main.

#### Does this PR introduce a user-facing change?

```release-note
Scheduling: Fixed a bug where Workloads differing only in PodSet names formed separate equivalence classes, so BestEffortFIFO queues re-evaluated each one individually and admission slowed on busy clusters. Controlled by the alpha `SchedulingEquivalenceHashingIgnorePodSetName` feature gate, disabled by default. When enabled, Workloads differing only in PodSet names share a scheduling equivalence class, so BestEffortFIFO queues stop re-evaluating each one individually. Requires `SchedulingEquivalenceHashing`.
```
