### PR TITLE
Preserve unmodeled spec fields when MultiKueue SyncJob creates remote jobs

### DIFF
--- a/pkg/controller/jobframework/multikueue_spec.go
+++ b/pkg/controller/jobframework/multikueue_spec.go
@@ -1,0 +1,219 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jobframework
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetUnstructured fetches an object without decoding it through the vendored
+// typed API, preserving fields that the typed API does not model.
+func GetUnstructured(ctx context.Context, c client.Reader, key types.NamespacedName, gvk schema.GroupVersionKind) (*unstructured.Unstructured, error) {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(gvk)
+	if err := c.Get(ctx, key, obj); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+// CreateWithPreservedSpec creates an unstructured destination from
+// the typed destination while applying its typed spec changes to the raw source
+// spec. This preserves source fields unknown to the vendored API. Returning an
+// unstructured object is important: converting back to a typed object would
+// discard those fields during client serialization.
+func CreateWithPreservedSpec(ctx context.Context, c client.Writer, source *unstructured.Unstructured, typedSource, typedDestination runtime.Object) error {
+	obj, err := NewUnstructuredWithPreservedSpec(source, typedSource, typedDestination)
+	if err != nil {
+		return err
+	}
+	return c.Create(ctx, obj)
+}
+
+func NewUnstructuredWithPreservedSpec(source *unstructured.Unstructured, typedSource, typedDestination runtime.Object) (*unstructured.Unstructured, error) {
+	sourceMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(typedSource)
+	if err != nil {
+		return nil, fmt.Errorf("converting typed source object: %w", err)
+	}
+	destinationMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(typedDestination)
+	if err != nil {
+		return nil, fmt.Errorf("converting typed destination object: %w", err)
+	}
+
+	sourceSpec, _, err := unstructured.NestedFieldNoCopy(sourceMap, "spec")
+	if err != nil {
+		return nil, fmt.Errorf("reading typed source spec: %w", err)
+	}
+	destinationSpec, _, err := unstructured.NestedFieldNoCopy(destinationMap, "spec")
+	if err != nil {
+		return nil, fmt.Errorf("reading typed destination spec: %w", err)
+	}
+	rawSourceSpec, found, err := unstructured.NestedFieldCopy(source.Object, "spec")
+	if err != nil {
+		return nil, fmt.Errorf("reading raw source spec: %w", err)
+	}
+	if found {
+		mergedSpec := merge3Way(sourceSpec, destinationSpec, rawSourceSpec)
+		if err := unstructured.SetNestedField(destinationMap, mergedSpec, "spec"); err != nil {
+			return nil, fmt.Errorf("setting merged destination spec: %w", err)
+		}
+	}
+
+	result := &unstructured.Unstructured{Object: destinationMap}
+	result.SetGroupVersionKind(source.GroupVersionKind())
+	return result, nil
+}
+
+var defaultMergeKeys = []string{"name", "manager", "key", "containerPort", "port", "type", "topologyKey", "ip"}
+
+func merge3Way(base, target, raw any) any {
+	baseMap, isBaseMap := base.(map[string]any)
+	targetMap, isTargetMap := target.(map[string]any)
+	rawMap, isRawMap := raw.(map[string]any)
+
+	if isBaseMap && isTargetMap && isRawMap {
+		resultMap := make(map[string]any, len(rawMap))
+		for k, v := range rawMap {
+			resultMap[k] = v
+		}
+
+		allKeys := make(map[string]struct{})
+		for k := range baseMap {
+			allKeys[k] = struct{}{}
+		}
+		for k := range targetMap {
+			allKeys[k] = struct{}{}
+		}
+		for k := range rawMap {
+			allKeys[k] = struct{}{}
+		}
+
+		for k := range allKeys {
+			baseVal, baseHas := baseMap[k]
+			targetVal, targetHas := targetMap[k]
+			rawVal, rawHas := rawMap[k]
+
+			switch {
+			case baseHas && !targetHas:
+				delete(resultMap, k)
+			case !baseHas && targetHas:
+				resultMap[k] = targetVal
+			case baseHas && targetHas:
+				if !rawHas {
+					resultMap[k] = targetVal
+				} else {
+					resultMap[k] = merge3Way(baseVal, targetVal, rawVal)
+				}
+			case !baseHas && !targetHas && rawHas:
+				resultMap[k] = rawVal
+			}
+		}
+		return resultMap
+	}
+
+	baseSlice, isBaseSlice := base.([]any)
+	targetSlice, isTargetSlice := target.([]any)
+	rawSlice, isRawSlice := raw.([]any)
+
+	if isBaseSlice && isTargetSlice && isRawSlice {
+		for _, key := range defaultMergeKeys {
+			baseIndexed, baseOK := isUniqueKeyedList(baseSlice, key)
+			targetIndexed, targetOK := isUniqueKeyedList(targetSlice, key)
+			rawIndexed, rawOK := isUniqueKeyedList(rawSlice, key)
+
+			if baseOK && targetOK && rawOK && (len(baseSlice) > 0 || len(targetSlice) > 0 || len(rawSlice) > 0) {
+				resultSlice := make([]any, 0, len(targetSlice))
+				for _, targetElem := range targetSlice {
+					targetMap := targetElem.(map[string]any)
+					k := fmt.Sprintf("%v", targetMap[key])
+					baseElem, baseExists := baseIndexed[k]
+					rawElem, rawExists := rawIndexed[k]
+					if rawExists {
+						if baseExists {
+							resultSlice = append(resultSlice, merge3Way(baseElem, targetElem, rawElem))
+						} else {
+							resultSlice = append(resultSlice, targetElem)
+						}
+						continue
+					}
+					resultSlice = append(resultSlice, targetElem)
+				}
+
+				// Preserve unmodeled elements in raw that were never known to typed base or target
+				for _, rawElem := range rawSlice {
+					rawMap := rawElem.(map[string]any)
+					k := fmt.Sprintf("%v", rawMap[key])
+					_, baseExists := baseIndexed[k]
+					_, targetExists := targetIndexed[k]
+					if !baseExists && !targetExists {
+						resultSlice = append(resultSlice, rawElem)
+					}
+				}
+				return resultSlice
+			}
+		}
+
+		if len(baseSlice) == len(targetSlice) && len(baseSlice) == len(rawSlice) {
+			resultSlice := make([]any, len(targetSlice))
+			for i := range targetSlice {
+				resultSlice[i] = merge3Way(baseSlice[i], targetSlice[i], rawSlice[i])
+			}
+			return resultSlice
+		}
+
+		if reflect.DeepEqual(baseSlice, targetSlice) {
+			return rawSlice
+		}
+		return targetSlice
+	}
+
+	if reflect.DeepEqual(base, target) {
+		return raw
+	}
+	return target
+}
+
+func isUniqueKeyedList(slice []any, key string) (map[string]map[string]any, bool) {
+	if len(slice) == 0 {
+		return map[string]map[string]any{}, true
+	}
+	indexed := make(map[string]map[string]any, len(slice))
+	for _, item := range slice {
+		itemMap, ok := item.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		val, found := itemMap[key]
+		if !found || val == nil || val == "" {
+			return nil, false
+		}
+		keyStr := fmt.Sprintf("%v", val)
+		if _, duplicate := indexed[keyStr]; duplicate {
+			return nil, false
+		}
+		indexed[keyStr] = itemMap
+	}
+	return indexed, true
+}

--- a/pkg/controller/jobframework/multikueue_spec_test.go
+++ b/pkg/controller/jobframework/multikueue_spec_test.go
@@ -1,0 +1,324 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jobframework
+
+import (
+	"testing"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestCreateWithPreservedSpec(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"}
+	key := types.NamespacedName{Name: "job", Namespace: "ns"}
+	managedBy := "kueue.x-k8s.io/multikueue"
+	local := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace},
+		Spec:       batchv1.JobSpec{ManagedBy: &managedBy},
+	}
+	destination := local.DeepCopy()
+	destination.Spec.ManagedBy = nil
+	rawSource := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "batch/v1",
+		"kind":       "Job",
+		"metadata": map[string]any{
+			"name":      key.Name,
+			"namespace": key.Namespace,
+		},
+		"spec": map[string]any{
+			"managedBy":    managedBy,
+			"futureField":  "retained",
+			"futureConfig": map[string]any{"enabled": true},
+		},
+	}}
+	rawSource.SetGroupVersionKind(gvk)
+
+	created, err := NewUnstructuredWithPreservedSpec(rawSource, local, destination)
+	if err != nil {
+		t.Fatalf("NewUnstructuredWithPreservedSpec() error = %v", err)
+	}
+	if got, found, err := unstructured.NestedString(created.Object, "spec", "futureField"); err != nil || !found || got != "retained" {
+		t.Fatalf("futureField = %q, found = %t, err = %v; want retained", got, found, err)
+	}
+	if got, found, err := unstructured.NestedMap(created.Object, "spec", "futureConfig"); err != nil || !found || got["enabled"] != true {
+		t.Fatalf("futureConfig = %#v, found = %t, err = %v; want enabled=true", got, found, err)
+	}
+	if _, found, err := unstructured.NestedFieldNoCopy(created.Object, "spec", "managedBy"); err != nil || found {
+		t.Fatalf("managedBy found = %t, err = %v; want absent", found, err)
+	}
+}
+
+// TestNewUnstructuredWithPreservedSpec_RetainedArrayElementUnknownFields verifies
+// that when a typed destination removes an element from an array, the removed
+// element is deleted while unknown/unmodeled fields on retained sibling elements
+// are preserved.
+func TestNewUnstructuredWithPreservedSpec_RetainedArrayElementUnknownFields(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"}
+	key := types.NamespacedName{Name: "job", Namespace: "ns"}
+	managedBy := "kueue.x-k8s.io/multikueue"
+
+	local := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace},
+		Spec: batchv1.JobSpec{
+			ManagedBy: &managedBy,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "injected-to-remove", Image: "helper:v1"},
+						{Name: "user-app", Image: "app:v1"},
+					},
+				},
+			},
+		},
+	}
+	destination := local.DeepCopy()
+	destination.Spec.ManagedBy = nil
+	destination.Spec.Template.Spec.Containers = []corev1.Container{
+		{Name: "user-app", Image: "app:v1"},
+	}
+
+	rawSource := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "batch/v1",
+		"kind":       "Job",
+		"metadata": map[string]any{
+			"name":      key.Name,
+			"namespace": key.Namespace,
+		},
+		"spec": map[string]any{
+			"managedBy": managedBy,
+			"template": map[string]any{
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{
+							"name":  "injected-to-remove",
+							"image": "helper:v1",
+						},
+						map[string]any{
+							"name":             "user-app",
+							"image":            "app:v1",
+							"futureAnnotation": "preserved",
+						},
+					},
+				},
+			},
+		},
+	}}
+	rawSource.SetGroupVersionKind(gvk)
+
+	created, err := NewUnstructuredWithPreservedSpec(rawSource, local, destination)
+	if err != nil {
+		t.Fatalf("NewUnstructuredWithPreservedSpec() error = %v", err)
+	}
+
+	containers, found, err := unstructured.NestedSlice(created.Object, "spec", "template", "spec", "containers")
+	if err != nil || !found {
+		t.Fatalf("containers not found: found=%t err=%v", found, err)
+	}
+	if len(containers) != 1 {
+		t.Fatalf("containers len = %d; want 1", len(containers))
+	}
+	c0, ok := containers[0].(map[string]any)
+	if !ok {
+		t.Fatalf("containers[0] is not a map")
+	}
+	if got := c0["futureAnnotation"]; got != "preserved" {
+		t.Errorf("containers[0].futureAnnotation = %v; want \"preserved\"", got)
+	}
+	if got := c0["name"]; got != "user-app" {
+		t.Errorf("containers[0].name = %v; want \"user-app\"", got)
+	}
+	// The managedBy field must have been removed.
+	if _, found, err := unstructured.NestedFieldNoCopy(created.Object, "spec", "managedBy"); err != nil || found {
+		t.Fatalf("managedBy found = %t, err = %v; want absent", found, err)
+	}
+}
+
+func TestNewUnstructuredWithPreservedSpec_ArrayModificationPreservesSiblingUnknownFields(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"}
+	key := types.NamespacedName{Name: "job", Namespace: "ns"}
+
+	local := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main", Image: "app:v1"},
+						{Name: "sidecar", Image: "sidecar:v1"},
+					},
+				},
+			},
+		},
+	}
+
+	destination := local.DeepCopy()
+	destination.Spec.Template.Spec.Containers[0].Image = "app:v2"
+
+	rawSource := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "batch/v1",
+		"kind":       "Job",
+		"metadata": map[string]any{
+			"name":      key.Name,
+			"namespace": key.Namespace,
+		},
+		"spec": map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{
+							"name":  "main",
+							"image": "app:v1",
+						},
+						map[string]any{
+							"name":        "sidecar",
+							"image":       "sidecar:v1",
+							"futureField": "keep-me",
+						},
+					},
+				},
+			},
+		},
+	}}
+	rawSource.SetGroupVersionKind(gvk)
+
+	created, err := NewUnstructuredWithPreservedSpec(rawSource, local, destination)
+	if err != nil {
+		t.Fatalf("NewUnstructuredWithPreservedSpec() error = %v", err)
+	}
+
+	containers, found, err := unstructured.NestedSlice(created.Object, "spec", "template", "spec", "containers")
+	if err != nil || !found {
+		t.Fatalf("containers not found: found=%t err=%v", found, err)
+	}
+	if len(containers) != 2 {
+		t.Fatalf("containers length = %d; want 2", len(containers))
+	}
+
+	c0, ok := containers[0].(map[string]any)
+	if !ok {
+		t.Fatalf("containers[0] is not a map")
+	}
+	if got := c0["image"]; got != "app:v2" {
+		t.Errorf("containers[0].image = %v; want \"app:v2\"", got)
+	}
+
+	c1, ok := containers[1].(map[string]any)
+	if !ok {
+		t.Fatalf("containers[1] is not a map")
+	}
+	if got := c1["futureField"]; got != "keep-me" {
+		t.Errorf("containers[1].futureField = %v; want \"keep-me\"", got)
+	}
+}
+
+func TestNewUnstructuredWithPreservedSpec_DuplicateKeysFallbackToPositional(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"}
+	key := types.NamespacedName{Name: "job", Namespace: "ns"}
+
+	local := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "dup", Image: "app:v1"},
+						{Name: "dup", Image: "app:v2"},
+					},
+				},
+			},
+		},
+	}
+
+	destination := local.DeepCopy()
+	destination.Spec.Template.Spec.Containers[0].Image = "app:v1-updated"
+
+	rawSource := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "batch/v1",
+		"kind":       "Job",
+		"metadata": map[string]any{
+			"name":      key.Name,
+			"namespace": key.Namespace,
+		},
+		"spec": map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{
+							"name":   "dup",
+							"image":  "app:v1",
+							"extra1": "keep-1",
+						},
+						map[string]any{
+							"name":   "dup",
+							"image":  "app:v2",
+							"extra2": "keep-2",
+						},
+					},
+				},
+			},
+		},
+	}}
+	rawSource.SetGroupVersionKind(gvk)
+
+	created, err := NewUnstructuredWithPreservedSpec(rawSource, local, destination)
+	if err != nil {
+		t.Fatalf("NewUnstructuredWithPreservedSpec() error = %v", err)
+	}
+
+	containers, found, err := unstructured.NestedSlice(created.Object, "spec", "template", "spec", "containers")
+	if err != nil || !found {
+		t.Fatalf("containers not found: found=%t err=%v", found, err)
+	}
+	if len(containers) != 2 {
+		t.Fatalf("containers length = %d; want 2", len(containers))
+	}
+
+	c0, ok := containers[0].(map[string]any)
+	if !ok {
+		t.Fatalf("containers[0] is not a map")
+	}
+	if got := c0["image"]; got != "app:v1-updated" {
+		t.Errorf("containers[0].image = %v; want \"app:v1-updated\"", got)
+	}
+	if got := c0["extra1"]; got != "keep-1" {
+		t.Errorf("containers[0].extra1 = %v; want \"keep-1\"", got)
+	}
+	if _, found := c0["extra2"]; found {
+		t.Errorf("containers[0] unexpectedly contains extra2")
+	}
+
+	c1, ok := containers[1].(map[string]any)
+	if !ok {
+		t.Fatalf("containers[1] is not a map")
+	}
+	if got := c1["image"]; got != "app:v2" {
+		t.Errorf("containers[1].image = %v; want \"app:v2\"", got)
+	}
+	if got := c1["extra2"]; got != "keep-2" {
+		t.Errorf("containers[1].extra2 = %v; want \"keep-2\"", got)
+	}
+	if _, found := c1["extra1"]; found {
+		t.Errorf("containers[1] unexpectedly contains extra1")
+	}
+}
+
+

