### PR TITLE
fix(pod): Clean up prebuilt Pod groups

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1029,6 +1029,14 @@ func (r *JobReconciler) ensureOneWorkload(ctx context.Context, job GenericJob, o
 		}
 
 		if cj, implements := job.(ComposableJob); implements {
+			// Prebuilt composable workloads bypass the ordinary matching path. Run it
+			// here as well so replaced members are finalized before validating the
+			// prebuilt Workload against the remaining live members.
+			if match, _, matchErr := cj.FindMatchingWorkloads(ctx, r.client, r.record); matchErr != nil {
+				return nil, matchErr
+			} else if match != nil && match.Name == prebuiltWorkload {
+				wl = match
+			}
 			err = cj.EnsureWorkloadOwnedByAllMembers(ctx, r.client, r.record, wl)
 		} else {
 			err = EnsurePrebuiltWorkloadOwnership(ctx, r.client, wl, object)

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -921,7 +921,8 @@ func (p *Pod) partitionPods() (active, inactive []corev1.Pod) {
 }
 
 func isDeletingPrebuiltPod(pod *corev1.Pod) bool {
-	return !pod.DeletionTimestamp.IsZero() && jobframework.PrebuiltWorkloadNameFor(pod) != ""
+	_, mirrored := pod.Labels[kueue.MultiKueueOriginLabel]
+	return !mirrored && !pod.DeletionTimestamp.IsZero() && jobframework.PrebuiltWorkloadNameFor(pod) != ""
 }
 
 // shouldFinalizeNow reports whether a group pod's finalizer can be removed as part of this
@@ -1314,6 +1315,11 @@ func (p *Pod) FindMatchingWorkloads(ctx context.Context, c client.Client, r even
 		log.Error(err, "Unable to get related workload")
 		return nil, nil, err
 	}
+	// MultiKueue owns mirrored membership. A deleted manager Pod can still have a
+	// running worker copy, so trimming by age here could delete its replacement.
+	if _, mirrored := p.pod.Labels[kueue.MultiKueueOriginLabel]; prebuiltWorkload != "" && mirrored {
+		return workload, nil, nil
+	}
 
 	// For ordinary Pod groups, only adopt Workloads created by the pod-group framework.
 	// Refuse without putting the foreign Workload in toDelete, or the reconciler would
@@ -1472,9 +1478,10 @@ func (p *Pod) ReclaimablePods(ctx context.Context, _ client.Client) ([]kueue.Rec
 
 	var result []kueue.ReclaimablePod
 	for _, pod := range p.list.Items {
-		// A deleting member of a prebuilt group can be replaced under the same
-		// fixed-size Workload. It still consumes its reserved slot, so it must not
-		// release quota that reclaimable counts cannot later reacquire.
+		// Do not count a deleting member of a prebuilt group as a finished slot,
+		// even if it Succeeded: in a fixed-size group the slot is mid-handover to
+		// a replacement, not done. Reclaimable counts only grow, so quota released
+		// here could never be reacquired for the replacement.
 		if pod.Status.Phase == corev1.PodSucceeded && !isDeletingPrebuiltPod(&pod) {
 			roleHash, err := getRoleHash(pod)
 			if err != nil {

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -530,6 +530,15 @@ func (p *Pod) Stop(ctx context.Context, c client.Client, _ []podset.PodSetInfo, 
 	stoppedNow := make([]client.Object, 0)
 	for i := range podsInGroup {
 		if !podsInGroup[i].DeletionTimestamp.IsZero() {
+			// A prebuilt Workload can disappear while its Pods are already deleting.
+			// There is no admission object left to coordinate with, so retaining the
+			// Kueue finalizer would make the deletion permanent.
+			if stopReason == jobframework.StopReasonNoMatchingWorkload && isDeletingPrebuiltPod(&podsInGroup[i]) {
+				if _, err := removePodFinalizers(ctx, c, &podsInGroup[i]); client.IgnoreNotFound(err) != nil {
+					return stoppedNow, err
+				}
+				continue
+			}
 			// Already deleting from an earlier Stop() call; finalize now if it has since terminated.
 			if p.shouldFinalizeNow(&podsInGroup[i], stopReason) {
 				if _, err := removePodFinalizers(ctx, c, &podsInGroup[i]); client.IgnoreNotFound(err) != nil {
@@ -897,13 +906,22 @@ func (p *Pod) validatePodGroupMetadata(r events.EventRecorder, activePods []core
 // partitionPods splits pods in the group into active and inactive pods
 func (p *Pod) partitionPods() (active, inactive []corev1.Pod) {
 	for i := range p.list.Items {
-		if isPodRunnableOrSucceeded(&p.list.Items[i]) {
+		pod := &p.list.Items[i]
+		// An external controller can replace a deleting member of a prebuilt
+		// group before kubelet records its terminal phase. Treat that member as
+		// inactive so the replacement, rather than the terminating Pod, consumes
+		// the fixed Workload slot.
+		if !isDeletingPrebuiltPod(pod) && isPodRunnableOrSucceeded(pod) {
 			active = append(active, p.list.Items[i])
 		} else {
 			inactive = append(inactive, p.list.Items[i])
 		}
 	}
 	return active, inactive
+}
+
+func isDeletingPrebuiltPod(pod *corev1.Pod) bool {
+	return !pod.DeletionTimestamp.IsZero() && jobframework.PrebuiltWorkloadNameFor(pod) != ""
 }
 
 // shouldFinalizeNow reports whether a group pod's finalizer can be removed as part of this
@@ -1281,10 +1299,15 @@ func (p *Pod) FindMatchingWorkloads(ctx context.Context, c client.Client, r even
 	if groupName == "" {
 		return jobframework.FindMatchingWorkloads(ctx, c, p)
 	}
+	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(&p.pod)
+	workloadName := groupName
+	if prebuiltWorkload != "" {
+		workloadName = prebuiltWorkload
+	}
 
 	// Find a matching workload first if there is one.
 	workload := &kueue.Workload{}
-	if err := c.Get(ctx, types.NamespacedName{Name: groupName, Namespace: p.pod.GetNamespace()}, workload); err != nil {
+	if err := c.Get(ctx, types.NamespacedName{Name: workloadName, Namespace: p.pod.GetNamespace()}, workload); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, nil, nil
 		}
@@ -1292,9 +1315,10 @@ func (p *Pod) FindMatchingWorkloads(ctx context.Context, c client.Client, r even
 		return nil, nil, err
 	}
 
-	// Only adopt Workloads created by the pod-group framework. Refuse without putting the
-	// foreign Workload in toDelete, or the reconciler would delete the victim's Workload.
-	if features.Enabled(features.PodIntegrationValidateGroupOwner) &&
+	// For ordinary Pod groups, only adopt Workloads created by the pod-group framework.
+	// Refuse without putting the foreign Workload in toDelete, or the reconciler would
+	// delete the victim's Workload.
+	if prebuiltWorkload == "" && features.Enabled(features.PodIntegrationValidateGroupOwner) &&
 		workload.Annotations[podconstants.IsGroupWorkloadAnnotationKey] != podconstants.IsGroupWorkloadAnnotationValue {
 		log.V(4).Info("Existing workload with the pod group name was not created by the pod group framework; refusing adoption",
 			"workload", klog.KObj(workload))
@@ -1448,7 +1472,10 @@ func (p *Pod) ReclaimablePods(ctx context.Context, _ client.Client) ([]kueue.Rec
 
 	var result []kueue.ReclaimablePod
 	for _, pod := range p.list.Items {
-		if pod.Status.Phase == corev1.PodSucceeded {
+		// A deleting member of a prebuilt group can be replaced under the same
+		// fixed-size Workload. It still consumes its reserved slot, so it must not
+		// release quota that reclaimable counts cannot later reacquire.
+		if pod.Status.Phase == corev1.PodSucceeded && !isDeletingPrebuiltPod(&pod) {
 			roleHash, err := getRoleHash(pod)
 			if err != nil {
 				return nil, err

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -6792,6 +6792,79 @@ func TestReconciler(t *testing.T) {
 	}
 }
 
+func TestFindMatchingWorkloadsPreservesMultiKueueMembers(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	oldPod := testingpod.MakePod("old", "ns").UID("old-uid").
+		GroupNameLabel("group").GroupTotalCount("1").RoleHash("role").
+		PrebuiltWorkloadLabel("prebuilt").Label(kueue.MultiKueueOriginLabel, "manager").
+		KueueFinalizer().StatusPhase(corev1.PodRunning).NodeName("node").Obj()
+	replacement := testingpod.MakePod("replacement", "ns").UID("new-uid").
+		GroupNameLabel("group").GroupTotalCount("1").RoleHash("role").
+		PrebuiltWorkloadLabel("prebuilt").Label(kueue.MultiKueueOriginLabel, "manager").
+		KueueFinalizer().KueueSchedulingGate().Obj()
+	wl := utiltestingapi.MakeWorkload("prebuilt", "ns").
+		PodSets(*utiltestingapi.MakePodSet("role", 1).Obj()).Obj()
+	c := utiltesting.NewClientBuilder().WithObjects(oldPod, replacement, wl).Build()
+	p := &Pod{pod: *oldPod, isGroup: true, list: corev1.PodList{Items: []corev1.Pod{*oldPod, *replacement}}}
+	wantPods := p.list.DeepCopy()
+
+	matched, toDelete, err := p.FindMatchingWorkloads(ctx, c, &utiltesting.EventRecorder{})
+	if err != nil {
+		t.Fatalf("FindMatchingWorkloads returned error: %v", err)
+	}
+	if matched == nil || matched.Name != wl.Name || len(toDelete) != 0 {
+		t.Fatalf("Expected the prebuilt Workload without cleanup, got match %v and deletions %v", matched, toDelete)
+	}
+	if diff := cmp.Diff(wantPods, &p.list); diff != "" {
+		t.Errorf("Mirrored membership changed (-want,+got):\n%s", diff)
+	}
+	for _, pod := range wantPods.Items {
+		got := &corev1.Pod{}
+		if err := c.Get(ctx, client.ObjectKeyFromObject(&pod), got); err != nil {
+			t.Fatalf("Could not get mirrored Pod: %v", err)
+		}
+		if diff := cmp.Diff(pod, *got, podCmpOpts...); diff != "" {
+			t.Errorf("Mirrored Pod changed (-want,+got):\n%s", diff)
+		}
+	}
+}
+
+func TestDeletingPrebuiltPodAccounting(t *testing.T) {
+	for name, tc := range map[string]struct {
+		mirrored        bool
+		wantActive      int
+		wantReclaimable []kueue.ReclaimablePod
+	}{
+		"local replacement retains its slot": {},
+		"mirrored completion retains existing accounting": {
+			mirrored: true, wantActive: 1,
+			wantReclaimable: []kueue.ReclaimablePod{{Name: "role", Count: 1}},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx, _ := utiltesting.ContextWithLog(t)
+			pod := testingpod.MakePod("pod", "ns").GroupNameLabel("group").RoleHash("role").
+				PrebuiltWorkloadLabel("prebuilt").StatusPhase(corev1.PodSucceeded).
+				NodeName("node").DeletionTimestamp(time.Now()).Obj()
+			if tc.mirrored {
+				pod.Labels[kueue.MultiKueueOriginLabel] = "manager"
+			}
+			p := &Pod{pod: *pod, isGroup: true, list: corev1.PodList{Items: []corev1.Pod{*pod}}}
+			active, _ := p.partitionPods()
+			if len(active) != tc.wantActive {
+				t.Errorf("Expected %d active Pods, got %d", tc.wantActive, len(active))
+			}
+			reclaimable, err := p.ReclaimablePods(ctx, nil)
+			if err != nil {
+				t.Fatalf("ReclaimablePods returned error: %v", err)
+			}
+			if diff := cmp.Diff(tc.wantReclaimable, reclaimable); diff != "" {
+				t.Errorf("Reclaimable Pods differ (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestRecordPodSchedulingGateRemovalSeconds(t *testing.T) {
 	const pogGroupPodSetName = "dc85db45"
 

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -6202,6 +6202,108 @@ func TestReconciler(t *testing.T) {
 					Obj(),
 			},
 		},
+		"deleting prebuilt group pods are finalized when the workload is missing": {
+			pods: []corev1.Pod{
+				*basePodWrapper.
+					Clone().
+					ManagedByKueueLabel().
+					PrebuiltWorkloadLabel("test-group").
+					KueueFinalizer().
+					GroupNameLabel("test-group").
+					GroupTotalCount("1").
+					StatusPhase(corev1.PodFailed).
+					DeletionTimestamp(now.Add(-time.Minute)).
+					Obj(),
+			},
+			wantPods:      []corev1.Pod{},
+			wantWorkloads: []kueue.Workload{},
+			wantErr:       jobframework.ErrPrebuiltWorkloadNotFound,
+		},
+		"replaced terminating pods are finalized for a prebuilt pod group": {
+			pods: []corev1.Pod{
+				*basePodWrapper.
+					Clone().
+					Name("running").
+					UID("running-uid").
+					ManagedByKueueLabel().
+					PrebuiltWorkloadLabel("prebuilt-workload").
+					KueueFinalizer().
+					GroupNameLabel("test-group").
+					GroupTotalCount("1").
+					StatusPhase(corev1.PodRunning).
+					NodeName("test-node").
+					DeletionTimestamp(now.Add(-time.Minute)).
+					Obj(),
+				*basePodWrapper.
+					Clone().
+					Name("succeeded").
+					UID("succeeded-uid").
+					ManagedByKueueLabel().
+					PrebuiltWorkloadLabel("prebuilt-workload").
+					KueueFinalizer().
+					GroupNameLabel("test-group").
+					GroupTotalCount("1").
+					StatusPhase(corev1.PodSucceeded).
+					DeletionTimestamp(now.Add(-time.Minute)).
+					Obj(),
+				*basePodWrapper.
+					Clone().
+					Name("replacement").
+					UID("replacement-uid").
+					ManagedByKueueLabel().
+					PrebuiltWorkloadLabel("prebuilt-workload").
+					KueueFinalizer().
+					GroupNameLabel("test-group").
+					GroupTotalCount("1").
+					StatusPhase(corev1.PodRunning).
+					Obj(),
+			},
+			wantPods: []corev1.Pod{
+				*basePodWrapper.
+					Clone().
+					Name("replacement").
+					UID("replacement-uid").
+					ManagedByKueueLabel().
+					PrebuiltWorkloadLabel("prebuilt-workload").
+					KueueFinalizer().
+					GroupNameLabel("test-group").
+					GroupTotalCount("1").
+					StatusPhase(corev1.PodRunning).
+					Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("prebuilt-workload", "ns").
+					Annotation(podconstants.IsGroupWorkloadAnnotationKey, podconstants.IsGroupWorkloadAnnotationValue).
+					PodSets(*utiltestingapi.MakePodSet(kueue.NewPodSetReference(podUID), 1).Request(corev1.ResourceCPU, "1").Obj()).
+					Queue(localUserQueueName).
+					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "running", "running-uid").
+					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "succeeded", "succeeded-uid").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(clusterQueueName)).PodSets(utiltestingapi.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(1).Obj()).Obj(), now).
+					AdmittedAt(true, now).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("prebuilt-workload", "ns").
+					Annotation(podconstants.IsGroupWorkloadAnnotationKey, podconstants.IsGroupWorkloadAnnotationValue).
+					PodSets(*utiltestingapi.MakePodSet(kueue.NewPodSetReference(podUID), 1).Request(corev1.ResourceCPU, "1").Obj()).
+					Queue(localUserQueueName).
+					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "running", "running-uid").
+					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "succeeded", "succeeded-uid").
+					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "replacement", "replacement-uid").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(clusterQueueName)).PodSets(utiltestingapi.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(1).Obj()).Obj(), now).
+					AdmittedAt(true, now).
+					Obj(),
+			},
+			workloadCmpOpts: defaultWorkloadCmpOpts,
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: "prebuilt-workload", Namespace: "ns"},
+					EventType: "Normal",
+					Reason:    "OwnerReferencesAdded",
+					Message:   "Added 1 owner reference(s)",
+				},
+			},
+		},
 		"when the prebuilt workload exists its owner info is updated": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{

--- a/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
@@ -1781,7 +1781,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 				})
 			})
 
-			ginkgo.It("Should ungate pods with prebuilt workload", framework.SlowSpec, func() {
+			ginkgo.It("Should replace deleting members of an admitted prebuilt workload", framework.SlowSpec, func() {
 				const (
 					workloadName = "test-workload"
 				)
@@ -1872,6 +1872,50 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 				ginkgo.By("Checking the second pod is unsuspended", func() {
 					util.ExpectPodUnsuspendedWithNodeSelectors(ctx, k8sClient, pod2LookupKey, map[string]string{corev1.LabelArchStable: "arm64"})
 				})
+
+				gomega.Expect(k8sClient.Get(ctx, wlLookupKey, wl)).To(gomega.Succeed())
+				workloadUID := wl.UID
+				admission := wl.Status.Admission.DeepCopy()
+				replacement := testingpod.MakePod("test-pod-replacement", ns.Name).
+					GroupNameLabel(workloadName).GroupTotalCount("2").
+					Request(corev1.ResourceCPU, "1").Queue(lq.Name).
+					PrebuiltWorkloadLabel(workloadName).RoleHash("leader").Obj()
+
+				ginkgo.By("Replacing a deleting, node-assigned Running member", func() {
+					util.BindPodWithNode(ctx, k8sClient, "node1", pod1, pod2)
+					util.SetPodsPhase(ctx, k8sClient, corev1.PodRunning, pod1, pod2)
+					gomega.Expect(k8sClient.Delete(ctx, pod1, client.GracePeriodSeconds(0))).To(gomega.Succeed())
+					gomega.Expect(k8sClient.Get(ctx, pod1LookupKey, pod1)).To(gomega.Succeed())
+					gomega.Expect(pod1.DeletionTimestamp.IsZero()).To(gomega.BeFalse())
+					gomega.Expect(pod1.Finalizers).To(gomega.ContainElement(podconstants.PodFinalizer))
+					util.MustCreate(ctx, k8sClient, replacement)
+				})
+
+				ginkgo.By("Finalizing the predecessor and admitting its replacement", func() {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, pod1, false)
+					util.ExpectPodUnsuspendedWithNodeSelectors(ctx, k8sClient, client.ObjectKeyFromObject(replacement), map[string]string{corev1.LabelArchStable: "arm64"})
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, wlLookupKey, wl)).To(gomega.Succeed())
+						g.Expect(wl.OwnerReferences).To(gomega.ContainElement(gomega.HaveField("UID", replacement.UID)))
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("Preserving admission, reserved quota, and the surviving member", func() {
+					gomega.Consistently(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, wlLookupKey, wl)).To(gomega.Succeed())
+						g.Expect(wl.UID).To(gomega.Equal(workloadUID))
+						g.Expect(wl.Status.Admission).To(gomega.Equal(admission))
+						g.Expect(wl.Status.Conditions).To(utiltesting.HaveConditionStatusTrue(kueue.WorkloadQuotaReserved))
+						g.Expect(wl.Status.Conditions).To(utiltesting.HaveConditionStatusTrue(kueue.WorkloadAdmitted))
+						g.Expect(wl.Status.Conditions).NotTo(utiltesting.HaveConditionStatusTrue(kueue.WorkloadFinished))
+						g.Expect(wl.Status.ReclaimablePods).To(gomega.BeEmpty())
+						survivingPod := &corev1.Pod{}
+						g.Expect(k8sClient.Get(ctx, pod2LookupKey, survivingPod)).To(gomega.Succeed())
+						g.Expect(survivingPod.UID).To(gomega.Equal(pod2.UID))
+						g.Expect(survivingPod.DeletionTimestamp.IsZero()).To(gomega.BeTrue())
+					}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+				})
+				pod1 = replacement
 
 				ginkgo.By("Finish pods", func() {
 					util.SetPodsPhase(ctx, k8sClient, corev1.PodSucceeded, pod1)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

/kind bug
/area integrations

#### What this PR does / why we need it:

Prebuilt composable Workloads bypass the ordinary Pod-group matching path. When an external
controller creates a replacement before kubelet records the deleting predecessor as terminal, the
predecessor can remain counted as an active member of the fixed-size group. A deleting Succeeded
predecessor can also publish reclaimable quota that the Workload cannot reacquire for its
replacement. This can leave the replacement gated while the predecessor remains blocked by Kueue's
finalizer.

This change runs the existing composable matching and cleanup path before validating a prebuilt
Workload. It treats only deleting prebuilt members as replacement predecessors, keeps their fixed
slots non-reclaimable, and finalizes an already-deleting prebuilt Pod when its Workload is missing so
deletion can complete.

Ordinary Pod groups are unchanged. This complements the serving-group eviction cleanup in #14632,
which handles terminated serving members during Kueue eviction; this change covers externally
replaced prebuilt groups, including groups that are not marked as serving.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

None. Related context: #13830 and #14632 address the distinct serving-group eviction path.

#### Special notes for your reviewer:

The implementation deliberately reuses `ComposableJob.FindMatchingWorkloads` instead of adding a
second prebuilt cleanup algorithm. All new behavior is guarded by an explicit prebuilt Workload
identifier and a non-zero deletion timestamp.

The reconciler tests cover both affected edge cases:

- a prebuilt Workload is missing while its Kueue-finalized member is already deleting; and
- deleting Failed and Succeeded predecessors coexist with a live replacement under one admitted,
  fixed-size prebuilt Workload.

The replacement case verifies that the replacement remains, receives Workload ownership, preserves
the existing admission, and does not create `reclaimablePods` status.

Validation performed on current upstream `main`:

e2e testing in dev + currently deployed in our prod environment combined with https://github.com/ai-dynamo/grove/pull/707 and some private patches with TAS enabled on GB300 multi-node GPU replicas

basic tests too

```text
go test ./pkg/controller/jobframework ./pkg/controller/jobs/pod
go test -race ./pkg/controller/jobframework ./pkg/controller/jobs/pod
golangci-lint run ./pkg/controller/jobframework ./pkg/controller/jobs/pod
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
Prebuilt Pod groups now clean up deleting replaced members without releasing their fixed quota or
leaving Pods blocked by Kueue's finalizer when the prebuilt Workload is missing.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of prebuilt pod groups when members are deleted or replaced.
  - Replacement pods can now take over reserved workload slots without being blocked by terminating members.
  - Obsolete pod members are finalized correctly while preserving quota for slots still in use.
  - Improved workload matching and support for mirrored MultiKueue pod members.
  - Preserved workload admission status and ownership during pod replacement.
- **Tests**
  - Added coverage for deleted, failed, succeeded, mirrored, and replacement pods in prebuilt groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->