### PR TITLE
WAS: Discard logs in simulator context to avoid race during teardown

### DIFF
--- a/pkg/cache/scheduler/was/scheduling_simulator.go
+++ b/pkg/cache/scheduler/was/scheduling_simulator.go
@@ -7,12 +7,14 @@ import (
 	"fmt"
 	"iter"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
 	schedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/backend/cache"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultbinder"
@@ -90,14 +92,16 @@ func newWASSimulator(ctx context.Context, client kubernetes.Interface) (simulato
 	// Register node and pod informers with the factory; sync errors are caught by AsError() below.
 	_ = informerFactory.Core().V1().Nodes().Informer()
 	_ = informerFactory.Core().V1().Pods().Informer()
-	informerFactory.StartWithContext(ctx)
-	if err := informerFactory.WaitForCacheSyncWithContext(ctx).AsError(); err != nil {
+	simCtx := klog.NewContext(ctx, logr.Discard())
+	informerFactory.StartWithContext(simCtx)
+	if err := informerFactory.WaitForCacheSyncWithContext(simCtx).AsError(); err != nil {
 		return nil, err
 	}
 
 	snapshotFn := func(ctx context.Context, pods []*corev1.Pod, nodes []*corev1.Node) (*schedLibSnapshot.ClusterSnapshot, error) {
 		snap := cache.NewSnapshot(pods, nodes)
-		profiles, err := framework.NewProfileMap(ctx, client, informerFactory, snap, cfg)
+		simCtx := klog.NewContext(ctx, logr.Discard())
+		profiles, err := framework.NewProfileMap(simCtx, client, informerFactory, snap, cfg)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cache/scheduler/was/scheduling_simulator.go
+++ b/pkg/cache/scheduler/was/scheduling_simulator.go
@@ -92,16 +92,14 @@ func newWASSimulator(ctx context.Context, client kubernetes.Interface) (simulato
 	// Register node and pod informers with the factory; sync errors are caught by AsError() below.
 	_ = informerFactory.Core().V1().Nodes().Informer()
 	_ = informerFactory.Core().V1().Pods().Informer()
-	simCtx := klog.NewContext(ctx, logr.Discard())
-	informerFactory.StartWithContext(simCtx)
-	if err := informerFactory.WaitForCacheSyncWithContext(simCtx).AsError(); err != nil {
+	informerFactory.StartWithContext(ctx)
+	if err := informerFactory.WaitForCacheSyncWithContext(ctx).AsError(); err != nil {
 		return nil, err
 	}
 
 	snapshotFn := func(ctx context.Context, pods []*corev1.Pod, nodes []*corev1.Node) (*schedLibSnapshot.ClusterSnapshot, error) {
 		snap := cache.NewSnapshot(pods, nodes)
-		simCtx := klog.NewContext(ctx, logr.Discard())
-		profiles, err := framework.NewProfileMap(simCtx, client, informerFactory, snap, cfg)
+		profiles, err := framework.NewProfileMap(ctx, client, informerFactory, snap, cfg)
 		if err != nil {
 			return nil, err
 		}
@@ -118,8 +116,10 @@ func newWASSimulator(ctx context.Context, client kubernetes.Interface) (simulato
 
 // NewWASSimulatorForTest creates a WAS simulator backed by a fake client,
 // suitable for unit tests that need the full production plugin pipeline.
+// It wraps ctx with a discard logger to prevent background informer goroutines
+// from racing with test teardown when t.Context() carries a test logger.
 func NewWASSimulatorForTest(ctx context.Context) (simulator.SchedulingSimulator, error) {
-	return newWASSimulator(ctx, fake.NewSimpleClientset())
+	return newWASSimulator(klog.NewContext(ctx, logr.Discard()), fake.NewSimpleClientset())
 }
 
 func NewWASSimulator(ctx context.Context, restConfig *rest.Config) (simulator.SchedulingSimulator, error) {


### PR DESCRIPTION
#### What type of PR is this?
/kind flake
/area tas
/area was

#### What this PR does / why we need it:
Fixes a data race in `TestScheduleForTAS` where background informer reflectors started by the WAS scheduling simulator log stopping messages during context cancellation, racing with `testing.T` teardown. Wrapping the simulator context with `logr.Discard()` prevents background teardown logging from racing with the unit test runner.

#### Which issue(s) this PR fixes:
Fixes #14903

#### AI Usage:
Assisted by AI tool to diagnose the race trace and prepare the fix.

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduling simulator initialization for more predictable behavior.
  * Prevented initialization logging from interfering with simulator operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->