### PR TITLE
Rely on admission count when ungating pods

### DIFF
--- a/pkg/controller/elasticjobs/elastic_job_ungater.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater.go
@@ -305,7 +305,7 @@ func (r *elasticJobUngater) podsToUngate(ctx context.Context, wl *kueue.Workload
 		return nil, fmt.Errorf("listing pods for workload slice: %w", err)
 	}
 
-	granted := workload.ExtractPodSetAssignmentsCounts(wl.Status.Admission.PodSetAssignments)
+	granted := workload.ExtractGrantedPodSetCounts(wl)
 	gatedPerPodSet := make(map[kueue.PodSetReference][]*corev1.Pod)
 	ungatedPerPodSet := make(map[kueue.PodSetReference]int32)
 	admissionUpdates := make(map[kueue.PodSetReference]podAdmissionUpdate)

--- a/pkg/controller/elasticjobs/elastic_job_ungater.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater.go
@@ -305,7 +305,7 @@ func (r *elasticJobUngater) podsToUngate(ctx context.Context, wl *kueue.Workload
 		return nil, fmt.Errorf("listing pods for workload slice: %w", err)
 	}
 
-	granted := workload.ExtractPodSetCountsFromWorkload(wl)
+	granted := workload.ExtractPodSetAssignmentsCounts(wl.Status.Admission.PodSetAssignments)
 	gatedPerPodSet := make(map[kueue.PodSetReference][]*corev1.Pod)
 	ungatedPerPodSet := make(map[kueue.PodSetReference]int32)
 	admissionUpdates := make(map[kueue.PodSetReference]podAdmissionUpdate)

--- a/pkg/controller/elasticjobs/elastic_job_ungater_test.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater_test.go
@@ -78,6 +78,7 @@ func makeAdmittedTwoPodSetWorkload(now time.Time) *kueue.Workload {
 						Obj(),
 					utiltestingapi.MakePodSetAssignment(workersPodSet).
 						Assignment(corev1.ResourceCPU, "flavor", "2").
+						Count(2).
 						Obj(),
 				).
 				Obj(), now,
@@ -246,6 +247,7 @@ func TestReconcile(t *testing.T) {
 						utiltestingapi.MakeAdmission("cq").
 							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
 								Assignment(corev1.ResourceCPU, "flavor", "3").
+								Count(3).
 								Obj()).
 							Obj(), now,
 					).
@@ -406,6 +408,7 @@ func TestReconcile(t *testing.T) {
 						utiltestingapi.MakeAdmission("cq").
 							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
 								Assignment(corev1.ResourceCPU, "flavor", "2").
+								Count(2).
 								Obj()).
 							Obj(), now,
 					).
@@ -890,6 +893,7 @@ func TestReconcile(t *testing.T) {
 						utiltestingapi.MakeAdmission("cq").
 							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
 								Assignment(corev1.ResourceCPU, "flavor", "3").
+								Count(3).
 								Obj()).
 							Obj(), now,
 					).
@@ -984,6 +988,7 @@ func TestReconcile(t *testing.T) {
 						utiltestingapi.MakeAdmission("cq").
 							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
 								Assignment(corev1.ResourceCPU, "flavor", "2").
+								Count(2).
 								Obj()).
 							Obj(), now,
 					).

--- a/pkg/workload/podsetscounts.go
+++ b/pkg/workload/podsetscounts.go
@@ -64,6 +64,18 @@ func ExtractPodSetCounts(podSets []kueue.PodSet) PodSetsCounts {
 	})
 }
 
+// ExtractPodSetAssignmentsCounts builds a PodSetsCounts map from a list of PodSetAssignments.
+// Each entry maps PodSet name to its replica count.
+func ExtractPodSetAssignmentsCounts(podSets []kueue.PodSetAssignment) PodSetsCounts {
+	return utilslices.ToMap(podSets, func(i int) (kueue.PodSetReference, int32) {
+		val := int32(0)
+		if podSets[i].Count != nil {
+			val = *podSets[i].Count
+		}
+		return podSets[i].Name, val
+	})
+}
+
 // ExtractPodSetCountsFromWorkload returns a PodSetsCounts map derived from the provided Workload.
 //
 // Important: This function assumes the Workload is not nil. It does not perform a nil check,

--- a/pkg/workload/podsetscounts.go
+++ b/pkg/workload/podsetscounts.go
@@ -19,6 +19,8 @@ package workload
 import (
 	"maps"
 
+	"k8s.io/utils/ptr"
+
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	utilslices "sigs.k8s.io/kueue/pkg/util/slices"
 )
