### PR TITLE
test: improve test coverage for failed preemptions in scheduler

### DIFF
--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"maps"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -31,6 +32,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -9855,5 +9857,115 @@ func TestFitsDedupsOverlappingVictims(t *testing.T) {
 	got := fits(snapshot, cq, &incomingUsage, preempted, targets)
 	if got != schdcache.FitsCheckNoQuota {
 		t.Fatalf("fits() = %v, want %v (overlapping victim must be subtracted once)", got, schdcache.FitsCheckNoQuota)
+	}
+}
+func TestSchedulerWhenPreemptionFails(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	ctx, log := utiltesting.ContextWithLog(t)
+
+	ns := utiltesting.MakeNamespaceWrapper("default").Obj()
+	rf := utiltestingapi.MakeResourceFlavor("default").Obj()
+	cq := utiltestingapi.MakeClusterQueue("cq").
+		ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("default").
+				Resource(corev1.ResourceCPU, "3").
+				Obj(),
+		).
+		Preemption(kueue.ClusterQueuePreemption{
+			WithinClusterQueue: kueue.PreemptionPolicyLowerPriority,
+		}).
+		Obj()
+	lq := utiltestingapi.MakeLocalQueue("lq", metav1.NamespaceDefault).ClusterQueue(cq.Name).Obj()
+
+	targetWl := utiltestingapi.MakeWorkload("target-wl", metav1.NamespaceDefault).
+		Priority(-1).
+		Queue(kueue.LocalQueueName(lq.Name)).
+		PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+			Request(corev1.ResourceCPU, "3").
+			Obj()).
+		ReserveQuotaAt(
+			utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(cq.Name)).
+				PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceCPU, "default", "3").
+					Obj()).
+				Obj(),
+			now,
+		).
+		Obj()
+
+	preemptorWl := utiltestingapi.MakeWorkload("preemptor-wl", metav1.NamespaceDefault).
+		Priority(1).
+		Queue(kueue.LocalQueueName(lq.Name)).
+		PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+			Request(corev1.ResourceCPU, "3").
+			Obj()).
+		Obj()
+
+	clientBuilder := utiltesting.NewClientBuilder().
+		WithObjects(ns, rf, cq, lq, targetWl, preemptorWl).
+		WithStatusSubresource(&kueue.Workload{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourcePatch: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+				if wl, ok := obj.(*kueue.Workload); ok && subResourceName == "status" && wl.Name == "target-wl" {
+					return errors.New("simulated eviction patch error")
+				}
+				return utiltesting.TreatSSAAsStrategicMerge(ctx, c, subResourceName, obj, patch, opts...)
+			},
+		})
+	cl := clientBuilder.Build()
+	recorder := &utiltesting.EventRecorder{}
+
+	cqCache := schdcache.New(cl)
+	qManager := qcache.NewManagerForUnitTests(cl, cqCache)
+
+	cqCache.AddOrUpdateResourceFlavor(log, rf)
+	if err := cqCache.AddClusterQueue(ctx, cq); err != nil {
+		t.Fatalf("Inserting clusterQueue %s in cache: %v", cq.Name, err)
+	}
+	if err := qManager.AddClusterQueue(ctx, cq); err != nil {
+		t.Fatalf("Inserting clusterQueue %s in manager: %v", cq.Name, err)
+	}
+	if err := qManager.AddLocalQueue(ctx, lq); err != nil {
+		t.Fatalf("Inserting queue %s/%s in manager: %v", lq.Namespace, lq.Name, err)
+	}
+
+	scheduler := New(qManager, cqCache, cl, recorder, WithClock(t, testingclock.NewFakeClock(now)), WithPreemptionExpectations(preemptexpectations.New()))
+
+	wg := sync.WaitGroup{}
+	scheduler.setAdmissionRoutineWrapper(routine.NewWrapper(
+		func() { wg.Add(1) },
+		func() { wg.Done() },
+	))
+
+	ctx, cancel := context.WithTimeout(ctx, queueingTimeout)
+	go qManager.CleanUpOnContext(ctx)
+	defer cancel()
+
+	scheduler.schedule(ctx)
+	wg.Wait()
+
+	gotPreemptor := &kueue.Workload{}
+	if err := cl.Get(ctx, client.ObjectKeyFromObject(preemptorWl), gotPreemptor); err != nil {
+		t.Fatalf("Failed getting preemptor workload: %v", err)
+	}
+
+	cond := apimeta.FindStatusCondition(gotPreemptor.Status.Conditions, kueue.WorkloadQuotaReserved)
+	if cond == nil {
+		t.Fatal("Expected QuotaReserved condition on preemptor workload")
+	}
+	if cond.Status != metav1.ConditionFalse {
+		t.Errorf("Expected QuotaReserved=False, got %v", cond.Status)
+	}
+	if !strings.Contains(cond.Message, "Preempting 1 workload(s) failed, will retry.") {
+		t.Errorf("Unexpected condition message: %q", cond.Message)
+	}
+
+	// Verify preemptor is requeued into active workloads
+	qDump := qManager.Dump()
+	wantActive := map[kueue.ClusterQueueReference][]workload.Reference{
+		kueue.ClusterQueueReference(cq.Name): {workload.Key(preemptorWl)},
+	}
+	if diff := cmp.Diff(wantActive, qDump, cmpDump...); diff != "" {
+		t.Errorf("Unexpected active workloads (-want,+got):\n%s", diff)
 	}
 }