--- a/pkg/controller/jobs/appwrapper/appwrapper_multikueue_adapter.go
+++ b/pkg/controller/jobs/appwrapper/appwrapper_multikueue_adapter.go
@@ -60,6 +60,11 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 		})
 	}
 
+	localAppWrapperRaw, err := jobframework.GetUnstructured(ctx, localClient, key, gvk)
+	if err != nil {
+		return false, err
+	}
+
 	// Make a copy of the local AppWrapper
 	remoteAppWrapper = awv1beta2.AppWrapper{
 		ObjectMeta: api.CloneObjectMetaForCreation(&localAppWrapper.ObjectMeta),
@@ -72,7 +77,7 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 	// clear the managedBy to enable the remote AppWrapper controller to take over
 	remoteAppWrapper.Spec.ManagedBy = nil
 
-	return false, remoteClient.Create(ctx, &remoteAppWrapper)
+	return false, jobframework.CreateWithPreservedSpec(ctx, remoteClient, localAppWrapperRaw, &localAppWrapper, &remoteAppWrapper)
 }
 
 func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, _ client.Client, remoteClient client.Client, key types.NamespacedName) error {

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -56,6 +56,11 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 		return false, err
 	}
 
+	localJobRaw, err := jobframework.GetUnstructured(ctx, localClient, key, gvk)
+	if err != nil {
+		return false, err
+	}
+
 	remoteJob := batchv1.Job{}
 	err = remoteClient.Get(ctx, key, &remoteJob)
 	if client.IgnoreNotFound(err) != nil {
@@ -109,7 +114,7 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 	// clear the managedBy enables the batch/Job controller to take over
 	remoteJob.Spec.ManagedBy = nil
 
-	return false, remoteClient.Create(ctx, &remoteJob)
+	return false, jobframework.CreateWithPreservedSpec(ctx, remoteClient, localJobRaw, &localJob, &remoteJob)
 }
 
 // determineStatusUpdate returns the JobStatus to write to the local Job, plus

