### PR TITLE
Refactor indexer tests to use structured Kubernetes object wrappers

### DIFF
--- a/pkg/controller/core/indexer/indexer_test.go
+++ b/pkg/controller/core/indexer/indexer_test.go
@@ -298,16 +298,6 @@ func TestIndexWorkloadQuotaReserved(t *testing.T) {
 }
 
 func TestIndexWorkloadRuntimeClass(t *testing.T) {
-	rc1, rc2 := "rc-fast", "rc-slow"
-
-	podSet := func(name string, rc *string) kueue.PodSet {
-		w := utiltestingapi.MakePodSet(kueue.PodSetReference(name), 1)
-		if rc != nil {
-			w = w.RuntimeClass(*rc)
-		}
-		return *w.Obj()
-	}
-
 	cases := map[string]struct {
 		obj  client.Object
 		want []string
@@ -321,19 +311,33 @@ func TestIndexWorkloadRuntimeClass(t *testing.T) {
 			want: nil,
 		},
 		"podset with no runtime class returns nil": {
-			obj:  utiltestingapi.MakeWorkload("wl", "ns").PodSets(podSet("main", nil)).Obj(),
+			obj: utiltestingapi.MakeWorkload("wl", "ns").
+				PodSets(*utiltestingapi.MakePodSet("main", 1).Obj()).
+				Obj(),
 			want: nil,
 		},
 		"workload with single runtime class": {
-			obj:  utiltestingapi.MakeWorkload("wl", "ns").PodSets(podSet("main", &rc1)).Obj(),
+			obj: utiltestingapi.MakeWorkload("wl", "ns").
+				PodSets(*utiltestingapi.MakePodSet("main", 1).RuntimeClass("rc-fast").Obj()).
+				Obj(),
 			want: []string{"rc-fast"},
 		},
 		"workload with multiple distinct runtime classes": {
-			obj:  utiltestingapi.MakeWorkload("wl", "ns").PodSets(podSet("ps1", &rc1), podSet("ps2", &rc2)).Obj(),
+			obj: utiltestingapi.MakeWorkload("wl", "ns").
+				PodSets(
+					*utiltestingapi.MakePodSet("ps1", 1).RuntimeClass("rc-fast").Obj(),
+					*utiltestingapi.MakePodSet("ps2", 1).RuntimeClass("rc-slow").Obj(),
+				).
+				Obj(),
 			want: []string{"rc-fast", "rc-slow"},
 		},
 		"duplicate runtime class across podsets is deduplicated": {
-			obj:  utiltestingapi.MakeWorkload("wl", "ns").PodSets(podSet("ps1", &rc1), podSet("ps2", &rc1)).Obj(),
+			obj: utiltestingapi.MakeWorkload("wl", "ns").
+				PodSets(
+					*utiltestingapi.MakePodSet("ps1", 1).RuntimeClass("rc-fast").Obj(),
+					*utiltestingapi.MakePodSet("ps2", 1).RuntimeClass("rc-fast").Obj(),
+				).
+				Obj(),
 			want: []string{"rc-fast"},
 		},
 	}
@@ -596,10 +600,6 @@ func TestIndexWorkloadExtendedResources(t *testing.T) {
 		return *c.Obj()
 	}
 
-	podSetWithContainers := func(containers ...corev1.Container) kueue.PodSet {
-		return *utiltestingapi.MakePodSet("main", 1).Containers(containers...).Obj()
-	}
-
 	containerWithLimits := func(name string, limits corev1.ResourceList) corev1.Container {
 		c := utiltesting.MakeContainer().Name(name)
 		for r, q := range limits {
@@ -618,44 +618,44 @@ func TestIndexWorkloadExtendedResources(t *testing.T) {
 		},
 		"workload with only cpu and memory": {
 			obj: utiltestingapi.MakeWorkload("wl", "ns").
-				PodSets(podSetWithContainers(container("c", corev1.ResourceList{
+				PodSets(*utiltestingapi.MakePodSet("main", 1).Containers(container("c", corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("1"),
 					corev1.ResourceMemory: resource.MustParse("1Gi"),
-				}))).
+				})).Obj()).
 				Obj(),
 			want: nil,
 		},
 		"workload with single extended resource": {
 			obj: utiltestingapi.MakeWorkload("wl", "ns").
-				PodSets(podSetWithContainers(container("c", corev1.ResourceList{
+				PodSets(*utiltestingapi.MakePodSet("main", 1).Containers(container("c", corev1.ResourceList{
 					"nvidia.com/gpu": resource.MustParse("1"),
-				}))).
+				})).Obj()).
 				Obj(),
 			want: []string{"nvidia.com/gpu"},
 		},
 		"workload with extended resource only in limits": {
 			obj: utiltestingapi.MakeWorkload("wl", "ns").
-				PodSets(podSetWithContainers(containerWithLimits("c", corev1.ResourceList{
+				PodSets(*utiltestingapi.MakePodSet("main", 1).Containers(containerWithLimits("c", corev1.ResourceList{
 					"nvidia.com/gpu": resource.MustParse("1"),
-				}))).
+				})).Obj()).
 				Obj(),
 			want: []string{"nvidia.com/gpu"},
 		},
 		"workload with multiple extended resources": {
 			obj: utiltestingapi.MakeWorkload("wl", "ns").
-				PodSets(podSetWithContainers(
+				PodSets(*utiltestingapi.MakePodSet("main", 1).Containers(
 					container("c1", corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("1")}),
 					container("c2", corev1.ResourceList{"google.com/tpu": resource.MustParse("2")}),
-				)).
+				).Obj()).
 				Obj(),
 			want: []string{"google.com/tpu", "nvidia.com/gpu"},
 		},
 		"duplicate extended resource across containers is deduplicated": {
 			obj: utiltestingapi.MakeWorkload("wl", "ns").
-				PodSets(podSetWithContainers(
+				PodSets(*utiltestingapi.MakePodSet("main", 1).Containers(
 					container("c1", corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("1")}),
 					container("c2", corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("2")}),
-				)).
+				).Obj()).
 				Obj(),
 			want: []string{"nvidia.com/gpu"},
 		},

