### PR TITLE
Retry the e2e Kueue image pull and report failures

### DIFF
--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -643,10 +643,14 @@ function prepare_docker_images {
 
     # When using a pre-built Kueue image (released or staging), ensure it's available for kind load.
     # Check remote first; if not found remotely, use local image if present; otherwise error.
-    if docker manifest inspect "$IMAGE_TAG" >/dev/null 2>&1; then
-        docker pull "$IMAGE_TAG"
+    local manifest_error
+    if manifest_error=$(docker manifest inspect "$IMAGE_TAG" 2>&1 >/dev/null); then
+        # E2E_SKIP_IMAGE_RELOAD covers dependency images only: the Kueue image may
+        # have been rebuilt with the same tag, so it is always pulled.
+        E2E_SKIP_IMAGE_RELOAD=false e2e_docker_pull_if_needed "$IMAGE_TAG"
     elif ! docker image inspect "$IMAGE_TAG" >/dev/null 2>&1; then
-        echo "ERROR: Image '$IMAGE_TAG' not found remotely or locally." >&2
+        echo "ERROR: Image '$IMAGE_TAG' is not available remotely or locally." >&2
+        echo "$manifest_error" >&2
         return 1
     fi
 

--- a/hack/testing/e2e-common_test.sh
+++ b/hack/testing/e2e-common_test.sh
@@ -127,6 +127,36 @@ exit 1
 EOF
 chmod +x "${test_dir}/kind"
 
+cat >"${test_dir}/docker" <<'EOF'
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+printf '%s\n' "$*" >>"${DOCKER_FAKE_LOG:?}"
+
+case "$*" in
+  "pull "*)
+    attempts=$(cat "${DOCKER_FAKE_STATE:?}")
+    attempts=$((attempts + 1))
+    printf '%s' "${attempts}" >"${DOCKER_FAKE_STATE}"
+    if [[ "${attempts}" -lt "${DOCKER_FAKE_PULL_OK_AFTER:-1}" ]]; then
+      printf '%s\n' "${DOCKER_FAKE_PULL_ERROR:?}" >&2
+      exit 1
+    fi
+    printf 'Status: Downloaded newer image\n'
+    exit 0
+    ;;
+  "image inspect "*)
+    exit "${DOCKER_FAKE_IMAGE_PRESENT:-1}"
+    ;;
+esac
+
+printf 'unexpected docker call: %s\n' "$*" >&2
+exit 1
+EOF
+chmod +x "${test_dir}/docker"
+
 # shellcheck source=hack/testing/e2e-common.sh
 source "${ROOT_DIR}/hack/testing/e2e-common.sh"
 
@@ -241,6 +271,71 @@ fi
 
 if [[ ! -f "${ARTIFACTS}/persistent-test-create.log" ]]; then
   echo "expected the final attempt's log to remain for failure reporting" >&2
+  exit 1
+fi
+
+# A transient registry error is retried until the pull succeeds.
+DOCKER_FAKE_LOG="${test_dir}/docker.log"
+DOCKER_FAKE_STATE="${test_dir}/docker-state"
+export DOCKER_FAKE_LOG DOCKER_FAKE_STATE
+: >"${DOCKER_FAKE_LOG}"
+printf '0' >"${DOCKER_FAKE_STATE}"
+export DOCKER_FAKE_PULL_OK_AFTER=2
+export DOCKER_FAKE_PULL_ERROR='Error response from daemon: Get "https://registry.example.com/v2/kueue/manifests/sha256:0badc0de": net/http: TLS handshake timeout'
+
+e2e_docker_pull_if_needed "registry.example.com/kueue:test"
+
+pull_attempts=$(grep -c "^pull " "${DOCKER_FAKE_LOG}" || true)
+if [[ "${pull_attempts}" != "2" ]]; then
+  echo "expected a TLS handshake timeout to be retried; got ${pull_attempts} attempt(s)" >&2
+  exit 1
+fi
+
+# A missing image is not a transient failure, so it aborts after a single attempt.
+: >"${DOCKER_FAKE_LOG}"
+printf '0' >"${DOCKER_FAKE_STATE}"
+export DOCKER_FAKE_PULL_OK_AFTER=99
+export DOCKER_FAKE_PULL_ERROR='Error response from daemon: manifest for registry.example.com/kueue:missing not found'
+
+if e2e_docker_pull_if_needed "registry.example.com/kueue:missing"; then
+  echo "expected a missing manifest to fail the pull" >&2
+  exit 1
+fi
+unset DOCKER_FAKE_PULL_ERROR
+
+pull_attempts=$(grep -c "^pull " "${DOCKER_FAKE_LOG}" || true)
+if [[ "${pull_attempts}" != "1" ]]; then
+  echo "expected a missing manifest to fail fast without retrying; got ${pull_attempts} attempt(s)" >&2
+  exit 1
+fi
+
+# In dev mode a cached dependency image is reused instead of pulled again.
+: >"${DOCKER_FAKE_LOG}"
+printf '0' >"${DOCKER_FAKE_STATE}"
+export DOCKER_FAKE_PULL_OK_AFTER=1
+export DOCKER_FAKE_IMAGE_PRESENT=0
+
+E2E_MODE=dev E2E_SKIP_IMAGE_RELOAD=true e2e_docker_pull_if_needed "registry.example.com/dependency:test"
+
+pull_attempts=$(grep -c "^pull " "${DOCKER_FAKE_LOG}" || true)
+if [[ "${pull_attempts}" != "0" ]]; then
+  echo "expected a cached dependency image to be reused in dev mode; got ${pull_attempts} pull(s)" >&2
+  exit 1
+fi
+
+# Opting out of E2E_SKIP_IMAGE_RELOAD pulls even when the image is cached locally.
+: >"${DOCKER_FAKE_LOG}"
+printf '0' >"${DOCKER_FAKE_STATE}"
+export DOCKER_FAKE_PULL_OK_AFTER=1
+export DOCKER_FAKE_IMAGE_PRESENT=0
+
+E2E_MODE=dev E2E_SKIP_IMAGE_RELOAD=false e2e_docker_pull_if_needed "registry.example.com/kueue:test"
+unset DOCKER_FAKE_PULL_OK_AFTER
+unset DOCKER_FAKE_IMAGE_PRESENT
+
+pull_attempts=$(grep -c "^pull " "${DOCKER_FAKE_LOG}" || true)
+if [[ "${pull_attempts}" != "1" ]]; then
+  echo "expected a cached image to be pulled when E2E_SKIP_IMAGE_RELOAD is off; got ${pull_attempts} pull(s)" >&2
   exit 1
 fi
 

