### PR TITLE
kep: exact topology distribution KEP-13416

### DIFF
--- a/keps/13416-exact-topology-distribution/README.md
+++ b/keps/13416-exact-topology-distribution/README.md
@@ -46,116 +46,69 @@
 
 ## Summary
 
-This KEP extends Topology Aware Scheduling (TAS) so that a PodSet can request
-an exact, potentially uneven distribution of pods across topology domains.
-For example, a PodSet with eight pods can request that Kueue select three
-distinct racks and assign exactly one pod to one rack, three pods to another,
-and four pods to the third.
+This KEP extends Topology Aware Scheduling (TAS) so that a PodSet can request an
+exact, potentially uneven distribution of pods across topology domains. For
+example, a PodSet with eight pods can request that Kueue select three distinct
+racks and assign exactly one pod to one rack, three to another, and four to the
+third.
 
-The existing multi-layer topology constraint API accepts one scalar `size` at
-each topology level. A scalar size creates equal, fungible slices and therefore
-only constrains assignments to multiples of that size. It cannot express an
-uneven distribution such as `[1, 3, 4]`.
-
-This KEP adds a `sizes` alternative to
-`PodsetSliceRequiredTopologyConstraint`. `sizes` is an ordered list of pod
-counts. Each entry defines a contiguous pod-rank block and is assigned to a
-distinct topology domain selected by Kueue. The sum of all entries must equal
-the fixed PodSet count.
-
-The alpha scope supports one exact-distribution constraint at any configured
-topology level. It does not support repeating patterns, multiple exact levels,
-explicit physical domain names, or elastic PodSet counts.
-
-Exact distribution is an opt-in, required placement constraint for workloads
-whose performance or application behavior depends on a predictable topology
-shape. It is not intended to replace ordinary TAS placement: requesting an
-exact shape reduces Kueue's placement flexibility and can increase
-fragmentation and admission latency.
+It adds a `sizes` alternative to `PodsetSliceRequiredTopologyConstraint`.
+`sizes` is an ordered list of pod counts. Each entry defines a contiguous
+pod-rank block and is assigned to a distinct topology domain selected by Kueue.
+The sum of all entries must equal the fixed PodSet count.
 
 ## Motivation
 
 Distributed training and high-performance computing workloads can have
 communication patterns whose runtime performance depends on how workers are
-distributed across topology domains. For these workloads, selecting the right
-number of racks or blocks is not always sufficient: the number of pods placed
-in each selected domain can determine network contention, collective
-communication cost, and overall job duration. For example, an even placement
-such as `[4, 4]` can behave substantially differently from an uneven placement
-such as `[1, 3, 4]`.
+distributed across topology domains. Selecting the right *number* of racks or
+blocks is not always sufficient: the number of pods placed in each selected
+domain determines network contention, collective communication cost, and overall
+job duration. An even placement such as `[4, 4]` can behave substantially
+differently from an uneven `[1, 3, 4]`. Reproducing a benchmark configuration and
+investigating a performance regression are important secondary use cases.
 
-Some users therefore need a predictable topology shape as an application-level
-placement requirement. Reproducing a benchmark configuration, investigating a
-performance regression, and debugging topology-dependent behavior are
-important secondary use cases, but the primary purpose of this proposal is to
-provide stable placement semantics for workloads whose performance depends on
-the distribution.
+Kueue currently provides required topology (whole PodSet in one domain),
+preferred topology (increasingly coarser domains before allowing a distributed
+assignment), slice topology (equal-sized logical slices), and multi-layer slice
+topology (an equal scalar slice size at each of up to three levels).
 
-Kueue currently provides the following topology controls:
-
-- Required topology places an entire PodSet within one domain at a requested
-  level.
-- Preferred topology attempts increasingly coarser domains before allowing a
-  distributed assignment.
-- Slice topology places equal-sized logical slices within domains at a
-  requested level.
-- Multi-layer slice topology applies an equal scalar slice size at each of up
-  to three topology levels.
-
-Equal slice sizes do not determine the final count assigned to each domain.
-For an eight-pod PodSet with a rack slice size of two, the scheduler creates
-four equal slices. Multiple slices can share a rack, so assignments such as
-`[2, 2, 4]`, `[2, 6]`, and `[8]` are all possible. No scalar slice size can
-require the final distribution `[1, 3, 4]`.
-
-Exact placement necessarily trades cluster efficiency for predictability. It
-can reject otherwise usable placements, leave capacity unused across topology
-domains, and keep a workload pending even when sufficient aggregate capacity
-exists. Consequently, this capability is explicitly requested by the user and
-is treated as a hard constraint. Workloads that only need locality should
-continue to use existing required, preferred, or scalar slice topology
-controls, which give Kueue more freedom to find an efficient placement.
+None of these determine the final count per domain. For an eight-pod PodSet with
+a rack slice size of two, the scheduler creates four equal slices, and multiple
+slices can share a rack — so `[2, 2, 4]`, `[2, 6]`, and `[8]` are all valid
+outcomes. No scalar slice size can require `[1, 3, 4]`.
 
 The default Kubernetes scheduler can balance pods using topology spread
-constraints or bind pods to named topology domains using node affinity. It
-cannot dynamically select topology domains and reserve an arbitrary exact
-distribution for a complete PodSet. Kueue already performs group-level
-admission and produces a `TopologyAssignment`, making it the appropriate layer
-for this capability.
+constraints or bind them to named domains using node affinity, but it cannot
+dynamically select domains and reserve an arbitrary exact distribution for a
+complete PodSet. Kueue already performs group-level admission and produces a
+`TopologyAssignment`, making it the right layer for this capability.
 
 ### Goals
 
-- Allow a fixed-size PodSet to request an exact, uneven pod distribution at a
-  configured topology level.
-- Provide predictable topology shapes for workloads whose performance or
-  application behavior depends on their per-domain pod distribution.
-- Allow the exact level to be a rack, block, zone, hostname, or any other level
-  represented in the selected TAS topology.
-- Have Kueue select the physical topology domains based on feasibility and the
-  configured TAS strategy.
-- Assign each requested count to a distinct topology domain.
-- Deterministically map each ordered count to a contiguous range of pod ranks.
-- Require a stable, unique pod-rank source for exact-distribution PodSets.
+- Allow a fixed-size PodSet to request an exact, uneven pod distribution at any
+  configured topology level — rack, block, zone, hostname, or otherwise.
+- Have Kueue select the physical domains based on feasibility and the configured
+  TAS strategy, assigning each requested count to a distinct domain.
+- Deterministically map each ordered count to a contiguous range of pod ranks,
+  which requires a stable, unique pod-rank source.
 - Reject or leave pending a workload when the complete distribution cannot be
   satisfied.
-- Preserve existing scalar `size` behavior without changes.
-- Keep exact distribution opt-in so ordinary TAS workloads retain existing
-  placement flexibility and schedulability.
-- Bound the alpha scheduling problem so feasibility can be determined with a
+- Preserve existing scalar `size` behavior unchanged, and keep exact distribution
+  opt-in.
+- Bound the alpha scheduling problem so feasibility is decidable with a
   deterministic matching algorithm.
 
 ### Non-Goals
 
-- Selecting topology domains by explicit label value, such as `rack-a` or
-  `rack-b`.
-- Expressing exact physical node counts when multiple pods can share a node.
-  The proposed values are pod counts per topology domain.
+- Selecting topology domains by explicit label value, such as `rack-a`.
+- Expressing exact physical node counts when multiple pods can share a node. The
+  values are pod counts per domain.
 - Repeating a shorter distribution to fill a larger PodSet.
-- Supporting more than one `sizes` constraint in a PodSet topology request.
-- Expressing a nested exact distribution at multiple topology levels.
-- Supporting partial admission or elastic changes to the PodSet count.
-- Supporting exact distributions for PodSets without stable pod indexes at
-  alpha.
+- More than one `sizes` constraint per request, or a nested exact distribution
+  across multiple topology levels.
+- Partial admission or elastic changes to the PodSet count.
+- Exact distributions for PodSets without stable pod indexes at alpha.
 - Rebalancing an admitted and running PodSet when topology capacity changes.
 - Extending topology spread constraints in the default Kubernetes scheduler.
 
@@ -163,8 +116,6 @@ for this capability.
 
 Add an optional `sizes` field to each multi-layer topology constraint entry.
 Exactly one of `size` and `sizes` must be specified.
-
-For example:
 
 ```yaml
 apiVersion: batch/v1
@@ -196,150 +147,100 @@ spec:
       restartPolicy: Never
 ```
 
-Kueue selects one feasible block and three distinct racks within that block.
-The three selected racks receive one, three, and four pods respectively. The
-list does not bind a particular count to a named rack. Its order binds the
-counts to contiguous rank blocks: rank 0 is in the one-pod group, ranks 1-3 are
-in the three-pod group, and ranks 4-7 are in the four-pod group.
+Kueue selects one feasible block and three distinct racks within it, receiving
+one, three, and four pods respectively. The list does not bind a count to a named
+rack. Its *order* binds counts to contiguous rank blocks: rank 0 is in the
+one-pod group, ranks 1-3 in the three-pod group, and ranks 4-7 in the four-pod
+group.
 
 ### User Stories
 
 #### Story 1: Reproducible Uneven Rack Placement
 
-As a machine learning infrastructure engineer, I want one PodSet of eight
-workers to be placed across three distinct racks with exact counts `[1, 3, 4]`
-so that I can obtain predictable communication behavior and reproduce that
-behavior when measuring performance or investigating a regression. I want
-Kueue to select the rack identities dynamically rather than encoding them in
-the workload.
+As a machine learning infrastructure engineer, I want one PodSet of eight workers
+placed across three distinct racks with exact counts `[1, 3, 4]`, so that I get
+predictable communication behavior and can reproduce it when measuring
+performance or investigating a regression. Kueue should select the rack
+identities dynamically rather than requiring them in the workload.
 
 #### Story 2: Exact Distribution Across Blocks
 
 As a cluster user, I want to place 24 pods into two distinct blocks with exact
 counts `[8, 16]` within one data center, without binding the workload to
-cluster-specific block names.
-
-For example:
-
-```yaml
-kueue.x-k8s.io/podset-required-topology: topology.example.com/datacenter
-kueue.x-k8s.io/podset-slice-required-topology-constraints: |
-  [
-    {
-      "topology": "topology.example.com/block",
-      "sizes": [8, 16]
-    }
-  ]
-```
+cluster-specific block names. This is the same request shape at a coarser level:
+`podset-required-topology` names the data center and the constraint entry names
+the block level.
 
 ### Semantics
 
-The `sizes` field has the following semantics:
-
 1. `sizes` is ordered. `[1, 3, 4]` and `[4, 3, 1]` request the same aggregate
    domain counts but different pod-rank mappings.
-2. Each list entry is assigned to one distinct topology domain at the entry's
-   `topology` level.
+2. Each entry is assigned to one distinct domain at the entry's `topology` level,
+   and its value is the exact number of pods Kueue assigns to that domain.
 3. Entry `i` owns the next `sizes[i]` contiguous pod ranks after all preceding
-   entries. For `[1, 3, 4]`, the rank blocks are rank 0, ranks 1-3, and ranks
-   4-7.
-4. Kueue selects the physical topology domain for each entry. A list position
-   identifies a rank block, not a topology label value such as `rack-a`.
-5. The value assigned to a domain is the exact number of pods from this PodSet
-   that Kueue assigns to that domain.
-6. Duplicate values are allowed. For example, `[2, 2, 4]` requests three
-   distinct domains.
-7. The sum of the list must equal the fixed PodSet count.
-8. An exact distribution is a required constraint. Kueue does not fall back to
+   entries. For `[1, 3, 4]`, the rank blocks are rank 0, ranks 1-3, and ranks 4-7.
+4. Kueue selects the physical domain for each entry. A list position identifies a
+   rank block, not a topology label value.
+5. Duplicate values are allowed. `[2, 2, 4]` requests three distinct domains.
+6. The sum of the list must equal the fixed PodSet count.
+7. An exact distribution is a required constraint. Kueue does not fall back to
    scalar slicing or ordinary greedy placement when it cannot be satisfied.
-9. At alpha, a topology request may contain only one constraint entry when
-   that entry uses `sizes`. Containment is expressed using
-   `podset-required-topology`.
-10. The required topology level, when specified, must be strictly coarser than
-   the exact-distribution level when `sizes` contains more than one entry.
-11. Below the exact-distribution level, Kueue uses its existing capacity-based
-    placement to assign pods to finer domains and hosts.
+8. At alpha, an entry using `sizes` must be the only entry in the constraints
+   list. Containment is expressed using `podset-required-topology`, which must be
+   strictly coarser than the exact level when `sizes` has more than one entry. A
+   request naming the same level in both is contradictory and is rejected at
+   scheduling time.
+9. Below the exact level, Kueue uses its existing capacity-based placement to
+   assign pods to finer domains and hosts.
 
-Ordered rank-block semantics require every pod in the PodSet to have a stable,
-unique rank in `[0, PodSet.Count)`. At alpha, `sizes` is accepted only when the
-job integration supplies a `PodIndexLabel` and guarantees those indexes, such
-as an Indexed Job. Integrations using subgroup indexes must provide the
-existing `SubGroupIndexLabel` and `SubGroupCount` information needed to derive
-one unique rank space for the complete PodSet.
+Ordered rank-block semantics require every pod to have a stable, unique rank in
+`[0, PodSet.Count)`. At alpha, `sizes` is accepted only when the job integration
+supplies a `PodIndexLabel` and guarantees those indexes, such as an Indexed Job.
+Integrations using subgroup indexes must also provide `SubGroupIndexLabel` and
+`SubGroupCount`, which are what make one unique rank space derivable for the
+complete PodSet.
 
-If a pod is missing its expected rank label, has a duplicate rank, or has an
-out-of-range rank, the topology ungater keeps the affected pods gated and
-reports an error. It must not fall back to greedy domain assignment for an
-exact-distribution PodSet, because that could silently violate the ordered
-rank-block contract.
-
-For example, the following request is contradictory and is rejected at
-scheduling time because required topology asks for one rack while `sizes`
-requires three distinct racks:
-
-```yaml
-kueue.x-k8s.io/podset-required-topology: topology.example.com/rack
-kueue.x-k8s.io/podset-slice-required-topology-constraints: |
-  [
-    {
-      "topology": "topology.example.com/rack",
-      "sizes": [1, 3, 4]
-    }
-  ]
-```
+If a pod is missing its rank label, has a duplicate rank, or has an out-of-range
+rank, the topology ungater keeps the affected pods gated and reports an error. It
+must not fall back to greedy domain assignment for an exact-distribution PodSet.
+Greedy assignment still satisfies the aggregate per-domain counts, so the
+violation would be silent — the workload would run with the wrong ranks
+co-located and nothing would report a failure.
 
 ### Notes, Constraints, and Caveats
 
-The values represent pod counts, not physical node counts. A distribution of
-`[1, 3, 4]` corresponds to the same number of nodes only when workload
-resource requests, affinity, or other scheduling constraints effectively
-ensure one pod per node.
+The values are pod counts, not node counts. `[1, 3, 4]` corresponds to the same
+number of nodes only when resource requests, affinity, or other constraints
+effectively ensure one pod per node.
 
-The complete distribution is attached to one PodSet. A workload with multiple
-PodSets validates and schedules each PodSet independently, subject to existing
-restrictions on PodSet groups and multi-layer topology constraints.
-
-The alpha API intentionally requires users to provide the complete ordered
-distribution. A 16-pod PodSet cannot specify `[1, 3, 4]` and rely on Kueue to
-repeat it. It can explicitly request `[1, 3, 4, 1, 3, 4]`, which requires six
-distinct domains and defines six rank blocks in that order.
+The distribution is attached to one PodSet. A workload with multiple PodSets
+validates and schedules each independently, subject to existing restrictions on
+PodSet groups and multi-layer constraints.
 
 A single-entry list such as `sizes: [8]` is permitted and is equivalent to
-requiring the whole PodSet in one domain at that level. It is allowed for
-uniformity rather than because it adds expressiveness, and
-`podset-required-topology` remains the clearer way to express it. Validation
-therefore accepts it instead of special-casing `MinItems=2`, and user
-documentation directs single-domain users to required topology.
-
-Users should request `sizes` only when the exact per-domain distribution is
-material to workload performance or behavior. If locality alone is sufficient,
-the existing TAS controls are more appropriate because they allow Kueue to use
-available capacity more efficiently.
+required topology at that level. It is allowed for uniformity rather than
+expressiveness; documentation directs single-domain users to
+`podset-required-topology`.
 
 ### Risks and Mitigations
 
-**Scheduling cost:** Each candidate enclosing domain requires a feasibility
-check against its descendant domains. The alpha API bounds `sizes` to 128
-entries and supports only one exact level. Matching uses sorted scalar pod
-capacities and is polynomial in the number of requested and available
-domains.
+**Scheduling cost:** Each candidate enclosing domain requires a feasibility check
+against its descendant domains. The alpha API bounds `sizes` to 128 entries and
+supports only one exact level. Matching uses sorted scalar pod capacities and is
+polynomial in the number of requested and available domains.
 
-**Fragmentation and admission latency:** An exact request can leave unused
-capacity in selected domains and can remain pending when a less constrained
-placement would fit. This is an inherent tradeoff of making the distribution a
-hard requirement. The feature is opt-in, documentation directs users to
-ordinary TAS controls when exactness is unnecessary, and domain selection
-continues to follow the active TAS placement strategy.
-
-**Starvation:** Exact distributions are stricter than aggregate capacity and
-may remain pending even when the total number of free pod slots is sufficient.
-The scheduler reports an explicit failure reason distinguishing exact-domain
-infeasibility from insufficient aggregate capacity.
+**Fragmentation and starvation:** An exact request is stricter than aggregate
+capacity. It can leave capacity unused in selected domains and remain pending
+even when the total number of free pod slots would suffice. This is inherent to
+making the distribution a hard requirement. The feature is opt-in, documentation
+directs users to ordinary TAS controls when exactness is unnecessary, domain
+selection follows the active TAS placement strategy, and the scheduler reports an
+explicit failure reason distinguishing exact-domain infeasibility from
+insufficient aggregate capacity.
 
 **Feature interaction:** Partial admission, elastic workload slices, repeating
-slices, and multiple exact levels introduce ambiguous grouping semantics. The
-alpha validation rejects these combinations rather than attempting an implicit
-interpretation.
+slices, and multiple exact levels introduce ambiguous grouping semantics. Alpha
+validation rejects these combinations rather than guessing.
 
 ## Design Details
 
