### PR TITLE
[release-0.18] Fix operator precedence in the LeaderWorkerSet revision check

### DIFF
--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -768,7 +768,7 @@ func (h *lwsStsHandler) enqueue(ctx context.Context, obj client.Object, q workqu
 	// Handle only when .Status.CurrentRevision != .Status.UpdateRevision.
 	// This ensures that Pods are finalized and scheduling gates are removed
 	// when the revision changes.
-	if sts.Status.CurrentRevision == "" || sts.Status.UpdateRevision == "" &&
+	if sts.Status.CurrentRevision == "" || sts.Status.UpdateRevision == "" ||
 		sts.Status.CurrentRevision == sts.Status.UpdateRevision {
 		return
 	}

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
@@ -70,6 +70,36 @@ var (
 	stsGVK = appsv1.SchemeGroupVersion.WithKind("StatefulSet")
 )
 
+func TestEnqueue(t *testing.T) {
+	queued := []reconcile.Request{{NamespacedName: types.NamespacedName{Namespace: testNS, Name: testLWS}}}
+	cases := map[string]struct {
+		current string
+		update  string
+		want    []reconcile.Request
+	}{
+		"a rollout in progress is queued":     {current: "rev1", update: "rev2", want: queued},
+		"a settled revision is left alone":    {current: "rev1", update: "rev1"},
+		"and so is an unset update revision":  {current: "rev1", update: ""},
+		"and so is an unset current revision": {current: "", update: "rev1"},
+		"and so are two unset revisions":      {current: "", update: ""},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			sts := statefulset.MakeStatefulSet(testSTS, testNS).
+				Label(leaderworkersetv1.SetNameLabelKey, testLWS).
+				PodTemplateAnnotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
+				CurrentRevision(tc.current).
+				UpdateRevision(tc.update).
+				Obj()
+			q := &utiltesting.MockTypedRateLimitingInterface{}
+			(&lwsStsHandler{}).enqueue(t.Context(), sts, q)
+			if diff := cmp.Diff(tc.want, q.Items); diff != "" {
+				t.Errorf("enqueue() queued (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestReconciler(t *testing.T) {
 	now := time.Now().Truncate(time.Second)
 	request := reconcile.Request{NamespacedName: types.NamespacedName{Name: testLWS, Namespace: testNS}}


### PR DESCRIPTION
Manual cherry-pick of #14447, which the robot could not apply.

The conflict is the comment above the guard, not the guard. This branch says the handler also finalizes Pods, and main no longer does, so I left the comment as it is here and changed only the operator. The production diff is one character.

The test comes over unchanged. Putting `&&` back turns two of its five cases red, the settled revision and the unset update revision.

`go build ./...`, `go vet ./...` and the package tests pass on this branch.

/assign @tenzen-y

```release-note
NONE
```

/kind bug
/area integrations