--- a/test/integration/singlecluster/scheduler/preemption_test.go
+++ b/test/integration/singlecluster/scheduler/preemption_test.go
@@ -210,6 +210,61 @@ var _ = ginkgo.Describe("Preemption", func() {
 			gomega.Expect(attempt.Load()).To(gomega.BeNumerically(">=", 2))
 		})
 
+		ginkgo.It("Should not make failed preemptor sticky under BestEffortFIFO and allow subsequent workloads to be admitted", func() {
+			setFakeSubResourcePatchSpec(func(obj client.Object) (fakeClientUsage, error) {
+				wl, ok := obj.(*kueue.Workload)
+				if !ok {
+					return fallThrough, nil
+				}
+				if cond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadEvicted); cond == nil || cond.Status != metav1.ConditionTrue {
+					return fallThrough, nil
+				}
+				// Ignore patches triggered by util.FinishEvictionForWorkloads()
+				if cond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadQuotaReserved); cond != nil && cond.Status == metav1.ConditionFalse && cond.Message == "By test" {
+					return fallThrough, nil
+				}
+				return emitResponse, errors.New("simulate API server error while preempting workload")
+			})
+
+			ginkgo.By("Creating a low priority Workload consuming 3 CPUs")
+			lowWl := utiltestingapi.MakeWorkload("low-wl", ns.Name).
+				Queue(kueue.LocalQueueName(q.Name)).
+				Priority(lowPriority).
+				Request(corev1.ResourceCPU, "3").
+				Obj()
+			util.MustCreate(ctx, k8sClient, lowWl)
+			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, cq.Name, lowWl)
+
+			ginkgo.By("Creating a mid priority Workload requiring 3 CPUs (triggers preemption which fails)")
+			failedPreemptorWl := utiltestingapi.MakeWorkload("failed-preemptor-wl", ns.Name).
+				Queue(kueue.LocalQueueName(q.Name)).
+				Priority(midPriority).
+				Request(corev1.ResourceCPU, "3").
+				Obj()
+			util.MustCreate(ctx, k8sClient, failedPreemptorWl)
+
+			ginkgo.By("Waiting for failed preemption on mid-priority workload to be recorded")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(failedPreemptorWl), failedPreemptorWl)).To(gomega.Succeed())
+				cond := apimeta.FindStatusCondition(failedPreemptorWl.Status.Conditions, kueue.WorkloadQuotaReserved)
+				g.Expect(cond).NotTo(gomega.BeNil())
+				g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionFalse))
+				g.Expect(cond.Message).To(gomega.ContainSubstring("failed, will retry"))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Creating a subsequent higher priority Workload requiring 1 CPU that fits in remaining quota")
+			higherPriorityWl := utiltestingapi.MakeWorkload("higher-priority-wl", ns.Name).
+				Queue(kueue.LocalQueueName(q.Name)).
+				Priority(highPriority).
+				Request(corev1.ResourceCPU, "1").
+				Obj()
+			util.MustCreate(ctx, k8sClient, higherPriorityWl)
+
+			ginkgo.By("Verifying higher priority workload is admitted while failed preemptor remains pending (not sticky)")
+			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, cq.Name, lowWl, higherPriorityWl)
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, failedPreemptorWl)
+		})
+
 		ginkgo.It("Should preempt newer Workloads with the same priority when there is not enough quota", framework.SlowSpec, func() {
 			ginkgo.By("Creating initial Workloads")
 			wl1 := utiltestingapi.MakeWorkload("wl-1", ns.Name).


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind test

#### What this PR does / why we need it:
This PR improves test coverage for failed preemptions introduced in #7665, addressing #7806 and following up on #10894:

1. **Unit Tests in `pkg/scheduler`**:
   - Adds `TestSchedulerWhenPreemptionFails` to verify full scheduler loop execution when preemption eviction patching fails, asserting that `QuotaReserved=False` with `"Preempting 1 workload(s) failed, will retry."` is recorded and the workload is requeued into active workloads with `RequeueReasonPreemptionFailed`.

2. **Integration Tests in `test/integration/singlecluster/scheduler`**:
   - Adds integration spec `"Should not make failed preemptor sticky under BestEffortFIFO and allow subsequent workloads to be admitted"`, proving in a live cluster environment that a workload with `RequeueReasonPreemptionFailed` does not block subsequent eligible workloads from obtaining quota reservation under `BestEffortFIFO`.

#### Which issue(s) this PR fixes:
Fixes #7806

#### Special notes for your reviewer:
Follow-up to #7665, #7157, and #10894.


#### Does this PR introduce a user-facing change?
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workload scheduling when preemption attempts fail.
  * Failed preemptors are retried instead of remaining stuck.
  * Higher-priority workloads that fit available quota can still be admitted after a failed preemption attempt.
  * Workloads now receive a clear status message when preemption fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->