### PR TITLE
integration: Bound MultiKueue manager shutdown during teardown

### DIFF
--- a/test/integration/multikueue/scheduler/suite_test.go
+++ b/test/integration/multikueue/scheduler/suite_test.go
@@ -67,7 +67,9 @@ func (c *cluster) kubeConfigBytes() ([]byte, error) {
 }
 
 func (c *cluster) stopAndTeardown() {
-	c.fwk.StopManager(c.ctx)
+	ctx, cancel := context.WithTimeout(c.ctx, util.LongTimeout)
+	defer cancel()
+	c.fwk.StopManager(ctx)
 	c.fwk.Teardown()
 }
 

--- a/test/integration/multikueue/suite_test.go
+++ b/test/integration/multikueue/suite_test.go
@@ -99,7 +99,9 @@ func (c *cluster) kubeConfigBytes() ([]byte, error) {
 }
 
 func (c *cluster) stopAndTeardown() {
-	c.fwk.StopManager(c.ctx)
+	ctx, cancel := context.WithTimeout(c.ctx, util.LongTimeout)
+	defer cancel()
+	c.fwk.StopManager(ctx)
 	c.fwk.Teardown()
 }
 

--- a/test/integration/multikueue/tas/suite_test.go
+++ b/test/integration/multikueue/tas/suite_test.go
@@ -69,7 +69,9 @@ func (c *cluster) kubeConfigBytes() ([]byte, error) {
 }
 
 func (c *cluster) stopAndTeardown() {
-	c.fwk.StopManager(c.ctx)
+	ctx, cancel := context.WithTimeout(c.ctx, util.LongTimeout)
+	defer cancel()
+	c.fwk.StopManager(ctx)
 	c.fwk.Teardown()
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area multikueue

#### What this PR does / why we need it:

Bounds MultiKueue manager shutdown during integration test teardown with `util.LongTimeout` across the base, scheduler, and TAS suites. This prevents teardown from hanging indefinitely while preserving the order where `StopManager` completes before `Teardown`.

_AI usage disclosure: Drafted and verified with the assistance of AI per Kubernetes AI Tool Usage Policy._

#### Which issue(s) this PR fixes:

Fixes #14898

#### Special notes for your reviewer:

Addresses review feedback from #14844.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved integration test teardown reliability by allowing manager shutdown operations additional time to complete.
  * Ensured shutdown contexts are properly released after teardown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->