### PR TITLE
Reuse util.ExpectWorkloadResourceUsage in DRA counter e2e

### DIFF
--- a/test/e2e/dra/counter/dra_test.go
+++ b/test/e2e/dra/counter/dra_test.go
@@ -17,12 +17,9 @@ limitations under the License.
 package counter
 
 import (
-	"context"
-
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -34,21 +31,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/workload"
 	"sigs.k8s.io/kueue/test/util"
 )
-
-func expectWorkloadCounterCharge(ctx context.Context, wlKey types.NamespacedName, expectedMemory string) {
-	createdWorkload := &kueue.Workload{}
-	gomega.Eventually(func(g gomega.Gomega) {
-		g.Expect(k8sClient.Get(ctx, wlKey, createdWorkload)).To(gomega.Succeed())
-		g.Expect(workload.HasQuotaReservation(createdWorkload)).To(gomega.BeTrue())
-		g.Expect(createdWorkload.Status.Admission).NotTo(gomega.BeNil())
-		g.Expect(createdWorkload.Status.Admission.PodSetAssignments).To(gomega.HaveLen(1))
-
-		assignment := createdWorkload.Status.Admission.PodSetAssignments[0]
-		g.Expect(assignment.ResourceUsage).To(gomega.HaveKey(corev1.ResourceName("gpu.memory")))
-		memUsage := assignment.ResourceUsage["gpu.memory"]
-		g.Expect(memUsage.Cmp(resource.MustParse(expectedMemory))).To(gomega.Equal(0))
-	}, util.Timeout, util.Interval).Should(gomega.Succeed(), util.AssertMsg("workload should have counter charge of "+expectedMemory, createdWorkload))
-}
 
 var _ = ginkgo.Describe("DRA Partitionable Devices", func() {
 	var ns *corev1.Namespace
@@ -112,7 +94,7 @@ var _ = ginkgo.Describe("DRA Partitionable Devices", func() {
 			}
 
 			ginkgo.By("Verifying workload is admitted with counter charge of 20Gi")
-			expectWorkloadCounterCharge(ctx, wlLookupKey, "20Gi")
+			util.ExpectWorkloadResourceUsage(ctx, k8sClient, wlLookupKey, "gpu.memory", "20Gi")
 
 			ginkgo.By("Verifying job completes successfully")
 			util.ExpectJobToBeCompleted(ctx, k8sClient, job)
@@ -142,7 +124,7 @@ var _ = ginkgo.Describe("DRA Partitionable Devices", func() {
 			}
 
 			ginkgo.By("Verifying counter charge is 40Gi (20Gi x 2)")
-			expectWorkloadCounterCharge(ctx, wlLookupKey, "40Gi")
+			util.ExpectWorkloadResourceUsage(ctx, k8sClient, wlLookupKey, "gpu.memory", "40Gi")
 
 			util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, wlLookupKey, util.LongTimeout)
 		})
@@ -170,7 +152,7 @@ var _ = ginkgo.Describe("DRA Partitionable Devices", func() {
 			}
 
 			ginkgo.By("Verifying counter charge is 80Gi (largest across matched devices)")
-			expectWorkloadCounterCharge(ctx, wlLookupKey, "80Gi")
+			util.ExpectWorkloadResourceUsage(ctx, k8sClient, wlLookupKey, "gpu.memory", "80Gi")
 
 			util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, wlLookupKey, util.LongTimeout)
 		})
@@ -197,7 +179,7 @@ var _ = ginkgo.Describe("DRA Partitionable Devices", func() {
 			}
 
 			ginkgo.By("Verifying counter charge is 80Gi (largest across all devices)")
-			expectWorkloadCounterCharge(ctx, wlLookupKey, "80Gi")
+			util.ExpectWorkloadResourceUsage(ctx, k8sClient, wlLookupKey, "gpu.memory", "80Gi")
 
 			util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, wlLookupKey, util.LongTimeout)
 		})
@@ -231,7 +213,7 @@ var _ = ginkgo.Describe("DRA Partitionable Devices", func() {
 			}
 
 			ginkgo.By("Verifying combined counter charge is 100Gi (80Gi full + 20Gi partition)")
-			expectWorkloadCounterCharge(ctx, wlLookupKey, "100Gi")
+			util.ExpectWorkloadResourceUsage(ctx, k8sClient, wlLookupKey, "gpu.memory", "100Gi")
 
 			ginkgo.By("Verifying job completes successfully")
 			util.ExpectJobToBeCompleted(ctx, k8sClient, job)
@@ -309,7 +291,7 @@ var _ = ginkgo.Describe("DRA Partitionable Devices", func() {
 			}
 
 			for _, wlKey := range []types.NamespacedName{wlLookupKey1, wlLookupKey2} {
-				expectWorkloadCounterCharge(ctx, wlKey, "20Gi")
+				util.ExpectWorkloadResourceUsage(ctx, k8sClient, wlKey, "gpu.memory", "20Gi")
 			}
 
 			ginkgo.By("Verifying both jobs complete")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end resource usage checks to use the shared validation utility.
  * Removed redundant test-only helper logic and unused imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->