@@ -70,8 +72,8 @@ func ExtractGrantedPodSetCounts(wl *kueue.Workload) PodSetsCounts {
 	if wl.Status.Admission == nil {
 		return nil
 	}
-	counts := ExtractPodSetSetCountsFromWorkload(wl)
-	granted := make(PodSetCounts, len(wl.Status.Admission.PodSetAssignments))
+	counts := ExtractPodSetCounts(wl.Spec.PodSets)
+	granted := make(PodSetsCounts, len(wl.Status.Admission.PodSetAssignments))
 	for _, psa := range wl.Status.Admission.PodSetAssignments {
 		count := counts[psa.Name]
 		granted[psa.Name] = min(ptr.Deref(psa.Count, count), count)

--- a/pkg/workload/podsetscounts.go
+++ b/pkg/workload/podsetscounts.go
@@ -64,16 +64,19 @@ func ExtractPodSetCounts(podSets []kueue.PodSet) PodSetsCounts {
 	})
 }
 
-// ExtractPodSetAssignmentsCounts builds a PodSetsCounts map from a list of PodSetAssignments.
+// ExtractGrantedPodSetCounts builds a PodSetsCounts map from a list of PodSetAssignments.
 // Each entry maps PodSet name to its replica count.
-func ExtractPodSetAssignmentsCounts(podSets []kueue.PodSetAssignment) PodSetsCounts {
-	return utilslices.ToMap(podSets, func(i int) (kueue.PodSetReference, int32) {
-		val := int32(0)
-		if podSets[i].Count != nil {
-			val = *podSets[i].Count
-		}
-		return podSets[i].Name, val
-	})
+func ExtractGrantedPodSetCounts(wl *kueue.Workload) PodSetsCounts {
+	if wl.Status.Admission == nil {
+		return nil
+	}
+	counts := ExtractPodSetSetCountsFromWorkload(wl)
+	granted := make(PodSetCounts, len(wl.Status.Admission.PodSetAssignments))
+	for _, psa := range wl.Status.Admission.PodSetAssignments {
+		count := counts[psa.Name]
+		granted[psa.Name] = min(ptr.Deref(psa.Count, count), count)
+	}
+	return granted
 }
 
 // ExtractPodSetCountsFromWorkload returns a PodSetsCounts map derived from the provided Workload.

--- a/pkg/workload/podsetscounts_test.go
+++ b/pkg/workload/podsetscounts_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 )
@@ -68,28 +69,59 @@ func TestExtractPodSetCounts(t *testing.T) {
 	}
 }
 