--- a/pkg/controller/jobs/jobset/jobset_multikueue_adapter.go
+++ b/pkg/controller/jobs/jobset/jobset_multikueue_adapter.go
@@ -46,6 +46,11 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 		return false, err
 	}
 
+	localJobRaw, err := jobframework.GetUnstructured(ctx, localClient, key, gvk)
+	if err != nil {
+		return false, err
+	}
+
 	remoteJob := jobset.JobSet{}
 	err = remoteClient.Get(ctx, key, &remoteJob)
 	if client.IgnoreNotFound(err) != nil {
@@ -71,7 +76,7 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 	// clear the managedBy enables the JobSet controller to take over
 	remoteJob.Spec.ManagedBy = nil
 
-	return false, remoteClient.Create(ctx, &remoteJob)
+	return false, jobframework.CreateWithPreservedSpec(ctx, remoteClient, localJobRaw, &localJob, &remoteJob)
 }
 
 func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, _ client.Client, remoteClient client.Client, key types.NamespacedName) error {

--- a/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_multikueue_adapter.go
+++ b/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_multikueue_adapter.go
@@ -100,6 +100,11 @@ func (a adapter[PtrT, T]) SyncJob(
 		return false, err
 	}
 
+	localJobRaw, err := jobframework.GetUnstructured(ctx, localClient, key, a.gvk)
+	if err != nil {
+		return false, err
+	}
+
 	remoteJob := PtrT(new(T))
 	err = remoteClient.Get(ctx, key, remoteJob)
 	if client.IgnoreNotFound(err) != nil {
@@ -123,7 +128,10 @@ func (a adapter[PtrT, T]) SyncJob(
 	// clearing the managedBy enables the controller to take over
 	a.fromObject(remoteJob).SetManagedBy(nil)
 
-	return false, remoteClient.Create(ctx, remoteJob)
+	if err := jobframework.CreateWithPreservedSpec(ctx, remoteClient, localJobRaw, localJob, remoteJob); err != nil {
+		return false, err
+	}
+	return false, nil
 }
 
 func (a adapter[PtrT, T]) DeleteRemoteObject(ctx context.Context, _ client.Client, remoteClient client.Client, key types.NamespacedName) error {

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_multikueue_adapter.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_multikueue_adapter.go
@@ -49,6 +49,11 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 		return false, err
 	}
 
+	localLWSRaw, err := jobframework.GetUnstructured(ctx, localClient, key, gvk)
+	if err != nil {
+		return false, err
+	}
+
 	remoteLWS := leaderworkersetv1.LeaderWorkerSet{}
 	err = remoteClient.Get(ctx, key, &remoteLWS)
 	if client.IgnoreNotFound(err) != nil {
@@ -78,7 +83,10 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 
 	// Use IgnoreAlreadyExists because LWS has multiple workloads (one per replica),
 	// and they may all try to create the same LWS concurrently.
-	return false, client.IgnoreAlreadyExists(remoteClient.Create(ctx, &remoteLWS))
+	if err := jobframework.CreateWithPreservedSpec(ctx, remoteClient, localLWSRaw, &localLWS, &remoteLWS); err != nil {
+		return false, client.IgnoreAlreadyExists(err)
+	}
+	return false, nil
 }
 
 func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, _ client.Client, remoteClient client.Client, key types.NamespacedName) error {

--- a/pkg/controller/jobs/mpijob/mpijob_multikueue_adapter.go
+++ b/pkg/controller/jobs/mpijob/mpijob_multikueue_adapter.go
@@ -46,6 +46,11 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 		return false, err
 	}
 
+	localJobRaw, err := jobframework.GetUnstructured(ctx, localClient, key, gvk)
+	if err != nil {
+		return false, err
+	}
+
 	remoteJob := kfmpi.MPIJob{}
 	err = remoteClient.Get(ctx, key, &remoteJob)
 	if client.IgnoreNotFound(err) != nil {
@@ -71,7 +76,7 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 	// clear the managedBy enables the controller to take over
 	remoteJob.Spec.RunPolicy.ManagedBy = nil
 
-	return false, remoteClient.Create(ctx, &remoteJob)
+	return false, jobframework.CreateWithPreservedSpec(ctx, remoteClient, localJobRaw, &localJob, &remoteJob)
 }
 
 func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, _ client.Client, remoteClient client.Client, key types.NamespacedName) error {

--- a/pkg/controller/jobs/pod/pod_multikueue_adapter.go
+++ b/pkg/controller/jobs/pod/pod_multikueue_adapter.go
@@ -196,6 +196,10 @@ func syncLocalPodWithRemote(
 	}
 
 	// If the remote pod does not exist, create it
+	localPodRaw, err := jobframework.GetUnstructured(ctx, localClient, key, gvk)
+	if err != nil {
+		return err
+	}
 	remotePod = corev1.Pod{
 		ObjectMeta: api.CloneObjectMetaForCreation(&localPod.ObjectMeta),
 		Spec:       *localPod.Spec.DeepCopy(),
@@ -204,7 +208,7 @@ func syncLocalPodWithRemote(
 	// Add prebuilt workload name and multikueue origin
 	jobframework.SetMultiKueueMeta(&remotePod, workloadName, origin)
 
-	if err = remoteClient.Create(ctx, &remotePod); err != nil {
+	if err = jobframework.CreateWithPreservedSpec(ctx, remoteClient, localPodRaw, localPod, &remotePod); err != nil {
 		log.Error(err, "Failed to create remote pod", "podName", remotePod.Name)
 		return err
 	}

--- a/pkg/controller/jobs/ray/ray_multikueue_adapter.go
+++ b/pkg/controller/jobs/ray/ray_multikueue_adapter.go
@@ -184,6 +184,11 @@ func (a *adapter[PtrT, T]) SyncJob(
 		return false, err
 	}
 
+	localJobRaw, err := jobframework.GetUnstructured(ctx, localClient, key, a.gvk)
+	if err != nil {
+		return false, err
+	}
+
 	remoteJob := PtrT(new(T))
 	err = remoteClient.Get(ctx, key, remoteJob)
 	if client.IgnoreNotFound(err) != nil {
@@ -210,14 +215,16 @@ func (a *adapter[PtrT, T]) SyncJob(
 
 	remoteJob = PtrT(new(T))
 	a.copySpec(remoteJob, localJob)
-
 	// Add prebuilt workload name and multikueue origin
 	jobframework.SetMultiKueueMeta(remoteJob, workloadName, origin)
 
 	// clearing the managedBy enables the controller to take over
 	a.setManagedBy(remoteJob, nil)
 
-	return false, remoteClient.Create(ctx, remoteJob)
+	if err := jobframework.CreateWithPreservedSpec(ctx, remoteClient, localJobRaw, localJob, remoteJob); err != nil {
+		return false, err
+	}
+	return false, nil
 }
 
 // needElasticSync reports whether the remote object must be updated to reflect

--- a/pkg/controller/jobs/statefulset/statefulset_multikueue_adapter.go
+++ b/pkg/controller/jobs/statefulset/statefulset_multikueue_adapter.go
@@ -57,6 +57,11 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 		return false, nil
 	}
 
+	localStatefulSetRaw, err := jobframework.GetUnstructured(ctx, localClient, key, gvk)
+	if err != nil {
+		return false, err
+	}
+
 	remoteStatefulSet = appsv1.StatefulSet{
 		ObjectMeta: api.CloneObjectMetaForCreation(&localStatefulSet.ObjectMeta),
 		Spec:       *localStatefulSet.Spec.DeepCopy(),
@@ -70,7 +75,7 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 	}
 	remoteStatefulSet.Annotations[kueue.MultiKueueOriginUIDAnnotation] = string(localStatefulSet.UID)
 
-	return false, remoteClient.Create(ctx, &remoteStatefulSet)
+	return false, jobframework.CreateWithPreservedSpec(ctx, remoteClient, localStatefulSetRaw, &localStatefulSet, &remoteStatefulSet)
 }
 
 func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, _ client.Client, remoteClient client.Client, key types.NamespacedName) error {

--- a/pkg/controller/jobs/trainjob/trainjob_multikueue_adapter.go
+++ b/pkg/controller/jobs/trainjob/trainjob_multikueue_adapter.go
@@ -61,6 +61,11 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 		})
 	}
 
