### PR TITLE
fix: index extended resources specified only in limits

### DIFF
--- a/pkg/controller/core/indexer/indexer.go
+++ b/pkg/controller/core/indexer/indexer.go
@@ -217,25 +217,29 @@ func IndexWorkloadPriorityClass(obj client.Object) []string {
 }
 
 // IndexWorkloadExtendedResources indexes Workloads by the extended resource names
-// in their container requests. Used by the DeviceClass handler to find workloads
+// in their container requests or limits. Used by the DeviceClass handler to find workloads
 // affected by a specific DeviceClass change.
 func IndexWorkloadExtendedResources(obj client.Object) []string {
 	wl, ok := obj.(*kueue.Workload)
 	if !ok {
 		return nil
 	}
+
 	resNames := sets.New[string]()
 	for _, ps := range wl.Spec.PodSets {
 		for _, containers := range [][]corev1.Container{ps.Template.Spec.InitContainers, ps.Template.Spec.Containers} {
 			for _, c := range containers {
-				for name, qty := range c.Resources.Requests {
-					if !qty.IsZero() && utilresource.IsExtendedResourceName(name) {
-						resNames.Insert(string(name))
+				for _, resources := range []corev1.ResourceList{c.Resources.Requests, c.Resources.Limits} {
+					for name, qty := range resources {
+						if !qty.IsZero() && utilresource.IsExtendedResourceName(name) {
+							resNames.Insert(string(name))
+						}
 					}
 				}
 			}
 		}
 	}
+
 	if resNames.Len() > 0 {
 		return resNames.UnsortedList()
 	}

--- a/pkg/controller/core/indexer/indexer_test.go
+++ b/pkg/controller/core/indexer/indexer_test.go
@@ -707,6 +707,15 @@ func TestIndexWorkloadExtendedResources(t *testing.T) {
 		}
 	}
 
+	containerWithLimits := func(name string, limits corev1.ResourceList) corev1.Container {
+		return corev1.Container{
+			Name: name,
+			Resources: corev1.ResourceRequirements{
+				Limits: limits,
+			},
+		}
+	}
+
 	cases := map[string]struct {
 		obj  client.Object
 		want []string
@@ -745,6 +754,26 @@ func TestIndexWorkloadExtendedResources(t *testing.T) {
 							Containers: []corev1.Container{container("c", corev1.ResourceList{
 								"nvidia.com/gpu": resource.MustParse("1"),
 							})},
+						},
+					},
+				}}
+				return wl
+			}(),
+			want: []string{"nvidia.com/gpu"},
+		},
+		"workload with extended resource only in limits": {
+			obj: func() client.Object {
+				wl := makeWorkload("wl", "ns")
+				wl.Spec.PodSets = []kueue.PodSet{{
+					Name:  "main",
+					Count: 1,
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								containerWithLimits("c", corev1.ResourceList{
+									"nvidia.com/gpu": resource.MustParse("1"),
+								}),
+							},
 						},
 					},
 				}}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fix the workload indexer to recognize extended resources specified only in container limits.

#### Which issue(s) this PR fixes:

Fixes #14801

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended resource information is now detected from both container requests and limits.
  * Workloads that specify extended resources only in limits are now indexed correctly.

* **Tests**
  * Added coverage for extended resources declared exclusively in container limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->