### PR TITLE
Pin DRA reserved workload behavior on DeviceClass changes

### DIFF
--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -388,7 +388,11 @@ is documented here:
      to resolve DeviceClasses deterministically.
    - Per KEP-5004, admins should ensure one `extendedResourceName` maps to at most one
      DeviceClass.
-   - Post-scheduling quota reconciliation will be evaluated for Beta.
+   - On a DeviceClass change, only pending Workloads (`QuotaReserved=False`) are requeued.
+     Workloads that have already reserved quota keep their admission-time charge and are
+     not revisited, because dropping an existing reservation to re-admit would need the
+     DeviceClass the scheduler actually allocated from, which the workload controller
+     does not watch today.
    - TAS + DRA is the longer-term path to closing this admission-scheduling gap.
 
 **Consumable capacity under-charge on exclusive devices**: if the `deviceSelector` matches
@@ -1909,7 +1913,6 @@ tracks adding this). This follows the same pattern as upstream K8s integration t
 - support integration with MultiKueue
 - e2e tests
 - CEL expression validation against ResourceSlice devices
-- re-evaluate post-scheduling quota reconciliation for DeviceClass drift
 
 ##### KueueDRAIntegrationExtendedResource
 

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -1884,7 +1884,10 @@ func extendedResourceName(dc *resourcev1.DeviceClass) string {
 func (h *deviceClassHandler) reconcileWorkloads(ctx context.Context, q workqueue.TypedRateLimitingInterface[reconcile.Request], resourceNames ...string) {
 	log := h.r.logger()
 
-	// Requeue only workloads that request the affected extended resources.
+	// Requeue only workloads that request the affected extended resources and have
+	// not reserved quota yet. A reserved Workload keeps the quota key resolved at
+	// reservation time: re-admitting it would need the DeviceClass the scheduler
+	// actually allocated from, which we don't watch today (#14563).
 	for _, name := range resourceNames {
 		if name == "" {
 			continue

--- a/pkg/controller/core/workload_controller_dra_test.go
+++ b/pkg/controller/core/workload_controller_dra_test.go
@@ -23,11 +23,17 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
+	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
@@ -433,4 +439,61 @@ func TestReconcileDRA(t *testing.T) {
 		},
 	}
 	runReconcileTestCases(t, cases, fakeClock)
+
+	// The DeviceClass handler runs outside the reconcile loop: a DeviceClass
+	// event requeues Workloads through deviceClassHandler.reconcileWorkloads,
+	// which Reconcile never triggers, so this scenario drives the handler
+	// directly instead of going through runReconcileTestCases above. It pins the
+	// deliberate decision that only Workloads without a quota reservation are
+	// requeued; a reserved Workload keeps its admission-time charge and is not
+	// revisited on a DeviceClass event (see issue #14563). If that decision
+	// changes, update this subtest alongside the handler.
+	t.Run("DeviceClass handler skips reserved workloads", func(t *testing.T) {
+		const extResource = "example.com/gpu"
+
+		pending := utiltestingapi.MakeWorkload("wl-pending", "ns").
+			Queue("lq").
+			Request(corev1.ResourceName(extResource), "1").
+			Obj()
+		reserved := utiltestingapi.MakeWorkload("wl-reserved", "ns").
+			Queue("lq").
+			Request(corev1.ResourceName(extResource), "1").
+			SimpleReserveQuota("cq", "default", time.Now()).
+			Obj()
+
+		cl := utiltesting.NewClientBuilder().
+			WithIndex(&kueue.Workload{}, indexer.WorkloadQuotaReservedKey, indexer.IndexWorkloadQuotaReserved).
+			WithIndex(&kueue.Workload{}, indexer.WorkloadExtendedResourceKey, indexer.IndexWorkloadExtendedResources).
+			WithIndex(&corev1.LimitRange{}, indexer.LimitRangeHasContainerOrPodType, indexer.IndexLimitRangeHasContainerOrPodType).
+			WithObjects(pending, reserved).
+			Build()
+
+		cqCache := schdcache.New(cl)
+		qManager := qcache.NewManagerForUnitTests(cl, cqCache)
+		r := NewWorkloadReconciler(cl, qManager, cqCache, &utiltesting.EventRecorder{})
+		h := &deviceClassHandler{r: r}
+
+		ctx, _ := utiltesting.ContextWithLog(t)
+		q := &recordingQueue{TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueue(
+			workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())}
+		defer q.ShutDown()
+
+		h.reconcileWorkloads(ctx, q, extResource)
+
+		// Both Workloads request the same extended resource, so only the
+		// QuotaReserved filter distinguishes them: pending is requeued, reserved
+		// is deliberately skipped.
+		if got, want := sets.New(q.added...), sets.New("wl-pending"); !got.Equal(want) {
+			t.Errorf("requeued workloads = %v, want %v", sets.List(got), sets.List(want))
+		}
+	})
+}
+
+type recordingQueue struct {
+	workqueue.TypedRateLimitingInterface[reconcile.Request]
+	added []string
+}
+
+func (q *recordingQueue) AddAfter(item reconcile.Request, _ time.Duration) {
+	q.added = append(q.added, item.Name)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area dra

#### What this PR does / why we need it:

The DeviceClass handler requeues only Workloads without a quota reservation (`QuotaReserved=False`). A Workload that has already reserved quota keeps the DeviceClass key it resolved at admission time and is not revisited when a DeviceClass changes.

Following the discussion on the issue, this is the intended behavior: dropping an existing reservation to re-admit would need the DeviceClass the scheduler actually allocated from, which is not available to the controller today, and post-scheduling quota reconciliation is a KEP Beta follow-up. This change records that decision and pins it:

- a regression test, TestDeviceClassHandlerSkipsReservedWorkloads
- a note in the DRA KEP under Risks and Mitigations

No behavior change.

#### Which issue(s) this PR fixes:

Fixes #14563

#### Special notes for your reviewer:

This pins the current behavior as working-as-intended per the issue discussion. If the direction is instead to drop the reservation on a DeviceClass change, the comment and KEP note should flip and a behavior change would be needed. Confirmation on the direction would be appreciated before merge.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated DeviceClass handling so only workloads without reserved quota are requeued.
  * Workloads with existing quota reservations retain their admission-time charge and are not revisited when DeviceClass changes.

* **Documentation**
  * Clarified quota reconciliation behavior and limitations for extended resource scheduling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