+	localJobRaw, err := jobframework.GetUnstructured(ctx, localClient, key, gvk)
+	if err != nil {
+		return false, err
+	}
+
 	remoteJob = kftrainerapi.TrainJob{
 		ObjectMeta: api.CloneObjectMetaForCreation(&localJob.ObjectMeta),
 		Spec:       *localJob.Spec.DeepCopy(),
@@ -77,7 +82,7 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 		return p.Manager == runtimePatchManagerName
 	})
 
-	return false, remoteClient.Create(ctx, &remoteJob)
+	return false, jobframework.CreateWithPreservedSpec(ctx, remoteClient, localJobRaw, &localJob, &remoteJob)
 }
 
 func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, _ client.Client, remoteClient client.Client, key types.NamespacedName) error {
@@ -123,3 +128,4 @@ func (*multiKueueAdapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedN
 
 	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: trainJob.Namespace}}, nil
 }
+

--- a/pkg/controller/jobs/trainjob/trainjob_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/trainjob/trainjob_multikueue_adapter_test.go
@@ -110,6 +110,39 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 		},
+		"sync creates remote TrainJob preserving user runtime patch and stripping kueue runtime patch": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			managersTrainJobs: []kftrainerapi.TrainJob{
+				*baseTrainJobManagedByKueueBuilder.Clone().
+					RuntimePatches([]kftrainerapi.RuntimePatch{
+						testingtrainjob.MakeRuntimePatch("user-manager").Obj(),
+						testingtrainjob.MakeRuntimePatch(runtimePatchManagerName).Obj(),
+					}).
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "trainjob1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
+			},
+
+			wantManagersTrainJobs: []kftrainerapi.TrainJob{
+				*baseTrainJobManagedByKueueBuilder.Clone().
+					RuntimePatches([]kftrainerapi.RuntimePatch{
+						testingtrainjob.MakeRuntimePatch("user-manager").Obj(),
+						testingtrainjob.MakeRuntimePatch(runtimePatchManagerName).Obj(),
+					}).
+					Obj(),
+			},
+			wantWorkerTrainJobs: []kftrainerapi.TrainJob{
+				*baseTrainJobBuilder.Clone().
+					PrebuiltWorkloadLabel("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					RuntimePatches([]kftrainerapi.RuntimePatch{
+						testingtrainjob.MakeRuntimePatch("user-manager").Obj(),
+					}).
+					Obj(),
+			},
+		},
 		"sync status from remote trainjob": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersTrainJobs: []kftrainerapi.TrainJob{
@@ -353,3 +386,4 @@ func TestMultiKueueAdapter(t *testing.T) {
 		})
 	}
 }
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release note, so that it is included in the convenient release notes: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If this contributes to a release milestone, please label it with the correct milestone: https://git.k8s.io/community/contributors/guide/release-notes.md#milestones
4. You can use any of the following to close issues, for example: 'fixes #1234': https://help.github.com/articles/closing-issues-using-keywords
5. Please write pull request description in accordance with the template, and make sure that you have covered all the steps: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#step-2-write-a-proper-pull-request-description
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
MultiKueue `SyncJob` implementations previously copied the remote job specification directly from typed Go structs via `*localJob.Spec.DeepCopy()`. This caused fields that were not modeled by Kueue's vendored CRD/API types to be silently dropped when creating the remote job.

