### PR TITLE
[release-0.19] MultiKueue: Prevent worker Job TTL cleanup

### DIFF
--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -91,7 +91,13 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 		Spec:       *localJob.Spec.DeepCopy(),
 	}
 
-	// cleanup
+	if features.Enabled(features.MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster) {
+		// The manager cluster is the source of truth for Job lifecycle. Propagating
+		// the TTL to the worker can delete the remote Job before its terminal status
+		// is synchronized back to the manager, causing the completed Job to be
+		// dispatched again.
+		remoteJob.Spec.TTLSecondsAfterFinished = nil
+	}
 	// drop the selector
 	remoteJob.Spec.Selector = nil
 	// drop the templates cleanup labels

--- a/pkg/controller/jobs/job/job_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter_test.go
@@ -88,6 +88,61 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 		},
+		"sync does not propagate ttl seconds after finished to remote job when clearing is enabled": {
+			featureGates: map[featuregate.Feature]bool{
+				features.MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster: true,
+				features.WorkloadIdentifierAnnotations:                                    false,
+			},
+			managersJobs: []batchv1.Job{
+				*baseJobManagedByKueueBuilder.Clone().
+					TTLSecondsAfterFinished(0).
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "job1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
+			},
+
+			wantManagersJobs: []batchv1.Job{
+				*baseJobManagedByKueueBuilder.Clone().
+					TTLSecondsAfterFinished(0).
+					Obj(),
+			},
+			wantWorkerJobs: []batchv1.Job{
+				*baseJobBuilder.Clone().
+					PrebuiltWorkloadLabel("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					Obj(),
+			},
+		},
+		"sync propagates ttl seconds after finished to remote job when clearing is disabled": {
+			featureGates: map[featuregate.Feature]bool{
+				features.MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster: false,
+				features.WorkloadIdentifierAnnotations:                                    false,
+			},
+			managersJobs: []batchv1.Job{
+				*baseJobManagedByKueueBuilder.Clone().
+					TTLSecondsAfterFinished(0).
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "job1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
+			},
+
+			wantManagersJobs: []batchv1.Job{
+				*baseJobManagedByKueueBuilder.Clone().
+					TTLSecondsAfterFinished(0).
+					Obj(),
+			},
+			wantWorkerJobs: []batchv1.Job{
+				*baseJobBuilder.Clone().
+					TTLSecondsAfterFinished(0).
+					PrebuiltWorkloadLabel("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					Obj(),
+			},
+		},
 		"sync intermediate status from remote job": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersJobs: []batchv1.Job{

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -77,6 +77,12 @@ const (
 	// Enables MultiKueue support.
 	MultiKueue featuregate.Feature = "MultiKueue"
 
+	// owner: @kevin85421
+	// issue: https://github.com/kubernetes-sigs/kueue/issues/14779
+	//
+	// Enables clearing ttlSecondsAfterFinished when creating remote batch Jobs.
+	MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster featuregate.Feature = "MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster"
+
 	// owner: @mimowo
 	//
 	// Enable Topology Aware Scheduling allowing to optimize placement of Pods
@@ -704,6 +710,9 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	MultiKueue: {
 		{Version: version.MustParse("0.6"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("0.9"), Default: true, PreRelease: featuregate.Beta},
+	},
+	MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster: {
+		{Version: version.MustParse("0.19"), Default: false, PreRelease: featuregate.Alpha},
 	},
 	TopologyAwareScheduling: {
 		{Version: version.MustParse("0.9"), Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/util/testingjobs/job/wrappers.go
+++ b/pkg/util/testingjobs/job/wrappers.go
@@ -103,6 +103,11 @@ func (j *JobWrapper) BackoffLimit(limit int32) *JobWrapper {
 	return j
 }
 
+func (j *JobWrapper) TTLSecondsAfterFinished(seconds int32) *JobWrapper {
+	j.Spec.TTLSecondsAfterFinished = new(seconds)
+	return j
+}
+
 func (j *JobWrapper) BackoffLimitPerIndex(limit int32) *JobWrapper {
 	j.Spec.BackoffLimitPerIndex = new(limit)
 	return j

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -245,6 +245,12 @@
     lockToDefault: true
     preRelease: Deprecated
     version: "0.19"
+- name: MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.19"
 - name: MultiKueueClusterProfile
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -245,6 +245,12 @@
     lockToDefault: true
     preRelease: Deprecated
     version: "0.19"
+- name: MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.19"
 - name: MultiKueueClusterProfile
   versionedSpecs:
   - default: false

--- a/test/e2e/config/multikueue/baseline/controller_manager_config.yaml
+++ b/test/e2e/config/multikueue/baseline/controller_manager_config.yaml
@@ -24,6 +24,7 @@ integrations:
   - "deployment"
   - "statefulset"
 featureGates:
+  MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster: true
   MultiKueueManagerQuotaAutomation: true
 tls:
   minVersion: "VersionTLS12"

--- a/test/e2e/config/multikueue/baseline/controller_manager_config.yaml
+++ b/test/e2e/config/multikueue/baseline/controller_manager_config.yaml
@@ -24,7 +24,6 @@ integrations:
   - "deployment"
   - "statefulset"
 featureGates:
-  MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster: true
   MultiKueueManagerQuotaAutomation: true
 tls:
   minVersion: "VersionTLS12"

--- a/test/e2e/multikueue/baseline/e2e_test.go
+++ b/test/e2e/multikueue/baseline/e2e_test.go
@@ -34,12 +34,14 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	workloadpod "sigs.k8s.io/kueue/pkg/controller/jobs/pod"
 	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
 	workloadstatefulset "sigs.k8s.io/kueue/pkg/controller/jobs/statefulset"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/admissioncheck"
 	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -679,7 +681,23 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			})
 		})
 
-		ginkgo.It("Should not propagate Job TTL and should clean up the completed manager Job", func() {
+		ginkgo.It("Should not propagate Job TTL and should clean up the completed manager Job", ginkgo.Serial, func() {
+			defaultManagerKueueCfg := util.GetKueueConfiguration(ctx, k8sManagerClient)
+			ginkgo.DeferCleanup(func() {
+				ginkgo.By("Restoring the manager Kueue configuration", func() {
+					util.UpdateKueueConfigurationAndRestart(ctx, k8sManagerClient, defaultManagerKueueCfg, managerClusterName)
+				})
+			})
+
+			ginkgo.By("Enabling worker Job TTL clearing", func() {
+				util.UpdateKueueConfigurationAndRestart(ctx, k8sManagerClient, defaultManagerKueueCfg, managerClusterName, func(cfg *configapi.Configuration) {
+					if cfg.FeatureGates == nil {
+						cfg.FeatureGates = make(map[string]bool)
+					}
+					cfg.FeatureGates[string(features.MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster)] = true
+				})
+			})
+
 			job := testingjob.MakeJob("job-with-ttl", managerNs.Name).
 				Queue(kueue.LocalQueueName(managerLq.Name)).
 				TTLSecondsAfterFinished(0).

--- a/test/e2e/multikueue/baseline/e2e_test.go
+++ b/test/e2e/multikueue/baseline/e2e_test.go
@@ -699,6 +699,9 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			})
 
 			ginkgo.By("Waiting for the MultiKueue remote clients to reconnect", func() {
+				// The Active condition survives a controller restart, so it can be stale while the new leader
+				// rebuilds its remote clients. Force an observable False-to-True transition to ensure the remote
+				// caches are synchronized before creating the Job.
 				restoreWorker1Connection := util.BreakConnection(ctx, k8sManagerClient, workerCluster1, util.GetKueueNamespace())
 				restoreWorker1Connection()
 				restoreWorker2Connection := util.BreakConnection(ctx, k8sManagerClient, workerCluster2, util.GetKueueNamespace())

--- a/test/e2e/multikueue/baseline/e2e_test.go
+++ b/test/e2e/multikueue/baseline/e2e_test.go
@@ -700,7 +700,8 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 
 			ginkgo.By("Waiting for the MultiKueue remote clients to reconnect", func() {
 				// The Active condition survives a controller restart, so it can be stale while the new leader
-				// rebuilds its remote clients. Force an observable False-to-True transition to ensure the remote
+				// rebuilds its remote clients. If no worker is actually active when the Job is created, its Workload
+				// is requeued with a long delay. Force an observable False-to-True transition to ensure the remote
 				// caches are synchronized before creating the Job.
 				restoreWorker1Connection := util.BreakConnection(ctx, k8sManagerClient, workerCluster1, util.GetKueueNamespace())
 				restoreWorker1Connection()

--- a/test/e2e/multikueue/baseline/e2e_test.go
+++ b/test/e2e/multikueue/baseline/e2e_test.go
@@ -701,8 +701,8 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			ginkgo.By("Waiting for the MultiKueue remote clients to reconnect", func() {
 				// The Active condition survives a controller restart, so it can be stale while the new leader
 				// rebuilds its remote clients. If no worker is actually active when the Job is created, its Workload
-				// is requeued with a long delay. Force an observable False-to-True transition to ensure the remote
-				// caches are synchronized before creating the Job.
+				// is requeued with a long delay, causing the test to time out. Force an observable False-to-True
+				// transition to ensure the remote caches are synchronized before creating the Job.
 				restoreWorker1Connection := util.BreakConnection(ctx, k8sManagerClient, workerCluster1, util.GetKueueNamespace())
 				restoreWorker1Connection()
 				restoreWorker2Connection := util.BreakConnection(ctx, k8sManagerClient, workerCluster2, util.GetKueueNamespace())

--- a/test/e2e/multikueue/baseline/e2e_test.go
+++ b/test/e2e/multikueue/baseline/e2e_test.go
@@ -698,6 +698,13 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 				})
 			})
 
+			ginkgo.By("Waiting for the MultiKueue remote clients to reconnect", func() {
+				restoreWorker1Connection := util.BreakConnection(ctx, k8sManagerClient, workerCluster1, util.GetKueueNamespace())
+				restoreWorker1Connection()
+				restoreWorker2Connection := util.BreakConnection(ctx, k8sManagerClient, workerCluster2, util.GetKueueNamespace())
+				restoreWorker2Connection()
+			})
+
 			job := testingjob.MakeJob("job-with-ttl", managerNs.Name).
 				Queue(kueue.LocalQueueName(managerLq.Name)).
 				TTLSecondsAfterFinished(0).

--- a/test/e2e/multikueue/baseline/e2e_test.go
+++ b/test/e2e/multikueue/baseline/e2e_test.go
@@ -678,6 +678,46 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 					cmpopts.IgnoreFields(batchv1.JobCondition{}, "LastTransitionTime", "LastProbeTime", "Reason", "Message"))))
 			})
 		})
+
+		ginkgo.It("Should not propagate Job TTL and should clean up the completed manager Job", func() {
+			job := testingjob.MakeJob("job-with-ttl", managerNs.Name).
+				Queue(kueue.LocalQueueName(managerLq.Name)).
+				TTLSecondsAfterFinished(0).
+				TerminationGracePeriod(1).
+				RequestAndLimit(corev1.ResourceCPU, "100m").
+				RequestAndLimit(corev1.ResourceMemory, "100M").
+				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+				Obj()
+
+			ginkgo.By("Creating the job with immediate TTL cleanup", func() {
+				util.MustCreate(ctx, k8sManagerClient, job)
+			})
+
+			wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: managerNs.Name}
+			admittedWorkerName := util.ExpectWorkloadsToBeAdmittedAndGetWorkerName(ctx, k8sManagerClient, wlLookupKey, multiKueueAc.Name)
+			admittedWorker := kubernetesClients[admittedWorkerName]
+
+			ginkgo.By("Checking that the remote Job does not inherit the manager Job TTL", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					remoteJob := &batchv1.Job{}
+					g.Expect(admittedWorker.client.Get(ctx, client.ObjectKeyFromObject(job), remoteJob)).To(gomega.Succeed())
+					g.Expect(remoteJob.Spec.TTLSecondsAfterFinished).To(gomega.BeNil())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Finishing the remote Job", func() {
+				listOpts := util.GetListOptsFromLabel(fmt.Sprintf("batch.kubernetes.io/job-name=%s", job.Name))
+				util.WaitForActivePodsAndTerminate(ctx, admittedWorker.client, admittedWorker.restClient, admittedWorker.cfg, job.Namespace, 1, 0, listOpts)
+			})
+
+			ginkgo.By("Waiting for the completed manager Job to be deleted by the TTL controller", func() {
+				util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sManagerClient, job, false, util.MediumTimeout)
+			})
+
+			ginkgo.By("Checking that the remote Jobs are cleaned up", func() {
+				util.ExpectObjectToBeDeletedOnClusters(ctx, job, k8sWorker1Client, k8sWorker2Client)
+			})
+		})
 	})
 
 	ginkgo.When("Preemption with a multikueue admission check", func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area multikueue

#### What this PR does / why we need it:

Backports #14734 to release-0.19.

MultiKueue copies `spec.ttlSecondsAfterFinished` from a manager Job to its remote worker Job. The worker TTL controller can delete a completed remote Job before MultiKueue synchronizes its terminal status back to the manager, causing the completed Job to be dispatched again.

This backport allows MultiKueue to omit the field when creating a remote Job. Existing remote Jobs are not modified. Unlike `main`, the `MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster` feature gate is Alpha and disabled by default on release-0.19, so users must explicitly enable it to opt in to the fix.

#### Which issue(s) this PR fixes:

Backport of #14734. GA graduation is tracked in #14826.

#### Special notes for your reviewer:

The merged commit was cherry-picked and the expected generated feature-gate metadata conflicts were resolved for release-0.19 as Alpha/default-off.

Tests:
- `go test ./pkg/controller/jobs/job ./pkg/features -count=1`
- `go test ./test/e2e/multikueue/baseline -run '^$' -count=1`

AI usage disclosure: This backport was prepared with assistance from AI tooling.

#### Does this PR introduce a user-facing change?

```release-note
MultiKueue: Fixed a bug where a Job is dispatched again due to propagated `spec.ttlSecondsAfterFinished` even after Job completion. Enable the Alpha `MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster` feature gate to enable fixing.
```
