### PR TITLE
Validate Kubeflow Trainer TrainJob CRD compatibility at setup and document v2.3.0 

### DIFF
--- a/pkg/controller/jobs/trainjob/crd_validation.go
+++ b/pkg/controller/jobs/trainjob/crd_validation.go
@@ -1,0 +1,92 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package trainjob
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ValidateTrainJobCRDVersion validates that the installed TrainJob CRD is v2.2.0 or later.
+// It checks if the CRD schema supports the RuntimePatches field which was added in v2.2.0.
+// Returns an error if the CRD is v2.1 or earlier, or if validation cannot be performed.
+func ValidateTrainJobCRDVersion(ctx context.Context, c client.Client) error {
+	crd := &unstructured.Unstructured{}
+	crd.SetAPIVersion("apiextensions.k8s.io/v1")
+	crd.SetKind("CustomResourceDefinition")
+
+	crdKey := client.ObjectKey{Name: "trainjobs.trainer.kubeflow.org"}
+	if err := c.Get(ctx, crdKey, crd); err != nil {
+		return fmt.Errorf(
+			"unable to fetch TrainJob CRD. "+
+				"Ensure Kubeflow Trainer is installed and v2.2.0 or later. "+
+				"Error: %w",
+			err,
+		)
+	}
+
+	// Check if the CRD schema has the runtimePatches field in TrainJobSpec
+	// This field was added in Kubeflow Trainer v2.2.0
+	if !hasRuntimePatchesField(crd) {
+		return fmt.Errorf(
+			"TrainJob CRD does not support the 'runtimePatches' field. " +
+				"This field is required by Kueue and was added in Kubeflow Trainer v2.2.0. " +
+				"Currently installed TrainJob CRD appears to be v2.1 or earlier. " +
+				"Please upgrade Kubeflow Trainer to v2.2.0 or later. " +
+				"See: https://github.com/kubeflow/trainer/releases",
+		)
+	}
+
+	return nil
+}
+
+// hasRuntimePatchesField checks if the CRD schema contains the runtimePatches field
+// in the TrainJobSpec by inspecting the OpenAPI v3 schema definition.
+func hasRuntimePatchesField(crd *unstructured.Unstructured) bool {
+	// Navigate: spec.versions[0].schema.openAPIV3Schema.properties.spec.properties
+	versions, found, err := unstructured.NestedSlice(crd.Object, "spec", "versions")
+	if err != nil || !found || len(versions) == 0 {
+		return false
+	}
+
+	// Get the first version (should be the served one, but we check first non-empty)
+	for _, v := range versions {
+		versionMap, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		// Navigate to the schema properties
+		schemaProps, found, err := unstructured.NestedMap(
+			versionMap,
+			"schema", "openAPIV3Schema", "properties", "spec", "properties",
+		)
+		if err != nil || !found {
+			continue
+		}
+
+		// Check if runtimePatches exists in spec.properties
+		if _, exists := schemaProps["runtimePatches"]; exists {
+			return true // v2.2.0+ detected
+		}
+	}
+
+	return false
+}