@@ -381,142 +282,112 @@ type PodsetSliceRequiredTopologyConstraint struct {
 }
 ```
 
-The existing beta `Size` field changes from `+required` to `+optional` so that
-the generated CRD no longer unconditionally includes `size` in each item's
-`required` list. The CEL union instead requires exactly one of `size` and
-`sizes`. Existing objects containing `size` remain valid.
+The existing beta `Size` field changes from `+required` to `+optional`, so the
+generated CRD no longer unconditionally lists `size` in each item's `required`
+set; the CEL union enforces exactly one arm instead. Existing objects containing
+`size` remain valid. `Size` stays an `int32` rather than becoming a pointer, to
+preserve Go source compatibility for clients constructing the existing type. With
+`omitempty`, a client setting `Size: 0` serializes `size` as absent, and if
+`Sizes` is also absent the CEL union rejects the object as specifying neither.
 
-`Size` remains an `int32` rather than changing to a pointer to preserve Go
-source compatibility for clients that construct the existing API type. With
-`omitempty`, a Go client setting `Size: 0` serializes `size` as absent. If
-`Sizes` is also absent, the CEL union rejects the object as specifying neither
-alternative. The generated CRD schema and admission validation enforce the
-field union.
-
-The existing annotation name remains unchanged:
-
-```text
-kueue.x-k8s.io/podset-slice-required-topology-constraints
-```
-
-No change is required to `TopologyAssignment`. It already records domain paths
-and assigned counts, which can represent the result of exact matching.
-
-The `v1beta1` Workload API has no multi-layer constraint field. Existing
-conversion behavior that drops multi-layer constraints when converting from
-`v1beta2` to `v1beta1` remains unchanged.
+The annotation name `kueue.x-k8s.io/podset-slice-required-topology-constraints`
+is unchanged. `TopologyAssignment` needs no change — it already records domain
+paths and assigned counts. The `v1beta1` Workload API has no multi-layer
+constraint field, and the existing behavior of dropping multi-layer constraints
+during `v1beta2` to `v1beta1` conversion is unchanged.
 
 ### Validation
 
-Validation is split between job integration validation, the Workload webhook,
-and scheduling-time validation when the selected `Topology` hierarchy is
-known.
+Validation is split between job integration validation, the Workload webhook, and
+scheduling-time validation once the selected `Topology` hierarchy is known.
 
 Creation-time validation enforces:
 
-- Exactly one of `size` and `sizes` is present in every constraint entry.
-- `sizes` has between 1 and 128 entries.
-- Every value in `sizes` is greater than zero.
-- At most one entry uses `sizes`.
-- At alpha, if an entry uses `sizes`, it is the only entry in the constraints
-  list.
-- The sum is computed using `int64` and must equal `PodSet.Count`.
+- The structural schema above: exactly one of `size` and `sizes`, 1 to 128
+  entries, every value greater than zero.
+- At alpha, an entry using `sizes` is the only entry in the constraints list.
+- The sum, computed using `int64`, equals `PodSet.Count`.
 - The integration provides a stable `PodIndexLabel`; for Kubernetes Jobs,
   `completionMode` must be `Indexed`. Subgroup-based integrations must also
   provide valid subgroup index and count metadata.
 - The PodSet does not use partial admission (`MinCount` is unset).
-- The parent Job or other integrated workload has not opted into elastic
-  workload slicing with `kueue.x-k8s.io/elastic-job: "true"`. This restriction
-  applies even when `ElasticJobsViaWorkloadSlicesWithTAS` is enabled.
-- The PodSet does not combine `sizes` with preferred outer topology at alpha.
+- The parent workload has not opted into elastic workload slicing with
+  `kueue.x-k8s.io/elastic-job: "true"`, even when
+  `ElasticJobsViaWorkloadSlicesWithTAS` is enabled.
+- `sizes` is not combined with preferred outer topology at alpha.
 - Existing mutual exclusions with the legacy slice annotations and
   `podset-group-name` continue to apply.
 - The `TASExactTopologyDistribution` feature gate is enabled.
 
-The Workload webhook repeats structural, numeric, partial-admission, and
+The Workload webhook repeats the structural, numeric, partial-admission, and
 elastic-workload checks as defense in depth for direct Workload writes.
 
 Update-time validation preserves the fixed-count invariant:
 
-- Before quota reservation, `sizes` or the PodSet count may change only when
-  the resulting ordered list remains valid and its sum equals the new count.
+- Before quota reservation, `sizes` or the PodSet count may change only when the
+  resulting ordered list remains valid and its sum equals the new count.
 - After quota reservation, the PodSet count and the value and order of `sizes`
-  are immutable.
-- Job integration webhooks reject updates to `parallelism`, `completions`,
-  `replicas`, or another integration-specific field when the update would
-  change the effective PodSet count of an exact-distribution request.
-- Direct Workload updates that change the count or `sizes` after reservation
-  are rejected.
+  are immutable. Job integration webhooks reject updates to `parallelism`,
+  `completions`, `replicas`, or another integration-specific field that would
+  change the effective PodSet count, and direct Workload updates changing the
+  count or `sizes` are rejected.
 
-Scheduling-time validation enforces:
-
-- The exact topology key exists in the selected ResourceFlavor's `Topology`.
-- The exact level is below the required topology level when more than one
-  distinct domain is requested.
-- The selected topology contains enough eligible domains to satisfy the list.
+Scheduling-time validation enforces that the exact topology key exists in the
+selected ResourceFlavor's `Topology`, that the exact level is below the required
+topology level when more than one distinct domain is requested, and that the
+topology contains enough eligible domains to satisfy the list.
 
 ### Scheduling
 
-The scheduler continues to use the existing phase that calculates how many
-pods can fit in each leaf and ancestor domain. The calculated `podCount` for a
-domain is the scalar capacity used by exact matching.
-
-The exact path is selected when the PodSet topology request contains `sizes`.
-The scalar path remains unchanged.
+The scheduler continues to use the existing phase that calculates how many pods
+fit in each leaf and ancestor domain; the resulting `podCount` is the scalar
+capacity used by exact matching. The exact path is selected when the topology
+request contains `sizes`. The scalar path is unchanged.
 
 #### Scope Selection
 
-When `podset-required-topology` is present, Kueue evaluates candidate domains
-at that level as enclosing scopes. For a required block and exact rack sizes,
-each candidate block is evaluated using only racks descended from that block.
+When `podset-required-topology` is present, Kueue evaluates candidate domains at
+that level as enclosing scopes — for a required block and exact rack sizes, each
+candidate block is evaluated using only its descendant racks. When no required
+topology is present, the eligible topology of the selected ResourceFlavor is the
+enclosing scope.
 
-When no required topology is present, the eligible topology represented by
-the selected ResourceFlavor is treated as the enclosing scope.
-
-Preferred outer topology is not supported with exact distributions at alpha.
-This avoids an implicit fallback changing the enclosing scope while retaining
-a hard inner distribution.
+Preferred outer topology is not supported with exact distributions at alpha, to
+avoid an implicit fallback changing the enclosing scope while a hard inner
+distribution is retained.
 
 #### Exact Domain Matching
 
 For one candidate enclosing scope, Kueue obtains the available pod capacity of
-every eligible domain at the exact level. It then matches the requested values
-to distinct candidate domains.
-
-A deterministic implementation separates feasibility from policy-driven
-selection:
+every eligible domain at the exact level, then matches the requested values to
+distinct domains, separating feasibility from policy-driven selection:
 
 1. Tag every requested size with its original list index.
-2. For feasibility, sort the tagged entries from largest to smallest, breaking
-   equal-size ties by original index. Match each entry to the smallest unused
+2. For feasibility, sort the tagged entries largest to smallest, breaking
+   equal-size ties by original index, and match each to the smallest unused
    capacity that fits. Fail the candidate scope if any entry cannot be matched.
-3. After feasibility is established, build the selected matching by processing
-   entries largest-first and choosing an unused fitting domain according to the
-   active TAS placement mode. Existing affinity tiers are considered before
-   capacity ordering, and topology domain identity is the final deterministic
-   tie-breaker.
+3. Build the selected matching by processing entries largest-first and choosing
+   an unused fitting domain according to the active TAS placement mode. Existing
+   affinity tiers are considered before capacity ordering, and domain identity is
+   the final deterministic tie-breaker.
 4. Retain the original list index on every match so assignment construction can
    restore rank-block order.
 
-At the exact level, the existing placement modes are interpreted as follows:
+At the exact level the placement modes are interpreted as follows:
 
 - `BestFit` starts with fitting domains that have the most free pod capacity.
-  This is the default mode and applies to every exact request unless
+  This is the default and applies to every exact request unless
   `LeastFreeCapacity` is selected below.
 - `LeastFreeCapacity` starts with the fitting domain that has the least free pod
   capacity. It applies only when the request is classified as unconstrained
-  **and** the `TASProfileMixed` feature gate is enabled. With `TASProfileMixed`
-  disabled, which is the default, exact requests always use `BestFit`.
-- `BalancedPlacement` is not applicable to exact distributions at alpha.
-  Balanced placement requires preferred topology, while preferred outer
-  topology is rejected for `sizes` at alpha.
+  **and** `TASProfileMixed` is enabled. With `TASProfileMixed` disabled, which is
+  the default, exact requests always use `BestFit`.
+- `BalancedPlacement` is not applicable at alpha, because it requires preferred
+  topology, which is rejected for `sizes`.
 
-The request is classified using the existing TAS profile rules. In particular,
-an exact-only slice request is an unconstrained TAS request, while a request
-with `podset-required-topology` is a required TAS request. Exact matching does
-not override the placement mode selected for that request.
-
-For example:
+The request is classified using the existing TAS profile rules: an exact-only
+slice request is unconstrained, while a request with `podset-required-topology`
+is required. Exact matching does not override the resulting placement mode.
 
 ```text
 requested sizes: [1, 3, 4]
