### PR TITLE
kueuectl: Use UID precondition when deleting owners

### DIFF
--- a/cmd/kueuectl/app/delete/delete_workload.go
+++ b/cmd/kueuectl/app/delete/delete_workload.go
@@ -350,9 +350,7 @@ func (o *WorkloadOptions) deleteWorkloads(ctx context.Context, workloadNameResou
 
 		for _, nr := range nrs {
 			resourceDeleteOptions := deleteOptions
-			if nr.UID != "" {
-				resourceDeleteOptions.Preconditions = &metav1.Preconditions{UID: &nr.UID}
-			}
+			resourceDeleteOptions.Preconditions = &metav1.Preconditions{UID: &nr.UID}
 			if o.DryRunStrategy != dryrun.Client {
 				if err := o.DynamicClient.Resource(nr.GroupVersionResource).Namespace(wl.Namespace).
 					Delete(ctx, nr.Name, resourceDeleteOptions); client.IgnoreNotFound(err) != nil {

--- a/cmd/kueuectl/app/delete/delete_workload.go
+++ b/cmd/kueuectl/app/delete/delete_workload.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
@@ -174,17 +175,14 @@ func (o *WorkloadOptions) Complete(clientGetter clientgetter.ClientGetter, cmd *
 	return nil
 }
 
-type GroupVersionResourceName struct {
+type GroupVersionResourceRef struct {
 	schema.GroupVersionResource
 	Name string
+	UID  types.UID
 }
 
-func (g GroupVersionResourceName) String() string {
+func (g GroupVersionResourceRef) String() string {
 	return strings.Join([]string{g.GroupResource().String(), g.Name}, "/")
-}
-
-func GroupVersionResourceWithName(gvr schema.GroupVersionResource, name string) GroupVersionResourceName {
-	return GroupVersionResourceName{GroupVersionResource: gvr, Name: name}
 }
 
 // Run delete a resource
@@ -279,11 +277,11 @@ func (o *WorkloadOptions) getWorkloads(ctx context.Context) ([]*kueue.Workload, 
 	return workloads, haveAssociatedWorkloads, nil
 }
 
-func (o *WorkloadOptions) getWorkloadResources(workloads []*kueue.Workload) (map[*kueue.Workload][]GroupVersionResourceName, error) {
-	workloadResources := make(map[*kueue.Workload][]GroupVersionResourceName, len(workloads))
+func (o *WorkloadOptions) getWorkloadResources(workloads []*kueue.Workload) (map[*kueue.Workload][]GroupVersionResourceRef, error) {
+	workloadResources := make(map[*kueue.Workload][]GroupVersionResourceRef, len(workloads))
 
 	for _, wl := range workloads {
-		workloadResources[wl] = make([]GroupVersionResourceName, 0, len(wl.OwnerReferences))
+		workloadResources[wl] = make([]GroupVersionResourceRef, 0, len(wl.OwnerReferences))
 
 		for _, or := range wl.OwnerReferences {
 			gv, err := schema.ParseGroupVersion(or.APIVersion)
@@ -296,14 +294,18 @@ func (o *WorkloadOptions) getWorkloadResources(workloads []*kueue.Workload) (map
 				return nil, err
 			}
 
-			workloadResources[wl] = append(workloadResources[wl], GroupVersionResourceWithName(mapping.Resource, or.Name))
+			workloadResources[wl] = append(workloadResources[wl], GroupVersionResourceRef{
+				GroupVersionResource: mapping.Resource,
+				Name:                 or.Name,
+				UID:                  or.UID,
+			})
 		}
 	}
 
 	return workloadResources, nil
 }
 
-func (o *WorkloadOptions) generateConfirmationMessage(workloadResources map[*kueue.Workload][]GroupVersionResourceName) string {
+func (o *WorkloadOptions) generateConfirmationMessage(workloadResources map[*kueue.Workload][]GroupVersionResourceRef) string {
 	associatedResources := make([]string, 0, len(workloadResources))
 
 	for wl, resources := range workloadResources {
@@ -338,7 +340,7 @@ func (o *WorkloadOptions) confirmation(message string) bool {
 	return strings.EqualFold(input, "y")
 }
 
-func (o *WorkloadOptions) deleteWorkloads(ctx context.Context, workloadNameResources map[*kueue.Workload][]GroupVersionResourceName) error {
+func (o *WorkloadOptions) deleteWorkloads(ctx context.Context, workloadNameResources map[*kueue.Workload][]GroupVersionResourceRef) error {
 	for wl, nrs := range workloadNameResources {
 		deleteOptions := metav1.DeleteOptions{}
 
@@ -347,9 +349,13 @@ func (o *WorkloadOptions) deleteWorkloads(ctx context.Context, workloadNameResou
 		}
 
 		for _, nr := range nrs {
+			resourceDeleteOptions := deleteOptions
+			if nr.UID != "" {
+				resourceDeleteOptions.Preconditions = &metav1.Preconditions{UID: &nr.UID}
+			}
 			if o.DryRunStrategy != dryrun.Client {
 				if err := o.DynamicClient.Resource(nr.GroupVersionResource).Namespace(wl.Namespace).
-					Delete(ctx, nr.Name, deleteOptions); client.IgnoreNotFound(err) != nil {
+					Delete(ctx, nr.Name, resourceDeleteOptions); client.IgnoreNotFound(err) != nil {
 					return err
 				}
 			}

--- a/cmd/kueuectl/app/delete/delete_workload_test.go
+++ b/cmd/kueuectl/app/delete/delete_workload_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
@@ -55,7 +56,7 @@ func TestWorkloadCmd(t *testing.T) {
 		wantOut       string
 		wantOutErr    string
 		wantErr       string
-		wantDeleteUID string
+		wantDeleteUID map[string]types.UID
 	}{
 		"no arguments": {
 			args:    []string{},
@@ -64,21 +65,21 @@ func TestWorkloadCmd(t *testing.T) {
 		"shouldn't delete a workload and its corresponding job without confirmation": {
 			args: []string{"wl1"},
 			workloads: []runtime.Object{
-				utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "").Obj(),
+				utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "j1-uid").Obj(),
 			},
 			jobs: []runtime.Object{
-				&bactchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j1", Namespace: metav1.NamespaceDefault}},
+				&bactchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j1", Namespace: metav1.NamespaceDefault, UID: "j1-uid"}},
 			},
 			gvk: schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"},
 			wantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "").Obj(),
+				*utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "j1-uid").Obj(),
 			},
 			wantJobList: &bactchv1.JobList{
 				TypeMeta: metav1.TypeMeta{Kind: "JobList", APIVersion: "batch/v1"},
 				Items: []bactchv1.Job{
 					{
 						TypeMeta:   metav1.TypeMeta{Kind: "Job", APIVersion: "batch/v1"},
-						ObjectMeta: metav1.ObjectMeta{Name: "j1", Namespace: metav1.NamespaceDefault},
+						ObjectMeta: metav1.ObjectMeta{Name: "j1", Namespace: metav1.NamespaceDefault, UID: "j1-uid"},
 					},
 				},
 			},
@@ -90,23 +91,23 @@ Do you want to proceed (y/n)? Deletion is canceled
 		"should delete just a workload without confirmation because there is no associated job requiring it": {
 			args: []string{"wl2"},
 			workloads: []runtime.Object{
-				utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "").Obj(),
+				utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "j1-uid").Obj(),
 				utiltestingapi.MakeWorkload("wl2", metav1.NamespaceDefault).Obj(),
 			},
 			jobs: []runtime.Object{
-				&bactchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j1", Namespace: metav1.NamespaceDefault}},
+				&bactchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j1", Namespace: metav1.NamespaceDefault, UID: "j1-uid"}},
 				&bactchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j2", Namespace: metav1.NamespaceDefault}},
 			},
 			gvk: schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"},
 			wantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "").Obj(),
+				*utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "j1-uid").Obj(),
 			},
 			wantJobList: &bactchv1.JobList{
 				TypeMeta: metav1.TypeMeta{Kind: "JobList", APIVersion: "batch/v1"},
 				Items: []bactchv1.Job{
 					{
 						TypeMeta:   metav1.TypeMeta{Kind: "Job", APIVersion: "batch/v1"},
-						ObjectMeta: metav1.ObjectMeta{Name: "j1", Namespace: metav1.NamespaceDefault},
+						ObjectMeta: metav1.ObjectMeta{Name: "j1", Namespace: metav1.NamespaceDefault, UID: "j1-uid"},
 					},
 					{
 						TypeMeta:   metav1.TypeMeta{Kind: "Job", APIVersion: "batch/v1"},
@@ -124,16 +125,16 @@ Do you want to proceed (y/n)? Deletion is canceled
 			args:  []string{"wl1"},
 			input: "y\n",
 			workloads: []runtime.Object{
-				utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "").Obj(),
+				utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "j1-uid").Obj(),
 				utiltestingapi.MakeWorkload("wl2", metav1.NamespaceDefault).Obj(),
 			},
 			jobs: []runtime.Object{
-				&bactchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j1", Namespace: metav1.NamespaceDefault}},
+				&bactchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j1", Namespace: metav1.NamespaceDefault, UID: "j1-uid"}},
 				&bactchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j2", Namespace: metav1.NamespaceDefault}},
 			},
 			gvk: schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"},
 			wantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "").Obj(),
+				*utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "j1-uid").Obj(),
 				*utiltestingapi.MakeWorkload("wl2", metav1.NamespaceDefault).Obj(),
 			},
 			wantJobList: &bactchv1.JobList{
@@ -149,6 +150,7 @@ Do you want to proceed (y/n)? Deletion is canceled
   - jobs.batch/j1 associated with the default/wl1 workload
 Do you want to proceed (y/n)? jobs.batch/j1 deleted
 `,
+			wantDeleteUID: map[string]types.UID{"j1": "j1-uid"},
 		},
 		"should delete jobs corresponding to the workload with yes flag": {
 			args: []string{"wl1", "--yes"},
@@ -175,22 +177,51 @@ Do you want to proceed (y/n)? jobs.batch/j1 deleted
 				},
 			},
 			wantOut:       "jobs.batch/j1 deleted\n",
-			wantDeleteUID: "job-uid",
+			wantDeleteUID: map[string]types.UID{"j1": "job-uid"},
+		},
+		"should delete multiple owners with their UID preconditions": {
+			args: []string{"wl1", "--yes"},
+			workloads: []runtime.Object{
+				utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).
+					OwnerReference(jobGVK, "j1", "j1-uid").
+					OwnerReference(jobGVK, "j2", "j2-uid").
+					Obj(),
+			},
+			jobs: []runtime.Object{
+				&bactchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j1", Namespace: metav1.NamespaceDefault, UID: "j1-uid"}},
+				&bactchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j2", Namespace: metav1.NamespaceDefault, UID: "j2-uid"}},
+			},
+			gvk: schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).
+					OwnerReference(jobGVK, "j1", "j1-uid").
+					OwnerReference(jobGVK, "j2", "j2-uid").
+					Obj(),
+			},
+			wantJobList: &bactchv1.JobList{
+				TypeMeta: metav1.TypeMeta{Kind: "JobList", APIVersion: "batch/v1"},
+				Items:    []bactchv1.Job{},
+			},
+			wantOut: "jobs.batch/j1 deleted\njobs.batch/j2 deleted\n",
+			wantDeleteUID: map[string]types.UID{
+				"j1": "j1-uid",
+				"j2": "j2-uid",
+			},
 		},
 		"should delete all jobs corresponding to the workloads and any workloads without corresponding jobs in default namespace": {
 			args: []string{"--all", "--yes"},
 			workloads: []runtime.Object{
-				utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "").Obj(),
+				utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "j1-uid").Obj(),
 				utiltestingapi.MakeWorkload("wl2", metav1.NamespaceDefault).Obj(),
 				utiltestingapi.MakeWorkload("wl3", "test").Obj(),
 			},
 			jobs: []runtime.Object{
-				&bactchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j1", Namespace: metav1.NamespaceDefault}},
+				&bactchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j1", Namespace: metav1.NamespaceDefault, UID: "j1-uid"}},
 				&bactchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j2", Namespace: metav1.NamespaceDefault}},
 			},
 			gvk: schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"},
 			wantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "").Obj(),
+				*utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "j1-uid").Obj(),
 				*utiltestingapi.MakeWorkload("wl3", "test").Obj(),
 			},
 			wantJobList: &bactchv1.JobList{
@@ -203,22 +234,23 @@ Do you want to proceed (y/n)? jobs.batch/j1 deleted
 				},
 			},
 			// We do not know in which order the result will be displayed.
-			ignoreOut: true,
+			ignoreOut:     true,
+			wantDeleteUID: map[string]types.UID{"j1": "j1-uid"},
 		},
 		"should delete all jobs corresponding to the workloads and any workloads without corresponding jobs in all namespaces": {
 			args: []string{"--all", "-y", "-A"},
 			workloads: []runtime.Object{
-				utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "").Obj(),
+				utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "j1-uid").Obj(),
 				utiltestingapi.MakeWorkload("wl2", metav1.NamespaceDefault).Obj(),
 				utiltestingapi.MakeWorkload("wl3", "test").Obj(),
 			},
 			jobs: []runtime.Object{
-				&bactchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j1", Namespace: metav1.NamespaceDefault}},
+				&bactchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j1", Namespace: metav1.NamespaceDefault, UID: "j1-uid"}},
 				&bactchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j2", Namespace: metav1.NamespaceDefault}},
 			},
 			gvk: schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"},
 			wantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "").Obj(),
+				*utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "j1-uid").Obj(),
 			},
 			wantJobList: &bactchv1.JobList{
 				TypeMeta: metav1.TypeMeta{Kind: "JobList", APIVersion: "batch/v1"},
@@ -230,26 +262,27 @@ Do you want to proceed (y/n)? jobs.batch/j1 deleted
 				},
 			},
 			// We do not know in which order the result will be displayed.
-			ignoreOut: true,
+			ignoreOut:     true,
+			wantDeleteUID: map[string]types.UID{"j1": "j1-uid"},
 		},
 		"shouldn't delete the jobs corresponding to the workloads jobs when using client dry-run flag": {
 			args: []string{"wl1", "--dry-run", "client"},
 			workloads: []runtime.Object{
-				utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "").Obj(),
+				utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "j1-uid").Obj(),
 			},
 			jobs: []runtime.Object{
-				&bactchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j1", Namespace: metav1.NamespaceDefault}},
+				&bactchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j1", Namespace: metav1.NamespaceDefault, UID: "j1-uid"}},
 			},
 			gvk: schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"},
 			wantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "").Obj(),
+				*utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "j1-uid").Obj(),
 			},
 			wantJobList: &bactchv1.JobList{
 				TypeMeta: metav1.TypeMeta{Kind: "JobList", APIVersion: "batch/v1"},
 				Items: []bactchv1.Job{
 					{
 						TypeMeta:   metav1.TypeMeta{Kind: "Job", APIVersion: "batch/v1"},
-						ObjectMeta: metav1.ObjectMeta{Name: "j1", Namespace: metav1.NamespaceDefault},
+						ObjectMeta: metav1.ObjectMeta{Name: "j1", Namespace: metav1.NamespaceDefault, UID: "j1-uid"},
 					},
 				},
 			},
@@ -258,25 +291,26 @@ Do you want to proceed (y/n)? jobs.batch/j1 deleted
 		"shouldn't delete the jobs corresponding to the workloads jobs when using server dry-run flag": {
 			args: []string{"wl1", "--dry-run", "server"},
 			workloads: []runtime.Object{
-				utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "").Obj(),
+				utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "j1-uid").Obj(),
 			},
 			jobs: []runtime.Object{
-				&bactchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j1", Namespace: metav1.NamespaceDefault}},
+				&bactchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j1", Namespace: metav1.NamespaceDefault, UID: "j1-uid"}},
 			},
 			gvk: schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"},
 			wantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "").Obj(),
+				*utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "j1-uid").Obj(),
 			},
 			wantJobList: &bactchv1.JobList{
 				TypeMeta: metav1.TypeMeta{Kind: "JobList", APIVersion: "batch/v1"},
 				Items: []bactchv1.Job{
 					{
 						TypeMeta:   metav1.TypeMeta{Kind: "Job", APIVersion: "batch/v1"},
-						ObjectMeta: metav1.ObjectMeta{Name: "j1", Namespace: metav1.NamespaceDefault},
+						ObjectMeta: metav1.ObjectMeta{Name: "j1", Namespace: metav1.NamespaceDefault, UID: "j1-uid"},
 					},
 				},
 			},
-			wantOut: "jobs.batch/j1 deleted (server dry run)\n",
+			wantOut:       "jobs.batch/j1 deleted (server dry run)\n",
+			wantDeleteUID: map[string]types.UID{"j1": "j1-uid"},
 		},
 	}
 	for name, tc := range testCases {
@@ -308,11 +342,15 @@ Do you want to proceed (y/n)? jobs.batch/j1 deleted
 					t.Fatal(err)
 				}
 				dynamicClient.PrependReactor("delete", mapping.Resource.Resource, func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
-					if tc.wantDeleteUID != "" {
-						preconditions := action.(kubetesting.DeleteAction).GetDeleteOptions().Preconditions
-						if preconditions == nil || preconditions.UID == nil || string(*preconditions.UID) != tc.wantDeleteUID {
-							t.Errorf("Unexpected delete UID precondition: %v", preconditions)
+					deleteAction := action.(kubetesting.DeleteAction)
+					preconditions := deleteAction.GetDeleteOptions().Preconditions
+					wantUID, wantPreconditions := tc.wantDeleteUID[deleteAction.GetName()]
+					if !wantPreconditions {
+						if preconditions != nil {
+							t.Errorf("Unexpected delete preconditions for %q: %v", deleteAction.GetName(), preconditions)
 						}
+					} else if preconditions == nil || preconditions.UID == nil || *preconditions.UID != wantUID {
+						t.Errorf("Unexpected delete UID precondition for %q: %v", deleteAction.GetName(), preconditions)
 					}
 					// SimpleDynamicClient still don't have DryRun option on delete Reactor.
 					if slices.Contains(tc.args, "--dry-run") {

--- a/cmd/kueuectl/app/delete/delete_workload_test.go
+++ b/cmd/kueuectl/app/delete/delete_workload_test.go
@@ -55,6 +55,7 @@ func TestWorkloadCmd(t *testing.T) {
 		wantOut       string
 		wantOutErr    string
 		wantErr       string
+		wantDeleteUID string
 	}{
 		"no arguments": {
 			args:    []string{},
@@ -152,16 +153,16 @@ Do you want to proceed (y/n)? jobs.batch/j1 deleted
 		"should delete jobs corresponding to the workload with yes flag": {
 			args: []string{"wl1", "--yes"},
 			workloads: []runtime.Object{
-				utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "").Obj(),
+				utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "job-uid").Obj(),
 				utiltestingapi.MakeWorkload("wl2", metav1.NamespaceDefault).Obj(),
 			},
 			jobs: []runtime.Object{
-				&bactchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j1", Namespace: metav1.NamespaceDefault}},
+				&bactchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j1", Namespace: metav1.NamespaceDefault, UID: "job-uid"}},
 				&bactchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "j2", Namespace: metav1.NamespaceDefault}},
 			},
 			gvk: schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"},
 			wantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "").Obj(),
+				*utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).OwnerReference(jobGVK, "j1", "job-uid").Obj(),
 				*utiltestingapi.MakeWorkload("wl2", metav1.NamespaceDefault).Obj(),
 			},
 			wantJobList: &bactchv1.JobList{
@@ -173,7 +174,8 @@ Do you want to proceed (y/n)? jobs.batch/j1 deleted
 					},
 				},
 			},
-			wantOut: "jobs.batch/j1 deleted\n",
+			wantOut:       "jobs.batch/j1 deleted\n",
+			wantDeleteUID: "job-uid",
 		},
 		"should delete all jobs corresponding to the workloads and any workloads without corresponding jobs in default namespace": {
 			args: []string{"--all", "--yes"},
@@ -306,6 +308,12 @@ Do you want to proceed (y/n)? jobs.batch/j1 deleted
 					t.Fatal(err)
 				}
 				dynamicClient.PrependReactor("delete", mapping.Resource.Resource, func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+					if tc.wantDeleteUID != "" {
+						preconditions := action.(kubetesting.DeleteAction).GetDeleteOptions().Preconditions
+						if preconditions == nil || preconditions.UID == nil || string(*preconditions.UID) != tc.wantDeleteUID {
+							t.Errorf("Unexpected delete UID precondition: %v", preconditions)
+						}
+					}
 					// SimpleDynamicClient still don't have DryRun option on delete Reactor.
 					if slices.Contains(tc.args, "--dry-run") {
 						handled = true


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Preserves the UID from each Workload owner reference and uses it as a delete precondition when `kueuectl delete workload` removes the associated resource. This prevents a stale Workload from deleting a replacement object that reused the original owner's name.

#### Which issue(s) this PR fixes:

Fixes #14830

#### Special notes for your reviewer:

This PR was written in part with the assistance of generative AI.

#### Does this PR introduce a user-facing change?

```release-note
KueueCtl: Fixed a bug where `kueuectl delete workload` deleted a recreated owner with a different UID.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workload-associated resources are now deleted only when their recorded UID matches, preventing accidental deletion of newly recreated resources with the same name.
  * Resource ownership details are preserved during workload deletion, enabling safer cleanup of associated resources.

* **Tests**
  * Expanded coverage for confirmation, bulk, multi-owner, and server dry-run deletion scenarios.
  * Added validation that each deletion request uses the correct resource UID precondition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->