### PR TITLE
docs: fix duplicated word and grammar typos in setup_failure_recovery.md

### DIFF
--- a/site/content/en/docs/tasks/manage/setup_failure_recovery.md
+++ b/site/content/en/docs/tasks/manage/setup_failure_recovery.md
@@ -157,7 +157,7 @@ This will cause the node to stop sending health pings to the control plane.
 ## 3. Observe the node being down
 
 The `kubelet` on worker nodes periodically sends heartbeat pings to the control plane to report their health.
-If this this does not happen for `node-monitor-grace-period` (by default 50 seconds), the node's readiness status will be
+If this does not happen for `node-monitor-grace-period` (by default 50 seconds), the node's readiness status will be
 deemed `Unknown` and a `node.kubernetes.io/unreachable` taint will be added to the node.
 
 After waiting for the `node-monitor-grace-period` to elapse and running:
@@ -195,7 +195,7 @@ Without the failure recovery policy, the pod will be unable to progress past thi
 
 By default, pods have a 30 second grace period to terminate gracefully.
 Additionally, the failure recovery controller also waits 60 seconds before forcefully marking the stuck pod as `Failed`.
-In total, the pod should transition to `Failed` after 90 seconds since the it was marked for termination.
+In total, the pod should transition to `Failed` after 90 seconds since it was marked for termination.
 
 Fetching all the pods after it elapses:
 ```sh


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:

-->
/kind documentation

#### What this PR does / why we need it:
Fix duplicated word and grammar typos in `setup_failure_recovery.md`.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected two typographical errors in the setup failure recovery guide.
  * Improved wording in instructions covering node-down observations and pod transitions to a failed state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->