@@ -533,340 +404,261 @@ LeastFreeCapacity matching (unconstrained request, TASProfileMixed enabled):
 1 -> capacity 1
 ```
 
-The algorithm assigns at most one requested entry to each domain. This is a
-threshold matching problem rather than general bin packing. Largest-first
-processing ensures a smaller entry does not consume the only domain capable of
-satisfying a larger entry. The feasibility result is independent of placement
-policy; the selected feasible matching follows the active policy.
-
-Both greedy variants above are in fact optimal for threshold matching by the
-usual exchange argument, so the policy-driven pass in step 3 cannot fail on a
-scope that step 2 declared feasible. The passes are kept separate so that
-feasibility remains a property of capacity alone. A future placement mode that
-is not capacity-monotonic can then be added without silently making previously
-admissible workloads unschedulable, and step 2 continues to answer parent domain
-feasibility with one well-understood rule.
+At most one requested entry is assigned to each domain, so this is threshold
+matching rather than general bin packing, and largest-first processing ensures a
+smaller entry does not consume the only domain capable of satisfying a larger
+one. Both greedy variants above are optimal for threshold matching by the usual
+exchange argument, so step 3 cannot fail on a scope that step 2 declared
+feasible. The passes are kept separate so feasibility remains a property of
+capacity alone: a future placement mode that is not capacity-monotonic can then
+be added without silently making previously admissible workloads unschedulable.
 
 #### Parent Domain Feasibility
 
-Aggregate capacity does not prove that an exact distribution fits. For
-example, domain capacities `[2, 2, 4]` total eight pods but cannot satisfy
-`[1, 3, 4]` because no domain can accommodate three pods after reserving a
-distinct domain for each entry.
+Aggregate capacity does not prove that an exact distribution fits. Domain
+capacities `[2, 2, 4]` total eight pods but cannot satisfy `[1, 3, 4]`, because
+no domain can accommodate three pods once a distinct domain is reserved for each
+entry.
 
 The scheduler therefore performs exact matching while evaluating candidate
-enclosing domains. A candidate required domain is considered feasible only if
-the complete requested list can be matched within it. The normal TAS
-strategy is then used to choose among feasible enclosing domains.
-
-This prevents the scheduler from selecting an aggregate-capacity fit that
-fails during downward traversal when another enclosing domain could satisfy
-the request.
+enclosing domains, treating a candidate as feasible only if the complete list can
+be matched within it, and then uses the normal TAS strategy to choose among
+feasible candidates. This prevents selecting an aggregate-capacity fit that fails
+during downward traversal when another enclosing domain could have satisfied the
+request.
 
 #### Preemption
 
-TAS already evaluates assignments twice: once against current free capacity,
-and once against a snapshot that simulates the capacity that preemption would
-release. Exact distributions reuse that mechanism unchanged at alpha. Exact
-matching runs against whichever snapshot the scheduler is currently evaluating,
-so a preempting workload becomes admissible exactly when the complete list can
-be matched within the simulated capacity.
+TAS already evaluates assignments against both current free capacity and a
+snapshot simulating the capacity preemption would release. Exact distributions
+reuse that mechanism unchanged: matching runs against whichever snapshot is being
+evaluated, so a preempting workload becomes admissible exactly when the complete
+list is matchable within simulated capacity.
 
-Two consequences follow and are accepted for alpha:
-
-- Preemption targets are still chosen by the existing preemption logic, which
-  reasons about quota and priority rather than about exact-domain feasibility.
-  It is therefore possible to preempt enough aggregate capacity without making
-  the distribution matchable, in which case the exact request remains pending
-  and the released capacity is available to other workloads. This mirrors the
-  existing behavior for required topology, which has the same property.
-- Kueue does not attempt to minimize preemptions with respect to the exact
-  matching. Choosing the target set that makes `[1, 3, 4]` feasible at the
-  lowest preemption cost is an optimization over both preemption and matching
-  simultaneously, and is deliberately out of scope for alpha.
-
-Making preemption exact-domain aware is a candidate beta improvement and is
-listed under graduation criteria rather than implemented here.
+Two consequences are accepted for alpha. Preemption targets are still chosen by
+the existing logic, which reasons about quota and priority rather than
+exact-domain feasibility, so it is possible to preempt enough aggregate capacity
+without making the distribution matchable — the same property required topology
+already has. And Kueue does not attempt to minimize preemptions with respect to
+the matching, since that is a joint optimization over both. Making preemption
+exact-domain aware is a candidate beta improvement.
 
 #### Assignment Construction
 
-After matching, Kueue sets each selected exact-level domain's assigned pod
-count to its matched value. Existing downward traversal distributes that count
-through finer topology levels to leaves. Existing assignment construction then
-encodes the selected leaf domains and counts into `TopologyAssignment`.
+After matching, Kueue sets each selected exact-level domain's assigned pod count
+to its matched value. Existing downward traversal distributes that count through
+finer levels to leaves, and existing assignment construction encodes the selected
+leaves and counts into `TopologyAssignment`.
 
 Assignment construction emits exact groups in original `sizes` order. All leaf
-domain entries descended from one selected exact-level domain are contiguous,
-and their counts sum to that entry's requested size. Within an exact group,
-existing TAS ordering determines leaf order. Assignment construction must not
-reorder leaf entries across exact groups.
+entries descended from one selected exact-level domain are contiguous and their
+counts sum to that entry's requested size; within a group, existing TAS ordering
+determines leaf order. Construction must not reorder leaf entries across groups.
 
 The topology ungater consumes domain counts in `TopologyAssignment` order and
-maps consecutive indexed-pod ranks to those domains. Therefore, preserving the
-ordered exact groups gives each `sizes` entry its specified contiguous rank
-block without requiring a new status format. For `[1, 3, 4]`, rank 0 maps to
-the first selected exact domain, ranks 1-3 to the second, and ranks 4-7 to the
-third.
+maps consecutive indexed-pod ranks to those domains. Preserving group order is
+therefore what gives each `sizes` entry its contiguous rank block, without
+requiring a new status format.
 
 ### Failed Node Replacement
 
-Existing failed-node replacement detects incomplete uniform slices using
-modulo arithmetic. That is insufficient for an uneven exact distribution.
+Existing failed-node replacement detects incomplete uniform slices using modulo
+arithmetic, which is insufficient for an uneven distribution.
 
-For an exact assignment, replacement must preserve the assigned count of the
-affected exact-level domain. The ancestor domain is derived from the assignment
-itself rather than stored separately. `TopologyAssignment.Levels` records the
-level keys, and each domain entry records its `Values`, so truncating an
-unhealthy leaf's `Values` at the exact level yields the identifying path of its
-exact-level ancestor. Kueue computes that path before removing the unhealthy
-leaf, and constrains replacement pods to the domain it identifies.
+Replacement must preserve the assigned count of the affected exact-level domain.
+The ancestor is derived from the assignment rather than stored separately:
+`TopologyAssignment.Levels` records the level keys and each entry records its
+`Values`, so truncating an unhealthy leaf's `Values` at the exact level yields
+the ancestor's identifying path. Kueue computes that path *before* removing the
+leaf — otherwise, when the removed leaf is the only one in its group, removal
+would erase the only record of the ancestor. The group keeps its position with a
+temporarily unsatisfied count while replacement is pending. If the ancestor
+domain no longer exists in the current snapshot, replacement fails and the
+configured failure behavior applies.
 
-Two cases need explicit handling:
-
-- **The removed leaf is one of several in its exact group.** The remaining
-  leaves still carry the ancestor path, so the derivation above is confirmed by
-  the surviving entries.
-- **The removed leaf is the only leaf of its exact group.** Removing it first
-  would erase the only record of that group's ancestor. Kueue therefore derives
-  and retains the path before mutating the assignment, and the exact group keeps
-  its position in the assignment with a count that is temporarily unsatisfied
-  while replacement is pending. If the ancestor domain no longer exists in the
-  current topology snapshot, replacement fails and the configured failure
-  behavior applies.
-
-Replacement updates leaf entries within the affected exact group's existing
-position in `TopologyAssignment`. It does not move that group before or after
-another ordered group. Thus, the contiguous rank block owned by each `sizes`
-entry remains stable when a finer-level leaf is replaced.
+Replacement updates leaf entries within the affected group's existing position
+and does not move that group relative to another, so each `sizes` entry's rank
+block stays stable.
 
 Preserving that position requires a change to assignment merging. Replacement
-currently builds its result by merging the replacement assignment with the
-existing one, and that merge re-sorts every domain entry lexicographically by
-level values. Applied to an exact assignment it would reorder groups relative
-to the requested `sizes` order and silently reassign rank blocks to different
-domains, which is the same hazard that ordinary assignment construction must
-avoid. Merging therefore needs an exact-aware path, enabled by the
-`TASExactTopologyDistribution` feature gate, that merges replacement leaves into
-their existing exact group and preserves group order. The scalar path keeps its
-current lexicographic behavior unchanged.
-
-The same requirement applies to any other code path that rebuilds a
-`TopologyAssignment` from parts. Leader and worker PodSets are merged by the
-same routine, and PodSet groups are already mutually exclusive with `sizes`, so
-that path is not reachable for exact distributions at alpha. Validation must
-keep enforcing that exclusion for the merge invariant to hold, and a test
+currently merges the replacement assignment with the existing one, and that merge
+re-sorts every entry lexicographically by level values — which would reorder
+groups relative to `sizes` order and silently reassign rank blocks. Merging
+therefore needs an exact-aware path, gated by
+`TASExactTopologyDistribution`, that merges replacement leaves into their
+existing group and preserves group order; the scalar path keeps its current
+behavior. The same requirement applies to any other path that rebuilds a
+`TopologyAssignment` from parts. Leader and worker PodSets use the same merge
+routine, but PodSet groups are mutually exclusive with `sizes`, so that path is
+unreachable at alpha — validation must keep enforcing that exclusion, and a test
 asserts it.
 
 If replacement cannot fit within the affected domain, Kueue does not place the
-pods in another domain because doing so would change the exact distribution.
-The existing configured failure behavior, including fail-fast or eviction,
-applies.
-
-Moving an entire exact group to a different domain is out of scope for alpha.
+pods elsewhere, because that would change the distribution; the configured
+failure behavior, including fail-fast or eviction, applies. Moving an entire
+exact group to a different domain is out of scope for alpha.
 
 ### Failure Reporting
 
-The distinguishing failure mode of this feature is that a workload stays
-pending while aggregate free capacity looks sufficient. Reporting it as a
-generic topology fit failure would make that indistinguishable from ordinary
-capacity exhaustion, so exact matching reports its own reason.
+The distinguishing failure mode of this feature is a workload staying pending
+while aggregate free capacity looks sufficient. Reported as a generic topology
+fit failure it would be indistinguishable from ordinary capacity exhaustion, so
+exact matching reuses the existing TAS failure-reason plumbing — which already
+carries a per-PodSet reason into the workload's pending condition — with two new
+reasons:
 
-Exact matching reuses the existing TAS failure-reason plumbing, which already
-carries a per-PodSet reason string into the workload's pending condition
-message. Two new reasons are added:
-
-- `topology exact distribution infeasible` when no candidate enclosing scope
-  can match the complete list. The message names the requested list, the number
-  of eligible domains at the exact level, and the largest entry that could not
-  be matched, so that a user can tell an under-provisioned cluster from a
+- `topology exact distribution infeasible` when no candidate enclosing scope can
+  match the complete list. The message names the requested list, the number of
+  eligible domains at the exact level, and the largest entry that could not be
+  matched, so a user can distinguish an under-provisioned cluster from a
   fragmented one.
-- `topology exact distribution needs more domains` when the number of eligible
-  domains at the exact level is smaller than the number of entries. This is the
-  common misconfiguration of requesting more distinct domains than the topology
-  contains, and it is not fixable by waiting.
+- `topology exact distribution needs more domains` when there are fewer eligible
+  domains than entries. This is the common misconfiguration of requesting more
+  distinct domains than the topology contains, and waiting will not fix it.
 
-One metric is added, following the existing Kueue naming convention:
+One metric is added:
 
 ```text
 kueue_tas_exact_distribution_failures_total
 ```
 
-It is a counter of failed exact-matching attempts, labeled by
-`cluster_queue` and `reason`, where `reason` takes the values above. The
-`cluster_queue` and `reason` pairing matches existing ClusterQueue-scoped
-metrics such as the eviction counters, and introduces no per-workload
-cardinality. The metric carries the standard configurable ClusterQueue label
-suffix and a `+metricsdoc:labels` marker, as required for new metrics. It is
-registered only when the `TASExactTopologyDistribution` feature gate is enabled,
-following the existing pattern for gated metrics.
+It counts failed matching attempts, labeled by `cluster_queue` and `reason`. That
+pairing matches existing ClusterQueue-scoped metrics such as the eviction
+counters and introduces no per-workload cardinality. The metric carries the
+standard configurable ClusterQueue label suffix and a `+metricsdoc:labels`
+marker, and is registered only when the feature gate is enabled.
 
 ### Feature Gate
 
-Introduce the alpha feature gate:
+Introduce the alpha feature gate `TASExactTopologyDistribution`, depending on
+`TopologyAwareScheduling` and `TASMultiLayerTopology` in the feature gate
+dependency table. The dependency on `TASMultiLayerTopology` is structural rather
+than behavioral: `sizes` is carried on `PodsetSliceRequiredTopologyConstraints`,
+which that gate owns.
 
-```text
-TASExactTopologyDistribution
-```
-
-The gate depends on `TopologyAwareScheduling` and `TASMultiLayerTopology`, and
-is declared as such in the feature gate dependency table. The dependency on
-`TASMultiLayerTopology` is structural rather than behavioral: `sizes` is carried
-on `PodsetSliceRequiredTopologyConstraints`, which that gate owns, so enabling
-exact distribution without it would expose a field that is otherwise inert.
-
-A separate gate is used because `TASMultiLayerTopology` is already beta while
-the `sizes` semantics and matching behavior are new. Disabling the gate
-preserves all existing scalar multi-layer behavior and rejects new requests
-that contain `sizes`.
+A separate gate is used because `TASMultiLayerTopology` is already beta while the
+`sizes` semantics and matching behavior are new. Disabling the gate preserves all
+existing scalar multi-layer behavior and rejects new requests containing `sizes`.
 
 ### Upgrade, Downgrade, and Backwards Compatibility
 
-Adding `sizes` preserves existing manifests and Go clients using `Size`.
-Existing scalar requests follow the unchanged scheduling path. The schema
-change relaxes the existing beta field from unconditionally required to one
-optional arm of a required union; it does not make a previously valid scalar
-object invalid.
+Adding `sizes` preserves existing manifests and Go clients using `Size`, and
+existing scalar requests follow the unchanged scheduling path. The schema change
+relaxes the existing beta field from unconditionally required to one optional arm
+of a required union; no previously valid object becomes invalid. Upgrading the
+CRDs adds the optional field before the feature is enabled, and while the gate is
+disabled new `sizes` requests are rejected.
 
-Upgrading the CRDs adds the optional field before the feature is enabled. When
-the gate is disabled, new `sizes` requests are rejected.
-
-Before downgrading to a Kueue version whose CRD does not contain `sizes`,
-operators must ensure that no Jobs, Workloads, or other integrated workload
-templates contain the field. An older CRD schema has `required: [size,
-topology]` for every constraint item. It rejects an object containing `sizes`
-without `size` at API-server validation, before the older controller can read
-or reconcile the object. This is a hard downgrade incompatibility rather than
-an older-controller fallback behavior.
-
-Stored Workloads containing `sizes` must be completed or deleted, and Job
-templates containing the annotation must be removed, before installing the
-older CRD. Downgrade documentation and release notes call out this prerequisite.
+Downgrade is a hard incompatibility, not an older-controller fallback. An older
+CRD schema has `required: [size, topology]` for every constraint item, so it
+rejects an object containing `sizes` without `size` at API-server validation,
+before the older controller can read it. Before installing the older CRD,
+operators must complete or delete stored Workloads containing `sizes` and remove
+the annotation from Job templates. Downgrade documentation and release notes call
+out this prerequisite.
 
 ### Test Plan
 
-[x] I/we understand the owners of the involved components may require updates
-to existing tests to make the code solid enough before committing the changes
+[x] I/we understand the owners of the involved components may require updates to
+existing tests to make the code solid enough before committing the changes
 necessary to implement this enhancement.
 
 #### Unit Tests
 
 API and job framework tests cover:
 
-- Parsing valid `sizes` annotations.
-- Preserving `sizes` list order through annotation parsing, JSON round trips,
-  and deepcopy.
-- Rejecting both `size` and `sizes` in one entry.
-- Rejecting entries with neither field.
-- Rejecting a Go/API object for which `Size: 0` is omitted and `Sizes` is also
-  absent.
-- Rejecting empty lists, non-positive values, and more than 128 entries.
-- Accepting duplicate values.
+- Parsing valid `sizes` annotations, and preserving list order through annotation
+  parsing, JSON round trips, and deepcopy.
+- The field union: accepting either arm, rejecting both and neither, including
+  the Go client case where `Size: 0` is omitted and `Sizes` is absent.
+- Schema bounds: empty lists, non-positive values, more than 128 entries, and
+  accepting duplicates.
 - Rejecting a sum different from the PodSet count.
 - Rejecting non-indexed Jobs and integrations without a stable rank source.
-- Rejecting partial admission and preferred outer topology.
+- Rejecting partial admission, preferred outer topology, multiple constraint
+  entries at alpha, and a disabled feature gate.
 - Rejecting `sizes` for an elastic Job, including when
   `ElasticJobsViaWorkloadSlicesWithTAS` is enabled.
-- Rejecting scale-up, scale-down, and other post-reservation changes to the
-  effective PodSet count.
-- Allowing a pre-reservation count or `sizes` update only when the new sum and
-  count match.
-- Rejecting multiple constraint entries when one uses `sizes` at alpha.
-- Rejecting `sizes` when the feature gate is disabled.
+- Rejecting post-reservation changes to the effective PodSet count, and allowing
+  a pre-reservation update only when the new sum and count match.
 - Workload webhook defense-in-depth validation.
-- Generated deepcopy behavior for the `Sizes` slice.
-- Generated CRD validation accepts the existing scalar form and the new exact
-  form, but rejects both and neither.
 - An older CRD schema rejects an exact constraint that omits `size`.
 
 Scheduler unit tests cover:
 
-- Distinct rank-block semantics for `[1, 3, 4]` and `[4, 3, 1]`.
-- Largest-first internal matching retains each entry's original list index.
-- Missing, duplicate, or out-of-range pod ranks remain gated rather than
+- Distinct rank-block semantics for `[1, 3, 4]` and `[4, 3, 1]`, with matching
+  retaining each entry's original list index.
+- Missing, duplicate, or out-of-range pod ranks remaining gated rather than
   falling back to greedy assignment.
+- Placement mode selection: `LeastFreeCapacity` only for an unconstrained request
+  with `TASProfileMixed` enabled, `BestFit` otherwise, each producing its
+  documented matching for the same capacities; no `BalancedPlacement` at alpha.
 - Deterministic selection when multiple domains have equal capacity.
-- `BestFit` and `LeastFreeCapacity` select their documented exact-level
-  matchings for the same feasible capacities.
-- Exact distributions do not enter `BalancedPlacement` at alpha.
-- Aggregate capacity sufficient but exact matching infeasible.
-- Too few distinct domains.
-- Duplicate sizes such as `[2, 2, 4]`.
-- Selecting a feasible enclosing block over an aggregate-only fit.
-- Applying the active TAS strategy among multiple feasible scopes.
+- Aggregate capacity sufficient but matching infeasible; too few distinct
+  domains; duplicate sizes such as `[2, 2, 4]`.
+- Selecting a feasible enclosing block over an aggregate-only fit, and applying
+  the active TAS strategy among multiple feasible scopes.
 - Exact distributions at block, rack, and hostname levels.
-- `LeastFreeCapacity` is used only for an unconstrained exact request with
-  `TASProfileMixed` enabled, and `BestFit` is used otherwise.
-- A single-entry list such as `[8]` behaves like required topology at that
-  level.
+- Replacement constrained to the affected exact domain without changing rank
+  blocks, with merging preserving group order rather than re-sorting
+  lexicographically, and deriving the ancestor when the unhealthy leaf is the
+  only leaf of its group — failing cleanly when that ancestor is gone.
+- Scalar assignments still merging lexicographically with the gate enabled.
+- Matching against a preemption-simulated snapshot admitting only when the
+  complete list is matchable within simulated capacity.
+- Failure reasons distinguishing infeasibility from too few domains, and the
+  counter incrementing with the matching `reason` label.
 - No regression in existing scalar slice and multi-layer tests.
-- Failed-node replacement constrained to the affected exact domain without
-  changing ordered rank blocks.
-- Merging a replacement assignment preserves exact group order rather than
-  re-sorting entries lexicographically by level values.
-- Replacement derives the exact-level ancestor when the unhealthy leaf is the
-  only leaf of its exact group, and fails cleanly when that ancestor no longer
-  exists in the topology snapshot.
-- Scalar assignments still merge in lexicographic order when the feature gate
-  is enabled, so the exact-aware merge path does not change existing behavior.
-- Exact matching against a preemption-simulated snapshot admits the workload
-  only when the complete list is matchable within simulated capacity.
-- Failure reasons distinguish exact-domain infeasibility from too few eligible
-  domains, and the failure counter increments with the matching `reason` label.
 
 #### Integration Tests
 
 Single-cluster TAS integration tests verify:
 
-- An eight-pod indexed Job obtains rack-level aggregate counts `[1, 3, 4]`,
-  with rank 0 in the first selected rack, ranks 1-3 in the second, and ranks
-  4-7 in the third.
-- Reordering the request to `[4, 3, 1]` changes those rank ranges while
-  retaining the same aggregate multiset of domain counts.
-- A 24-pod Job obtains block-level aggregate counts `[8, 16]`.
-- A workload remains pending when exact matching is impossible even though
-  aggregate capacity is sufficient, and reports the exact-distribution failure
-  reason rather than a generic topology fit failure.
+- An eight-pod indexed Job obtains rack-level counts `[1, 3, 4]`, with rank 0 in
+  the first selected rack, ranks 1-3 in the second, and ranks 4-7 in the third.
+- Reordering to `[4, 3, 1]` changes those rank ranges while retaining the same
+  aggregate multiset of domain counts.
+- A 24-pod Job obtains block-level counts `[8, 16]`.
+- A workload remains pending when matching is impossible despite sufficient
+  aggregate capacity, reporting the exact-distribution failure reason.
 - A workload selects a feasible enclosing domain when another candidate is
   infeasible.
 - Disabling the feature gate rejects the annotation.
-- Replacement of an unhealthy node preserves both the exact-level distribution
-  and the original rank-to-exact-domain mapping, including when the replaced
-  leaf was the only leaf of its exact group.
+- Replacing an unhealthy node preserves both the distribution and the original
+  rank-to-domain mapping, including when the replaced leaf was the only leaf of
+  its group.
 - A workload admitted by preempting a lower-priority workload obtains the full
   ordered distribution.
 
 #### End-to-End Tests
 
-Add an extended TAS end-to-end test using a fixed test topology. The test
-creates an indexed Job, waits for admission, and verifies the aggregate
-topology assignment, the contiguous rank range assigned to each exact domain,
-and the resulting pod placement. Existing scalar TAS end-to-end tests continue
-to run unchanged.
+Add an extended TAS end-to-end test using a fixed test topology. It creates an
+indexed Job, waits for admission, and verifies the aggregate topology assignment,
+the contiguous rank range assigned to each exact domain, and the resulting pod
+placement. Existing scalar TAS end-to-end tests run unchanged.
 
 ### Graduation Criteria
 
 #### Alpha
 
-- API field, feature gate, validation, matching, and assignment are
-  implemented.
+- API field, feature gate, validation, matching, and assignment are implemented.
 - Unit and integration tests cover feasible and infeasible distributions.
-- User documentation describes exact-distribution semantics and limitations.
+- User documentation describes semantics and limitations.
 - Failed-node replacement does not silently violate the distribution.
 
 #### Beta
 
 - Positive operational feedback from users running exact distributions.
-- Scheduling latency and memory impact are measured for the maximum supported
-  list length.
+- Scheduling latency and memory impact measured for the maximum list length.
 - Failure reasons are actionable and covered by tests, and
   `kueue_tas_exact_distribution_failures_total` is confirmed useful for
-  diagnosing pending exact workloads in practice.
+  diagnosing pending exact workloads.
 - At least one release of alpha usage without unresolved correctness issues.
 - The API limit and interactions with outer scalar constraints are revisited
   based on experience.
-- Whether preemption should become exact-domain aware is decided based on
-  observed pending workloads that had enough preemptible aggregate capacity but
-  no matchable distribution.
+- Whether preemption should become exact-domain aware is decided from observed
+  workloads that had enough preemptible aggregate capacity but no matchable
+  distribution.
 
 #### Stable
 
@@ -884,91 +676,45 @@ to run unchanged.
 - 2026-08-28: Added preemption behavior, failure reporting and metric, exact
   group ordering requirements for assignment merging, and exact-level ancestor
   derivation during failed node replacement.
+- 2026-09-01: Condensed for length; no semantic changes.
 
 ## Drawbacks
 
-Exact distributions can reduce schedulability and increase fragmentation
-compared with ordinary TAS placement. A workload may remain pending even when
-the cluster has enough aggregate capacity. This cost is justified only when a
-predictable per-domain distribution materially affects workload performance or
-behavior; testing and debugging are supported use cases, but exact placement is
-not intended to be the default.
+Exact placement trades cluster efficiency for predictability. It can reject
+otherwise usable placements, leave capacity unused across domains, and keep a
+workload pending even when aggregate capacity would suffice. That cost is
+justified only when a predictable per-domain distribution materially affects
+workload performance or behavior, so workloads that only need locality should
+keep using required, preferred, or scalar slice topology, which give Kueue more
+freedom to place efficiently.
 
-The proposal adds another placement path to a core scheduling component and
+The proposal also adds another placement path to a core scheduling component and
 requires special handling in failure recovery. Restricting alpha to one fixed
-distribution level limits this additional complexity.
-
-The API describes pod counts rather than physical node counts, which users may
-misinterpret when multiple pods can share a node.
+distribution level limits that complexity.
 
 ## Alternatives
 
 ### Multiple JobSet ReplicatedJobs
 
-A JobSet can model an uneven distribution as multiple `ReplicatedJob`s. Kueue
-creates one PodSet for each `ReplicatedJob`, so a JobSet could define three
-single-replica entries whose PodSet counts are one, three, and four. Each entry
-can independently require rack topology:
+A JobSet can model an uneven distribution as multiple `ReplicatedJob`s, since
+Kueue creates one PodSet per `ReplicatedJob`. Three single-replica entries with
+`parallelism` of one, three, and four, each annotated with
+`kueue.x-k8s.io/podset-required-topology: topology.example.com/rack`, produce
+three PodSets that each fit within some rack. No slice size is needed, because
+each ReplicatedJob is already one PodSet confined to one domain.
 
-```yaml
-spec:
-  replicatedJobs:
-  - name: group-1
-    replicas: 1
-    template:
-      spec:
-        parallelism: 1
-        completions: 1
-        template:
-          metadata:
-            annotations:
-              kueue.x-k8s.io/podset-required-topology: topology.example.com/rack
-  - name: group-3
-    replicas: 1
-    template:
-      spec:
-        parallelism: 3
-        completions: 3
-        template:
-          metadata:
-            annotations:
-              kueue.x-k8s.io/podset-required-topology: topology.example.com/rack
-  - name: group-4
-    replicas: 1
-    template:
-      spec:
-        parallelism: 4
-        completions: 4
-        template:
-          metadata:
-            annotations:
-              kueue.x-k8s.io/podset-required-topology: topology.example.com/rack
-```
+This is sufficient when the application genuinely consists of separate
+ReplicatedJobs and only needs each group rack-local. It does not provide the
+semantics proposed here: the PodSets are placed independently, so their racks are
+not required to be distinct or to descend from a common block. It is also
+unavailable to workload types that cannot express the groups as separate PodSets.
 
-This is sufficient when the application already consists of separate
-ReplicatedJobs and only requires each group to fit within some rack. A slice
-size is unnecessary when each single-replica ReplicatedJob is already one
-PodSet that must fit within one topology domain.
-
-It does not provide the semantics proposed by this KEP. The PodSets are placed
-independently, so their selected racks are not required to be distinct and are
-not necessarily descendants of the same enclosing block. It also changes the
-application model from one PodSet and one pod index space into multiple
-ReplicatedJobs, and it is unavailable to workload types that cannot express
-the groups as separate PodSets.
-
-Splitting the PodSet also discards the ordered rank blocks that motivate this
-proposal. Each ReplicatedJob has its own index space starting at zero, so there
-is no single rank ordering over the eight workers and no way to state that ranks
-1-3 must be co-located while rank 0 is not. Applications that derive collective
-communicator ranks from one contiguous index space cannot use this alternative
-without changing how they assign ranks.
-
-This KEP retains `sizes` for workloads that require one PodSet to be divided
-across dynamically selected distinct domains, optionally within one enclosing
-domain. Users whose application can use independent ReplicatedJobs without
-distinct-domain or shared-parent guarantees should use the existing JobSet
-functionality instead.
+Most importantly, splitting the PodSet discards the ordered rank blocks that
+motivate this proposal. Each ReplicatedJob has its own index space starting at
+zero, so there is no single rank ordering over the eight workers and no way to
+require that ranks 1-3 are co-located while rank 0 is not. Applications deriving
+collective communicator ranks from one contiguous index space cannot use this
+alternative without changing how they assign ranks.
 
 ### A Separate Annotation
 
@@ -979,35 +725,29 @@ topology grouping requests in one API family.
 
 ### Binding Counts to Named Domains
 
-The API could map label values directly to counts:
-
-```yaml
-rack-a: 1
-rack-b: 3
-rack-c: 4
-```
-
-This supports physical-domain reproduction but couples workloads to a specific
-cluster and bypasses TAS domain selection. It is left for a separate feature if
-users require explicit domain identity.
+The API could map label values directly to counts (`rack-a: 1`, `rack-b: 3`,
+`rack-c: 4`). This supports physical-domain reproduction but couples workloads to
+a specific cluster and bypasses TAS domain selection. It is left for a separate
+feature if users require explicit domain identity.
 
 ### Repeating a Distribution Pattern
 
-Kueue could allow a 16-pod PodSet to specify `[1, 3, 4]` and repeat the pattern
-twice. This requires defining whether repeats share enclosing domains, whether
-entries from different repeats may share exact-level domains, and how logical
-pattern identity survives failure recovery. Alpha instead requires users to
-provide the complete list.
+Kueue could allow a 16-pod PodSet to specify `[1, 3, 4]` and repeat it twice.
+This requires defining whether repeats share enclosing domains, whether entries
+from different repeats may share exact-level domains, and how pattern identity
+survives failure recovery. Alpha instead requires the complete list — a 16-pod
+PodSet can explicitly request `[1, 3, 4, 1, 3, 4]`, which needs six distinct
+domains and defines six rank blocks in that order.
 
 ### Multiple Exact Levels
 
 A flat list cannot unambiguously describe different child distributions for
-different parent sizes. For example, block sizes `[8, 16]` require separate
-rack distributions for each block. Supporting this use case likely requires a
-nested tree-shaped API rather than multiple independent `sizes` lists.
+different parent sizes. Block sizes `[8, 16]` would require separate rack
+distributions per block. Supporting this likely requires a nested tree-shaped API
+rather than multiple independent `sizes` lists.
 
 ### Pod Topology Spread Constraints
 
-Kubernetes topology spread constraints bound the skew between eligible
-domains. They can encourage an even distribution but cannot require an
-arbitrary vector such as `[1, 3, 4]` across dynamically selected domains.
+Kubernetes topology spread constraints bound the skew between eligible domains.
+They can encourage an even distribution but cannot require an arbitrary vector
+such as `[1, 3, 4]` across dynamically selected domains.

--- a/keps/13416-exact-topology-distribution/README.md
+++ b/keps/13416-exact-topology-distribution/README.md
@@ -26,9 +26,10 @@
   - [Feature Gate](#feature-gate)
   - [Upgrade, Downgrade, and Backwards Compatibility](#upgrade-downgrade-and-backwards-compatibility)
   - [Test Plan](#test-plan)
-    - [Unit Tests](#unit-tests)
-    - [Integration Tests](#integration-tests)
-    - [End-to-End Tests](#end-to-end-tests)
+    - [Prerequisite testing updates](#prerequisite-testing-updates)
+    - [Unit tests](#unit-tests)
+    - [Integration tests](#integration-tests)
+    - [e2e tests](#e2e-tests)
   - [Graduation Criteria](#graduation-criteria)
     - [Alpha](#alpha)
     - [Beta](#beta)
@@ -96,8 +97,7 @@ complete PodSet. Kueue already performs group-level admission and produces a
   satisfied.
 - Preserve existing scalar `size` behavior unchanged, and keep exact distribution
   opt-in.
-- Bound the alpha scheduling problem so feasibility is decidable with a
-  deterministic matching algorithm.
+
 
 ### Non-Goals
 
@@ -110,7 +110,6 @@ complete PodSet. Kueue already performs group-level admission and produces a
 - Partial admission or elastic changes to the PodSet count.
 - Exact distributions for PodSets without stable pod indexes at alpha.
 - Rebalancing an admitted and running PodSet when topology capacity changes.
-- Extending topology spread constraints in the default Kubernetes scheduler.
 
 ## Proposal
 
@@ -173,24 +172,25 @@ the block level.
 
 ### Semantics
 
-1. `sizes` is ordered. `[1, 3, 4]` and `[4, 3, 1]` request the same aggregate
-   domain counts but different pod-rank mappings.
-2. Each entry is assigned to one distinct domain at the entry's `topology` level,
-   and its value is the exact number of pods Kueue assigns to that domain.
-3. Entry `i` owns the next `sizes[i]` contiguous pod ranks after all preceding
-   entries. For `[1, 3, 4]`, the rank blocks are rank 0, ranks 1-3, and ranks 4-7.
-4. Kueue selects the physical domain for each entry. A list position identifies a
-   rank block, not a topology label value.
-5. Duplicate values are allowed. `[2, 2, 4]` requests three distinct domains.
-6. The sum of the list must equal the fixed PodSet count.
-7. An exact distribution is a required constraint. Kueue does not fall back to
+1. `sizes` is ordered. Entry `i` defines the next `sizes[i]` contiguous pod ranks.
+   For `[1, 3, 4]`, the groups are rank 0, ranks 1-3, and ranks 4-7.
+2. Each entry specifies the exact pod count for one distinct domain at the named
+   topology level, so the list length is the number of domains used at that
+   level. Kueue selects the physical domains; a list position does not name a
+   domain or correspond to any ordering of the topology itself.
+3. Thus, `[1, 3, 4]` and `[4, 3, 1]` require the same three domain sizes but group
+   ranks differently.
+4. Duplicate values are allowed. `[2, 2, 4]` requests three distinct domains.
+5. The sum of the list must equal the fixed PodSet count.
+6. An exact distribution is a required constraint. Kueue does not fall back to
    scalar slicing or ordinary greedy placement when it cannot be satisfied.
-8. At alpha, an entry using `sizes` must be the only entry in the constraints
+7. At alpha, an entry using `sizes` must be the only entry in the constraints
    list. Containment is expressed using `podset-required-topology`, which must be
    strictly coarser than the exact level when `sizes` has more than one entry. A
-   request naming the same level in both is contradictory and is rejected at
-   scheduling time.
-9. Below the exact level, Kueue uses its existing capacity-based placement to
+   request naming the same level in both is contradictory: the identical-string
+   case is rejected at creation time, and the general ordering check happens at
+   scheduling time, once the topology hierarchy is known.
+8. Below the exact level, Kueue uses its existing capacity-based placement to
    assign pods to finer domains and hosts.
 
 Ordered rank-block semantics require every pod to have a stable, unique rank in
@@ -200,9 +200,10 @@ Integrations using subgroup indexes must also provide `SubGroupIndexLabel` and
 `SubGroupCount`, which are what make one unique rank space derivable for the
 complete PodSet.
 
-If a pod is missing its rank label, has a duplicate rank, or has an out-of-range
-rank, the topology ungater keeps the affected pods gated and reports an error. It
-must not fall back to greedy domain assignment for an exact-distribution PodSet.
+If any pod is missing its rank label, has a duplicate rank, or has an
+out-of-range rank, ranks cannot be derived for the PodSet at all, so the topology
+ungater keeps every gated pod in that PodSet gated and reports an error. It must
+not fall back to greedy domain assignment for an exact-distribution PodSet.
 Greedy assignment still satisfies the aggregate per-domain counts, so the
 violation would be silent — the workload would run with the wrong ranks
 co-located and nothing would report a failure.
@@ -217,10 +218,14 @@ The distribution is attached to one PodSet. A workload with multiple PodSets
 validates and schedules each independently, subject to existing restrictions on
 PodSet groups and multi-layer constraints.
 
-A single-entry list such as `sizes: [8]` is permitted and is equivalent to
-required topology at that level. It is allowed for uniformity rather than
-expressiveness; documentation directs single-domain users to
-`podset-required-topology`.
+A single-entry list such as `sizes: [8]` is permitted: it places the whole
+PodSet in one domain, the same shape `podset-required-topology` produces at that
+level. The two are still not interchangeable. A request carrying only slice
+constraints counts as unconstrained, whereas `podset-required-topology` makes it
+a required request, and those two classes order candidate domains differently
+(see [Exact Domain Matching](#exact-domain-matching)) — so Kueue may pick a
+different domain for each. Use `podset-required-topology` for the single-domain
+case: it needs neither this feature gate nor a stable rank source.
 
 ### Risks and Mitigations
 
@@ -282,19 +287,17 @@ type PodsetSliceRequiredTopologyConstraint struct {
 }
 ```
 