This PR introduces:
1. `jobframework.GetUnstructured` and `jobframework.CreateWithPreservedSpec` / `jobframework.NewUnstructuredWithPreservedSpec` in `pkg/controller/jobframework`.
2. A JSON merge patch workflow between the typed local spec and typed transformed destination spec applied over the raw local unstructured spec.
3. Creation of the remote job directly via `*unstructured.Unstructured` to prevent serializer field loss.
4. Updates to all built-in MultiKueue adapters:
   - AppWrapper
   - batch/Job
   - JobSet
   - Kubeflow jobs (JAXJob, PaddleJob, PyTorchJob, TFJob, XGBoostJob)
   - LeaderWorkerSet
   - MPIJob
   - Pod / PodGroup
   - Ray (RayCluster, RayJob, RayService)
   - StatefulSet
   - TrainJob

#### Which issue(s) this PR fixes:
Fixes #14837

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
```release-note
Preserve unmodeled spec fields when MultiKueue SyncJob creates remote jobs.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Preserves original workload specification fields when synchronizing resources to remote clusters.
  - Supports Jobs, Pods, JobSets, AppWrappers, StatefulSets, TrainJobs, MPIJobs, Ray jobs, LeaderWorkerSets, and Kubeflow jobs.
  - Retains unknown, nested, and array-based specification fields while applying required updates.

- **Bug Fixes**
  - Prevents unsupported fields from being dropped during remote resource creation.
  - Preserves user runtime patches while removing managed patches from TrainJobs.
  - Improves synchronization error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->