--- a/pkg/controller/core/indexer/indexer_test.go
+++ b/pkg/controller/core/indexer/indexer_test.go
@@ -28,7 +28,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -592,22 +591,6 @@ func TestSetupToleratesNoMatchErrorForDeviceClass(t *testing.T) {
 }
 
 func TestIndexWorkloadExtendedResources(t *testing.T) {
-	container := func(name string, requests corev1.ResourceList) corev1.Container {
-		c := utiltesting.MakeContainer().Name(name)
-		for r, q := range requests {
-			c = c.WithResourceReq(r, q.String())
-		}
-		return *c.Obj()
-	}
-
-	containerWithLimits := func(name string, limits corev1.ResourceList) corev1.Container {
-		c := utiltesting.MakeContainer().Name(name)
-		for r, q := range limits {
-			c = c.WithResourceLimit(r, q.String())
-		}
-		return *c.Obj()
-	}
-
 	cases := map[string]struct {
 		obj  client.Object
 		want []string
@@ -618,34 +601,36 @@ func TestIndexWorkloadExtendedResources(t *testing.T) {
 		},
 		"workload with only cpu and memory": {
 			obj: utiltestingapi.MakeWorkload("wl", "ns").
-				PodSets(*utiltestingapi.MakePodSet("main", 1).Containers(container("c", corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("1"),
-					corev1.ResourceMemory: resource.MustParse("1Gi"),
-				})).Obj()).
+				PodSets(*utiltestingapi.MakePodSet("main", 1).Containers(
+					*utiltesting.MakeContainer().Name("c").
+						WithResourceReq(corev1.ResourceCPU, "1").
+						WithResourceReq(corev1.ResourceMemory, "1Gi").
+						Obj(),
+				).Obj()).
 				Obj(),
 			want: nil,
 		},
 		"workload with single extended resource": {
 			obj: utiltestingapi.MakeWorkload("wl", "ns").
-				PodSets(*utiltestingapi.MakePodSet("main", 1).Containers(container("c", corev1.ResourceList{
-					"nvidia.com/gpu": resource.MustParse("1"),
-				})).Obj()).
+				PodSets(*utiltestingapi.MakePodSet("main", 1).Containers(
+					*utiltesting.MakeContainer().Name("c").WithResourceReq("nvidia.com/gpu", "1").Obj(),
+				).Obj()).
 				Obj(),
 			want: []string{"nvidia.com/gpu"},
 		},
 		"workload with extended resource only in limits": {
 			obj: utiltestingapi.MakeWorkload("wl", "ns").
-				PodSets(*utiltestingapi.MakePodSet("main", 1).Containers(containerWithLimits("c", corev1.ResourceList{
-					"nvidia.com/gpu": resource.MustParse("1"),
-				})).Obj()).
+				PodSets(*utiltestingapi.MakePodSet("main", 1).Containers(
+					*utiltesting.MakeContainer().Name("c").WithResourceLimit("nvidia.com/gpu", "1").Obj(),
+				).Obj()).
 				Obj(),
 			want: []string{"nvidia.com/gpu"},
 		},
 		"workload with multiple extended resources": {
 			obj: utiltestingapi.MakeWorkload("wl", "ns").
 				PodSets(*utiltestingapi.MakePodSet("main", 1).Containers(
-					container("c1", corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("1")}),
-					container("c2", corev1.ResourceList{"google.com/tpu": resource.MustParse("2")}),
+					*utiltesting.MakeContainer().Name("c1").WithResourceReq("nvidia.com/gpu", "1").Obj(),
+					*utiltesting.MakeContainer().Name("c2").WithResourceReq("google.com/tpu", "2").Obj(),
 				).Obj()).
 				Obj(),
 			want: []string{"google.com/tpu", "nvidia.com/gpu"},
@@ -653,8 +638,8 @@ func TestIndexWorkloadExtendedResources(t *testing.T) {
 		"duplicate extended resource across containers is deduplicated": {
 			obj: utiltestingapi.MakeWorkload("wl", "ns").
 				PodSets(*utiltestingapi.MakePodSet("main", 1).Containers(
-					container("c1", corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("1")}),
-					container("c2", corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("2")}),
+					*utiltesting.MakeContainer().Name("c1").WithResourceReq("nvidia.com/gpu", "1").Obj(),
+					*utiltesting.MakeContainer().Name("c2").WithResourceReq("nvidia.com/gpu", "2").Obj(),
 				).Obj()).
 				Obj(),
 			want: []string{"nvidia.com/gpu"},

--- a/pkg/controller/core/indexer/indexer_test.go
+++ b/pkg/controller/core/indexer/indexer_test.go
@@ -14,7 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package indexer
+// Package indexer_test is an external test package so it can use the
+// structured object wrappers from pkg/util/testing without an import cycle
+// (those packages transitively import pkg/controller/core/indexer).
+package indexer_test
 
 import (
 	"context"
@@ -31,39 +34,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/features"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
 )
-
-// helpers to build test objects without importing any package that transitively
-// imports this (indexer) package, which would create an import cycle.
-
-func makeWorkload(name, ns string) *kueue.Workload {
-	return &kueue.Workload{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns}}
-}
-
-func makeLocalQueue(name, ns, cq string) *kueue.LocalQueue {
-	return &kueue.LocalQueue{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
-		Spec:       kueue.LocalQueueSpec{ClusterQueue: kueue.ClusterQueueReference(cq)},
-	}
-}
-
-func makeLimitRange(name, ns string, types ...corev1.LimitType) *corev1.LimitRange {
-	items := make([]corev1.LimitRangeItem, len(types))
-	for i, t := range types {
-		items[i] = corev1.LimitRangeItem{Type: t}
-	}
-	return &corev1.LimitRange{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
-		Spec:       corev1.LimitRangeSpec{Limits: items},
-	}
-}
-
-func makePod(name, ns string, annotations map[string]string) *corev1.Pod {
-	return &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, Annotations: annotations},
-	}
-}
 
 var batchJobGVK = schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"}
 
