### PR TITLE
[kueuectl] Fix missing request limit in list clusterqueue

### DIFF
--- a/cmd/kueuectl/app/list/list_clusterqueue.go
+++ b/cmd/kueuectl/app/list/list_clusterqueue.go
@@ -111,6 +111,11 @@ func NewClusterQueueCmd(clientGetter clientgetter.ClientGetter, streams generici
 func (o *ClusterQueueOptions) Complete(clientGetter clientgetter.ClientGetter, cmd *cobra.Command, args []string) error {
 	var err error
 
+	o.Limit, err = listRequestLimit()
+	if err != nil {
+		return err
+	}
+
 	clientset, err := clientGetter.KueueClientSet()
 	if err != nil {
 		return err

--- a/cmd/kueuectl/app/list/list_clusterqueue_test.go
+++ b/cmd/kueuectl/app/list/list_clusterqueue_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
@@ -162,6 +163,46 @@ cq1    cohort1   1                   2                    true     60m
 			gotOutErr := outErr.String()
 			if diff := cmp.Diff(tc.wantOutErr, gotOutErr); diff != "" {
 				t.Errorf("Unexpected output (-want/+got)\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestClusterQueueOptionsComplete(t *testing.T) {
+	testCases := map[string]struct {
+		envValue  string
+		wantLimit int64
+		wantErr   error
+	}{
+		"should use the default limit": {
+			wantLimit: defaultListRequestLimit,
+		},
+		"should use the limit from the env var": {
+			envValue:  "5",
+			wantLimit: 5,
+		},
+		"should return an error for an invalid limit env var": {
+			envValue: "invalid",
+			wantErr:  errInvalidListRequestLimit,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			if tc.envValue != "" {
+				t.Setenv(KueuectlListRequestLimitEnvName, tc.envValue)
+			}
+
+			streams, _, _, _ := genericiooptions.NewTestIOStreams()
+			tcg := cmdtesting.NewTestClientGetter().WithKueueClientset(fake.NewSimpleClientset())
+			o := NewClusterQueueOptions(streams, testingclock.NewFakeClock(time.Now()))
+
+			gotErr := o.Complete(tcg, &cobra.Command{}, nil)
+			if diff := cmp.Diff(tc.wantErr, gotErr, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("Unexpected error (-want/+got)\n%s", diff)
+			}
+
+			if tc.wantErr == nil && o.Limit != tc.wantLimit {
+				t.Errorf("Unexpected limit: got %d, want %d", o.Limit, tc.wantLimit)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

/kind bug

#### What this PR does / why we need it:

`list clusterqueue` never set `Options.Limit` in `Complete()`, unlike `list localqueue`, `list workload`, and `list resourceflavor` which all call `listRequestLimit()`.   
As a result, `KUEUECTL_LIST_REQUEST_LIMIT` had no effect on clusterqueue, and every call issued a single, unbounded LIST request instead of paging.   
This PR adds the missing call so clusterqueue behaves consistently with the other list commands.  

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
KueueCtl: Fixed the `kueuectl list clusterqueue` comand to respect KUEUECTL_LIST_REQUEST_LIMIT
and paginate API requests instead of issuing an unbounded LIST request.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - ClusterQueue listings now consistently apply the configured request limit, improving pagination behavior and reducing oversized list requests.
  - Added support for configuring the list request limit through the command-line environment configuration.
  - Invalid limit values are detected early with a clear error instead of proceeding with an unusable setting.

- **Tests**
  - Added coverage for configured limits, default fallback behavior, and invalid values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->