--- a/hack/testing/e2e-test.sh
+++ b/hack/testing/e2e-test.sh
@@ -25,6 +25,17 @@ ROOT_DIR="$SOURCE_DIR/../.."
 source "${SOURCE_DIR}/e2e-common.sh"
 
 function cleanup {
+    local exit_code=$?
+
+    # Deleting the cluster under an in-flight "kind create" SIGKILLs "kubeadm join",
+    # which surfaces as "exit status 137" and hides the real failure (#14673).
+    # Waiting is the only option: "timeout" escapes our process group and
+    # "kubeadm" runs inside the node container.
+    if [ -n "${STARTUP_PID:-}" ] && kill -0 "$STARTUP_PID" 2>/dev/null; then
+        echo "Exiting (code ${exit_code}) while the cluster bring-up is still running; waiting for it to finish before teardown."
+        wait "$STARTUP_PID" || true
+    fi
+
     if [ ! -d "$ARTIFACTS" ]; then
         mkdir -p "$ARTIFACTS"
     fi
@@ -50,8 +61,12 @@ function startup {
 trap cleanup EXIT
 build_kind_node_image
 startup &
+STARTUP_PID=$!
 prepare_docker_images
-wait
+# A bare "wait" reports success no matter how the background job exited, which
+# would let the run continue without a cluster.
+wait "$STARTUP_PID"
+STARTUP_PID=""
 kind_load "$KIND_CLUSTER_NAME" ""
 kueue_deploy
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->
/kind flake
/area testing
#### What this PR does / why we need it:
`prepare_docker_images` in `hack/testing/e2e-common.sh` pulled the pre-built Kueue image (`$IMAGE_TAG`) with a bare `docker pull`, the only image pull in that script not wrapped in `retry.sh`. In the linked run a TLS handshake timeout against the staging registry failed on that single attempt, and `set -o errexit` ended the run.

`e2e-test.sh` runs `startup` in the background and `prepare_docker_images` in the foreground, so the shell exited while `kind create cluster` was still mid `kubeadm join`. `trap cleanup EXIT` deleted the cluster from under it, which SIGKILLed `kubeadm`, so the run ended with `exit status 137` and no collected artifacts, about 180 log lines after the actual failure. That 137 is what the linked issue was filed about.

The pull now goes through `e2e_docker_pull_if_needed`, with `E2E_SKIP_IMAGE_RELOAD=false` since that flag covers dependency images only and the Kueue image can be rebuilt under the same tag. `cleanup` waits for an in-flight bring-up to finish before tearing the cluster down, and `wait "$STARTUP_PID"` replaces a bare `wait`, which returned 0 however the background job exited: a failed cluster create used to let the run continue into the whole suite.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14673

#### Special notes for your reviewer:
- Failing run: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-kueue-test-e2e-certmanager-release-0-19/2090327113415528448. The `exit status 137` in the issue title comes from our own teardown, so I did not add it to `cluster_create`'s retriable errors: the shell is already exiting by then, and it would hide genuine OOM kills behind three slow retries.
- `e2e_docker_pull_if_needed` had no coverage, so `hack/testing/e2e-common_test.sh` now stubs `docker` and asserts that a TLS handshake timeout is retried, that a missing manifest fails fast, and that `E2E_SKIP_IMAGE_RELOAD` still skips a cached dependency image. Also reproduced against a real `test-e2e-certmanager` run in CI mode, failing the pull on a retriable and on a non-retriable error: neither reported `137` or `API server is not reachable`.
- This PR was written in part with the assistance of generative AI.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end environment setup when container images are unavailable or registries return temporary TLS errors.
  * Image preparation now clearly reports whether images are missing locally or remotely.
  * Preserved startup failures during cluster creation and prevented teardown from interrupting active startup processes.
  * Improved reuse and reloading of cached dependency images based on configuration.

* **Tests**
  * Added coverage for image pulls, manifest inspection failures, registry errors, cached images, and startup process handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->