-The existing beta `Size` field changes from `+required` to `+optional`, so the
-generated CRD no longer unconditionally lists `size` in each item's `required`
-set; the CEL union enforces exactly one arm instead. Existing objects containing
-`size` remain valid. `Size` stays an `int32` rather than becoming a pointer, to
-preserve Go source compatibility for clients constructing the existing type. With
-`omitempty`, a client setting `Size: 0` serializes `size` as absent, and if
-`Sizes` is also absent the CEL union rejects the object as specifying neither.
+`Size` changes from `+required` to `+optional`, so the generated CRD stops
+listing it in each item's `required` set and the CEL union enforces exactly one
+arm instead. It stays an `int32` rather than a pointer, to preserve Go source
+compatibility for clients constructing the existing type — and with `omitempty`,
+a client setting `Size: 0` serializes it as absent, so the union correctly
+rejects an object that sets neither field.
 
-The annotation name `kueue.x-k8s.io/podset-slice-required-topology-constraints`
-is unchanged. `TopologyAssignment` needs no change — it already records domain
-paths and assigned counts. The `v1beta1` Workload API has no multi-layer
-constraint field, and the existing behavior of dropping multi-layer constraints
-during `v1beta2` to `v1beta1` conversion is unchanged.
+The `podset-slice-required-topology-constraints` annotation name is unchanged,
+and `TopologyAssignment` already records domain paths and assigned counts, so
+neither needs a change. `v1beta1` has no multi-layer constraint field, so `sizes`
+inherits the existing behavior of dropping those constraints during conversion.
 
 ### Validation
 
@@ -306,6 +309,9 @@ Creation-time validation enforces:
 - The structural schema above: exactly one of `size` and `sizes`, 1 to 128
   entries, every value greater than zero.
 - At alpha, an entry using `sizes` is the only entry in the constraints list.
+- The exact topology key is not the same string as `podset-required-topology`.
+  This catches the contradictory same-level request without needing the topology
+  hierarchy; the coarser-than ordering check happens at scheduling time.
 - The sum, computed using `int64`, equals `PodSet.Count`.
 - The integration provides a stable `PodIndexLabel`; for Kubernetes Jobs,
   `completionMode` must be `Indexed`. Subgroup-based integrations must also
@@ -320,17 +326,23 @@ Creation-time validation enforces:
 - The `TASExactTopologyDistribution` feature gate is enabled.
 
 The Workload webhook repeats the structural, numeric, partial-admission, and
-elastic-workload checks as defense in depth for direct Workload writes.
+elastic-workload checks, so that a Workload written directly is checked too.
 
-Update-time validation preserves the fixed-count invariant:
+Update-time validation preserves the fixed-count invariant. Existing Workload
+validation already makes the whole PodSet immutable once quota is reserved, so
+`sizes` and the count inherit that. Two additions:
 
-- Before quota reservation, `sizes` or the PodSet count may change only when the
-  resulting ordered list remains valid and its sum equals the new count.
-- After quota reservation, the PodSet count and the value and order of `sizes`
-  are immutable. Job integration webhooks reject updates to `parallelism`,
-  `completions`, `replicas`, or another integration-specific field that would
-  change the effective PodSet count, and direct Workload updates changing the
-  count or `sizes` are rejected.
+- Before quota reservation, `sizes` or the count may change only when the new sum
+  equals the new count.
+- That immutability check has an exception letting elastic jobs shrink the
+  count. The exception is keyed on the `ElasticJobsViaWorkloadSlices` gate, not
+  on whether this particular workload is elastic, so it must be refused for
+  `sizes` PodSets. Otherwise the sum stops matching the count.
+
+Job integration webhooks also reject `parallelism`, `completions`, or `replicas`
+updates that would change an exact-distribution PodSet's count. This is a
+behavior change scoped to those PodSets: today the edit is accepted and the
+workload is later finished as out of sync.
 
 Scheduling-time validation enforces that the exact topology key exists in the
 selected ResourceFlavor's `Topology`, that the exact level is below the required
@@ -375,19 +387,36 @@ distinct domains, separating feasibility from policy-driven selection:
 
 At the exact level the placement modes are interpreted as follows:
 
-- `BestFit` starts with fitting domains that have the most free pod capacity.
-  This is the default and applies to every exact request unless
-  `LeastFreeCapacity` is selected below.
+- `BestFit` starts with fitting domains that have the most free pod capacity. It
+  applies to any exact request carrying `podset-required-topology`, and to every
+  exact request under a BestFit-only profile.
 - `LeastFreeCapacity` starts with the fitting domain that has the least free pod
-  capacity. It applies only when the request is classified as unconstrained
-  **and** `TASProfileMixed` is enabled. With `TASProfileMixed` disabled, which is
-  the default, exact requests always use `BestFit`.
-- `BalancedPlacement` is not applicable at alpha, because it requires preferred
-  topology, which is rejected for `sizes`.
+  capacity. It applies to unconstrained requests under the default TAS profile
+  (`TASProfileMixed`, default since v0.15), so an exact-only slice request uses
+  it unless a cluster overrides the profile.
+- `BalancedPlacement` never runs at alpha. It only runs when a request is
+  neither required nor unconstrained, and every `sizes` request alpha allows is
+  one of those two: a `sizes`-only request counts as unconstrained, and adding
+  `podset-required-topology` makes it required. So there is nothing to turn off
+  here. If preferred topology is ever allowed with `sizes`, then `sizes` must
+  win, because balanced placement spreads pods evenly while `sizes` asks for an
+  uneven split. Both cannot be true at once.
 
 The request is classified using the existing TAS profile rules: an exact-only
 slice request is unconstrained, while a request with `podset-required-topology`
 is required. Exact matching does not override the resulting placement mode.
+
+Following the profile has one side effect worth calling out. By default a
+`sizes`-only request gets `LeastFreeCapacity`, which picks the domains that
+barely fit, leaving almost no spare room in them. If a node then fails,
+replacement has to stay inside that same domain and is not allowed to move the
+group elsewhere, so there may be nowhere to put the replacement pods.
+
+`BestFit` would leave spare room, but it uses roomier domains and so wastes more
+capacity. Alpha keeps following whichever profile the cluster is set to, rather
+than picking one for the user: forcing a different algorithm for just this
+feature is a big change to make without data. Beta decides it, based on how
+often replacement actually fails.
 
 ```text
 requested sizes: [1, 3, 4]
@@ -404,14 +433,10 @@ LeastFreeCapacity matching (unconstrained request, TASProfileMixed enabled):
 1 -> capacity 1
 ```
 
-At most one requested entry is assigned to each domain, so this is threshold
-matching rather than general bin packing, and largest-first processing ensures a
-smaller entry does not consume the only domain capable of satisfying a larger
-one. Both greedy variants above are optimal for threshold matching by the usual
-exchange argument, so step 3 cannot fail on a scope that step 2 declared
-feasible. The passes are kept separate so feasibility remains a property of
-capacity alone: a future placement mode that is not capacity-monotonic can then
-be added without silently making previously admissible workloads unschedulable.
+Each domain takes at most one entry from the list, so this is a simpler problem
+than bin packing: nothing is ever split across domains. Working from the largest
+entry down matters, because otherwise a small entry could take the only domain
+big enough for a large one.
 
 #### Parent Domain Feasibility
 
@@ -423,25 +448,41 @@ entry.
 The scheduler therefore performs exact matching while evaluating candidate
 enclosing domains, treating a candidate as feasible only if the complete list can
 be matched within it, and then uses the normal TAS strategy to choose among
-feasible candidates. This prevents selecting an aggregate-capacity fit that fails
-during downward traversal when another enclosing domain could have satisfied the
-request.
+feasible candidates.
 
 #### Preemption
 
-TAS already evaluates assignments against both current free capacity and a
-snapshot simulating the capacity preemption would release. Exact distributions
-reuse that mechanism unchanged: matching runs against whichever snapshot is being
-evaluated, so a preempting workload becomes admissible exactly when the complete
-list is matchable within simulated capacity.
+TAS already validates a preempting workload's placement twice, and exact
+matching plugs into both without new code:
 
-Two consequences are accepted for alpha. Preemption targets are still chosen by
-the existing logic, which reasons about quota and priority rather than
-exact-domain feasibility, so it is possible to preempt enough aggregate capacity
-without making the distribution matchable — the same property required topology
-already has. And Kueue does not attempt to minimize preemptions with respect to
-the matching, since that is a joint optimization over both. Making preemption
-exact-domain aware is a candidate beta improvement.
+1. **Upper bound.** Before preemption is contemplated, the assignment is
+   recomputed against a snapshot simulating the whole cluster as empty. If the
+   PodSet does not fit even then, the mode becomes `NoFit` and no preemption is
+   issued. For an exact distribution this catches the case where the topology
+   simply lacks enough eligible domains.
+2. **Candidate set.** Once specific preemption targets are chosen, the
+   assignment is recomputed against a snapshot with exactly those targets'
+   usage removed. Exact matching therefore runs against the capacity those
+   targets would actually release, rather than against aggregate quota.
+
+Step 2 is what stops this feature from preempting for nothing, and it needs one
+fix. Today the recomputed result is saved but the assignment mode is left alone,
+so even when no placement was found the mode stays at `Preempt` and the
+preemption goes ahead.
+
+For ordinary placement this rarely matters, because freeing more capacity almost
+always means more pods fit. Exact matching does not work that way. Freeing room
+for eight pods spread as `[2, 2, 4]` still cannot hold `[1, 3, 4]`, because
+nothing has room for three. So alpha treats a missing assignment after step 2 as
+`NoFit` and puts the workload back in the queue, instead of evicting other
+workloads for a shape that will not fit anyway.
+
+One limitation is accepted for alpha: Kueue does not *choose* preemption targets
+to make the distribution matchable. Target selection remains driven by quota and
+priority, and the checks above only reject unusable candidate sets rather than
+searching for a usable one. Selecting the target set that makes `[1, 3, 4]`
+feasible while evicting as little as possible means solving both problems at
+once, which is a candidate beta improvement.
 
 #### Assignment Construction
 
@@ -563,79 +604,64 @@ out this prerequisite.
 existing tests to make the code solid enough before committing the changes
 necessary to implement this enhancement.
 
-#### Unit Tests
+#### Prerequisite testing updates
 
-API and job framework tests cover:
+None. The existing TAS scheduler and ungater tests already cover the scalar
+paths this feature branches from, and those tests must keep passing unchanged.
 
-- Parsing valid `sizes` annotations, and preserving list order through annotation
-  parsing, JSON round trips, and deepcopy.
-- The field union: accepting either arm, rejecting both and neither, including
-  the Go client case where `Size: 0` is omitted and `Sizes` is absent.
-- Schema bounds: empty lists, non-positive values, more than 128 entries, and
-  accepting duplicates.
-- Rejecting a sum different from the PodSet count.
-- Rejecting non-indexed Jobs and integrations without a stable rank source.
-- Rejecting partial admission, preferred outer topology, multiple constraint
-  entries at alpha, and a disabled feature gate.
-- Rejecting `sizes` for an elastic Job, including when
-  `ElasticJobsViaWorkloadSlicesWithTAS` is enabled.
-- Rejecting post-reservation changes to the effective PodSet count, and allowing
-  a pre-reservation update only when the new sum and count match.
-- Workload webhook defense-in-depth validation.
-- An older CRD schema rejects an exact constraint that omits `size`.
+#### Unit tests
 
-Scheduler unit tests cover:
+New code gets full unit coverage as usual, so the validation and schema cases
+are not listed here. The packages this touches, and their coverage at the time
+of writing:
 
-- Distinct rank-block semantics for `[1, 3, 4]` and `[4, 3, 1]`, with matching
-  retaining each entry's original list index.
-- Missing, duplicate, or out-of-range pod ranks remaining gated rather than
-  falling back to greedy assignment.
-- Placement mode selection: `LeastFreeCapacity` only for an unconstrained request
-  with `TASProfileMixed` enabled, `BestFit` otherwise, each producing its
-  documented matching for the same capacities; no `BalancedPlacement` at alpha.
-- Deterministic selection when multiple domains have equal capacity.
-- Aggregate capacity sufficient but matching infeasible; too few distinct
-  domains; duplicate sizes such as `[2, 2, 4]`.
-- Selecting a feasible enclosing block over an aggregate-only fit, and applying
-  the active TAS strategy among multiple feasible scopes.
-- Exact distributions at block, rack, and hostname levels.
-- Replacement constrained to the affected exact domain without changing rank
-  blocks, with merging preserving group order rather than re-sorting
-  lexicographically, and deriving the ancestor when the unhealthy leaf is the
-  only leaf of its group — failing cleanly when that ancestor is gone.
-- Scalar assignments still merging lexicographically with the gate enabled.
-- Matching against a preemption-simulated snapshot admitting only when the
-  complete list is matchable within simulated capacity.
-- Failure reasons distinguishing infeasibility from too few domains, and the
-  counter incrementing with the matching `reason` label.
-- No regression in existing scalar slice and multi-layer tests.
+- `apis/kueue/v1beta2`: TBD
+- `pkg/controller/jobframework`: TBD
+- `pkg/cache/scheduler`: TBD
+- `pkg/controller/tas`: TBD
 
-#### Integration Tests
+A handful of cases are worth naming, because each one is a behavioral claim made
+elsewhere in this KEP rather than routine coverage:
+
+- `[1, 3, 4]` and `[4, 3, 1]` produce different rank blocks from the same
+  aggregate domain counts.
+- Merging a replacement assignment keeps exact groups in `sizes` order instead
+  of re-sorting them by label value, while scalar assignments still re-sort.
+- A pod with a missing, duplicate, or out-of-range rank leaves the whole PodSet
+  gated, rather than falling back to greedy assignment.
+- A `LeastFreeCapacity` placement that exactly fills its domains fails
+  replacement, while the same placement under `BestFit` has room to absorb it.
+- The elastic shrink exception is refused for a `sizes` PodSet and still allowed
+  for a scalar one.
+- Enough free capacity in total, but no matchable distribution, is reported as
+  infeasible and does not trigger preemption.
+
+#### Integration tests
 
 Single-cluster TAS integration tests verify:
 
 - An eight-pod indexed Job obtains rack-level counts `[1, 3, 4]`, with rank 0 in
   the first selected rack, ranks 1-3 in the second, and ranks 4-7 in the third.
-- Reordering to `[4, 3, 1]` changes those rank ranges while retaining the same
-  aggregate multiset of domain counts.
+- Reordering to `[4, 3, 1]` changes those rank ranges while keeping the same
+  aggregate counts.
 - A 24-pod Job obtains block-level counts `[8, 16]`.
-- A workload remains pending when matching is impossible despite sufficient
-  aggregate capacity, reporting the exact-distribution failure reason.
-- A workload selects a feasible enclosing domain when another candidate is
-  infeasible.
+- A workload stays pending when no matching is possible even though total free
+  capacity would be enough, and reports the exact-distribution failure reason.
+- A workload picks an enclosing domain that works when another candidate does
+  not.
 - Disabling the feature gate rejects the annotation.
-- Replacing an unhealthy node preserves both the distribution and the original
-  rank-to-domain mapping, including when the replaced leaf was the only leaf of
+- Replacing an unhealthy node keeps both the distribution and the original
+  rank-to-domain mapping, including when the replaced leaf was the only one in
   its group.
-- A workload admitted by preempting a lower-priority workload obtains the full
+- A workload admitted by preempting a lower-priority workload gets the full
   ordered distribution.
 
-#### End-to-End Tests
+#### e2e tests
 
-Add an extended TAS end-to-end test using a fixed test topology. It creates an
-indexed Job, waits for admission, and verifies the aggregate topology assignment,
-the contiguous rank range assigned to each exact domain, and the resulting pod
-placement. Existing scalar TAS end-to-end tests run unchanged.
+Add an extended TAS end-to-end test on a fixed test topology. It creates an
+indexed Job, waits for admission, and checks the topology assignment, the rank
+range given to each exact domain, and where the pods actually land. Existing
+scalar TAS end-to-end tests run unchanged.
 
 ### Graduation Criteria
 
@@ -659,6 +685,9 @@ placement. Existing scalar TAS end-to-end tests run unchanged.
 - Whether preemption should become exact-domain aware is decided from observed
   workloads that had enough preemptible aggregate capacity but no matchable
   distribution.
+- Whether exact requests should always use `BestFit` instead of following the
+  configured profile is decided from observed failed node replacements on
+  tightly packed exact placements.
 
 #### Stable
 
@@ -670,13 +699,7 @@ placement. Existing scalar TAS end-to-end tests run unchanged.
 
 ## Implementation History
 
-- 2026-08-24: Initial KEP draft.
-- 2026-08-28: Defined ordered rank mapping, placement-policy interaction, API
-  compatibility, and fixed-count lifecycle validation.
-- 2026-08-28: Added preemption behavior, failure reporting and metric, exact
-  group ordering requirements for assignment merging, and exact-level ancestor
-  derivation during failed node replacement.
-- 2026-09-01: Condensed for length; no semantic changes.
+- 2026-08-24: Initial draft.
 
 ## Drawbacks
 

