### PR TITLE
charts: omit namespace from KueueViz cluster RBAC

### DIFF
--- a/charts/kueue/templates/kueueviz/cluster-role-binding.yaml
+++ b/charts/kueue/templates/kueueviz/cluster-role-binding.yaml
@@ -21,7 +21,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: '{{ include "kueue.fullname" . }}-kueueviz-backend-read-access-binding'
-  namespace: '{{ .Release.Namespace }}'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/kueue/templates/kueueviz/clusterrole.yaml
+++ b/charts/kueue/templates/kueueviz/clusterrole.yaml
@@ -21,7 +21,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-kueueviz-backend-read-access'
-  namespace: '{{ .Release.Namespace }}'
 rules:
   - apiGroups: ["kueue.x-k8s.io"]
     resources: ["workloads", "clusterqueues", "localqueues", "resourceflavors", "cohorts"]

--- a/charts/kueue/tests/rbac_namespace_scope_test.yaml
+++ b/charts/kueue/tests/rbac_namespace_scope_test.yaml
@@ -1,0 +1,55 @@
+suite: test RBAC namespace scope
+templates:
+  - kueueviz/clusterrole.yaml
+  - kueueviz/cluster-role-binding.yaml
+  - rbac/manager_secrets_role.yaml
+  - rbac/manager_secrets_role_binding.yaml
+tests:
+  - it: should omit namespace from the KueueViz ClusterRole
+    template: kueueviz/clusterrole.yaml
+    release:
+      namespace: custom-namespace
+    set:
+      enableKueueViz: true
+    asserts:
+      - isKind:
+          of: ClusterRole
+      - notExists:
+          path: metadata.namespace
+
+  - it: should omit namespace from the KueueViz ClusterRoleBinding
+    template: kueueviz/cluster-role-binding.yaml
+    release:
+      namespace: custom-namespace
+    set:
+      enableKueueViz: true
+    asserts:
+      - isKind:
+          of: ClusterRoleBinding
+      - notExists:
+          path: metadata.namespace
+      - equal:
+          path: subjects[0].namespace
+          value: custom-namespace
+
+  - it: should retain namespace on a Role
+    template: rbac/manager_secrets_role.yaml
+    release:
+      namespace: custom-namespace
+    asserts:
+      - isKind:
+          of: Role
+      - equal:
+          path: metadata.namespace
+          value: custom-namespace
+
+  - it: should retain namespace on a RoleBinding
+    template: rbac/manager_secrets_role_binding.yaml
+    release:
+      namespace: custom-namespace
+    asserts:
+      - isKind:
+          of: RoleBinding
+      - equal:
+          path: metadata.namespace
+          value: custom-namespace

--- a/config/components/kueueviz/cluster-role-binding.yaml
+++ b/config/components/kueueviz/cluster-role-binding.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kueueviz-backend-read-access-binding
-  namespace: system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/config/components/kueueviz/clusterrole.yaml
+++ b/config/components/kueueviz/clusterrole.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kueueviz-backend-read-access
-  namespace: system
 rules:
   - apiGroups: ["kueue.x-k8s.io"]
     resources: ["workloads", "clusterqueues", "localqueues", "resourceflavors", "cohorts"]


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

KueueViz currently emits `metadata.namespace` on its `ClusterRole` and
`ClusterRoleBinding` even though both are cluster-scoped resources. Kubernetes
normalizes away namespace metadata for cluster-scoped resources before object
validation, so this is a manifest cleanup rather than an API rejection bug.

This change keeps the rendered RBAC manifests aligned with their resource scope
while preserving namespace where it is valid, including the ServiceAccount
subject and namespaced Role/RoleBinding resources.

Regression coverage uses a non-default Helm release namespace to verify that it
does not leak into cluster-scoped RBAC.

I independently reproduced the redundant rendered namespace metadata with
IaC-Guard-V 0.1.0a6; the supporting reproduction is available at:
https://github.com/lokesh0186/iac-guard-v/tree/4a55d51d852e36a5b64a7ee08e16254b7728078b/examples/public-reproductions/kueue-cluster-rbac-namespace

The immutable reproduction preserves the original direct-object-validation
interpretation. The corrected characterization here reflects the complete
kube-apiserver create path, which clears namespace metadata for cluster-scoped
resources before validation.

AI tools were used to assist with investigation and patch preparation. I reviewed
the resulting changes and validated them with the project's native test suite.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

Validation performed:

- Helm unit tests: 79/79 passed.
- `helm lint charts/kueue`: passed.
- The Helm rendering matrix from `helm-verify`: passed.
- The pinned YAML processing plan reproduced the generated chart changes exactly.
- `kubectl kustomize config/kueueviz`: passed.
- The rendered before/after diff contains only the two redundant top-level
  namespace removals.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Removed redundant namespace metadata from KueueViz cluster-scoped RBAC resources.
  * Preserved the service account's namespace assignment for proper access control.

* **Tests**
  * Added coverage validating namespace behavior for KueueViz and manager RBAC resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
