### PR TITLE
Wrap pending workloads bucket operations in helpers to keep scheduling hashes in sync

### DIFF
--- a/pkg/cache/queue/pending_workloads.go
+++ b/pkg/cache/queue/pending_workloads.go
@@ -107,16 +107,14 @@ func (p *PendingWorkloads) PopActive() *workload.Info {
 	defer p.Unlock()
 
 	if p.active.Len() == 0 {
-		p.inflight = nil
-		p.schedulingHashes.clearInflight()
+		p.clearInflight()
 		return nil
 	}
 
 	wl := p.active.Pop()
 	metrics.UntrackWorkload(p.customLabels, p.activeTracker, wl.Obj)
-	p.schedulingHashes.moveActiveToInflight(wl)
 	p.subtractPendingResources(wl)
-	p.inflight = wl
+	p.setInflight(wl)
 	p.inflight.LastEvaluatedGeneration = p.inflight.Obj.Generation
 	return p.inflight
 }
@@ -148,11 +146,10 @@ func (p *PendingWorkloads) PushActiveIfNotPresent(wInfo *workload.Info) bool {
 	if p.inadmissible.hasKey(key) {
 		return false
 	}
-	if !p.active.PushIfNotPresent(wInfo) {
+	if !p.addActive(wInfo) {
 		return false
 	}
 	p.addPendingResources(wInfo)
-	p.schedulingHashes.addActive(wInfo)
 	metrics.TrackWorkload(p.customLabels, p.activeTracker, wInfo.Obj)
 	return true
 }
@@ -169,9 +166,8 @@ func (p *PendingWorkloads) PushOrUpdateActive(wInfo *workload.Info) {
 		p.subtractPendingResources(old)
 		metrics.UntrackWorkload(p.customLabels, p.activeTracker, old.Obj)
 	}
-	p.active.PushOrUpdate(wInfo)
+	p.updateActive(old, wInfo)
 	p.addPendingResources(wInfo)
-	p.schedulingHashes.updateActive(old, wInfo)
 	metrics.TrackWorkload(p.customLabels, p.activeTracker, wInfo.Obj)
 }
 
@@ -182,9 +178,8 @@ func (p *PendingWorkloads) RemoveActive(key workload.Reference) {
 	defer p.Unlock()
 
 	if old := p.active.GetByKey(key); old != nil {
-		p.active.Delete(key)
+		p.deleteActive(key, old)
 		p.subtractPendingResources(old)
-		p.schedulingHashes.removeActive(old)
 		metrics.UntrackWorkload(p.customLabels, p.activeTracker, old.Obj)
 	}
 }
@@ -202,8 +197,7 @@ func (p *PendingWorkloads) ForgetInflightByKey(ref workload.Reference) {
 	defer p.Unlock()
 
 	if p.inflight != nil && workloadKey(p.inflight) == ref {
-		p.inflight = nil
-		p.schedulingHashes.clearInflight()
+		p.clearInflight()
 	}
 }
 
@@ -216,8 +210,7 @@ func (p *PendingWorkloads) GetInadmissible(key workload.Reference) *workload.Inf
 func (p *PendingWorkloads) UpdateInadmissible(key workload.Reference, oldInfo, newInfo *workload.Info) {
 	p.Lock()
 	defer p.Unlock()
-	p.inadmissible.insert(key, newInfo)
-	p.schedulingHashes.updateInadmissible(oldInfo, newInfo)
+	p.updateInadmissible(key, oldInfo, newInfo)
 	metrics.UntrackWorkload(p.customLabels, p.inadmissibleTracker, oldInfo.Obj)
 	metrics.TrackWorkload(p.customLabels, p.inadmissibleTracker, newInfo.Obj)
 }
