### PR TITLE
docs: fix stale v1beta1 ClusterQueue example and clarify gpucores enforcement in HAMi guide

### DIFF
--- a/site/content/en/docs/tasks/run/using_hami.md
+++ b/site/content/en/docs/tasks/run/using_hami.md
@@ -55,7 +55,7 @@ This configuration tells Kueue to multiply per-vGPU resource values by the numbe
 Configure your ClusterQueue to track both vGPU instance counts and total resources:
 
 ```yaml
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: vgpu-cluster-queue
@@ -98,6 +98,8 @@ resources:
 Kueue will automatically transform these into total resources:
 - `nvidia.com/total-gpucores: 40` (20 cores × 2 vGPUs)
 - `nvidia.com/total-gpumem: 2048` (1024 MiB × 2 vGPUs)
+
+> **Note:** `nvidia.com/gpucores` is enforced by HAMi as a reactive throttle, not a hard preemptive cap — a container's instantaneous GPU utilization can briefly exceed its requested core count before HAMi's monitor throttles it back down. Treat `nvidia.com/total-gpucores` quota in Kueue as a target you're dividing GPU compute capacity by across workloads, not as a guarantee that a container can never observe more than its requested share at any single instant. `nvidia.com/gpumem`, by contrast, is enforced as a hard ceiling.
 
 ## Example
 


### PR DESCRIPTION
## Summary
- Fixes the inline ClusterQueue example in `using_hami.md`, which still used `kueue.x-k8s.io/v1beta1`, inconsistent with the linked static `sample-hami.yaml` (already `v1beta2`) and the `ResourceTransformation` `Configuration` snippet earlier in the same doc (also `v1beta2`).
- Adds a short note clarifying that HAMi enforces `nvidia.com/gpucores` as a reactive throttle rather than a hard preemptive cap, so `total-gpucores` quota in Kueue should be read as a capacity-division target rather than a guarantee against any instantaneous overshoot. `nvidia.com/gpumem` remains a hard ceiling by contrast.

The gpucores enforcement behavior was confirmed through our own HAMi GPU-sharing validation testing on GKE.

## Test plan
- [x] Diffed the fixed snippet against `site/static/examples/serving-workloads/sample-hami.yaml` to confirm `v1beta2` is the correct, already-adopted API version elsewhere in the docs/examples.
- [x] Doc-only change; no code paths affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the HAMi ClusterQueue example to use the current `kueue.x-k8s.io/v1beta2` API version.
  - Clarified that `nvidia.com/gpucores` acts as a reactive throttle, while `nvidia.com/gpumem` enforces a hard limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->