### PR TITLE
fix(trainjob): update TrainJob using merge patch instead of full Update

### DIFF
--- a/pkg/controller/jobs/trainjob/trainjob_controller.go
+++ b/pkg/controller/jobs/trainjob/trainjob_controller.go
@@ -273,13 +273,16 @@ func (t *TrainJob) RunWithPodSetsInfo(ctx context.Context, c client.Client, podS
 		)
 	}
 
-	kueueRuntimePatch := getKueueRuntimePatch(t)
-	if kueueRuntimePatch == nil {
-		return errors.New("kueue runtime patch not found")
-	}
-	kueueRuntimePatch.TrainingRuntimeSpec.Template.Spec.ReplicatedJobs = replicatedJobPatches
-	// Update the runtimePatches while the job is suspended, since is a requirement from the trainjob admission webhook
-	err = c.Update(ctx, t.Object())
+	// Update the runtimePatches while the job is suspended, since is a requirement from the trainjob admission webhook.
+	// Use merge patch to only update the kueue-managed fields.
+	err = clientutil.Patch(ctx, c, t.Object(), func() (bool, error) {
+		kueueRuntimePatch := getKueueRuntimePatch(t)
+		if kueueRuntimePatch == nil {
+			return false, errors.New("kueue runtime patch not found")
+		}
+		kueueRuntimePatch.TrainingRuntimeSpec.Template.Spec.ReplicatedJobs = replicatedJobPatches
+		return true, nil
+	})
 	if err != nil {
 		return err
 	}
@@ -290,8 +293,10 @@ func (t *TrainJob) RunWithPodSetsInfo(ctx context.Context, c client.Client, podS
 
 func (t *TrainJob) Stop(ctx context.Context, c client.Client, podSetsInfo []podset.PodSetInfo, _ jobframework.StopReason, _ string) (bool, error) {
 	if !t.IsSuspended() {
-		t.Suspend()
-		if err := c.Update(ctx, t.Object()); err != nil {
+		if err := clientutil.Patch(ctx, c, t.Object(), func() (bool, error) {
+			t.Suspend()
+			return true, nil
+		}); err != nil {
 			return false, fmt.Errorf("error suspending trainjob: %w", err)
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/area integrations

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

Update TrainJob integration to use patches instead of merges.

The TrainJob controller's `RunWithPodSetsInfo` and `Stop` currently use c.Update(), which sends a full replace of the object as this API version's typed struct sees it. This can cause data loss if cluster has newer version of Trainer which contains additional fields not present in the vendored Trainer api.

Switch both call sites to clientutil.Patch (JSON merge patch via client.MergeFrom), matching the pattern RestorePodSetsInfo already uses. A merge patch only carries fields that actually changed, so fields this struct doesn't model are never touched, and only omitted from the diff rather than removed.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to #14722

#### Special notes for your reviewer:

This has been tested manually against a local KinD cluster.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TrainJob: Fix a bug where TrainJobs are stuck by using merge patches, instead of Updates, when admitting
or stopping TrainJobs, thus preserving the fields not represented in Kueue's vendored Trainer API.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TrainJob runtime updates to preserve unrelated configuration changes.
  * Improved TrainJob suspension handling for more reliable state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->