@@ -225,18 +218,16 @@ func (p *PendingWorkloads) UpdateInadmissible(key workload.Reference, oldInfo, n
 func (p *PendingWorkloads) InsertInadmissible(key workload.Reference, wInfo *workload.Info) {
 	p.Lock()
 	defer p.Unlock()
-	p.inadmissible.insert(key, wInfo)
+	p.addInadmissible(key, wInfo)
 	p.addPendingResources(wInfo)
-	p.schedulingHashes.addInadmissible(wInfo)
 	metrics.TrackWorkload(p.customLabels, p.inadmissibleTracker, wInfo.Obj)
 }
 
 func (p *PendingWorkloads) RemoveFromInadmissible(key workload.Reference, wInfo *workload.Info) {
 	p.Lock()
 	defer p.Unlock()
-	p.inadmissible.delete(key)
+	p.deleteInadmissible(key, wInfo)
 	p.subtractPendingResources(wInfo)
-	p.schedulingHashes.removeInadmissible(wInfo)
 	metrics.UntrackWorkload(p.customLabels, p.inadmissibleTracker, wInfo.Obj)
 }
 
@@ -302,14 +293,10 @@ func (p *PendingWorkloads) MoveToActive(key workload.Reference, wInfo *workload.
 	p.Lock()
 	defer p.Unlock()
 
-	if !p.active.PushIfNotPresent(wInfo) {
+	if !p.moveInadmissibleToActive(key, wInfo) {
 		return false
 	}
 	metrics.TrackWorkload(p.customLabels, p.activeTracker, wInfo.Obj)
-
-	p.schedulingHashes.moveToActive(wInfo)
-
-	p.inadmissible.delete(key)
 	metrics.UntrackWorkload(p.customLabels, p.inadmissibleTracker, wInfo.Obj)
 	return true
 }
@@ -321,12 +308,8 @@ func (p *PendingWorkloads) MoveToInadmissible(key workload.Reference, wInfo *wor
 	p.Lock()
 	defer p.Unlock()
 
-	p.active.Delete(key)
+	p.moveActiveToInadmissible(key, wInfo)
 	metrics.UntrackWorkload(p.customLabels, p.activeTracker, wInfo.Obj)
-
-	p.schedulingHashes.moveToInadmissible(wInfo)
-
-	p.inadmissible.insert(key, wInfo)
 	metrics.TrackWorkload(p.customLabels, p.inadmissibleTracker, wInfo.Obj)
 }
 
@@ -452,4 +435,62 @@ func (p *PendingWorkloads) DumpAll() []*workload.Info {
 		elements = append(elements, p.inflight)
 	}
 	return elements
+}
+
+func (p *PendingWorkloads) clearInflight() {
+	p.inflight = nil
+	p.schedulingHashes.clearInflight()
+}
+
+func (p *PendingWorkloads) setInflight(wl *workload.Info) {
+	p.inflight = wl
+	p.schedulingHashes.moveActiveToInflight(wl)
+}
+
+func (p *PendingWorkloads) addActive(wInfo *workload.Info) bool {
+	if p.active.PushIfNotPresent(wInfo) {
+		p.schedulingHashes.addActive(wInfo)
+		return true
+	}
+	return false
+}
+
+func (p *PendingWorkloads) updateActive(old, wInfo *workload.Info) {
+	p.active.PushOrUpdate(wInfo)
+	p.schedulingHashes.updateActive(old, wInfo)
+}
+
+func (p *PendingWorkloads) deleteActive(key workload.Reference, wInfo *workload.Info) {
+	p.active.Delete(key)
+	p.schedulingHashes.removeActive(wInfo)
+}
+
+func (p *PendingWorkloads) addInadmissible(key workload.Reference, wInfo *workload.Info) {
+	p.inadmissible.insert(key, wInfo)
+	p.schedulingHashes.addInadmissible(wInfo)
+}
+
+func (p *PendingWorkloads) updateInadmissible(key workload.Reference, oldInfo, newInfo *workload.Info) {
+	p.inadmissible.insert(key, newInfo)
+	p.schedulingHashes.updateInadmissible(oldInfo, newInfo)
+}
+
+func (p *PendingWorkloads) deleteInadmissible(key workload.Reference, wInfo *workload.Info) {
+	p.inadmissible.delete(key)
+	p.schedulingHashes.removeInadmissible(wInfo)
+}
+
+func (p *PendingWorkloads) moveInadmissibleToActive(key workload.Reference, wInfo *workload.Info) bool {
+	if p.active.PushIfNotPresent(wInfo) {
+		p.schedulingHashes.moveToActive(wInfo)
+		p.inadmissible.delete(key)
+		return true
+	}
+	return false
+}
+
+func (p *PendingWorkloads) moveActiveToInadmissible(key workload.Reference, wInfo *workload.Info) {
+	p.active.Delete(key)
+	p.schedulingHashes.moveToInadmissible(wInfo)
+	p.inadmissible.insert(key, wInfo)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The queue layer keeps pending workloads in three buckets (active, inadmissible, inflight), plus a mirror that counts their scheduling hashes for the `pending_scheduling_hashes` metric. Previously, whenever a workload moved between buckets or was added/removed/updated, the bucket and the mirror were updated as two separate calls across `pkg/cache/queue/pending_workloads.go`.

This PR encapsulates each bucket mutation together with its scheduling equivalence hashes mirror update inside dedicated helper methods on `PendingWorkloads` (`addActive`, `updateActive`, `deleteActive`, `addInadmissible`, `updateInadmissible`, `deleteInadmissible`, `moveInadmissibleToActive`, `moveActiveToInadmissible`, `setInflight`, `clearInflight`). This ensures that the buckets and mirror cannot be changed independently, preventing the metric from drifting out of sync.

_AI Disclosure: Assisted by Antigravity._

#### Which issue(s) this PR fixes:

Fixes #14877

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized workload queue bookkeeping and scheduling operations.
  * Preserved existing behavior and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->