-func TestExtractPodSetAssignmentsCounts(t *testing.T) {
-	type args struct {
-		podSets []kueue.PodSetAssignment
-	}
+func TestExtractGrantedPodSetCounts(t *testing.T) {
 	tests := map[string]struct {
-		args args
-		want PodSetsCounts
+		podSets           []kueue.PodSet
+		podSetsAssignment []kueue.PodSetAssignment
+		wantGranted       PodSetsCounts
 	}{
-		"EmptyPodSets": {},
-		"SinglePodSet": {
-			args: args{
-				podSets: []kueue.PodSetAssignment{testPodSetAssignment("test", 10)},
+		"EmptyPodSets": {
+			wantGranted: PodSetsCounts{},
+		},
+		"SinglePodSetAssignment": {
+			podSets: []kueue.PodSet{
+				{Name: kueue.NewPodSetReference("test"), Count: 20},
 			},
-			want: PodSetsCounts{
+			podSetsAssignment: []kueue.PodSetAssignment{
+				{
+					Name:  kueue.NewPodSetReference("test"),
+					Count: ptr.To[int32](10),
+				},
+			},
+			wantGranted: PodSetsCounts{
 				"test": 10,
 			},
 		},
-		"MultiplePodSets": {
-			args: args{
-				podSets: []kueue.PodSetAssignment{testPodSetAssignment("test-a", 10), testPodSetAssignment("test-b", 11)},
+		"MultiplePodSetAssignments": {
+			podSets: []kueue.PodSet{
+				{Name: kueue.NewPodSetReference("test-a"), Count: 20},
+				{Name: kueue.NewPodSetReference("test-b"), Count: 25},
 			},
-			want: PodSetsCounts{
+			podSetsAssignment: []kueue.PodSetAssignment{
+				{
+					Name:  kueue.NewPodSetReference("test-a"),
+					Count: ptr.To[int32](10),
+				},
+				{
+					Name:  kueue.NewPodSetReference("test-b"),
+					Count: ptr.To[int32](11),
+				},
+			},
+			wantGranted: PodSetsCounts{
+				"test-a": 10,
+				"test-b": 11,
+			},
+		},
+		"WorkloadAfterScaleDown": {
+			podSets: []kueue.PodSet{
+				{Name: kueue.NewPodSetReference("test-a"), Count: 10},
+				{Name: kueue.NewPodSetReference("test-b"), Count: 11},
+			},
+			podSetsAssignment: []kueue.PodSetAssignment{
+				{Name: kueue.NewPodSetReference("test-a"), Count: ptr.To[int32](20)},
+				{Name: kueue.NewPodSetReference("test-b"), Count: ptr.To[int32](25)},
+			},
+			wantGranted: PodSetsCounts{
 				"test-a": 10,
 				"test-b": 11,
 			},
@@ -97,7 +129,17 @@ func TestExtractPodSetAssignmentsCounts(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			if diff := cmp.Diff(ExtractPodSetAssignmentsCounts(tt.args.podSets), tt.want); diff != "" {
+			wl := &kueue.Workload{
+				Spec: kueue.WorkloadSpec{
+					PodSets: tt.podSets,
+				},
+				Status: kueue.WorkloadStatus{
+					Admission: &kueue.Admission{
+						PodSetAssignments: tt.podSetsAssignment,
+					},
+				},
+			}
+			if diff := cmp.Diff(ExtractGrantedPodSetCounts(wl), tt.wantGranted); diff != "" {
 				t.Errorf("ExtractPodSetAssignmentsCounts() got(-),want(+): %s", diff)
 			}
 		})

--- a/pkg/workload/podsetscounts_test.go
+++ b/pkg/workload/podsetscounts_test.go
@@ -68,6 +68,49 @@ func TestExtractPodSetCounts(t *testing.T) {
 	}
 }
 
+func testPodSetAssignment(name string, count int32) kueue.PodSetAssignment {
+	return kueue.PodSetAssignment{
+		Name:  kueue.NewPodSetReference(name),
+		Count: &count,
+	}
+}
+
+func TestExtractPodSetAssignmentsCounts(t *testing.T) {
+	type args struct {
+		podSets []kueue.PodSetAssignment
+	}
+	tests := map[string]struct {
+		args args
+		want PodSetsCounts
+	}{
+		"EmptyPodSets": {},
+		"SinglePodSet": {
+			args: args{
+				podSets: []kueue.PodSetAssignment{testPodSetAssignment("test", 10)},
+			},
+			want: PodSetsCounts{
+				"test": 10,
+			},
+		},
+		"MultiplePodSets": {
+			args: args{
+				podSets: []kueue.PodSetAssignment{testPodSetAssignment("test-a", 10), testPodSetAssignment("test-b", 11)},
+			},
+			want: PodSetsCounts{
+				"test-a": 10,
+				"test-b": 11,
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if diff := cmp.Diff(ExtractPodSetAssignmentsCounts(tt.args.podSets), tt.want); diff != "" {
+				t.Errorf("ExtractPodSetAssignmentsCounts() got(-),want(+): %s", diff)
+			}
+		})
+	}
+}
+
 func TestExtractPodSetCountsFromWorkload(t *testing.T) {
 	type args struct {
 		workload *kueue.Workload
@@ -80,6 +123,7 @@ func TestExtractPodSetCountsFromWorkload(t *testing.T) {
 			args: args{
 				workload: &kueue.Workload{},
 			},
+			want: nil,
 		},
 		"SinglePodSet": {
 			args: args{

--- a/pkg/workload/podsetscounts_test.go
+++ b/pkg/workload/podsetscounts_test.go
@@ -68,13 +68,6 @@ func TestExtractPodSetCounts(t *testing.T) {
 	}
 }
 
-func testPodSetAssignment(name string, count int32) kueue.PodSetAssignment {
-	return kueue.PodSetAssignment{
-		Name:  kueue.NewPodSetReference(name),
-		Count: &count,
-	}
-}
-
 func TestExtractPodSetAssignmentsCounts(t *testing.T) {
 	type args struct {
 		podSets []kueue.PodSetAssignment


### PR DESCRIPTION
#### What type of PR is this?
AI-assisted

#### What this PR does / why we need it:
Related to https://github.com/kubernetes-sigs/kueue/issues/12100


#### Special notes for your reviewer:
With this change the elastic job ungater relies on admission.count to get the number of pods that should be ungated. This is needed specifically for partial scale up feature, when the `admission.count` could differ from `podset.count`.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Pod ungating now follows the number of pods granted by the active admission decision.
* Prevented more pods from being ungated than the quota allocated to each pod set.
* Improved handling of workloads without admission data or explicit pod counts.
* Correctly accounts for updated pod counts after workloads are scaled down.

## Tests
* Added coverage for empty, single, and multiple pod-set assignments.
* Added validation for unspecified pod counts and scaled-down workloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->