--- a/pkg/controller/jobs/trainjob/crd_validation.go
+++ b/pkg/controller/jobs/trainjob/crd_validation.go
@@ -18,6 +18,7 @@ package trainjob
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -45,12 +46,11 @@ func ValidateTrainJobCRDVersion(ctx context.Context, c client.Client) error {
 	// Check if the CRD schema has the runtimePatches field in TrainJobSpec
 	// This field was added in Kubeflow Trainer v2.2.0
 	if !hasRuntimePatchesField(crd) {
-		return fmt.Errorf(
-			"TrainJob CRD does not support the 'runtimePatches' field. " +
-				"This field is required by Kueue and was added in Kubeflow Trainer v2.2.0. " +
-				"Currently installed TrainJob CRD appears to be v2.1 or earlier. " +
-				"Please upgrade Kubeflow Trainer to v2.2.0 or later. " +
-				"See: https://github.com/kubeflow/trainer/releases",
+		return errors.New("TrainJob CRD does not support the 'runtimePatches' field. " +
+			"This field is required by Kueue and was added in Kubeflow Trainer v2.2.0. " +
+			"Currently installed TrainJob CRD appears to be v2.1 or earlier. " +
+			"Please upgrade Kubeflow Trainer to v2.2.0 or later. " +
+			"See: https://github.com/kubeflow/trainer/releases",
 		)
 	}
 
@@ -68,7 +68,7 @@ func hasRuntimePatchesField(crd *unstructured.Unstructured) bool {
 
 	// Get the first version (should be the served one, but we check first non-empty)
 	for _, v := range versions {
-		versionMap, ok := v.(map[string]interface{})
+		versionMap, ok := v.(map[string]any)
 		if !ok {
 			continue
 		}

--- a/pkg/controller/jobs/trainjob/crd_validation_test.go
+++ b/pkg/controller/jobs/trainjob/crd_validation_test.go
@@ -1,0 +1,223 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package trainjob
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// TestValidateTrainJobCRDVersion_V2_2_Compatible tests validation with a v2.2+ compatible CRD
+func TestValidateTrainJobCRDVersion_V2_2_Compatible(t *testing.T) {
+	// Create a mock v2.2+ TrainJob CRD with runtimePatches field
+	crd := createMockTrainJobCRDv22()
+
+	client := fake.NewClientBuilder().
+		WithObjects(crd).
+		Build()
+
+	ctx := context.Background()
+	err := ValidateTrainJobCRDVersion(ctx, client)
+
+	if err != nil {
+		t.Errorf("ValidateTrainJobCRDVersion() with v2.2+ CRD should not error, but got: %v", err)
+	}
+}
+
+// TestValidateTrainJobCRDVersion_V2_1_Incompatible tests validation with a v2.1 incompatible CRD
+func TestValidateTrainJobCRDVersion_V2_1_Incompatible(t *testing.T) {
+	// Create a mock v2.1 TrainJob CRD without runtimePatches field
+	crd := createMockTrainJobCRDv21()
+
+	client := fake.NewClientBuilder().
+		WithObjects(crd).
+		Build()
+
+	ctx := context.Background()
+	err := ValidateTrainJobCRDVersion(ctx, client)
+
+	if err == nil {
+		t.Error("ValidateTrainJobCRDVersion() with v2.1 CRD should error, but got nil")
+	}
+
+	// Check error message contains expected guidance
+	if err != nil && err.Error() != "" {
+		if contains := "v2.2.0"; !containsSubstring(err.Error(), contains) {
+			t.Errorf("Expected error to mention v2.2.0, but got: %v", err)
+		}
+		if contains := "runtimePatches"; !containsSubstring(err.Error(), contains) {
+			t.Errorf("Expected error to mention runtimePatches, but got: %v", err)
+		}
+	}
+}
+
+// TestValidateTrainJobCRDVersion_NotInstalled tests validation when CRD is not installed
+func TestValidateTrainJobCRDVersion_NotInstalled(t *testing.T) {
+	// Create an empty client with no CRDs
+	client := fake.NewClientBuilder().Build()
+
+	ctx := context.Background()
+	err := ValidateTrainJobCRDVersion(ctx, client)
+
+	if err == nil {
+		t.Error("ValidateTrainJobCRDVersion() with missing CRD should error, but got nil")
+	}
+
+	// Check error message contains expected guidance
+	if err != nil && err.Error() != "" {
+		if contains := "Kubeflow Trainer"; !containsSubstring(err.Error(), contains) {
+			t.Errorf("Expected error to mention Kubeflow Trainer, but got: %v", err)
+		}
+	}
+}
+
+// TestHasRuntimePatchesField tests the field detection logic
+func TestHasRuntimePatchesField(t *testing.T) {
+	tests := []struct {
+		name     string
+		crd      *unstructured.Unstructured
+		expected bool
+	}{
+		{
+			name:     "v2.2+ CRD with runtimePatches",
+			crd:      createMockTrainJobCRDv22(),
+			expected: true,
+		},
+		{
+			name:     "v2.1 CRD without runtimePatches",
+			crd:      createMockTrainJobCRDv21(),
+			expected: false,
+		},
+		{
+			name:     "malformed CRD",
+			crd:      &unstructured.Unstructured{},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasRuntimePatchesField(tt.crd)
+			if result != tt.expected {
+				t.Errorf("hasRuntimePatchesField() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+// Helper functions
+
+// createMockTrainJobCRDv22 creates a mock TrainJob CRD with v2.2+ schema including runtimePatches
+func createMockTrainJobCRDv22() *unstructured.Unstructured {
+	crd := &unstructured.Unstructured{}
+	crd.SetAPIVersion("apiextensions.k8s.io/v1")
+	crd.SetKind("CustomResourceDefinition")
+	crd.SetName("trainjobs.trainer.kubeflow.org")
+
+	// Set the schema with runtimePatches field (v2.2+)
+	_ = unstructured.SetNestedField(crd.Object, []map[string]interface{}{
+		{
+			"name":    "v1alpha1",
+			"served":  true,
+			"storage": true,
+			"schema": map[string]interface{}{
+				"openAPIV3Schema": map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"type": "object",
+							"properties": map[string]interface{}{
+								"runtimeRef": map[string]interface{}{
+									"type": "object",
+								},
+								"trainer": map[string]interface{}{
+									"type": "object",
+								},
+								// v2.2+ field
+								"runtimePatches": map[string]interface{}{
+									"type": "array",
+									"items": map[string]interface{}{
+										"type": "object",
+									},
+								},
+								"suspend": map[string]interface{}{
+									"type": "boolean",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, "spec", "versions")
+
+	return crd
+}
+
+// createMockTrainJobCRDv21 creates a mock TrainJob CRD with v2.1 schema without runtimePatches
+func createMockTrainJobCRDv21() *unstructured.Unstructured {
+	crd := &unstructured.Unstructured{}
+	crd.SetAPIVersion("apiextensions.k8s.io/v1")
+	crd.SetKind("CustomResourceDefinition")
+	crd.SetName("trainjobs.trainer.kubeflow.org")
+
+	// Set the schema WITHOUT runtimePatches field (v2.1)
+	_ = unstructured.SetNestedField(crd.Object, []map[string]interface{}{
+		{
+			"name":    "v1alpha1",
+			"served":  true,
+			"storage": true,
+			"schema": map[string]interface{}{
+				"openAPIV3Schema": map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"type": "object",
+							"properties": map[string]interface{}{
+								"runtimeRef": map[string]interface{}{
+									"type": "object",
+								},
+								"trainer": map[string]interface{}{
+									"type": "object",
+								},
+								// v2.1 does NOT have runtimePatches
+								"suspend": map[string]interface{}{
+									"type": "boolean",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, "spec", "versions")
+
+	return crd
+}
+
+// containsSubstring checks if a string contains a substring (case-sensitive)
+func containsSubstring(text, substring string) bool {
+	for i := 0; i <= len(text)-len(substring); i++ {
+		if text[i:i+len(substring)] == substring {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/controller/jobs/trainjob/crd_validation_test.go
+++ b/pkg/controller/jobs/trainjob/crd_validation_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package trainjob
 
 import (
-	"context"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -33,7 +32,7 @@ func TestValidateTrainJobCRDVersion_V2_2_Compatible(t *testing.T) {
 		WithObjects(crd).
 		Build()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	err := ValidateTrainJobCRDVersion(ctx, client)
 
 	if err != nil {
@@ -50,7 +49,7 @@ func TestValidateTrainJobCRDVersion_V2_1_Incompatible(t *testing.T) {
 		WithObjects(crd).
 		Build()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	err := ValidateTrainJobCRDVersion(ctx, client)
 
 	if err == nil {
@@ -73,7 +72,7 @@ func TestValidateTrainJobCRDVersion_NotInstalled(t *testing.T) {
 	// Create an empty client with no CRDs
 	client := fake.NewClientBuilder().Build()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	err := ValidateTrainJobCRDVersion(ctx, client)
 
 	if err == nil {
@@ -132,32 +131,32 @@ func createMockTrainJobCRDv22() *unstructured.Unstructured {
 	crd.SetName("trainjobs.trainer.kubeflow.org")
 
 	// Set the schema with runtimePatches field (v2.2+)
-	_ = unstructured.SetNestedField(crd.Object, []map[string]interface{}{
+	_ = unstructured.SetNestedField(crd.Object, []map[string]any{
 		{
 			"name":    "v1alpha1",
 			"served":  true,
 			"storage": true,
-			"schema": map[string]interface{}{
-				"openAPIV3Schema": map[string]interface{}{
+			"schema": map[string]any{
+				"openAPIV3Schema": map[string]any{
 					"type": "object",
-					"properties": map[string]interface{}{
-						"spec": map[string]interface{}{
+					"properties": map[string]any{
+						"spec": map[string]any{
 							"type": "object",
-							"properties": map[string]interface{}{
-								"runtimeRef": map[string]interface{}{
+							"properties": map[string]any{
+								"runtimeRef": map[string]any{
 									"type": "object",
 								},
-								"trainer": map[string]interface{}{
+								"trainer": map[string]any{
 									"type": "object",
 								},
 								// v2.2+ field
-								"runtimePatches": map[string]interface{}{
+								"runtimePatches": map[string]any{
 									"type": "array",
-									"items": map[string]interface{}{
+									"items": map[string]any{
 										"type": "object",
 									},
 								},
-								"suspend": map[string]interface{}{
+								"suspend": map[string]any{
 									"type": "boolean",
 								},
 							},
@@ -179,26 +178,26 @@ func createMockTrainJobCRDv21() *unstructured.Unstructured {
 	crd.SetName("trainjobs.trainer.kubeflow.org")
 
 	// Set the schema WITHOUT runtimePatches field (v2.1)
-	_ = unstructured.SetNestedField(crd.Object, []map[string]interface{}{
+	_ = unstructured.SetNestedField(crd.Object, []map[string]any{
 		{
 			"name":    "v1alpha1",
 			"served":  true,
 			"storage": true,
-			"schema": map[string]interface{}{
-				"openAPIV3Schema": map[string]interface{}{
+			"schema": map[string]any{
+				"openAPIV3Schema": map[string]any{
 					"type": "object",
-					"properties": map[string]interface{}{
-						"spec": map[string]interface{}{
+					"properties": map[string]any{
+						"spec": map[string]any{
 							"type": "object",
-							"properties": map[string]interface{}{
-								"runtimeRef": map[string]interface{}{
+							"properties": map[string]any{
+								"runtimeRef": map[string]any{
 									"type": "object",
 								},
-								"trainer": map[string]interface{}{
+								"trainer": map[string]any{
 									"type": "object",
 								},
 								// v2.1 does NOT have runtimePatches
-								"suspend": map[string]interface{}{
+								"suspend": map[string]any{
 									"type": "boolean",
 								},
 							},

--- a/pkg/controller/jobs/trainjob/trainjob_controller.go
+++ b/pkg/controller/jobs/trainjob/trainjob_controller.go
@@ -87,6 +87,12 @@ func NewReconciler(
 	eventRecorder events.EventRecorder,
 	opts ...jobframework.Option,
 ) (jobframework.JobReconcilerInterface, error) {
+	// Validate TrainJob CRD version compatibility before proceeding.
+	// This check ensures we fail fast at startup if v2.1 or earlier is installed.
+	if err := ValidateTrainJobCRDVersion(ctx, c); err != nil {
+		return nil, fmt.Errorf("TrainJob CRD compatibility check failed during setup: %w", err)
+	}
+
 	if _, err := kftrainerruntimecore.New(ctx, c, indexer, nil); err != nil {
 		return nil, err
 	}

--- a/pkg/controller/jobs/trainjob/trainjob_webhook.go
+++ b/pkg/controller/jobs/trainjob/trainjob_webhook.go
@@ -148,6 +148,15 @@ func (w *TrainJobWebhook) validateUpdate(ctx context.Context, oldTrainJob, newTr
 func (w *TrainJobWebhook) validateCreate(ctx context.Context, trainjob *TrainJob) (field.ErrorList, error) {
 	var allErrs field.ErrorList
 	allErrs = append(allErrs, jobframework.ValidateJobOnCreate(trainjob)...)
+
+	// Validate that the installed TrainJob CRD supports v2.2.0+ API shape
+	if err := ValidateTrainJobCRDVersion(ctx, w.client); err != nil {
+		allErrs = append(allErrs, field.InternalError(
+			field.NewPath("spec"),
+			err,
+		))
+	}
+
 	if features.Enabled(features.TopologyAwareScheduling) {
 		validationErrs, err := w.validateTopologyRequest(ctx, trainjob)
 		if err != nil {

--- a/site/content/en/docs/tasks/run/trainjobs.md
+++ b/site/content/en/docs/tasks/run/trainjobs.md
@@ -24,7 +24,7 @@ This guide is for [batch users](/docs/tasks#batch-user) that have a basic unders
 
 2. Install Kubeflow Trainer v2. Check [the Trainer installation guide](https://www.kubeflow.org/docs/components/trainer/operator-guides/installation/).
 
-   **Note**: The minimum required Trainer version is v2.0.0.
+      **Note**: Kueue requires Kubeflow Trainer v2.2.0 or later. The TrainJob CRD API shape changed significantly between v2.1 and v2.2. Kueue only supports v2.2.0+ which includes the `runtimePatches` field required for scheduler integration. If you have v2.1 installed, you will see an error at startup: "TrainJob CRD does not support the 'runtimePatches' field". Please upgrade to v2.2.0 or later.
 
 3. Enable TrainJob integration in Kueue. You can [modify kueue configurations from installed releases](/docs/installation#install-a-custom-configured-released-version) to include TrainJobs as an allowed workload.
 

--- a/site/content/en/v0.18/docs/tasks/run/trainjobs.md
+++ b/site/content/en/v0.18/docs/tasks/run/trainjobs.md
@@ -24,7 +24,7 @@ This guide is for [batch users](/v0.18/docs/tasks#batch-user) that have a basic 
 
 2. Install Kubeflow Trainer v2. Check [the Trainer installation guide](https://www.kubeflow.org/docs/components/trainer/operator-guides/installation/).
 
-   **Note**: The minimum required Trainer version is v2.0.0.
+      **Note**: Kueue requires Kubeflow Trainer v2.2.0 or later. The TrainJob CRD API shape changed significantly between v2.1 and v2.2. Kueue only supports v2.2.0+ which includes the `runtimePatches` field required for scheduler integration. If you have v2.1 installed, you will see an error at startup: "TrainJob CRD does not support the 'runtimePatches' field". Please upgrade to v2.2.0 or later.
 
 3. Enable TrainJob integration in Kueue. You can [modify kueue configurations from installed releases](/v0.18/docs/installation#install-a-custom-configured-released-version) to include TrainJobs as an allowed workload.
 

--- a/site/content/en/v0.19/docs/tasks/run/trainjobs.md
+++ b/site/content/en/v0.19/docs/tasks/run/trainjobs.md
@@ -24,7 +24,7 @@ This guide is for [batch users](/v0.19/docs/tasks#batch-user) that have a basic 
 
 2. Install Kubeflow Trainer v2. Check [the Trainer installation guide](https://www.kubeflow.org/docs/components/trainer/operator-guides/installation/).
 
-   **Note**: The minimum required Trainer version is v2.0.0.
+      **Note**: Kueue requires Kubeflow Trainer v2.2.0 or later. The TrainJob CRD API shape changed significantly between v2.1 and v2.2. Kueue only supports v2.2.0+ which includes the `runtimePatches` field required for scheduler integration. If you have v2.1 installed, you will see an error at startup: "TrainJob CRD does not support the 'runtimePatches' field". Please upgrade to v2.2.0 or later.
 
 3. Enable TrainJob integration in Kueue. You can [modify kueue configurations from installed releases](/v0.19/docs/installation#install-a-custom-configured-released-version) to include TrainJobs as an allowed workload.
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/kind feature
/area testing


#### What this PR does / why we need it:


#### Which issue(s) this PR fixes:

Fixes #14819

#### Special notes for your reviewer:
Kueue startup calls validation immediately
Clear error if v2.1 detected: "TrainJob CRD does not support 'runtimePatches' field. Upgrade to v2.2.0 or later"
User knows exactly what to do

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation to ensure the installed TrainJob CRD supports the required v2.2.0 API.
  * Startup now fails with a clear error when the CRD is missing, outdated, or incompatible.
  * TrainJob creation reports a validation error when required CRD capabilities are unavailable.

* **Documentation**
  * Updated TrainJob requirements to Kubeflow Trainer v2.2.0 or later.
  * Added guidance about the required `runtimePatches` field and upgrade-related errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->