### PR TITLE
Fix reactivation for derived Workload deactivation reasons

### DIFF
--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -572,11 +573,12 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 		var requeueAfter time.Duration
 		err := workloadpatching.PatchAdmissionStatus(ctx, r.client, &wl, r.clock, func(wl *kueue.Workload) (bool, error) {
 			if cond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadRequeued); cond != nil && cond.Status == metav1.ConditionFalse {
-				switch cond.Reason {
-				case kueue.WorkloadDeactivated:
+				switch {
+				// Matches both the base "Deactivated" reason and derived "DeactivatedDueTo<Cause>" reasons.
+				case strings.HasPrefix(cond.Reason, kueue.WorkloadDeactivated):
 					workload.SetRequeuedCondition(wl, kueue.WorkloadReactivated, "The workload was reactivated", true)
 					updated = true
-				case kueue.WorkloadEvictedByPodsReadyTimeout, kueue.WorkloadEvictedByAdmissionCheck:
+				case cond.Reason == kueue.WorkloadEvictedByPodsReadyTimeout || cond.Reason == kueue.WorkloadEvictedByAdmissionCheck:
 
 					if wl.Status.RequeueState != nil && wl.Status.RequeueState.RequeueAt != nil {
 						requeueAfter = wl.Status.RequeueState.RequeueAt.Sub(r.clock.Now())

--- a/pkg/controller/core/workload_controller_requeue_test.go
+++ b/pkg/controller/core/workload_controller_requeue_test.go
@@ -391,6 +391,26 @@ func TestReconcileRequeue(t *testing.T) {
 				}).
 				Obj(),
 		},
+		"should set the WorkloadRequeued condition to true on re-activated with a derived deactivation reason": {
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				Active(true).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadRequeued,
+					Status:  metav1.ConditionFalse,
+					Reason:  "DeactivatedDueToRequeuingLimitExceeded",
+					Message: "The workload is deactivated due to exceeding the maximum number of re-queuing retries",
+				}).
+				Obj(),
+			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
+				Active(true).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadRequeued,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueue.WorkloadReactivated,
+					Message: "The workload was reactivated",
+				}).
+				Obj(),
+		},
 		"should keep the WorkloadRequeued condition until the WaitForPodsReady backoff expires": {
 			workload: utiltestingapi.MakeWorkload("wl", "ns").
 				Active(true).


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

A Workload could stay stuck after reactivation when its `WorkloadRequeued=False` condition carried a *derived* deactivation reason following the `DeactivatedDueTo<Cause>` pattern (e.g. `DeactivatedDueToRequeuingLimitExceeded`).

The reactivation logic in `WorkloadReconciler.Reconcile` matched only the exact base reason `WorkloadDeactivated` ("Deactivated"), so derived reasons never took the reactivation path. The stale requeue condition was left in place and the Workload was never re-queued.

This converts the expression `switch` on `cond.Reason` into a condition `switch` and matches the deactivation case by prefix (`strings.HasPrefix(cond.Reason, kueue.WorkloadDeactivated)`), so the base reason and all derived `DeactivatedDueTo…` reasons follow the same reactivation path. The eviction-backoff cases (`WorkloadEvictedByPodsReadyTimeout`, `WorkloadEvictedByAdmissionCheck`) are unchanged.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes-sigs/kueue/issues/14870

#### Special notes for your reviewer:

Follow-up from #14309 (review discussion https://github.com/kubernetes-sigs/kueue/pull/14309#discussion_r3884210569, requested by @tenzen-y).

Unit coverage added in `workload_controller_requeue_test.go`: a reactivated Workload whose `WorkloadRequeued=False` reason is `DeactivatedDueToRequeuingLimitExceeded` now transitions to `WorkloadReactivated`. Verified it fails without the fix. The full `./pkg/controller/core/...` suite passes.

AI assistance was used to help implement this change.

#### Does this PR introduce a user-facing change?

```release-note
Scheduling: Fixed a bug where a Workload deactivated with a derived `DeactivatedDueTo<Cause>` reason (such as `DeactivatedDueToRequeuingLimitExceeded`) could remain stuck after reactivation because its `WorkloadRequeued` condition was not transitioned. Such Workloads are now reactivated correctly.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved workload reactivation handling for deactivation-related conditions, including workloads deactivated after exceeding requeue limits.
  - Preserved existing eviction-specific backoff behavior.
  - Reactivated workloads now receive the standard reactivation status and message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->