--- a/keps/13416-exact-topology-distribution/README.md
+++ b/keps/13416-exact-topology-distribution/README.md
@@ -1,0 +1,626 @@
+# KEP-13416: Exact Topology Domain Distribution
+
+<!-- toc -->
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [User Stories](#user-stories)
+    - [Story 1: Reproducible Uneven Rack Placement](#story-1-reproducible-uneven-rack-placement)
+    - [Story 2: Exact Distribution Across Blocks](#story-2-exact-distribution-across-blocks)
+  - [Semantics](#semantics)
+  - [Notes, Constraints, and Caveats](#notes-constraints-and-caveats)
+  - [Risks and Mitigations](#risks-and-mitigations)
+- [Design Details](#design-details)
+  - [API Changes](#api-changes)
+  - [Validation](#validation)
+  - [Scheduling](#scheduling)
+    - [Scope Selection](#scope-selection)
+    - [Exact Domain Matching](#exact-domain-matching)
+    - [Parent Domain Feasibility](#parent-domain-feasibility)
+    - [Assignment Construction](#assignment-construction)
+  - [Failed Node Replacement](#failed-node-replacement)
+  - [Feature Gate](#feature-gate)
+  - [Upgrade, Downgrade, and Backwards Compatibility](#upgrade-downgrade-and-backwards-compatibility)
+  - [Test Plan](#test-plan)
+    - [Unit Tests](#unit-tests)
+    - [Integration Tests](#integration-tests)
+    - [End-to-End Tests](#end-to-end-tests)
+  - [Graduation Criteria](#graduation-criteria)
+    - [Alpha](#alpha)
+    - [Beta](#beta)
+    - [Stable](#stable)
+- [Implementation History](#implementation-history)
+- [Drawbacks](#drawbacks)
+- [Alternatives](#alternatives)
+  - [A Separate Annotation](#a-separate-annotation)
+  - [Binding Counts to Named Domains](#binding-counts-to-named-domains)
+  - [Repeating a Distribution Pattern](#repeating-a-distribution-pattern)
+  - [Multiple Exact Levels](#multiple-exact-levels)
+  - [Pod Topology Spread Constraints](#pod-topology-spread-constraints)
+<!-- /toc -->
+
+## Summary
+
+This KEP extends Topology Aware Scheduling (TAS) so that a PodSet can request
+an exact, potentially uneven distribution of pods across topology domains.
+For example, a PodSet with eight pods can request that Kueue select three
+distinct racks and assign exactly one pod to one rack, three pods to another,
+and four pods to the third.
+
+The existing multi-layer topology constraint API accepts one scalar `size` at
+each topology level. A scalar size creates equal, fungible slices and therefore
+only constrains assignments to multiples of that size. It cannot express an
+uneven distribution such as `[1, 3, 4]`.
+
+This KEP adds a `sizes` alternative to
+`PodsetSliceRequiredTopologyConstraint`. `sizes` is an unordered multiset of
+pod counts. Each entry is assigned to a distinct topology domain selected by
+Kueue, and the sum of all entries must equal the fixed PodSet count.
+
+The alpha scope supports one exact-distribution constraint at any configured
+topology level. It does not support repeating patterns, multiple exact levels,
+explicit physical domain names, or elastic PodSet counts.
+
+## Motivation
+
+Users running distributed training and high-performance computing workloads
+often need reproducible topology shapes for performance measurement and
+debugging. Communication behavior can differ substantially between an even
+placement such as `[4, 4]` and an uneven placement such as `[1, 3, 4]`.
+
+Kueue currently provides the following topology controls:
+
+- Required topology places an entire PodSet within one domain at a requested
+  level.
+- Preferred topology attempts increasingly coarser domains before allowing a
+  distributed assignment.
+- Slice topology places equal-sized logical slices within domains at a
+  requested level.
+- Multi-layer slice topology applies an equal scalar slice size at each of up
+  to three topology levels.
+
+Equal slice sizes do not determine the final count assigned to each domain.
+For an eight-pod PodSet with a rack slice size of two, the scheduler creates
+four equal slices. Multiple slices can share a rack, so assignments such as
+`[2, 2, 4]`, `[2, 6]`, and `[8]` are all possible. No scalar slice size can
+require the final distribution `[1, 3, 4]`.
+
+The default Kubernetes scheduler can balance pods using topology spread
+constraints or bind pods to named topology domains using node affinity. It
+cannot dynamically select topology domains and reserve an arbitrary exact
+distribution for a complete PodSet. Kueue already performs group-level
+admission and produces a `TopologyAssignment`, making it the appropriate layer
+for this capability.
+
+### Goals
+
+- Allow a fixed-size PodSet to request an exact, uneven pod distribution at a
+  configured topology level.
+- Allow the exact level to be a rack, block, zone, hostname, or any other level
+  represented in the selected TAS topology.
+- Have Kueue select the physical topology domains based on feasibility and the
+  configured TAS strategy.
+- Assign each requested count to a distinct topology domain.
+- Reject or leave pending a workload when the complete distribution cannot be
+  satisfied.
+- Preserve existing scalar `size` behavior without changes.
+- Bound the alpha scheduling problem so feasibility can be determined with a
+  deterministic matching algorithm.
+
+### Non-Goals
+
+- Selecting topology domains by explicit label value, such as `rack-a` or
+  `rack-b`.
+- Expressing exact physical node counts when multiple pods can share a node.
+  The proposed values are pod counts per topology domain.
+- Repeating a shorter distribution to fill a larger PodSet.
+- Supporting more than one `sizes` constraint in a PodSet topology request.
+- Expressing a nested exact distribution at multiple topology levels.
+- Supporting partial admission or elastic changes to the PodSet count.
+- Rebalancing an admitted and running PodSet when topology capacity changes.
+- Extending topology spread constraints in the default Kubernetes scheduler.
+
+## Proposal
+
+Add an optional `sizes` field to each multi-layer topology constraint entry.
+Exactly one of `size` and `sizes` must be specified.
+
+For example:
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uneven-rack-job
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue
+spec:
+  parallelism: 8
+  completions: 8
+  completionMode: Indexed
+  template:
+    metadata:
+      annotations:
+        kueue.x-k8s.io/podset-required-topology: topology.example.com/block
+        kueue.x-k8s.io/podset-slice-required-topology-constraints: |
+          [
+            {
+              "topology": "topology.example.com/rack",
+              "sizes": [1, 3, 4]
+            }
+          ]
+    spec:
+      containers:
+      - name: worker
+        image: registry.k8s.io/e2e-test-images/agnhost:2.53
+        args: ["pause"]
+      restartPolicy: Never
+```
+
+Kueue selects one feasible block and three distinct racks within that block.
+The three selected racks receive one, three, and four pods respectively. The
+list does not bind a particular count to a named rack.
+
+### User Stories
+
+#### Story 1: Reproducible Uneven Rack Placement
+
+As a machine learning infrastructure engineer, I want to place eight workers
+across three racks with exact counts `[1, 3, 4]` so that I can reproduce and
+measure communication behavior associated with that topology shape.
+
+#### Story 2: Exact Distribution Across Blocks
+
+As a cluster user, I want to place 24 pods into two distinct blocks with exact
+counts `[8, 16]` within one data center, without binding the workload to
+cluster-specific block names.
+
+For example:
+
+```yaml
+kueue.x-k8s.io/podset-required-topology: topology.example.com/datacenter
+kueue.x-k8s.io/podset-slice-required-topology-constraints: |
+  [
+    {
+      "topology": "topology.example.com/block",
+      "sizes": [8, 16]
+    }
+  ]
+```
+
+### Semantics
+
+The `sizes` field has the following semantics:
+
+1. `sizes` is an unordered multiset. `[1, 3, 4]` and `[4, 1, 3]` request the
+   same topology shape.
+2. Each list entry is assigned to one distinct topology domain at the entry's
+   `topology` level.
+3. Kueue selects the topology domains. List positions do not refer to physical
+   domain names or to an ordering of domains.
+4. The value assigned to a domain is the exact number of pods from this PodSet
+   that Kueue assigns to that domain.
+5. Duplicate values are allowed. For example, `[2, 2, 4]` requests three
+   distinct domains.
+6. The sum of the list must equal the fixed PodSet count.
+7. An exact distribution is a required constraint. Kueue does not fall back to
+   scalar slicing or ordinary greedy placement when it cannot be satisfied.
+8. At alpha, a topology request may contain only one constraint entry when
+   that entry uses `sizes`. Containment is expressed using
+   `podset-required-topology`.
+9. The required topology level, when specified, must be strictly coarser than
+   the exact-distribution level when `sizes` contains more than one entry.
+10. Below the exact-distribution level, Kueue uses its existing capacity-based
+    placement to assign pods to finer domains and hosts.
+
+For example, the following request is contradictory and is rejected at
+scheduling time because required topology asks for one rack while `sizes`
+requires three distinct racks:
+
+```yaml
+kueue.x-k8s.io/podset-required-topology: topology.example.com/rack
+kueue.x-k8s.io/podset-slice-required-topology-constraints: |
+  [
+    {
+      "topology": "topology.example.com/rack",
+      "sizes": [1, 3, 4]
+    }
+  ]
+```
+
+### Notes, Constraints, and Caveats
+
+The values represent pod counts, not physical node counts. A distribution of
+`[1, 3, 4]` corresponds to the same number of nodes only when workload
+resource requests, affinity, or other scheduling constraints effectively
+ensure one pod per node.
+
+The complete distribution is attached to one PodSet. A workload with multiple
+PodSets validates and schedules each PodSet independently, subject to existing
+restrictions on PodSet groups and multi-layer topology constraints.
+
+The alpha API intentionally requires users to provide the complete
+distribution. A 16-pod PodSet cannot specify `[1, 3, 4]` and rely on Kueue to
+repeat it. It can explicitly request `[1, 3, 4, 1, 3, 4]`, which requires six
+distinct domains.
+
+### Risks and Mitigations
+
+**Scheduling cost:** Each candidate enclosing domain requires a feasibility
+check against its descendant domains. The alpha API bounds `sizes` to 128
+entries and supports only one exact level. Matching uses sorted scalar pod
+capacities and is polynomial in the number of requested and available
+domains.
+
+**Fragmentation:** An exact request can leave unused capacity in selected
+domains. The matching algorithm uses the smallest fitting domains under the
+active TAS strategy to reduce avoidable waste.
+
+**Starvation:** Exact distributions are stricter than aggregate capacity and
+may remain pending even when the total number of free pod slots is sufficient.
+The scheduler reports an explicit failure reason distinguishing exact-domain
+infeasibility from insufficient aggregate capacity.
+
+**Feature interaction:** Elastic admission, repeating slices, and multiple
+exact levels introduce ambiguous grouping semantics. The alpha validation
+rejects these combinations rather than attempting an implicit interpretation.
+
+## Design Details
+
+### API Changes
+
+Extend `PodsetSliceRequiredTopologyConstraint` in the `kueue.x-k8s.io/v1beta2`
+Workload API:
+
+```go
+// PodsetSliceRequiredTopologyConstraint defines a single slice topology
+// constraint layer.
+//
+// Exactly one of size and sizes must be specified.
+// +kubebuilder:validation:XValidation:rule="has(self.size) != has(self.sizes)",message="exactly one of size and sizes must be specified"
+type PodsetSliceRequiredTopologyConstraint struct {
+    // topology indicates the topology level required for this constraint.
+    //
+    // +required
+    // +kubebuilder:validation:MinLength=1
+    // +kubebuilder:validation:MaxLength=63
+    Topology string `json:"topology,omitempty"`
+
+    // size indicates the number of pods in each equal group at this topology
+    // level.
+    //
+    // +optional
+    // +kubebuilder:validation:Minimum=1
+    Size int32 `json:"size,omitempty"`
+
+    // sizes indicates the exact pod counts to assign to distinct domains at
+    // this topology level. The list is an unordered multiset.
+    //
+    // +optional
+    // +listType=atomic
+    // +kubebuilder:validation:MinItems=1
+    // +kubebuilder:validation:MaxItems=128
+    // +kubebuilder:validation:items:Minimum=1
+    Sizes []int32 `json:"sizes,omitempty"`
+}
+```
+
+`Size` remains an `int32` rather than changing to a pointer to preserve Go
+source compatibility for clients that construct the existing API type. An
+omitted `size` is represented by zero, which is already invalid as a supplied
+slice size. The generated CRD schema and admission validation enforce the
+field union.
+
+The existing annotation name remains unchanged:
+
+```text
+kueue.x-k8s.io/podset-slice-required-topology-constraints
+```
+
+No change is required to `TopologyAssignment`. It already records domain paths
+and assigned counts, which can represent the result of exact matching.
+
+The `v1beta1` Workload API has no multi-layer constraint field. Existing
+conversion behavior that drops multi-layer constraints when converting from
+`v1beta2` to `v1beta1` remains unchanged.
+
+### Validation
+
+Validation is split between job integration validation, the Workload webhook,
+and scheduling-time validation when the selected `Topology` hierarchy is
+known.
+
+Creation-time validation enforces:
+
+- Exactly one of `size` and `sizes` is present in every constraint entry.
+- `sizes` has between 1 and 128 entries.
+- Every value in `sizes` is greater than zero.
+- At most one entry uses `sizes`.
+- At alpha, if an entry uses `sizes`, it is the only entry in the constraints
+  list.
+- The sum is computed using `int64` and must equal `PodSet.Count`.
+- The PodSet does not use partial admission (`MinCount` is unset).
+- The PodSet does not combine `sizes` with preferred outer topology at alpha.
+- Existing mutual exclusions with the legacy slice annotations and
+  `podset-group-name` continue to apply.
+- The `TASExactTopologyDistribution` feature gate is enabled.
+
+The Workload webhook repeats structural and numeric checks as defense in depth
+for direct Workload writes.
+
+Scheduling-time validation enforces:
+
+- The exact topology key exists in the selected ResourceFlavor's `Topology`.
+- The exact level is below the required topology level when more than one
+  distinct domain is requested.
+- The selected topology contains enough eligible domains to satisfy the list.
+
+### Scheduling
+
+The scheduler continues to use the existing phase that calculates how many
+pods can fit in each leaf and ancestor domain. The calculated `podCount` for a
+domain is the scalar capacity used by exact matching.
+
+The exact path is selected when the PodSet topology request contains `sizes`.
+The scalar path remains unchanged.
+
+#### Scope Selection
+
+When `podset-required-topology` is present, Kueue evaluates candidate domains
+at that level as enclosing scopes. For a required block and exact rack sizes,
+each candidate block is evaluated using only racks descended from that block.
+
+When no required topology is present, the eligible topology represented by
+the selected ResourceFlavor is treated as the enclosing scope.
+
+Preferred outer topology is not supported with exact distributions at alpha.
+This avoids an implicit fallback changing the enclosing scope while retaining
+a hard inner distribution.
+
+#### Exact Domain Matching
+
+For one candidate enclosing scope, Kueue obtains the available pod capacity of
+every eligible domain at the exact level. It then matches the requested values
+to distinct candidate domains.
+
+A deterministic implementation can:
+
+1. Sort requested sizes from largest to smallest.
+2. For each requested size, choose the smallest unused domain whose pod
+   capacity is at least that size.
+3. Use the existing TAS ordering and domain identity as deterministic
+   tie-breakers.
+4. Fail the candidate scope if no unused domain fits a requested size.
+
+For example:
+
+```text
+requested sizes: [1, 3, 4]
+domain capacity: [1, 2, 3, 7, 10]
+
+assignment:
+4 -> capacity 7
+3 -> capacity 3
+1 -> capacity 1
+```
+
+The algorithm assigns at most one requested entry to each domain. This is a
+threshold matching problem rather than general bin packing. Choosing the
+smallest fitting domain while processing larger requests first preserves
+larger domains for requirements that need them.
+
+#### Parent Domain Feasibility
+
+Aggregate capacity does not prove that an exact distribution fits. For
+example, domain capacities `[2, 2, 4]` total eight pods but cannot satisfy
+`[1, 3, 4]` because no domain can accommodate three pods after reserving a
+distinct domain for each entry.
+
+The scheduler therefore performs exact matching while evaluating candidate
+enclosing domains. A candidate required domain is considered feasible only if
+the complete requested multiset can be matched within it. The normal TAS
+strategy is then used to choose among feasible enclosing domains.
+
+This prevents the scheduler from selecting an aggregate-capacity fit that
+fails during downward traversal when another enclosing domain could satisfy
+the request.
+
+#### Assignment Construction
+
+After matching, Kueue sets each selected exact-level domain's assigned pod
+count to its matched value. Existing downward traversal distributes that count
+through finer topology levels to leaves. Existing assignment construction then
+encodes the selected leaf domains and counts into `TopologyAssignment`.
+
+The topology ungater already consumes domain counts from the assignment and
+maps indexed pods to assigned domains. It does not need a new status format.
+
+### Failed Node Replacement
+
+Existing failed-node replacement detects incomplete uniform slices using
+modulo arithmetic. That is insufficient for an uneven exact distribution.
+
+For an exact assignment, replacement must preserve the assigned count of the
+affected exact-level domain. Before removing the unhealthy leaf from the
+existing assignment, Kueue derives and retains its ancestor domain at the
+exact level. Replacement pods are constrained to that same domain.
+
+If replacement cannot fit within the affected domain, Kueue does not place the
+pods in another domain because doing so would change the exact distribution.
+The existing configured failure behavior, including fail-fast or eviction,
+applies.
+
+Moving an entire exact group to a different domain is out of scope for alpha.
+
+### Feature Gate
+
+Introduce the alpha feature gate:
+
+```text
+TASExactTopologyDistribution
+```
+
+A separate gate is used because `TASMultiLayerTopology` is already beta while
+the `sizes` semantics and matching behavior are new. Disabling the gate
+preserves all existing scalar multi-layer behavior and rejects new requests
+that contain `sizes`.
+
+### Upgrade, Downgrade, and Backwards Compatibility
+
+Adding `sizes` is backwards compatible for existing manifests and Go clients
+using `Size`. Existing scalar requests follow the unchanged scheduling path.
+
+Upgrading the CRDs adds the optional field before the feature is enabled. When
+the gate is disabled, new `sizes` requests are rejected.
+
+Before downgrading to a Kueue version whose CRD does not contain `sizes`,
+operators must ensure that no Jobs, Workloads, or other integrated workload
+templates contain the field. Older controllers cannot preserve or interpret
+the exact distribution and may see the constraint as missing its required
+scalar size.
+
+### Test Plan
+
+[x] I/we understand the owners of the involved components may require updates
+to existing tests to make the code solid enough before committing the changes
+necessary to implement this enhancement.
+
+#### Unit Tests
+
+API and job framework tests cover:
+
+- Parsing valid `sizes` annotations.
+- Rejecting both `size` and `sizes` in one entry.
+- Rejecting entries with neither field.
+- Rejecting empty lists, non-positive values, and more than 128 entries.
+- Accepting duplicate values.
+- Rejecting a sum different from the PodSet count.
+- Rejecting partial admission and preferred outer topology.
+- Rejecting multiple constraint entries when one uses `sizes` at alpha.
+- Rejecting `sizes` when the feature gate is disabled.
+- Workload webhook defense-in-depth validation.
+- Generated deepcopy behavior for the `Sizes` slice.
+
+Scheduler unit tests cover:
+
+- Exact matching for `[1, 3, 4]` independent of input order.
+- Deterministic selection when multiple domains have equal capacity.
+- Aggregate capacity sufficient but exact matching infeasible.
+- Too few distinct domains.
+- Duplicate sizes such as `[2, 2, 4]`.
+- Selecting a feasible enclosing block over an aggregate-only fit.
+- Applying the active TAS strategy among multiple feasible scopes.
+- Exact distributions at block, rack, and hostname levels.
+- No regression in existing scalar slice and multi-layer tests.
+- Failed-node replacement constrained to the affected exact domain.
+
+#### Integration Tests
+
+Single-cluster TAS integration tests verify:
+
+- An eight-pod indexed Job obtains rack-level aggregate counts `[1, 3, 4]`.
+- A 24-pod Job obtains block-level aggregate counts `[8, 16]`.
+- A workload remains pending when exact matching is impossible even though
+  aggregate capacity is sufficient.
+- A workload selects a feasible enclosing domain when another candidate is
+  infeasible.
+- Disabling the feature gate rejects the annotation.
+- Replacement of an unhealthy node preserves the exact-level distribution.
+
+#### End-to-End Tests
+
+Add an extended TAS end-to-end test using a fixed test topology. The test
+creates an indexed Job, waits for admission, and verifies the aggregate
+topology assignment and resulting pod placement. Existing scalar TAS end-to-end
+tests continue to run unchanged.
+
+### Graduation Criteria
+
+#### Alpha
+
+- API field, feature gate, validation, matching, and assignment are
+  implemented.
+- Unit and integration tests cover feasible and infeasible distributions.
+- User documentation describes exact-distribution semantics and limitations.
+- Failed-node replacement does not silently violate the distribution.
+
+#### Beta
+
+- Positive operational feedback from users running exact distributions.
+- Scheduling latency and memory impact are measured for the maximum supported
+  list length.
+- Failure reasons are actionable and covered by tests.
+- At least one release of alpha usage without unresolved correctness issues.
+- The API limit and interactions with outer scalar constraints are revisited
+  based on experience.
+
+#### Stable
+
+- At least two releases of beta usage without unresolved correctness issues.
+- End-to-end tests are stable in periodic jobs.
+- Upgrade and downgrade procedures are documented.
+- Any expansion to elastic, repeating, or nested semantics is either completed
+  under a separate KEP or explicitly retained as a non-goal.
+
+## Implementation History
+
+- 2026-08-24: Initial KEP draft.
+
+## Drawbacks
+
+Exact distributions can reduce schedulability and increase fragmentation
+compared with ordinary TAS placement. A workload may remain pending even when
+the cluster has enough aggregate capacity.
+
+The proposal adds another placement path to a core scheduling component and
+requires special handling in failure recovery. Restricting alpha to one fixed
+distribution level limits this additional complexity.
+
+The API describes pod counts rather than physical node counts, which users may
+misinterpret when multiple pods can share a node.
+
+## Alternatives
+
+### A Separate Annotation
+
+A new annotation such as `podset-domain-counts` could carry the distribution.
+This separates the feature from multi-layer constraints but duplicates the
+existing topology-and-size API. Extending the existing constraint entry keeps
+topology grouping requests in one API family.
+
+### Binding Counts to Named Domains
+
+The API could map label values directly to counts:
+
+```yaml
+rack-a: 1
+rack-b: 3
+rack-c: 4
+```
+
+This supports physical-domain reproduction but couples workloads to a specific
+cluster and bypasses TAS domain selection. It is left for a separate feature if
+users require explicit domain identity.
+
+### Repeating a Distribution Pattern
+
+Kueue could allow a 16-pod PodSet to specify `[1, 3, 4]` and repeat the pattern
+twice. This requires defining whether repeats share enclosing domains, whether
+entries from different repeats may share exact-level domains, and how logical
+pattern identity survives failure recovery. Alpha instead requires users to
+provide the complete list.
+
+### Multiple Exact Levels
+
+A flat list cannot unambiguously describe different child distributions for
+different parent sizes. For example, block sizes `[8, 16]` require separate
+rack distributions for each block. Supporting this use case likely requires a
+nested tree-shaped API rather than multiple independent `sizes` lists.
+
+### Pod Topology Spread Constraints
+
+Kubernetes topology spread constraints bound the skew between eligible
+domains. They can encourage an even distribution but cannot require an
+arbitrary vector such as `[1, 3, 4]` across dynamically selected domains.

--- a/keps/13416-exact-topology-distribution/README.md
+++ b/keps/13416-exact-topology-distribution/README.md
@@ -321,11 +321,16 @@ Creation-time validation enforces:
 - The `TASExactTopologyDistribution` feature gate is enabled.
 
 The Workload webhook repeats the structural, numeric, partial-admission, and
-elastic-workload checks, so that a Workload written directly is checked too. Its
-existing per-constraint check rejects any entry whose `size` is not positive,
-which an exact constraint never sets, so that check has to become union-aware.
-Until it does, the webhook refuses every `sizes` request and the job integration
-cannot create a Workload at all.
+elastic-workload checks, **including the feature gate check**, so that a Workload
+written directly is checked too. A Workload can be created without going through
+job integration validation, so the gate has to be enforced on both paths or a
+`sizes` request would be accepted while `TASExactTopologyDistribution` is
+disabled, contradicting the guarantee in [Feature Gate](#feature-gate).
+
+The webhook's existing per-constraint check also rejects any entry whose `size`
+is not positive, which an exact constraint never sets, so that check has to
+become union-aware. Until it does, the webhook refuses every `sizes` request and
+the job integration cannot create a Workload at all.
 
 Update-time validation preserves the fixed-count invariant. Existing Workload
 validation already makes the whole PodSet immutable once quota is reserved, so
@@ -660,6 +665,9 @@ elsewhere in this KEP rather than routine coverage:
   of re-sorting them by label value, while scalar assignments still re-sort.
 - A pod with a missing, duplicate, or out-of-range rank leaves the whole PodSet
   gated, rather than falling back to greedy assignment.
+- A Workload created directly, without going through job integration validation,
+  is rejected when it carries `sizes` and the feature gate is disabled, and is
+  subject to the same structural and sum checks when the gate is enabled.
 - A `LeastFreeCapacity` placement that exactly fills its domains fails
   replacement, while the same placement under `BestFit` has room to absorb it.
 - The elastic shrink exception is refused for a `sizes` PodSet and still allowed

--- a/keps/13416-exact-topology-distribution/README.md
+++ b/keps/13416-exact-topology-distribution/README.md
@@ -40,9 +40,6 @@
   - [Multiple JobSet ReplicatedJobs](#multiple-jobset-replicatedjobs)
   - [A Separate Annotation](#a-separate-annotation)
   - [Binding Counts to Named Domains](#binding-counts-to-named-domains)
-  - [Repeating a Distribution Pattern](#repeating-a-distribution-pattern)
-  - [Multiple Exact Levels](#multiple-exact-levels)
-  - [Pod Topology Spread Constraints](#pod-topology-spread-constraints)
 <!-- /toc -->
 
 ## Summary
@@ -78,12 +75,6 @@ None of these determine the final count per domain. For an eight-pod PodSet with
 a rack slice size of two, the scheduler creates four equal slices, and multiple
 slices can share a rack — so `[2, 2, 4]`, `[2, 6]`, and `[8]` are all valid
 outcomes. No scalar slice size can require `[1, 3, 4]`.
-
-The default Kubernetes scheduler can balance pods using topology spread
-constraints or bind them to named domains using node affinity, but it cannot
-dynamically select domains and reserve an arbitrary exact distribution for a
-complete PodSet. Kueue already performs group-level admission and produces a
-`TopologyAssignment`, making it the right layer for this capability.
 
 ### Goals
 
@@ -218,34 +209,29 @@ The distribution is attached to one PodSet. A workload with multiple PodSets
 validates and schedules each independently, subject to existing restrictions on
 PodSet groups and multi-layer constraints.
 
-A single-entry list such as `sizes: [8]` is permitted: it places the whole
-PodSet in one domain, the same shape `podset-required-topology` produces at that
-level. The two are still not interchangeable. A request carrying only slice
-constraints counts as unconstrained, whereas `podset-required-topology` makes it
-a required request, and those two classes order candidate domains differently
-(see [Exact Domain Matching](#exact-domain-matching)) — so Kueue may pick a
-different domain for each. Use `podset-required-topology` for the single-domain
-case: it needs neither this feature gate nor a stable rank source.
+A single-entry list such as `sizes: [8]` is permitted and puts the whole PodSet
+in one domain, the same shape `podset-required-topology` gives. The two are not
+interchangeable: they fall into different request classes and so may pick
+different domains (see [Exact Domain Matching](#exact-domain-matching)). Use
+`podset-required-topology` for the single-domain case — it needs neither this
+feature gate nor a stable rank source.
 
 ### Risks and Mitigations
 
-**Scheduling cost:** Each candidate enclosing domain requires a feasibility check
-against its descendant domains. The alpha API bounds `sizes` to 128 entries and
-supports only one exact level. Matching uses sorted scalar pod capacities and is
-polynomial in the number of requested and available domains.
+**Scheduling cost:** free capacity alone cannot tell you whether a request fits,
+because the shape matters — racks with room for 2, 2, and 4 pods have eight
+slots free but cannot hold `[1, 3, 4]`. Kueue therefore runs the match separately
+inside each candidate enclosing domain. Two limits keep that cheap. Allowing only
+one exact level keeps it a flat problem — sort the capacities, place each entry,
+done — instead of a search that tries layouts and backs out of dead ends. The
+128-entry cap bounds a single match. Cost then grows in step with the number of
+domains rather than exploding.
 
-**Fragmentation and starvation:** An exact request is stricter than aggregate
-capacity. It can leave capacity unused in selected domains and remain pending
-even when the total number of free pod slots would suffice. This is inherent to
-making the distribution a hard requirement. The feature is opt-in, documentation
-directs users to ordinary TAS controls when exactness is unnecessary, domain
-selection follows the active TAS placement strategy, and the scheduler reports an
-explicit failure reason distinguishing exact-domain infeasibility from
-insufficient aggregate capacity.
-
-**Feature interaction:** Partial admission, elastic workload slices, repeating
-slices, and multiple exact levels introduce ambiguous grouping semantics. Alpha
-validation rejects these combinations rather than guessing.
+**Starvation:** an exact request can stay pending even when the cluster has
+plenty of free pod slots, because those slots are in the wrong shape. This is
+inherent to making the distribution a hard requirement; see
+[Drawbacks](#drawbacks) for when that cost is worth paying, and
+[Failure Reporting](#failure-reporting) for how it is surfaced.
 
 ## Design Details
 
@@ -320,7 +306,9 @@ Creation-time validation enforces:
 - The parent workload has not opted into elastic workload slicing with
   `kueue.x-k8s.io/elastic-job: "true"`, even when
   `ElasticJobsViaWorkloadSlicesWithTAS` is enabled.
-- `sizes` is not combined with preferred outer topology at alpha.
+- `sizes` is not combined with `podset-preferred-topology` at alpha.
+  `podset-required-topology` is accepted, and `podset-unconstrained-topology` is
+  accepted as a no-op.
 - Existing mutual exclusions with the legacy slice annotations and
   `podset-group-name` continue to apply.
 - The `TASExactTopologyDistribution` feature gate is enabled.
@@ -358,15 +346,23 @@ request contains `sizes`. The scalar path is unchanged.
 
 #### Scope Selection
 
-When `podset-required-topology` is present, Kueue evaluates candidate domains at
-that level as enclosing scopes — for a required block and exact rack sizes, each
-candidate block is evaluated using only its descendant racks. When no required
-topology is present, the eligible topology of the selected ResourceFlavor is the
-enclosing scope.
+The outer annotations are already mutually exclusive, so there are three cases:
 
-Preferred outer topology is not supported with exact distributions at alpha, to
-avoid an implicit fallback changing the enclosing scope while a hard inner
-distribution is retained.
+- **`podset-required-topology`.** Kueue evaluates each domain at that level as a
+  separate enclosing scope — for a required block and exact rack sizes, each
+  candidate block is evaluated using only its descendant racks. This is the only
+  way to require that the selected domains share a parent.
+- **No outer annotation, or `podset-unconstrained-topology`.** The eligible
+  topology of the selected ResourceFlavor is the scope. Both forms behave the
+  same, because a request carrying only slice constraints is already classified
+  as unconstrained; the annotation is accepted as a no-op rather than rejected.
+  Note that this gives **no containment at all**: `sizes: [1, 3, 4]` picks three
+  distinct racks, but nothing requires them to sit in the same block.
+- **`podset-preferred-topology`.** Rejected at alpha. Preferred widens the scope
+  on its own when a level does not fit, so a soft outer scope would shift
+  underneath a hard inner distribution. It is also the only class in which
+  balanced placement runs, and balanced placement spreads pods evenly, which
+  `sizes` contradicts.
 
 #### Exact Domain Matching
 
@@ -385,49 +381,40 @@ distinct domains, separating feasibility from policy-driven selection:
 4. Retain the original list index on every match so assignment construction can
    restore rank-block order.
 
-At the exact level the placement modes are interpreted as follows:
+Step 3 orders candidate domains by the active placement mode:
 
-- `BestFit` starts with fitting domains that have the most free pod capacity. It
-  applies to any exact request carrying `podset-required-topology`, and to every
-  exact request under a BestFit-only profile.
-- `LeastFreeCapacity` starts with the fitting domain that has the least free pod
-  capacity. It applies to unconstrained requests under the default TAS profile
-  (`TASProfileMixed`, default since v0.15), so an exact-only slice request uses
-  it unless a cluster overrides the profile.
-- `BalancedPlacement` never runs at alpha. It only runs when a request is
-  neither required nor unconstrained, and every `sizes` request alpha allows is
-  one of those two: a `sizes`-only request counts as unconstrained, and adding
-  `podset-required-topology` makes it required. So there is nothing to turn off
-  here. If preferred topology is ever allowed with `sizes`, then `sizes` must
-  win, because balanced placement spreads pods evenly while `sizes` asks for an
-  uneven split. Both cannot be true at once.
+- `BestFit` starts with the fitting domains that have the most free capacity.
+- `LeastFreeCapacity` starts with the fitting domain that has the least.
+- `BalancedPlacement` never runs at alpha, because it applies only to a request
+  that is neither required nor unconstrained, and every `sizes` request alpha
+  allows is one of those two.
 
-The request is classified using the existing TAS profile rules: an exact-only
-slice request is unconstrained, while a request with `podset-required-topology`
-is required. Exact matching does not override the resulting placement mode.
+Which mode applies follows the existing TAS profile rules, and exact matching
+does not override them. A `sizes`-only request counts as unconstrained, so under
+the default profile it gets `LeastFreeCapacity`; adding `podset-required-topology`
+makes it required, which gets `BestFit`.
 
-Following the profile has one side effect worth calling out. By default a
-`sizes`-only request gets `LeastFreeCapacity`, which picks the domains that
-barely fit, leaving almost no spare room in them. If a node then fails,
-replacement has to stay inside that same domain and is not allowed to move the
-group elsewhere, so there may be nowhere to put the replacement pods.
+If preferred topology is ever allowed with `sizes`, then `sizes` must win:
+balanced placement spreads pods evenly while `sizes` asks for an uneven split,
+and both cannot be true at once.
 
-`BestFit` would leave spare room, but it uses roomier domains and so wastes more
-capacity. Alpha keeps following whichever profile the cluster is set to, rather
-than picking one for the user: forcing a different algorithm for just this
-feature is a big change to make without data. Beta decides it, based on how
-often replacement actually fails.
+This has one side effect worth calling out. `LeastFreeCapacity` picks the
+domains that barely fit, so if a node later fails, replacement must stay in that
+same domain and may have nowhere to go. `BestFit` would leave spare room but
+waste more capacity. Alpha follows whichever profile the cluster is set to
+rather than picking for the user, and beta decides based on how often
+replacement actually fails.
 
 ```text
 requested sizes: [1, 3, 4]
 domain capacity: [1, 2, 3, 7, 10]
 
-BestFit matching (default):
+BestFit (with podset-required-topology):
 4 -> capacity 10
 3 -> capacity 7
 1 -> capacity 3
 
-LeastFreeCapacity matching (unconstrained request, TASProfileMixed enabled):
+LeastFreeCapacity (sizes only, default profile):
 4 -> capacity 7
 3 -> capacity 3
 1 -> capacity 1
@@ -486,20 +473,32 @@ once, which is a candidate beta improvement.
 
 #### Assignment Construction
 
-After matching, Kueue sets each selected exact-level domain's assigned pod count
-to its matched value. Existing downward traversal distributes that count through
-finer levels to leaves, and existing assignment construction encodes the selected
-leaves and counts into `TopologyAssignment`.
+Matching has already decided which domain gets which entry. Kueue sets each
+selected domain's pod count to its matched value, and the existing code that
+walks down the tree spreads that count over the hosts inside it. Those hosts and
+their counts are what gets written into `TopologyAssignment`.
 
-Assignment construction emits exact groups in original `sizes` order. All leaf
-entries descended from one selected exact-level domain are contiguous and their
-counts sum to that entry's requested size; within a group, existing TAS ordering
-determines leaf order. Construction must not reorder leaf entries across groups.
+The one new rule is about **order**. Hosts belonging to the same selected domain
+must stay together in the list, and the groups must appear in the order the
+entries were written in `sizes`:
 
-The topology ungater consumes domain counts in `TopologyAssignment` order and
-maps consecutive indexed-pod ranks to those domains. Preserving group order is
-therefore what gives each `sizes` entry its contiguous rank block, without
-requiring a new status format.
+```text
+sizes: [1, 3, 4]  matched to  rack-z, rack-m, rack-a
+
+written as:  z1:1  |  m1:2, m2:1  |  a1:4
+ranks:       0     |  1, 2, 3     |  4, 5, 6, 7
+```
+
+Order matters because of what the ungater does with this list. It reads the
+domains in the order they are stored and hands out pod ranks in blocks: the
+first domain takes ranks from 0, the next carries on from there. So the order of
+the list *is* the rank mapping, and nothing new has to be added to the API to
+record it.
+
+The catch is that today's code sorts hosts by name before writing them out. That
+would produce `a1, m1, m2, z1`, putting rank 0 in the four-pod group and turning
+`[1, 3, 4]` into `[4, 3, 1]`.
+
 
 ### Failed Node Replacement
 
@@ -521,18 +520,33 @@ Replacement updates leaf entries within the affected group's existing position
 and does not move that group relative to another, so each `sizes` entry's rank
 block stays stable.
 
-Preserving that position requires a change to assignment merging. Replacement
-currently merges the replacement assignment with the existing one, and that merge
-re-sorts every entry lexicographically by level values — which would reorder
-groups relative to `sizes` order and silently reassign rank blocks. Merging
-therefore needs an exact-aware path, gated by
-`TASExactTopologyDistribution`, that merges replacement leaves into their
-existing group and preserves group order; the scalar path keeps its current
-behavior. The same requirement applies to any other path that rebuilds a
-`TopologyAssignment` from parts. Leader and worker PodSets use the same merge
-routine, but PodSet groups are mutually exclusive with `sizes`, so that path is
-unreachable at alpha — validation must keep enforcing that exclusion, and a test
-asserts it.
+Keeping that position needs a change to how assignments are merged. Kueue does
+not rebuild the whole assignment on replacement — it merges the small
+replacement piece into the existing one, and that merge sorts everything by name
+as it goes. For ordinary placement that is harmless. Here it is not:
+
+```text
+placed:        z1:1  |  m1:2, m2:1  |  a1:4      ranks 0 | 1,2,3 | 4,5,6,7
+m2 dies, m3 replaces it
+
+merged by name:  a1:4, m1:2, m3:1, z1:1          ranks 0,1,2,3 | 4,5 | 6 | 7
+```
+
+Rank 0 has moved into the four-pod group and `[1, 3, 4]` has become `[4, 3, 1]`,
+purely because a node was replaced. Every count is still correct and nothing
+reports an error.
+
+Merging therefore needs a second version, turned on by
+`TASExactTopologyDistribution`, that puts the replacement host back into its own
+group and leaves the group order alone — giving `z1:1 | m1:2, m3:1 | a1:4`.
+Scalar workloads keep the existing merge unchanged.
+
+The same merge is also used for workloads with a leader pod and worker pods, so
+the bug could in principle arrive that way too. It cannot today, because `sizes`
+may not be combined with `podset-group-name`, which those workloads use. That
+rule is now load-bearing rather than incidental: if it is ever relaxed without
+revisiting merging, the reordering returns through a different door. A test
+asserts the exclusion so that it fails loudly instead.
 
 If replacement cannot fit within the affected domain, Kueue does not place the
 pods elsewhere, because that would change the distribution; the configured
@@ -699,7 +713,7 @@ scalar TAS end-to-end tests run unchanged.
 
 ## Implementation History
 
-- 2026-08-24: Initial draft.
+- 2026-09-01: Initial draft.
 
 ## Drawbacks
 
@@ -752,25 +766,3 @@ The API could map label values directly to counts (`rack-a: 1`, `rack-b: 3`,
 `rack-c: 4`). This supports physical-domain reproduction but couples workloads to
 a specific cluster and bypasses TAS domain selection. It is left for a separate
 feature if users require explicit domain identity.
-
-### Repeating a Distribution Pattern
-
-Kueue could allow a 16-pod PodSet to specify `[1, 3, 4]` and repeat it twice.
-This requires defining whether repeats share enclosing domains, whether entries
-from different repeats may share exact-level domains, and how pattern identity
-survives failure recovery. Alpha instead requires the complete list — a 16-pod
-PodSet can explicitly request `[1, 3, 4, 1, 3, 4]`, which needs six distinct
-domains and defines six rank blocks in that order.
-
-### Multiple Exact Levels
-
-A flat list cannot unambiguously describe different child distributions for
-different parent sizes. Block sizes `[8, 16]` would require separate rack
-distributions per block. Supporting this likely requires a nested tree-shaped API
-rather than multiple independent `sizes` lists.
-
-### Pod Topology Spread Constraints
-
-Kubernetes topology spread constraints bound the skew between eligible domains.
-They can encourage an even distribution but cannot require an arbitrary vector
-such as `[1, 3, 4]` across dynamically selected domains.

--- a/keps/13416-exact-topology-distribution/README.md
+++ b/keps/13416-exact-topology-distribution/README.md
@@ -19,8 +19,10 @@
     - [Scope Selection](#scope-selection)
     - [Exact Domain Matching](#exact-domain-matching)
     - [Parent Domain Feasibility](#parent-domain-feasibility)
+    - [Preemption](#preemption)
     - [Assignment Construction](#assignment-construction)
   - [Failed Node Replacement](#failed-node-replacement)
+  - [Failure Reporting](#failure-reporting)
   - [Feature Gate](#feature-gate)
   - [Upgrade, Downgrade, and Backwards Compatibility](#upgrade-downgrade-and-backwards-compatibility)
   - [Test Plan](#test-plan)
@@ -34,6 +36,7 @@
 - [Implementation History](#implementation-history)
 - [Drawbacks](#drawbacks)
 - [Alternatives](#alternatives)
+  - [Multiple JobSet ReplicatedJobs](#multiple-jobset-replicatedjobs)
   - [A Separate Annotation](#a-separate-annotation)
   - [Binding Counts to Named Domains](#binding-counts-to-named-domains)
   - [Repeating a Distribution Pattern](#repeating-a-distribution-pattern)
@@ -55,20 +58,38 @@ only constrains assignments to multiples of that size. It cannot express an
 uneven distribution such as `[1, 3, 4]`.
 
 This KEP adds a `sizes` alternative to
-`PodsetSliceRequiredTopologyConstraint`. `sizes` is an unordered multiset of
-pod counts. Each entry is assigned to a distinct topology domain selected by
-Kueue, and the sum of all entries must equal the fixed PodSet count.
+`PodsetSliceRequiredTopologyConstraint`. `sizes` is an ordered list of pod
+counts. Each entry defines a contiguous pod-rank block and is assigned to a
+distinct topology domain selected by Kueue. The sum of all entries must equal
+the fixed PodSet count.
 
 The alpha scope supports one exact-distribution constraint at any configured
 topology level. It does not support repeating patterns, multiple exact levels,
 explicit physical domain names, or elastic PodSet counts.
 
+Exact distribution is an opt-in, required placement constraint for workloads
+whose performance or application behavior depends on a predictable topology
+shape. It is not intended to replace ordinary TAS placement: requesting an
+exact shape reduces Kueue's placement flexibility and can increase
+fragmentation and admission latency.
+
 ## Motivation
 
-Users running distributed training and high-performance computing workloads
-often need reproducible topology shapes for performance measurement and
-debugging. Communication behavior can differ substantially between an even
-placement such as `[4, 4]` and an uneven placement such as `[1, 3, 4]`.
+Distributed training and high-performance computing workloads can have
+communication patterns whose runtime performance depends on how workers are
+distributed across topology domains. For these workloads, selecting the right
+number of racks or blocks is not always sufficient: the number of pods placed
+in each selected domain can determine network contention, collective
+communication cost, and overall job duration. For example, an even placement
+such as `[4, 4]` can behave substantially differently from an uneven placement
+such as `[1, 3, 4]`.
+
+Some users therefore need a predictable topology shape as an application-level
+placement requirement. Reproducing a benchmark configuration, investigating a
+performance regression, and debugging topology-dependent behavior are
+important secondary use cases, but the primary purpose of this proposal is to
+provide stable placement semantics for workloads whose performance depends on
+the distribution.
 
 Kueue currently provides the following topology controls:
 
@@ -87,6 +108,14 @@ four equal slices. Multiple slices can share a rack, so assignments such as
 `[2, 2, 4]`, `[2, 6]`, and `[8]` are all possible. No scalar slice size can
 require the final distribution `[1, 3, 4]`.
 
+Exact placement necessarily trades cluster efficiency for predictability. It
+can reject otherwise usable placements, leave capacity unused across topology
+domains, and keep a workload pending even when sufficient aggregate capacity
+exists. Consequently, this capability is explicitly requested by the user and
+is treated as a hard constraint. Workloads that only need locality should
+continue to use existing required, preferred, or scalar slice topology
+controls, which give Kueue more freedom to find an efficient placement.
+
 The default Kubernetes scheduler can balance pods using topology spread
 constraints or bind pods to named topology domains using node affinity. It
 cannot dynamically select topology domains and reserve an arbitrary exact
@@ -98,14 +127,20 @@ for this capability.
 
 - Allow a fixed-size PodSet to request an exact, uneven pod distribution at a
   configured topology level.
+- Provide predictable topology shapes for workloads whose performance or
+  application behavior depends on their per-domain pod distribution.
 - Allow the exact level to be a rack, block, zone, hostname, or any other level
   represented in the selected TAS topology.
 - Have Kueue select the physical topology domains based on feasibility and the
   configured TAS strategy.
 - Assign each requested count to a distinct topology domain.
+- Deterministically map each ordered count to a contiguous range of pod ranks.
+- Require a stable, unique pod-rank source for exact-distribution PodSets.
 - Reject or leave pending a workload when the complete distribution cannot be
   satisfied.
 - Preserve existing scalar `size` behavior without changes.
+- Keep exact distribution opt-in so ordinary TAS workloads retain existing
+  placement flexibility and schedulability.
 - Bound the alpha scheduling problem so feasibility can be determined with a
   deterministic matching algorithm.
 
@@ -119,6 +154,8 @@ for this capability.
 - Supporting more than one `sizes` constraint in a PodSet topology request.
 - Expressing a nested exact distribution at multiple topology levels.
 - Supporting partial admission or elastic changes to the PodSet count.
+- Supporting exact distributions for PodSets without stable pod indexes at
+  alpha.
 - Rebalancing an admitted and running PodSet when topology capacity changes.
 - Extending topology spread constraints in the default Kubernetes scheduler.
 
@@ -161,15 +198,20 @@ spec:
 
 Kueue selects one feasible block and three distinct racks within that block.
 The three selected racks receive one, three, and four pods respectively. The
-list does not bind a particular count to a named rack.
+list does not bind a particular count to a named rack. Its order binds the
+counts to contiguous rank blocks: rank 0 is in the one-pod group, ranks 1-3 are
+in the three-pod group, and ranks 4-7 are in the four-pod group.
 
 ### User Stories
 
 #### Story 1: Reproducible Uneven Rack Placement
 
-As a machine learning infrastructure engineer, I want to place eight workers
-across three racks with exact counts `[1, 3, 4]` so that I can reproduce and
-measure communication behavior associated with that topology shape.
+As a machine learning infrastructure engineer, I want one PodSet of eight
+workers to be placed across three distinct racks with exact counts `[1, 3, 4]`
+so that I can obtain predictable communication behavior and reproduce that
+behavior when measuring performance or investigating a regression. I want
+Kueue to select the rack identities dynamically rather than encoding them in
+the workload.
 
 #### Story 2: Exact Distribution Across Blocks
 
@@ -194,26 +236,42 @@ kueue.x-k8s.io/podset-slice-required-topology-constraints: |
 
 The `sizes` field has the following semantics:
 
-1. `sizes` is an unordered multiset. `[1, 3, 4]` and `[4, 1, 3]` request the
-   same topology shape.
+1. `sizes` is ordered. `[1, 3, 4]` and `[4, 3, 1]` request the same aggregate
+   domain counts but different pod-rank mappings.
 2. Each list entry is assigned to one distinct topology domain at the entry's
    `topology` level.
-3. Kueue selects the topology domains. List positions do not refer to physical
-   domain names or to an ordering of domains.
-4. The value assigned to a domain is the exact number of pods from this PodSet
+3. Entry `i` owns the next `sizes[i]` contiguous pod ranks after all preceding
+   entries. For `[1, 3, 4]`, the rank blocks are rank 0, ranks 1-3, and ranks
+   4-7.
+4. Kueue selects the physical topology domain for each entry. A list position
+   identifies a rank block, not a topology label value such as `rack-a`.
+5. The value assigned to a domain is the exact number of pods from this PodSet
    that Kueue assigns to that domain.
-5. Duplicate values are allowed. For example, `[2, 2, 4]` requests three
+6. Duplicate values are allowed. For example, `[2, 2, 4]` requests three
    distinct domains.
-6. The sum of the list must equal the fixed PodSet count.
-7. An exact distribution is a required constraint. Kueue does not fall back to
+7. The sum of the list must equal the fixed PodSet count.
+8. An exact distribution is a required constraint. Kueue does not fall back to
    scalar slicing or ordinary greedy placement when it cannot be satisfied.
-8. At alpha, a topology request may contain only one constraint entry when
+9. At alpha, a topology request may contain only one constraint entry when
    that entry uses `sizes`. Containment is expressed using
    `podset-required-topology`.
-9. The required topology level, when specified, must be strictly coarser than
+10. The required topology level, when specified, must be strictly coarser than
    the exact-distribution level when `sizes` contains more than one entry.
-10. Below the exact-distribution level, Kueue uses its existing capacity-based
+11. Below the exact-distribution level, Kueue uses its existing capacity-based
     placement to assign pods to finer domains and hosts.
+
+Ordered rank-block semantics require every pod in the PodSet to have a stable,
+unique rank in `[0, PodSet.Count)`. At alpha, `sizes` is accepted only when the
+job integration supplies a `PodIndexLabel` and guarantees those indexes, such
+as an Indexed Job. Integrations using subgroup indexes must provide the
+existing `SubGroupIndexLabel` and `SubGroupCount` information needed to derive
+one unique rank space for the complete PodSet.
+
+If a pod is missing its expected rank label, has a duplicate rank, or has an
+out-of-range rank, the topology ungater keeps the affected pods gated and
+reports an error. It must not fall back to greedy domain assignment for an
+exact-distribution PodSet, because that could silently violate the ordered
+rank-block contract.
 
 For example, the following request is contradictory and is rejected at
 scheduling time because required topology asks for one rack while `sizes`
@@ -241,10 +299,22 @@ The complete distribution is attached to one PodSet. A workload with multiple
 PodSets validates and schedules each PodSet independently, subject to existing
 restrictions on PodSet groups and multi-layer topology constraints.
 
-The alpha API intentionally requires users to provide the complete
+The alpha API intentionally requires users to provide the complete ordered
 distribution. A 16-pod PodSet cannot specify `[1, 3, 4]` and rely on Kueue to
 repeat it. It can explicitly request `[1, 3, 4, 1, 3, 4]`, which requires six
-distinct domains.
+distinct domains and defines six rank blocks in that order.
+
+A single-entry list such as `sizes: [8]` is permitted and is equivalent to
+requiring the whole PodSet in one domain at that level. It is allowed for
+uniformity rather than because it adds expressiveness, and
+`podset-required-topology` remains the clearer way to express it. Validation
+therefore accepts it instead of special-casing `MinItems=2`, and user
+documentation directs single-domain users to required topology.
+
+Users should request `sizes` only when the exact per-domain distribution is
+material to workload performance or behavior. If locality alone is sufficient,
+the existing TAS controls are more appropriate because they allow Kueue to use
+available capacity more efficiently.
 
 ### Risks and Mitigations
 
@@ -254,18 +324,22 @@ entries and supports only one exact level. Matching uses sorted scalar pod
 capacities and is polynomial in the number of requested and available
 domains.
 
-**Fragmentation:** An exact request can leave unused capacity in selected
-domains. The matching algorithm uses the smallest fitting domains under the
-active TAS strategy to reduce avoidable waste.
+**Fragmentation and admission latency:** An exact request can leave unused
+capacity in selected domains and can remain pending when a less constrained
+placement would fit. This is an inherent tradeoff of making the distribution a
+hard requirement. The feature is opt-in, documentation directs users to
+ordinary TAS controls when exactness is unnecessary, and domain selection
+continues to follow the active TAS placement strategy.
 
 **Starvation:** Exact distributions are stricter than aggregate capacity and
 may remain pending even when the total number of free pod slots is sufficient.
 The scheduler reports an explicit failure reason distinguishing exact-domain
 infeasibility from insufficient aggregate capacity.
 
-**Feature interaction:** Elastic admission, repeating slices, and multiple
-exact levels introduce ambiguous grouping semantics. The alpha validation
-rejects these combinations rather than attempting an implicit interpretation.
+**Feature interaction:** Partial admission, elastic workload slices, repeating
+slices, and multiple exact levels introduce ambiguous grouping semantics. The
+alpha validation rejects these combinations rather than attempting an implicit
+interpretation.
 
 ## Design Details
 
@@ -296,7 +370,7 @@ type PodsetSliceRequiredTopologyConstraint struct {
     Size int32 `json:"size,omitempty"`
 
     // sizes indicates the exact pod counts to assign to distinct domains at
-    // this topology level. The list is an unordered multiset.
+    // this topology level. List order defines contiguous pod-rank blocks.
     //
     // +optional
     // +listType=atomic
@@ -307,10 +381,16 @@ type PodsetSliceRequiredTopologyConstraint struct {
 }
 ```
 
+The existing beta `Size` field changes from `+required` to `+optional` so that
+the generated CRD no longer unconditionally includes `size` in each item's
+`required` list. The CEL union instead requires exactly one of `size` and
+`sizes`. Existing objects containing `size` remain valid.
+
 `Size` remains an `int32` rather than changing to a pointer to preserve Go
-source compatibility for clients that construct the existing API type. An
-omitted `size` is represented by zero, which is already invalid as a supplied
-slice size. The generated CRD schema and admission validation enforce the
+source compatibility for clients that construct the existing API type. With
+`omitempty`, a Go client setting `Size: 0` serializes `size` as absent. If
+`Sizes` is also absent, the CEL union rejects the object as specifying neither
+alternative. The generated CRD schema and admission validation enforce the
 field union.
 
 The existing annotation name remains unchanged:
@@ -341,14 +421,32 @@ Creation-time validation enforces:
 - At alpha, if an entry uses `sizes`, it is the only entry in the constraints
   list.
 - The sum is computed using `int64` and must equal `PodSet.Count`.
+- The integration provides a stable `PodIndexLabel`; for Kubernetes Jobs,
+  `completionMode` must be `Indexed`. Subgroup-based integrations must also
+  provide valid subgroup index and count metadata.
 - The PodSet does not use partial admission (`MinCount` is unset).
+- The parent Job or other integrated workload has not opted into elastic
+  workload slicing with `kueue.x-k8s.io/elastic-job: "true"`. This restriction
+  applies even when `ElasticJobsViaWorkloadSlicesWithTAS` is enabled.
 - The PodSet does not combine `sizes` with preferred outer topology at alpha.
 - Existing mutual exclusions with the legacy slice annotations and
   `podset-group-name` continue to apply.
 - The `TASExactTopologyDistribution` feature gate is enabled.
 
-The Workload webhook repeats structural and numeric checks as defense in depth
-for direct Workload writes.
+The Workload webhook repeats structural, numeric, partial-admission, and
+elastic-workload checks as defense in depth for direct Workload writes.
+
+Update-time validation preserves the fixed-count invariant:
+
+- Before quota reservation, `sizes` or the PodSet count may change only when
+  the resulting ordered list remains valid and its sum equals the new count.
+- After quota reservation, the PodSet count and the value and order of `sizes`
+  are immutable.
+- Job integration webhooks reject updates to `parallelism`, `completions`,
+  `replicas`, or another integration-specific field when the update would
+  change the effective PodSet count of an exact-distribution request.
+- Direct Workload updates that change the count or `sizes` after reservation
+  are rejected.
 
 Scheduling-time validation enforces:
 
@@ -385,14 +483,38 @@ For one candidate enclosing scope, Kueue obtains the available pod capacity of
 every eligible domain at the exact level. It then matches the requested values
 to distinct candidate domains.
 
-A deterministic implementation can:
+A deterministic implementation separates feasibility from policy-driven
+selection:
 
-1. Sort requested sizes from largest to smallest.
-2. For each requested size, choose the smallest unused domain whose pod
-   capacity is at least that size.
-3. Use the existing TAS ordering and domain identity as deterministic
-   tie-breakers.
-4. Fail the candidate scope if no unused domain fits a requested size.
+1. Tag every requested size with its original list index.
+2. For feasibility, sort the tagged entries from largest to smallest, breaking
+   equal-size ties by original index. Match each entry to the smallest unused
+   capacity that fits. Fail the candidate scope if any entry cannot be matched.
+3. After feasibility is established, build the selected matching by processing
+   entries largest-first and choosing an unused fitting domain according to the
+   active TAS placement mode. Existing affinity tiers are considered before
+   capacity ordering, and topology domain identity is the final deterministic
+   tie-breaker.
+4. Retain the original list index on every match so assignment construction can
+   restore rank-block order.
+
+At the exact level, the existing placement modes are interpreted as follows:
+
+- `BestFit` starts with fitting domains that have the most free pod capacity.
+  This is the default mode and applies to every exact request unless
+  `LeastFreeCapacity` is selected below.
+- `LeastFreeCapacity` starts with the fitting domain that has the least free pod
+  capacity. It applies only when the request is classified as unconstrained
+  **and** the `TASProfileMixed` feature gate is enabled. With `TASProfileMixed`
+  disabled, which is the default, exact requests always use `BestFit`.
+- `BalancedPlacement` is not applicable to exact distributions at alpha.
+  Balanced placement requires preferred topology, while preferred outer
+  topology is rejected for `sizes` at alpha.
+
+The request is classified using the existing TAS profile rules. In particular,
+an exact-only slice request is an unconstrained TAS request, while a request
+with `podset-required-topology` is a required TAS request. Exact matching does
+not override the placement mode selected for that request.
 
 For example:
 
@@ -400,16 +522,30 @@ For example:
 requested sizes: [1, 3, 4]
 domain capacity: [1, 2, 3, 7, 10]
 
-assignment:
+BestFit matching (default):
+4 -> capacity 10
+3 -> capacity 7
+1 -> capacity 3
+
+LeastFreeCapacity matching (unconstrained request, TASProfileMixed enabled):
 4 -> capacity 7
 3 -> capacity 3
 1 -> capacity 1
 ```
 
 The algorithm assigns at most one requested entry to each domain. This is a
-threshold matching problem rather than general bin packing. Choosing the
-smallest fitting domain while processing larger requests first preserves
-larger domains for requirements that need them.
+threshold matching problem rather than general bin packing. Largest-first
+processing ensures a smaller entry does not consume the only domain capable of
+satisfying a larger entry. The feasibility result is independent of placement
+policy; the selected feasible matching follows the active policy.
+
+Both greedy variants above are in fact optimal for threshold matching by the
+usual exchange argument, so the policy-driven pass in step 3 cannot fail on a
+scope that step 2 declared feasible. The passes are kept separate so that
+feasibility remains a property of capacity alone. A future placement mode that
+is not capacity-monotonic can then be added without silently making previously
+admissible workloads unschedulable, and step 2 continues to answer parent domain
+feasibility with one well-understood rule.
 
 #### Parent Domain Feasibility
 
@@ -420,12 +556,37 @@ distinct domain for each entry.
 
 The scheduler therefore performs exact matching while evaluating candidate
 enclosing domains. A candidate required domain is considered feasible only if
-the complete requested multiset can be matched within it. The normal TAS
+the complete requested list can be matched within it. The normal TAS
 strategy is then used to choose among feasible enclosing domains.
 
 This prevents the scheduler from selecting an aggregate-capacity fit that
 fails during downward traversal when another enclosing domain could satisfy
 the request.
+
+#### Preemption
+
+TAS already evaluates assignments twice: once against current free capacity,
+and once against a snapshot that simulates the capacity that preemption would
+release. Exact distributions reuse that mechanism unchanged at alpha. Exact
+matching runs against whichever snapshot the scheduler is currently evaluating,
+so a preempting workload becomes admissible exactly when the complete list can
+be matched within the simulated capacity.
+
+Two consequences follow and are accepted for alpha:
+
+- Preemption targets are still chosen by the existing preemption logic, which
+  reasons about quota and priority rather than about exact-domain feasibility.
+  It is therefore possible to preempt enough aggregate capacity without making
+  the distribution matchable, in which case the exact request remains pending
+  and the released capacity is available to other workloads. This mirrors the
+  existing behavior for required topology, which has the same property.
+- Kueue does not attempt to minimize preemptions with respect to the exact
+  matching. Choosing the target set that makes `[1, 3, 4]` feasible at the
+  lowest preemption cost is an optimization over both preemption and matching
+  simultaneously, and is deliberately out of scope for alpha.
+
+Making preemption exact-domain aware is a candidate beta improvement and is
+listed under graduation criteria rather than implemented here.
 
 #### Assignment Construction
 
@@ -434,8 +595,18 @@ count to its matched value. Existing downward traversal distributes that count
 through finer topology levels to leaves. Existing assignment construction then
 encodes the selected leaf domains and counts into `TopologyAssignment`.
 
-The topology ungater already consumes domain counts from the assignment and
-maps indexed pods to assigned domains. It does not need a new status format.
+Assignment construction emits exact groups in original `sizes` order. All leaf
+domain entries descended from one selected exact-level domain are contiguous,
+and their counts sum to that entry's requested size. Within an exact group,
+existing TAS ordering determines leaf order. Assignment construction must not
+reorder leaf entries across exact groups.
+
+The topology ungater consumes domain counts in `TopologyAssignment` order and
+maps consecutive indexed-pod ranks to those domains. Therefore, preserving the
+ordered exact groups gives each `sizes` entry its specified contiguous rank
+block without requiring a new status format. For `[1, 3, 4]`, rank 0 maps to
+the first selected exact domain, ranks 1-3 to the second, and ranks 4-7 to the
+third.
 
 ### Failed Node Replacement
 
@@ -443,9 +614,48 @@ Existing failed-node replacement detects incomplete uniform slices using
 modulo arithmetic. That is insufficient for an uneven exact distribution.
 
 For an exact assignment, replacement must preserve the assigned count of the
-affected exact-level domain. Before removing the unhealthy leaf from the
-existing assignment, Kueue derives and retains its ancestor domain at the
-exact level. Replacement pods are constrained to that same domain.
+affected exact-level domain. The ancestor domain is derived from the assignment
+itself rather than stored separately. `TopologyAssignment.Levels` records the
+level keys, and each domain entry records its `Values`, so truncating an
+unhealthy leaf's `Values` at the exact level yields the identifying path of its
+exact-level ancestor. Kueue computes that path before removing the unhealthy
+leaf, and constrains replacement pods to the domain it identifies.
+
+Two cases need explicit handling:
+
+- **The removed leaf is one of several in its exact group.** The remaining
+  leaves still carry the ancestor path, so the derivation above is confirmed by
+  the surviving entries.
+- **The removed leaf is the only leaf of its exact group.** Removing it first
+  would erase the only record of that group's ancestor. Kueue therefore derives
+  and retains the path before mutating the assignment, and the exact group keeps
+  its position in the assignment with a count that is temporarily unsatisfied
+  while replacement is pending. If the ancestor domain no longer exists in the
+  current topology snapshot, replacement fails and the configured failure
+  behavior applies.
+
+Replacement updates leaf entries within the affected exact group's existing
+position in `TopologyAssignment`. It does not move that group before or after
+another ordered group. Thus, the contiguous rank block owned by each `sizes`
+entry remains stable when a finer-level leaf is replaced.
+
+Preserving that position requires a change to assignment merging. Replacement
+currently builds its result by merging the replacement assignment with the
+existing one, and that merge re-sorts every domain entry lexicographically by
+level values. Applied to an exact assignment it would reorder groups relative
+to the requested `sizes` order and silently reassign rank blocks to different
+domains, which is the same hazard that ordinary assignment construction must
+avoid. Merging therefore needs an exact-aware path, enabled by the
+`TASExactTopologyDistribution` feature gate, that merges replacement leaves into
+their existing exact group and preserves group order. The scalar path keeps its
+current lexicographic behavior unchanged.
+
+The same requirement applies to any other code path that rebuilds a
+`TopologyAssignment` from parts. Leader and worker PodSets are merged by the
+same routine, and PodSet groups are already mutually exclusive with `sizes`, so
+that path is not reachable for exact distributions at alpha. Validation must
+keep enforcing that exclusion for the merge invariant to hold, and a test
+asserts it.
 
 If replacement cannot fit within the affected domain, Kueue does not place the
 pods in another domain because doing so would change the exact distribution.
@@ -453,6 +663,42 @@ The existing configured failure behavior, including fail-fast or eviction,
 applies.
 
 Moving an entire exact group to a different domain is out of scope for alpha.
+
+### Failure Reporting
+
+The distinguishing failure mode of this feature is that a workload stays
+pending while aggregate free capacity looks sufficient. Reporting it as a
+generic topology fit failure would make that indistinguishable from ordinary
+capacity exhaustion, so exact matching reports its own reason.
+
+Exact matching reuses the existing TAS failure-reason plumbing, which already
+carries a per-PodSet reason string into the workload's pending condition
+message. Two new reasons are added:
+
+- `topology exact distribution infeasible` when no candidate enclosing scope
+  can match the complete list. The message names the requested list, the number
+  of eligible domains at the exact level, and the largest entry that could not
+  be matched, so that a user can tell an under-provisioned cluster from a
+  fragmented one.
+- `topology exact distribution needs more domains` when the number of eligible
+  domains at the exact level is smaller than the number of entries. This is the
+  common misconfiguration of requesting more distinct domains than the topology
+  contains, and it is not fixable by waiting.
+
+One metric is added, following the existing Kueue naming convention:
+
+```text
+kueue_tas_exact_distribution_failures_total
+```
+
+It is a counter of failed exact-matching attempts, labeled by
+`cluster_queue` and `reason`, where `reason` takes the values above. The
+`cluster_queue` and `reason` pairing matches existing ClusterQueue-scoped
+metrics such as the eviction counters, and introduces no per-workload
+cardinality. The metric carries the standard configurable ClusterQueue label
+suffix and a `+metricsdoc:labels` marker, as required for new metrics. It is
+registered only when the `TASExactTopologyDistribution` feature gate is enabled,
+following the existing pattern for gated metrics.
 
 ### Feature Gate
 
@@ -462,6 +708,12 @@ Introduce the alpha feature gate:
 TASExactTopologyDistribution
 ```
 
+The gate depends on `TopologyAwareScheduling` and `TASMultiLayerTopology`, and
+is declared as such in the feature gate dependency table. The dependency on
+`TASMultiLayerTopology` is structural rather than behavioral: `sizes` is carried
+on `PodsetSliceRequiredTopologyConstraints`, which that gate owns, so enabling
+exact distribution without it would expose a field that is otherwise inert.
+
 A separate gate is used because `TASMultiLayerTopology` is already beta while
 the `sizes` semantics and matching behavior are new. Disabling the gate
 preserves all existing scalar multi-layer behavior and rejects new requests
@@ -469,17 +721,26 @@ that contain `sizes`.
 
 ### Upgrade, Downgrade, and Backwards Compatibility
 
-Adding `sizes` is backwards compatible for existing manifests and Go clients
-using `Size`. Existing scalar requests follow the unchanged scheduling path.
+Adding `sizes` preserves existing manifests and Go clients using `Size`.
+Existing scalar requests follow the unchanged scheduling path. The schema
+change relaxes the existing beta field from unconditionally required to one
+optional arm of a required union; it does not make a previously valid scalar
+object invalid.
 
 Upgrading the CRDs adds the optional field before the feature is enabled. When
 the gate is disabled, new `sizes` requests are rejected.
 
 Before downgrading to a Kueue version whose CRD does not contain `sizes`,
 operators must ensure that no Jobs, Workloads, or other integrated workload
-templates contain the field. Older controllers cannot preserve or interpret
-the exact distribution and may see the constraint as missing its required
-scalar size.
+templates contain the field. An older CRD schema has `required: [size,
+topology]` for every constraint item. It rejects an object containing `sizes`
+without `size` at API-server validation, before the older controller can read
+or reconcile the object. This is a hard downgrade incompatibility rather than
+an older-controller fallback behavior.
+
+Stored Workloads containing `sizes` must be completed or deleted, and Job
+templates containing the annotation must be removed, before installing the
+older CRD. Downgrade documentation and release notes call out this prerequisite.
 
 ### Test Plan
 
@@ -492,49 +753,95 @@ necessary to implement this enhancement.
 API and job framework tests cover:
 
 - Parsing valid `sizes` annotations.
+- Preserving `sizes` list order through annotation parsing, JSON round trips,
+  and deepcopy.
 - Rejecting both `size` and `sizes` in one entry.
 - Rejecting entries with neither field.
+- Rejecting a Go/API object for which `Size: 0` is omitted and `Sizes` is also
+  absent.
 - Rejecting empty lists, non-positive values, and more than 128 entries.
 - Accepting duplicate values.
 - Rejecting a sum different from the PodSet count.
+- Rejecting non-indexed Jobs and integrations without a stable rank source.
 - Rejecting partial admission and preferred outer topology.
+- Rejecting `sizes` for an elastic Job, including when
+  `ElasticJobsViaWorkloadSlicesWithTAS` is enabled.
+- Rejecting scale-up, scale-down, and other post-reservation changes to the
+  effective PodSet count.
+- Allowing a pre-reservation count or `sizes` update only when the new sum and
+  count match.
 - Rejecting multiple constraint entries when one uses `sizes` at alpha.
 - Rejecting `sizes` when the feature gate is disabled.
 - Workload webhook defense-in-depth validation.
 - Generated deepcopy behavior for the `Sizes` slice.
+- Generated CRD validation accepts the existing scalar form and the new exact
+  form, but rejects both and neither.
+- An older CRD schema rejects an exact constraint that omits `size`.
 
 Scheduler unit tests cover:
 
-- Exact matching for `[1, 3, 4]` independent of input order.
+- Distinct rank-block semantics for `[1, 3, 4]` and `[4, 3, 1]`.
+- Largest-first internal matching retains each entry's original list index.
+- Missing, duplicate, or out-of-range pod ranks remain gated rather than
+  falling back to greedy assignment.
 - Deterministic selection when multiple domains have equal capacity.
+- `BestFit` and `LeastFreeCapacity` select their documented exact-level
+  matchings for the same feasible capacities.
+- Exact distributions do not enter `BalancedPlacement` at alpha.
 - Aggregate capacity sufficient but exact matching infeasible.
 - Too few distinct domains.
 - Duplicate sizes such as `[2, 2, 4]`.
 - Selecting a feasible enclosing block over an aggregate-only fit.
 - Applying the active TAS strategy among multiple feasible scopes.
 - Exact distributions at block, rack, and hostname levels.
+- `LeastFreeCapacity` is used only for an unconstrained exact request with
+  `TASProfileMixed` enabled, and `BestFit` is used otherwise.
+- A single-entry list such as `[8]` behaves like required topology at that
+  level.
 - No regression in existing scalar slice and multi-layer tests.
-- Failed-node replacement constrained to the affected exact domain.
+- Failed-node replacement constrained to the affected exact domain without
+  changing ordered rank blocks.
+- Merging a replacement assignment preserves exact group order rather than
+  re-sorting entries lexicographically by level values.
+- Replacement derives the exact-level ancestor when the unhealthy leaf is the
+  only leaf of its exact group, and fails cleanly when that ancestor no longer
+  exists in the topology snapshot.
+- Scalar assignments still merge in lexicographic order when the feature gate
+  is enabled, so the exact-aware merge path does not change existing behavior.
+- Exact matching against a preemption-simulated snapshot admits the workload
+  only when the complete list is matchable within simulated capacity.
+- Failure reasons distinguish exact-domain infeasibility from too few eligible
+  domains, and the failure counter increments with the matching `reason` label.
 
 #### Integration Tests
 
 Single-cluster TAS integration tests verify:
 
-- An eight-pod indexed Job obtains rack-level aggregate counts `[1, 3, 4]`.
+- An eight-pod indexed Job obtains rack-level aggregate counts `[1, 3, 4]`,
+  with rank 0 in the first selected rack, ranks 1-3 in the second, and ranks
+  4-7 in the third.
+- Reordering the request to `[4, 3, 1]` changes those rank ranges while
+  retaining the same aggregate multiset of domain counts.
 - A 24-pod Job obtains block-level aggregate counts `[8, 16]`.
 - A workload remains pending when exact matching is impossible even though
-  aggregate capacity is sufficient.
+  aggregate capacity is sufficient, and reports the exact-distribution failure
+  reason rather than a generic topology fit failure.
 - A workload selects a feasible enclosing domain when another candidate is
   infeasible.
 - Disabling the feature gate rejects the annotation.
-- Replacement of an unhealthy node preserves the exact-level distribution.
+- Replacement of an unhealthy node preserves both the exact-level distribution
+  and the original rank-to-exact-domain mapping, including when the replaced
+  leaf was the only leaf of its exact group.
+- A workload admitted by preempting a lower-priority workload obtains the full
+  ordered distribution.
 
 #### End-to-End Tests
 
 Add an extended TAS end-to-end test using a fixed test topology. The test
 creates an indexed Job, waits for admission, and verifies the aggregate
-topology assignment and resulting pod placement. Existing scalar TAS end-to-end
-tests continue to run unchanged.
+topology assignment, the contiguous rank range assigned to each exact domain,
+and the resulting pod placement. Existing scalar TAS end-to-end tests continue
+to run unchanged.
 
 ### Graduation Criteria
 
@@ -551,10 +858,15 @@ tests continue to run unchanged.
 - Positive operational feedback from users running exact distributions.
 - Scheduling latency and memory impact are measured for the maximum supported
   list length.
-- Failure reasons are actionable and covered by tests.
+- Failure reasons are actionable and covered by tests, and
+  `kueue_tas_exact_distribution_failures_total` is confirmed useful for
+  diagnosing pending exact workloads in practice.
 - At least one release of alpha usage without unresolved correctness issues.
 - The API limit and interactions with outer scalar constraints are revisited
   based on experience.
+- Whether preemption should become exact-domain aware is decided based on
+  observed pending workloads that had enough preemptible aggregate capacity but
+  no matchable distribution.
 
 #### Stable
 
@@ -567,12 +879,20 @@ tests continue to run unchanged.
 ## Implementation History
 
 - 2026-08-24: Initial KEP draft.
+- 2026-08-28: Defined ordered rank mapping, placement-policy interaction, API
+  compatibility, and fixed-count lifecycle validation.
+- 2026-08-28: Added preemption behavior, failure reporting and metric, exact
+  group ordering requirements for assignment merging, and exact-level ancestor
+  derivation during failed node replacement.
 
 ## Drawbacks
 
 Exact distributions can reduce schedulability and increase fragmentation
 compared with ordinary TAS placement. A workload may remain pending even when
-the cluster has enough aggregate capacity.
+the cluster has enough aggregate capacity. This cost is justified only when a
+predictable per-domain distribution materially affects workload performance or
+behavior; testing and debugging are supported use cases, but exact placement is
+not intended to be the default.
 
 The proposal adds another placement path to a core scheduling component and
 requires special handling in failure recovery. Restricting alpha to one fixed
@@ -582,6 +902,73 @@ The API describes pod counts rather than physical node counts, which users may
 misinterpret when multiple pods can share a node.
 
 ## Alternatives
+
+### Multiple JobSet ReplicatedJobs
+
+A JobSet can model an uneven distribution as multiple `ReplicatedJob`s. Kueue
+creates one PodSet for each `ReplicatedJob`, so a JobSet could define three
+single-replica entries whose PodSet counts are one, three, and four. Each entry
+can independently require rack topology:
+
+```yaml
+spec:
+  replicatedJobs:
+  - name: group-1
+    replicas: 1
+    template:
+      spec:
+        parallelism: 1
+        completions: 1
+        template:
+          metadata:
+            annotations:
+              kueue.x-k8s.io/podset-required-topology: topology.example.com/rack
+  - name: group-3
+    replicas: 1
+    template:
+      spec:
+        parallelism: 3
+        completions: 3
+        template:
+          metadata:
+            annotations:
+              kueue.x-k8s.io/podset-required-topology: topology.example.com/rack
+  - name: group-4
+    replicas: 1
+    template:
+      spec:
+        parallelism: 4
+        completions: 4
+        template:
+          metadata:
+            annotations:
+              kueue.x-k8s.io/podset-required-topology: topology.example.com/rack
+```
+
+This is sufficient when the application already consists of separate
+ReplicatedJobs and only requires each group to fit within some rack. A slice
+size is unnecessary when each single-replica ReplicatedJob is already one
+PodSet that must fit within one topology domain.
+
+It does not provide the semantics proposed by this KEP. The PodSets are placed
+independently, so their selected racks are not required to be distinct and are
+not necessarily descendants of the same enclosing block. It also changes the
+application model from one PodSet and one pod index space into multiple
+ReplicatedJobs, and it is unavailable to workload types that cannot express
+the groups as separate PodSets.
+
+Splitting the PodSet also discards the ordered rank blocks that motivate this
+proposal. Each ReplicatedJob has its own index space starting at zero, so there
+is no single rank ordering over the eight workers and no way to state that ranks
+1-3 must be co-located while rank 0 is not. Applications that derive collective
+communicator ranks from one contiguous index space cannot use this alternative
+without changing how they assign ranks.
+
+This KEP retains `sizes` for workloads that require one PodSet to be divided
+across dynamically selected distinct domains, optionally within one enclosing
+domain. Users whose application can use independent ReplicatedJobs without
+distinct-domain or shared-parent guarantees should use the existing JobSet
+functionality instead.
 
 ### A Separate Annotation
 

--- a/keps/13416-exact-topology-distribution/README.md
+++ b/keps/13416-exact-topology-distribution/README.md
@@ -40,6 +40,7 @@
   - [Multiple JobSet ReplicatedJobs](#multiple-jobset-replicatedjobs)
   - [A Separate Annotation](#a-separate-annotation)
   - [Binding Counts to Named Domains](#binding-counts-to-named-domains)
+  - [Pod Topology Spread Constraints](#pod-topology-spread-constraints)
 <!-- /toc -->
 
 ## Summary
@@ -88,7 +89,6 @@ outcomes. No scalar slice size can require `[1, 3, 4]`.
   satisfied.
 - Preserve existing scalar `size` behavior unchanged, and keep exact distribution
   opt-in.
-
 
 ### Non-Goals
 
@@ -163,25 +163,24 @@ the block level.
 
 ### Semantics
 
-1. `sizes` is ordered. Entry `i` defines the next `sizes[i]` contiguous pod ranks.
-   For `[1, 3, 4]`, the groups are rank 0, ranks 1-3, and ranks 4-7.
+1. `sizes` is ordered. Entry `i` defines the next `sizes[i]` contiguous pod
+   ranks: for `[1, 3, 4]` the groups are rank 0, ranks 1-3, and ranks 4-7, so
+   `[4, 3, 1]` asks for the same domain counts but a different rank layout.
 2. Each entry specifies the exact pod count for one distinct domain at the named
    topology level, so the list length is the number of domains used at that
    level. Kueue selects the physical domains; a list position does not name a
    domain or correspond to any ordering of the topology itself.
-3. Thus, `[1, 3, 4]` and `[4, 3, 1]` require the same three domain sizes but group
-   ranks differently.
-4. Duplicate values are allowed. `[2, 2, 4]` requests three distinct domains.
-5. The sum of the list must equal the fixed PodSet count.
-6. An exact distribution is a required constraint. Kueue does not fall back to
+3. Duplicate values are allowed. `[2, 2, 4]` requests three distinct domains.
+4. The sum of the list must equal the fixed PodSet count.
+5. An exact distribution is a required constraint. Kueue does not fall back to
    scalar slicing or ordinary greedy placement when it cannot be satisfied.
-7. At alpha, an entry using `sizes` must be the only entry in the constraints
+6. At alpha, an entry using `sizes` must be the only entry in the constraints
    list. Containment is expressed using `podset-required-topology`, which must be
    strictly coarser than the exact level when `sizes` has more than one entry. A
    request naming the same level in both is contradictory: the identical-string
    case is rejected at creation time, and the general ordering check happens at
    scheduling time, once the topology hierarchy is known.
-8. Below the exact level, Kueue uses its existing capacity-based placement to
+7. Below the exact level, Kueue uses its existing capacity-based placement to
    assign pods to finer domains and hosts.
 
 Ordered rank-block semantics require every pod to have a stable, unique rank in
@@ -208,6 +207,14 @@ effectively ensure one pod per node.
 The distribution is attached to one PodSet. A workload with multiple PodSets
 validates and schedules each independently, subject to existing restrictions on
 PodSet groups and multi-layer constraints.
+
+The list is always the complete distribution; Kueue does not repeat a shorter
+pattern to fill a larger PodSet. A 16-pod PodSet cannot write `[1, 3, 4]` and
+have it applied twice — write `[1, 3, 4, 1, 3, 4]`, which asks for six distinct
+domains. Note that is a different request from `[2, 6, 8]`, which asks for three
+domains holding twice as much. Nesting is out of scope for the same reason: a
+flat list cannot say which rack split belongs to which block, so block counts of
+`[8, 16]` with a per-block rack distribution would need a tree-shaped API.
 
 A single-entry list such as `sizes: [8]` is permitted and puts the whole PodSet
 in one domain, the same shape `podset-required-topology` gives. The two are not
@@ -314,7 +321,11 @@ Creation-time validation enforces:
 - The `TASExactTopologyDistribution` feature gate is enabled.
 
 The Workload webhook repeats the structural, numeric, partial-admission, and
-elastic-workload checks, so that a Workload written directly is checked too.
+elastic-workload checks, so that a Workload written directly is checked too. Its
+existing per-constraint check rejects any entry whose `size` is not positive,
+which an exact constraint never sets, so that check has to become union-aware.
+Until it does, the webhook refuses every `sizes` request and the job integration
+cannot create a Workload at all.
 
 Update-time validation preserves the fixed-count invariant. Existing Workload
 validation already makes the whole PodSet immutable once quota is reserved, so
@@ -343,6 +354,12 @@ The scheduler continues to use the existing phase that calculates how many pods
 fit in each leaf and ancestor domain; the resulting `podCount` is the scalar
 capacity used by exact matching. The exact path is selected when the topology
 request contains `sizes`. The scalar path is unchanged.
+
+One existing step runs before that choice is made and assumes a scalar size.
+Slice-size resolution rejects a constraint whose size is not positive, and must
+instead report a size of one for an exact constraint: an exact distribution does
+not slice, since each entry is placed whole in its own domain and pods below that
+level are assigned individually.
 
 #### Scope Selection
 
@@ -714,6 +731,9 @@ scalar TAS end-to-end tests run unchanged.
 ## Implementation History
 
 - 2026-09-01: Initial draft.
+- 2026-09-02: Prototyped on a four-rack kind cluster. Reordering `[1, 3, 4]` to
+  `[4, 3, 1]` kept the same domains and counts but swapped the rank blocks, and
+  infeasible requests stayed pending.
 
 ## Drawbacks
 
@@ -766,3 +786,14 @@ The API could map label values directly to counts (`rack-a: 1`, `rack-b: 3`,
 `rack-c: 4`). This supports physical-domain reproduction but couples workloads to
 a specific cluster and bypasses TAS domain selection. It is left for a separate
 feature if users require explicit domain identity.
+
+### Pod Topology Spread Constraints
+
+The Kubernetes scheduler can already spread pods with topology spread
+constraints, or pin them to named domains with node affinity. Neither does what
+this KEP needs. Spread constraints bound the *skew* between domains, so they can
+push towards an even split but cannot require an arbitrary shape such as
+`[1, 3, 4]`. Node affinity can name domains but not have the scheduler choose
+them. Both also decide pod by pod, whereas an exact distribution has to be
+reserved for the whole PodSet at once — which is what Kueue's group-level
+admission already does.

--- a/keps/13416-exact-topology-distribution/kep.yaml
+++ b/keps/13416-exact-topology-distribution/kep.yaml
@@ -3,9 +3,9 @@ kep-number: 13416
 authors:
   - "@sumukha-radhakrishna"
 status: provisional
-creation-date: 2026-08-24
+creation-date: 2026-09-01
 reviewers:
-  - TBD
+  - "@amy"
 approvers:
   - TBD
 

--- a/keps/13416-exact-topology-distribution/kep.yaml
+++ b/keps/13416-exact-topology-distribution/kep.yaml
@@ -16,11 +16,11 @@ see-also:
 # The target maturity stage in the current dev cycle for this KEP.
 stage: alpha
 
-# The release target remains open while the KEP is provisional.
-latest-milestone: "TBD"
+# v0.19 is released, so v0.20 is the next development cycle.
+latest-milestone: "v0.20"
 
 milestone:
-  alpha: "TBD"
+  alpha: "v0.20"
   beta: "TBD"
   stable: "TBD"
 
@@ -28,4 +28,5 @@ feature-gates:
   - name: TASExactTopologyDistribution
 disable-supported: true
 
-metrics: []
+metrics:
+  - kueue_tas_exact_distribution_failures_total

--- a/keps/13416-exact-topology-distribution/kep.yaml
+++ b/keps/13416-exact-topology-distribution/kep.yaml
@@ -1,0 +1,31 @@
+title: Exact Topology Domain Distribution
+kep-number: 13416
+authors:
+  - "@sumukha-radhakrishna"
+status: provisional
+creation-date: 2026-08-24
+reviewers:
+  - TBD
+approvers:
+  - TBD
+
+see-also:
+  - "/keps/2724-topology-aware-scheduling"
+  - "https://github.com/kubernetes-sigs/kueue/issues/13416"
+
+# The target maturity stage in the current dev cycle for this KEP.
+stage: alpha
+
+# The release target remains open while the KEP is provisional.
+latest-milestone: "TBD"
+
+milestone:
+  alpha: "TBD"
+  beta: "TBD"
+  stable: "TBD"
+
+feature-gates:
+  - name: TASExactTopologyDistribution
+disable-supported: true
+
+metrics: []


### PR DESCRIPTION
#### What type of PR is this?

/kind kep
/kind documentation
/area tas


#### What this PR does / why we need it:

Adds KEP-13416, proposing an exact, potentially uneven pod distribution across topology domains for Topology Aware Scheduling.

Today's slice topology only accepts a scalar `size`, which fixes group *size* but not the number of domains used — an 8-pod PodSet with a rack slice size of 2 can legitimately end up as `[2, 2, 4]`, `[2, 6]`, or `[8]`, because multiple slices may share a rack. No scalar size can require `[1, 3, 4]`.

The KEP adds a `sizes` alternative on `PodsetSliceRequiredTopologyConstraint`: an ordered list of pod counts, one distinct domain per entry, summing to the PodSet count. List order defines contiguous pod-rank blocks, so `[1, 3, 4]` puts rank 0 alone and keeps ranks 1-3 together — which is what workloads deriving collective communicator ranks from the pod index actually need.

Alpha is deliberately narrow: one exact level, no repeating patterns, no nesting, no partial admission or elastic counts, and only integrations with a stable pod index.

#### Which issue(s) this PR fixes:
Fixes #13416 

#### Special notes for your reviewer:

I prototyped the design against a four-rack kind cluster and tested basic cases of topology assignment and if there are failures/unfulfilled topology then the job stays pending.
POC - https://github.com/kubernetes-sigs/kueue/pull/15002/changes#diff-9d720134c63a45f5bb947d1c589aee02ea9fdec7fea6cefc2d60ae6d3c98c480 

I can demo it if required. 

#### Does this PR introduce a user-facing change?
```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Kubernetes Enhancement Proposal for exact, uneven pod distribution across topology domains.
  * Documented configuration, validation, scheduling, preemption, failure handling, metrics, feature-gate behavior, compatibility considerations, testing, and graduation criteria.
  * Added metadata for the provisional proposal, including milestones, related references, and planned observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->