@@ -88,7 +64,7 @@ func TestOwnerReferenceIndexKey(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := OwnerReferenceIndexKey(tc.gvk)
+			got := indexer.OwnerReferenceIndexKey(tc.gvk)
 			if got != tc.want {
 				t.Errorf("got %q, want %q", got, tc.want)
 			}
@@ -97,7 +73,7 @@ func TestOwnerReferenceIndexKey(t *testing.T) {
 }
 
 func TestOwnerReferenceIndexFieldMatcher(t *testing.T) {
-	got := OwnerReferenceIndexFieldMatcher(batchJobGVK, "my-job")
+	got := indexer.OwnerReferenceIndexFieldMatcher(batchJobGVK, "my-job")
 
 	want := client.MatchingFields{".metadata.ownerReferences[batch.Job]": "my-job"}
 	if diff := cmp.Diff(want, got); diff != "" {
@@ -106,60 +82,44 @@ func TestOwnerReferenceIndexFieldMatcher(t *testing.T) {
 }
 
 func TestWorkloadOwnerIndexFunc(t *testing.T) {
-	indexFn := WorkloadOwnerIndexFunc(batchJobGVK)
+	indexFn := indexer.WorkloadOwnerIndexFunc(batchJobGVK)
 
 	cases := map[string]struct {
 		obj  client.Object
 		want []string
 	}{
 		"non-workload object returns nil": {
-			obj:  makeLimitRange("lr", "ns"),
+			obj:  utiltesting.MakeLimitRange("lr", "ns").Obj(),
 			want: nil,
 		},
 		"workload with no owner references returns nil": {
-			obj:  makeWorkload("wl", "ns"),
+			obj:  utiltestingapi.MakeWorkload("wl", "ns").Obj(),
 			want: nil,
 		},
 		"workload with non-matching kind is skipped": {
-			obj: func() client.Object {
-				wl := makeWorkload("wl", "ns")
-				wl.OwnerReferences = []metav1.OwnerReference{
-					{APIVersion: "batch/v1", Kind: "CronJob", Name: "cron"},
-				}
-				return wl
-			}(),
+			obj: utiltestingapi.MakeWorkload("wl", "ns").
+				OwnerReference(schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "CronJob"}, "cron", "").
+				Obj(),
 			want: nil,
 		},
 		"workload with non-matching apiVersion is skipped": {
-			obj: func() client.Object {
-				wl := makeWorkload("wl", "ns")
-				wl.OwnerReferences = []metav1.OwnerReference{
-					{APIVersion: "apps/v1", Kind: "Job", Name: "job"},
-				}
-				return wl
-			}(),
+			obj: utiltestingapi.MakeWorkload("wl", "ns").
+				OwnerReference(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Job"}, "job", "").
+				Obj(),
 			want: nil,
 		},
 		"workload with single matching owner": {
-			obj: func() client.Object {
-				wl := makeWorkload("wl", "ns")
-				wl.OwnerReferences = []metav1.OwnerReference{
-					{APIVersion: "batch/v1", Kind: "Job", Name: "my-job"},
-				}
-				return wl
-			}(),
+			obj: utiltestingapi.MakeWorkload("wl", "ns").
+				OwnerReference(batchJobGVK, "my-job", "").
+				Obj(),
 			want: []string{"my-job"},
 		},
 		"workload with multiple owners, only matching ones returned": {
-			obj: func() client.Object {
-				wl := makeWorkload("wl", "ns")
-				wl.OwnerReferences = []metav1.OwnerReference{
-					{APIVersion: "batch/v1", Kind: "Job", Name: "job-1"},
-					{APIVersion: "apps/v1", Kind: "Deployment", Name: "deploy"},
-					{APIVersion: "batch/v1", Kind: "Job", Name: "job-2"},
-				}
-				return wl
-			}(),
+			obj: utiltestingapi.MakeWorkload("wl", "ns").
+				OwnerReference(batchJobGVK, "job-1", "").
+				OwnerReference(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}, "deploy", "").
+				OwnerReference(batchJobGVK, "job-2", "").
+				Obj(),
 			want: []string{"job-1", "job-2"},
 		},
 	}
@@ -180,22 +140,22 @@ func TestIndexQueueClusterQueue(t *testing.T) {
 		want []string
 	}{
 		"non-LocalQueue returns nil": {
-			obj:  makeWorkload("wl", "ns"),
+			obj:  utiltestingapi.MakeWorkload("wl", "ns").Obj(),
 			want: nil,
 		},
 		"LocalQueue returns its clusterQueue name": {
-			obj:  makeLocalQueue("lq", "ns", "my-cq"),
+			obj:  utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("my-cq").Obj(),
 			want: []string{"my-cq"},
 		},
 		"LocalQueue with empty clusterQueue": {
-			obj:  makeLocalQueue("lq", "ns", ""),
+			obj:  utiltestingapi.MakeLocalQueue("lq", "ns").Obj(),
 			want: []string{""},
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := IndexQueueClusterQueue(tc.obj)
+			got := indexer.IndexQueueClusterQueue(tc.obj)
 			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -209,26 +169,22 @@ func TestIndexWorkloadQueue(t *testing.T) {
 		want []string
 	}{
 		"non-Workload returns nil": {
-			obj:  makeLocalQueue("lq", "ns", "cq"),
+			obj:  utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
 			want: nil,
 		},
 		"workload returns its queue name": {
-			obj: func() client.Object {
-				wl := makeWorkload("wl", "ns")
-				wl.Spec.QueueName = "user-queue"
-				return wl
-			}(),
+			obj:  utiltestingapi.MakeWorkload("wl", "ns").Queue("user-queue").Obj(),
 			want: []string{"user-queue"},
 		},
 		"workload with empty queue name": {
-			obj:  makeWorkload("wl", "ns"),
+			obj:  utiltestingapi.MakeWorkload("wl", "ns").Obj(),
 			want: []string{""},
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := IndexWorkloadQueue(tc.obj)
+			got := indexer.IndexWorkloadQueue(tc.obj)
 			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -242,28 +198,24 @@ func TestIndexWorkloadClusterQueue(t *testing.T) {
 		want []string
 	}{
 		"non-Workload returns nil": {
-			obj:  makeLocalQueue("lq", "ns", "cq"),
+			obj:  utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
 			want: nil,
 		},
 		"workload without admission returns nil": {
-			obj:  makeWorkload("wl", "ns"),
+			obj:  utiltestingapi.MakeWorkload("wl", "ns").Obj(),
 			want: nil,
 		},
 		"workload with admission returns cluster queue": {
-			obj: func() client.Object {
-				wl := makeWorkload("wl", "ns")
-				wl.Status.Admission = &kueue.Admission{
-					ClusterQueue: "my-cq",
-				}
-				return wl
-			}(),
+			obj: utiltestingapi.MakeWorkload("wl", "ns").
+				Admission(utiltestingapi.MakeAdmission("my-cq").Obj()).
+				Obj(),
 			want: []string{"my-cq"},
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := IndexWorkloadClusterQueue(tc.obj)
+			got := indexer.IndexWorkloadClusterQueue(tc.obj)
 			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -277,30 +229,30 @@ func TestIndexLimitRangeHasContainerOrPodType(t *testing.T) {
 		want []string
 	}{
 		"non-LimitRange returns nil": {
-			obj:  makeWorkload("wl", "ns"),
+			obj:  utiltestingapi.MakeWorkload("wl", "ns").Obj(),
 			want: nil,
 		},
 		"LimitRange with no limits returns nil": {
-			obj:  makeLimitRange("lr", "ns"),
+			obj:  utiltesting.MakeLimitRange("lr", "ns").LimitTypes().Obj(),
 			want: nil,
 		},
 		"LimitRange with only Pod type returns nil": {
-			obj:  makeLimitRange("lr", "ns", corev1.LimitTypePod),
+			obj:  utiltesting.MakeLimitRange("lr", "ns").LimitTypes(corev1.LimitTypePod).Obj(),
 			want: []string{"true"},
 		},
 		"LimitRange with Container type returns true": {
-			obj:  makeLimitRange("lr", "ns", corev1.LimitTypeContainer),
+			obj:  utiltesting.MakeLimitRange("lr", "ns").LimitTypes(corev1.LimitTypeContainer).Obj(),
 			want: []string{"true"},
 		},
 		"LimitRange with both Pod and Container types returns true": {
-			obj:  makeLimitRange("lr", "ns", corev1.LimitTypePod, corev1.LimitTypeContainer),
+			obj:  utiltesting.MakeLimitRange("lr", "ns").LimitTypes(corev1.LimitTypePod, corev1.LimitTypeContainer).Obj(),
 			want: []string{"true"},
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := IndexLimitRangeHasContainerOrPodType(tc.obj)
+			got := indexer.IndexLimitRangeHasContainerOrPodType(tc.obj)
 			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -314,38 +266,30 @@ func TestIndexWorkloadQuotaReserved(t *testing.T) {
 		want []string
 	}{
 		"non-Workload returns nil": {
-			obj:  makeLocalQueue("lq", "ns", "cq"),
+			obj:  utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
 			want: nil,
 		},
 		"workload without QuotaReserved condition returns False": {
-			obj:  makeWorkload("wl", "ns"),
+			obj:  utiltestingapi.MakeWorkload("wl", "ns").Obj(),
 			want: []string{"False"},
 		},
 		"workload with QuotaReserved=True": {
-			obj: func() client.Object {
-				wl := makeWorkload("wl", "ns")
-				wl.Status.Conditions = []metav1.Condition{
-					{Type: kueue.WorkloadQuotaReserved, Status: metav1.ConditionTrue},
-				}
-				return wl
-			}(),
+			obj: utiltestingapi.MakeWorkload("wl", "ns").
+				Condition(metav1.Condition{Type: kueue.WorkloadQuotaReserved, Status: metav1.ConditionTrue}).
+				Obj(),
 			want: []string{"True"},
 		},
 		"workload with QuotaReserved=False": {
-			obj: func() client.Object {
-				wl := makeWorkload("wl", "ns")
-				wl.Status.Conditions = []metav1.Condition{
-					{Type: kueue.WorkloadQuotaReserved, Status: metav1.ConditionFalse},
-				}
-				return wl
-			}(),
+			obj: utiltestingapi.MakeWorkload("wl", "ns").
+				Condition(metav1.Condition{Type: kueue.WorkloadQuotaReserved, Status: metav1.ConditionFalse}).
+				Obj(),
 			want: []string{"False"},
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := IndexWorkloadQuotaReserved(tc.obj)
+			got := indexer.IndexWorkloadQuotaReserved(tc.obj)
 			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -357,11 +301,11 @@ func TestIndexWorkloadRuntimeClass(t *testing.T) {
 	rc1, rc2 := "rc-fast", "rc-slow"
 
 	podSet := func(name string, rc *string) kueue.PodSet {
-		return kueue.PodSet{
-			Name:     kueue.PodSetReference(name),
-			Count:    1,
-			Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{RuntimeClassName: rc}},
+		w := utiltestingapi.MakePodSet(kueue.PodSetReference(name), 1)
+		if rc != nil {
+			w = w.RuntimeClass(*rc)
 		}
+		return *w.Obj()
 	}
 
 	cases := map[string]struct {
@@ -369,50 +313,34 @@ func TestIndexWorkloadRuntimeClass(t *testing.T) {
 		want []string
 	}{
 		"non-Workload returns nil": {
-			obj:  makeLocalQueue("lq", "ns", "cq"),
+			obj:  utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
 			want: nil,
 		},
 		"workload with no podsets returns nil": {
-			obj:  makeWorkload("wl", "ns"),
+			obj:  utiltestingapi.MakeWorkload("wl", "ns").PodSets().Obj(),
 			want: nil,
 		},
 		"podset with no runtime class returns nil": {
-			obj: func() client.Object {
-				wl := makeWorkload("wl", "ns")
-				wl.Spec.PodSets = []kueue.PodSet{podSet("main", nil)}
-				return wl
-			}(),
+			obj:  utiltestingapi.MakeWorkload("wl", "ns").PodSets(podSet("main", nil)).Obj(),
 			want: nil,
 		},
 		"workload with single runtime class": {
-			obj: func() client.Object {
-				wl := makeWorkload("wl", "ns")
-				wl.Spec.PodSets = []kueue.PodSet{podSet("main", &rc1)}
-				return wl
-			}(),
+			obj:  utiltestingapi.MakeWorkload("wl", "ns").PodSets(podSet("main", &rc1)).Obj(),
 			want: []string{"rc-fast"},
 		},
 		"workload with multiple distinct runtime classes": {
-			obj: func() client.Object {
-				wl := makeWorkload("wl", "ns")
-				wl.Spec.PodSets = []kueue.PodSet{podSet("ps1", &rc1), podSet("ps2", &rc2)}
-				return wl
-			}(),
+			obj:  utiltestingapi.MakeWorkload("wl", "ns").PodSets(podSet("ps1", &rc1), podSet("ps2", &rc2)).Obj(),
 			want: []string{"rc-fast", "rc-slow"},
 		},
 		"duplicate runtime class across podsets is deduplicated": {
-			obj: func() client.Object {
-				wl := makeWorkload("wl", "ns")
-				wl.Spec.PodSets = []kueue.PodSet{podSet("ps1", &rc1), podSet("ps2", &rc1)}
-				return wl
-			}(),
+			obj:  utiltestingapi.MakeWorkload("wl", "ns").PodSets(podSet("ps1", &rc1), podSet("ps2", &rc1)).Obj(),
 			want: []string{"rc-fast"},
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := IndexWorkloadRuntimeClass(tc.obj)
+			got := indexer.IndexWorkloadRuntimeClass(tc.obj)
 			if diff := cmp.Diff(tc.want, got,
 				cmpopts.SortSlices(func(a, b string) bool { return a < b }),
 				cmpopts.EquateEmpty(),
@@ -429,34 +357,26 @@ func TestIndexOwnerUID(t *testing.T) {
 		want []string
 	}{
 		"object with no owner references returns nil": {
-			obj:  makeWorkload("wl", "ns"),
+			obj:  utiltestingapi.MakeWorkload("wl", "ns").Obj(),
 			want: nil,
 		},
 		"object with single owner returns its UID": {
-			obj: func() client.Object {
-				wl := makeWorkload("wl", "ns")
-				wl.OwnerReferences = []metav1.OwnerReference{{UID: "uid-abc"}}
-				return wl
-			}(),
+			obj:  utiltestingapi.MakeWorkload("wl", "ns").OwnerReference(schema.GroupVersionKind{}, "", "uid-abc").Obj(),
 			want: []string{"uid-abc"},
 		},
 		"object with multiple owners returns all UIDs in order": {
-			obj: func() client.Object {
-				wl := makeWorkload("wl", "ns")
-				wl.OwnerReferences = []metav1.OwnerReference{
-					{UID: "uid-1"},
-					{UID: "uid-2"},
-					{UID: "uid-3"},
-				}
-				return wl
-			}(),
+			obj: utiltestingapi.MakeWorkload("wl", "ns").
+				OwnerReference(schema.GroupVersionKind{}, "", "uid-1").
+				OwnerReference(schema.GroupVersionKind{}, "", "uid-2").
+				OwnerReference(schema.GroupVersionKind{}, "", "uid-3").
+				Obj(),
 			want: []string{"uid-1", "uid-2", "uid-3"},
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := IndexOwnerUID(tc.obj)
+			got := indexer.IndexOwnerUID(tc.obj)
 			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -470,33 +390,33 @@ func TestIndexPodWorkloadSliceName(t *testing.T) {
 		want []string
 	}{
 		"non-Pod returns nil": {
-			obj:  makeWorkload("wl", "ns"),
+			obj:  utiltestingapi.MakeWorkload("wl", "ns").Obj(),
 			want: nil,
 		},
 		"pod with no annotations returns nil": {
-			obj:  makePod("pod", "ns", nil),
+			obj:  testingpod.MakePod("pod", "ns").Obj(),
 			want: nil,
 		},
 		"pod with WorkloadSliceNameAnnotation": {
-			obj:  makePod("pod", "ns", map[string]string{kueue.WorkloadSliceNameAnnotation: "slice-123"}),
+			obj:  testingpod.MakePod("pod", "ns").Annotation(kueue.WorkloadSliceNameAnnotation, "slice-123").Obj(),
 			want: []string{"slice-123"},
 		},
 		"pod with only WorkloadAnnotation falls back to it": {
-			obj:  makePod("pod", "ns", map[string]string{kueue.WorkloadAnnotation: "wl-abc"}),
+			obj:  testingpod.MakePod("pod", "ns").Annotation(kueue.WorkloadAnnotation, "wl-abc").Obj(),
 			want: []string{"wl-abc"},
 		},
 		"pod with both annotations prefers WorkloadSliceNameAnnotation": {
-			obj: makePod("pod", "ns", map[string]string{
-				kueue.WorkloadSliceNameAnnotation: "slice-123",
-				kueue.WorkloadAnnotation:          "wl-abc",
-			}),
+			obj: testingpod.MakePod("pod", "ns").
+				Annotation(kueue.WorkloadSliceNameAnnotation, "slice-123").
+				Annotation(kueue.WorkloadAnnotation, "wl-abc").
+				Obj(),
 			want: []string{"slice-123"},
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := IndexPodWorkloadSliceName(tc.obj)
+			got := indexer.IndexPodWorkloadSliceName(tc.obj)
 			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -510,39 +430,28 @@ func TestIndexWorkloadAdmissionCheck(t *testing.T) {
 		want []string
 	}{
 		"non-Workload returns nil": {
-			obj:  makeLocalQueue("lq", "ns", "cq"),
+			obj:  utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
 			want: nil,
 		},
 		"workload with no admission checks returns nil": {
-			obj:  makeWorkload("wl", "ns"),
+			obj:  utiltestingapi.MakeWorkload("wl", "ns").Obj(),
 			want: nil,
 		},
 		"workload with single admission check": {
-			obj: func() client.Object {
-				wl := makeWorkload("wl", "ns")
-				wl.Status.AdmissionChecks = []kueue.AdmissionCheckState{
-					{Name: "check-a"},
-				}
-				return wl
-			}(),
+			obj:  utiltestingapi.MakeWorkload("wl", "ns").AdmissionChecks(kueue.AdmissionCheckState{Name: "check-a"}).Obj(),
 			want: []string{"check-a"},
 		},
 		"workload with multiple admission checks": {
-			obj: func() client.Object {
-				wl := makeWorkload("wl", "ns")
-				wl.Status.AdmissionChecks = []kueue.AdmissionCheckState{
-					{Name: "check-a"},
-					{Name: "check-b"},
-				}
-				return wl
-			}(),
+			obj: utiltestingapi.MakeWorkload("wl", "ns").
+				AdmissionChecks(kueue.AdmissionCheckState{Name: "check-a"}, kueue.AdmissionCheckState{Name: "check-b"}).
+				Obj(),
 			want: []string{"check-a", "check-b"},
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := IndexWorkloadAdmissionCheck(tc.obj)
+			got := indexer.IndexWorkloadAdmissionCheck(tc.obj)
 			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -556,54 +465,42 @@ func TestIndexWorkloadPriorityClass(t *testing.T) {
 		want []string
 	}{
 		"non-Workload returns nil": {
-			obj:  makeLocalQueue("lq", "ns", "cq"),
+			obj:  utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
 			want: nil,
 		},
 		"workload with no priority class ref returns nil": {
-			obj:  makeWorkload("wl", "ns"),
+			obj:  utiltestingapi.MakeWorkload("wl", "ns").Obj(),
 			want: nil,
 		},
 		"workload with wrong kind is ignored": {
-			obj: func() client.Object {
-				wl := makeWorkload("wl", "ns")
-				wl.Spec.PriorityClassRef = &kueue.PriorityClassRef{
+			obj: utiltestingapi.MakeWorkload("wl", "ns").
+				PriorityClassRef(&kueue.PriorityClassRef{
 					Group: kueue.WorkloadPriorityClassGroup,
 					Kind:  kueue.PodPriorityClassKind,
 					Name:  "my-pc",
-				}
-				return wl
-			}(),
+				}).
+				Obj(),
 			want: nil,
 		},
 		"workload with wrong group is ignored": {
-			obj: func() client.Object {
-				wl := makeWorkload("wl", "ns")
-				wl.Spec.PriorityClassRef = &kueue.PriorityClassRef{
+			obj: utiltestingapi.MakeWorkload("wl", "ns").
+				PriorityClassRef(&kueue.PriorityClassRef{
 					Group: "other.io",
 					Kind:  kueue.WorkloadPriorityClassKind,
 					Name:  "my-pc",
-				}
-				return wl
-			}(),
+				}).
+				Obj(),
 			want: nil,
 		},
 		"workload with correct WorkloadPriorityClass ref": {
-			obj: func() client.Object {
-				wl := makeWorkload("wl", "ns")
-				wl.Spec.PriorityClassRef = &kueue.PriorityClassRef{
-					Group: kueue.WorkloadPriorityClassGroup,
-					Kind:  kueue.WorkloadPriorityClassKind,
-					Name:  "high-priority",
-				}
-				return wl
-			}(),
+			obj:  utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high-priority").Obj(),
 			want: []string{"high-priority"},
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := IndexWorkloadPriorityClass(tc.obj)
+			got := indexer.IndexWorkloadPriorityClass(tc.obj)
 			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -612,40 +509,31 @@ func TestIndexWorkloadPriorityClass(t *testing.T) {
 }
 
 func TestIndexDeviceClassExtendedResourceName(t *testing.T) {
-	extName := "example.com/gpu"
-	empty := ""
-
 	cases := map[string]struct {
 		obj  client.Object
 		want []string
 	}{
 		"non-DeviceClass returns nil": {
-			obj:  makeWorkload("wl", "ns"),
+			obj:  utiltestingapi.MakeWorkload("wl", "ns").Obj(),
 			want: nil,
 		},
 		"DeviceClass with nil ExtendedResourceName returns nil": {
-			obj:  &resourceapi.DeviceClass{ObjectMeta: metav1.ObjectMeta{Name: "dc"}},
+			obj:  utiltesting.MakeDeviceClass("dc").Obj(),
 			want: nil,
 		},
 		"DeviceClass with empty ExtendedResourceName returns nil": {
-			obj: &resourceapi.DeviceClass{
-				ObjectMeta: metav1.ObjectMeta{Name: "dc"},
-				Spec:       resourceapi.DeviceClassSpec{ExtendedResourceName: &empty},
-			},
+			obj:  utiltesting.MakeDeviceClass("dc").ExtendedResourceName("").Obj(),
 			want: nil,
 		},
 		"DeviceClass with valid ExtendedResourceName": {
-			obj: &resourceapi.DeviceClass{
-				ObjectMeta: metav1.ObjectMeta{Name: "dc"},
-				Spec:       resourceapi.DeviceClassSpec{ExtendedResourceName: &extName},
-			},
+			obj:  utiltesting.MakeDeviceClass("dc").ExtendedResourceName("example.com/gpu").Obj(),
 			want: []string{"example.com/gpu"},
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := IndexDeviceClassExtendedResourceName(tc.obj)
+			got := indexer.IndexDeviceClassExtendedResourceName(tc.obj)
 			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
@@ -691,7 +579,7 @@ func TestSetupToleratesNoMatchErrorForDeviceClass(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			err := Setup(t.Context(), tc.indexer)
+			err := indexer.Setup(t.Context(), tc.indexer)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("Setup() error = %v, wantErr %v", err, tc.wantErr)
 			}
@@ -701,10 +589,15 @@ func TestSetupToleratesNoMatchErrorForDeviceClass(t *testing.T) {
 
 func TestIndexWorkloadExtendedResources(t *testing.T) {
 	container := func(name string, requests corev1.ResourceList) corev1.Container {
-		return corev1.Container{
-			Name:      name,
-			Resources: corev1.ResourceRequirements{Requests: requests},
+		c := utiltesting.MakeContainer().Name(name)
+		for r, q := range requests {
+			c = c.WithResourceReq(r, q.String())
 		}
+		return *c.Obj()
+	}
+
+	podSetWithContainers := func(containers ...corev1.Container) kueue.PodSet {
+		return *utiltestingapi.MakePodSet("main", 1).Containers(containers...).Obj()
 	}
 
 	containerWithLimits := func(name string, limits corev1.ResourceList) corev1.Container {
@@ -721,44 +614,24 @@ func TestIndexWorkloadExtendedResources(t *testing.T) {
 		want []string
 	}{
 		"non-Workload returns nil": {
-			obj:  makeLocalQueue("lq", "ns", "cq"),
+			obj:  utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
 			want: nil,
 		},
 		"workload with only cpu and memory": {
-			obj: func() client.Object {
-				wl := makeWorkload("wl", "ns")
-				wl.Spec.PodSets = []kueue.PodSet{{
-					Name:  "main",
-					Count: 1,
-					Template: corev1.PodTemplateSpec{
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{container("c", corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("1"),
-								corev1.ResourceMemory: resource.MustParse("1Gi"),
-							})},
-						},
-					},
-				}}
-				return wl
-			}(),
+			obj: utiltestingapi.MakeWorkload("wl", "ns").
+				PodSets(podSetWithContainers(container("c", corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				}))).
+				Obj(),
 			want: nil,
 		},
 		"workload with single extended resource": {
-			obj: func() client.Object {
-				wl := makeWorkload("wl", "ns")
-				wl.Spec.PodSets = []kueue.PodSet{{
-					Name:  "main",
-					Count: 1,
-					Template: corev1.PodTemplateSpec{
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{container("c", corev1.ResourceList{
-								"nvidia.com/gpu": resource.MustParse("1"),
-							})},
-						},
-					},
-				}}
-				return wl
-			}(),
+			obj: utiltestingapi.MakeWorkload("wl", "ns").
+				PodSets(podSetWithContainers(container("c", corev1.ResourceList{
+					"nvidia.com/gpu": resource.MustParse("1"),
+				}))).
+				Obj(),
 			want: []string{"nvidia.com/gpu"},
 		},
 		"workload with extended resource only in limits": {
@@ -782,48 +655,28 @@ func TestIndexWorkloadExtendedResources(t *testing.T) {
 			want: []string{"nvidia.com/gpu"},
 		},
 		"workload with multiple extended resources": {
-			obj: func() client.Object {
-				wl := makeWorkload("wl", "ns")
-				wl.Spec.PodSets = []kueue.PodSet{{
-					Name:  "main",
-					Count: 1,
-					Template: corev1.PodTemplateSpec{
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{
-								container("c1", corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("1")}),
-								container("c2", corev1.ResourceList{"google.com/tpu": resource.MustParse("2")}),
-							},
-						},
-					},
-				}}
-				return wl
-			}(),
+			obj: utiltestingapi.MakeWorkload("wl", "ns").
+				PodSets(podSetWithContainers(
+					container("c1", corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("1")}),
+					container("c2", corev1.ResourceList{"google.com/tpu": resource.MustParse("2")}),
+				)).
+				Obj(),
 			want: []string{"google.com/tpu", "nvidia.com/gpu"},
 		},
 		"duplicate extended resource across containers is deduplicated": {
-			obj: func() client.Object {
-				wl := makeWorkload("wl", "ns")
-				wl.Spec.PodSets = []kueue.PodSet{{
-					Name:  "main",
-					Count: 1,
-					Template: corev1.PodTemplateSpec{
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{
-								container("c1", corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("1")}),
-								container("c2", corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("2")}),
-							},
-						},
-					},
-				}}
-				return wl
-			}(),
+			obj: utiltestingapi.MakeWorkload("wl", "ns").
+				PodSets(podSetWithContainers(
+					container("c1", corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("1")}),
+					container("c2", corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("2")}),
+				)).
+				Obj(),
 			want: []string{"nvidia.com/gpu"},
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := IndexWorkloadExtendedResources(tc.obj)
+			got := indexer.IndexWorkloadExtendedResources(tc.obj)
 			if diff := cmp.Diff(tc.want, got,
 				cmpopts.SortSlices(func(a, b string) bool { return a < b }),
 				cmpopts.EquateEmpty(),

--- a/pkg/controller/core/indexer/indexer_test.go
+++ b/pkg/controller/core/indexer/indexer_test.go
@@ -601,12 +601,11 @@ func TestIndexWorkloadExtendedResources(t *testing.T) {
 	}
 
 	containerWithLimits := func(name string, limits corev1.ResourceList) corev1.Container {
-		return corev1.Container{
-			Name: name,
-			Resources: corev1.ResourceRequirements{
-				Limits: limits,
-			},
+		c := utiltesting.MakeContainer().Name(name)
+		for r, q := range limits {
+			c = c.WithResourceLimit(r, q.String())
 		}
+		return *c.Obj()
 	}
 
 	cases := map[string]struct {
@@ -635,23 +634,11 @@ func TestIndexWorkloadExtendedResources(t *testing.T) {
 			want: []string{"nvidia.com/gpu"},
 		},
 		"workload with extended resource only in limits": {
-			obj: func() client.Object {
-				wl := makeWorkload("wl", "ns")
-				wl.Spec.PodSets = []kueue.PodSet{{
-					Name:  "main",
-					Count: 1,
-					Template: corev1.PodTemplateSpec{
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{
-								containerWithLimits("c", corev1.ResourceList{
-									"nvidia.com/gpu": resource.MustParse("1"),
-								}),
-							},
-						},
-					},
-				}}
-				return wl
-			}(),
+			obj: utiltestingapi.MakeWorkload("wl", "ns").
+				PodSets(podSetWithContainers(containerWithLimits("c", corev1.ResourceList{
+					"nvidia.com/gpu": resource.MustParse("1"),
+				}))).
+				Obj(),
 			want: []string{"nvidia.com/gpu"},
 		},
 		"workload with multiple extended resources": {

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -113,6 +113,17 @@ func (lr *LimitRangeWrapper) WithType(t corev1.LimitType) *LimitRangeWrapper {
 	return lr
 }
 
+// LimitTypes replaces the LimitRange's items with one bare item per given type,
+// or clears them when called with no arguments.
+func (lr *LimitRangeWrapper) LimitTypes(types ...corev1.LimitType) *LimitRangeWrapper {
+	items := make([]corev1.LimitRangeItem, len(types))
+	for i, t := range types {
+		items[i] = corev1.LimitRangeItem{Type: t}
+	}
+	lr.Spec.Limits = items
+	return lr
+}
+
 func (lr *LimitRangeWrapper) WithValue(member string, t corev1.ResourceName, q string) *LimitRangeWrapper {
 	target := lr.Spec.Limits[0].Max
 	switch member {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area testing

#### What this PR does / why we need it:

Replaces the inline callback closures in `pkg/controller/core/indexer/indexer_test.go` that manually construct `Workload`, `LocalQueue`, `LimitRange`, and `Pod` objects with the existing structured test wrappers from `pkg/util/testing`, `pkg/util/testing/v1beta2`, and `pkg/util/testingjobs/pod`.

The test file previously lived in `package indexer` (an internal test) and defined its own minimal `makeWorkload`/`makeLocalQueue`/`makeLimitRange`/`makePod` helpers to avoid an import cycle, since the wrapper packages transitively import `pkg/controller/core/indexer`. This PR converts the file to an external `package indexer_test`, which breaks the cycle and lets the tests use the real wrappers directly.

A `LimitRangeWrapper.LimitTypes(...)` method was added to `pkg/util/testing/wrappers.go` since no existing wrapper supported building a `LimitRange` with an arbitrary, possibly empty, set of bare `LimitRangeItem` types.

Test coverage and assertions are unchanged; all existing subtests and cases are preserved.

This PR uses AI-assisted development (Claude Code).

#### Which issue(s) this PR fixes:

Fixes #14884

#### Special notes for your reviewer:

Follow-up from #14808, requested by @tenzen-y.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved indexer test construction with reusable, consistent testing builders.
  * Preserved existing expected behavior across workload, queue, pod, resource, and admission scenarios.

* **Developer Tools**
  * Added support for configuring LimitRange types in testing utilities.
  * Simplified setup of test scenarios involving resource limits and workload behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->