### PR TITLE
Add a pinned Kubernetes 1.37 WAS e2e lane

### DIFF
--- a/hack/make/test.mk
+++ b/hack/make/test.mk
@@ -50,7 +50,7 @@ INTEGRATION_API_LOG_LEVEL ?= 0
 
 # Folder where the e2e tests are located.
 E2E_TARGET ?= ./test/e2e/...
-E2E_K8S_VERSIONS ?= 1.34.8 1.35.5 1.36.1
+E2E_K8S_VERSIONS ?= 1.34.8 1.35.5 1.36.1 1.37.0
 E2E_K8S_VERSION ?= 1.36
 E2E_K8S_FULL_VERSION ?= $(filter $(E2E_K8S_VERSION).%,$(E2E_K8S_VERSIONS))
 # Default to E2E_K8S_VERSION.0 if no match is found
@@ -635,6 +635,34 @@ run-test-e2e-k8s-main-was:
 		KUBERAY_VERSION=$(KUBERAY_VERSION) RAY_VERSION=$(RAY_VERSION) RAYMINI_VERSION=$(RAYMINI_VERSION) USE_RAY_FOR_TESTS="ray" \
 		PROMETHEUS_OPERATOR_VERSION=$(PROMETHEUS_OPERATOR_VERSION) \
 		KIND_CLUSTER_FILE="kind-cluster.yaml" E2E_TARGET_FOLDER="singlecluster" \
+		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
+		E2E_USE_HELM=$(E2E_USE_HELM) \
+		WAS_ENABLED=true \
+		./hack/testing/e2e-test.sh
+
+# Complements test-e2e-k8s-main-was: that lane tracks k/k main for early warning,
+# this one pins a release to develop WAS features against a stable target.
+# The suite needs an API server that serves scheduling.k8s.io/v1beta1, so the lane
+# defaults to 1.37 instead of the repo-wide default, while still following
+# E2E_K8S_VERSION when a caller picks a version.
+ifeq ($(origin E2E_K8S_VERSION),file)
+E2E_WAS_K8S_VERSION := 1.37
+else
+E2E_WAS_K8S_VERSION := $(E2E_K8S_VERSION)
+endif
+E2E_WAS_K8S_FULL_VERSION := $(or $(filter $(E2E_WAS_K8S_VERSION).%,$(E2E_K8S_VERSIONS)),$(E2E_WAS_K8S_VERSION).0)
+
+.PHONY: test-e2e-was
+test-e2e-was: setup-e2e-env run-test-e2e-was-$(E2E_WAS_K8S_FULL_VERSION) ## Run the WAS e2e test suite on a kind cluster of a released Kubernetes version (follows E2E_K8S_VERSION, defaults to 1.37).
+
+run-test-e2e-was-%: K8S_VERSION = $(@:run-test-e2e-was-%=%)
+run-test-e2e-was-%:
+	@echo Running WAS e2e for k8s ${K8S_VERSION}
+	E2E_KIND_VERSION="kindest/node:v$(K8S_VERSION)" KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) \
+		ARTIFACTS="$(ARTIFACTS)/$@" IMAGE_TAG=$(IMAGE_TAG) GINKGO_ARGS="$(E2E_GINKGO_ARGS)" \
+		E2E_MODE=$(E2E_MODE) \
+		E2E_SKIP_REINSTALL=$(E2E_SKIP_REINSTALL) \
+		KIND_CLUSTER_FILE="kind-cluster.yaml" E2E_TARGET_FOLDER="singlecluster/was" \
 		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
 		E2E_USE_HELM=$(E2E_USE_HELM) \
 		WAS_ENABLED=true \

--- a/test/e2e/singlecluster/was/job_test.go
+++ b/test/e2e/singlecluster/was/job_test.go
@@ -39,10 +39,12 @@ import (
 // with Job), which builds on the GenericWorkload prerequisite gate.
 //
 // The tests require:
-// - A kind cluster built from Kubernetes main (not a release)
-// - The GenericWorkload and WorkloadWithJob feature gates enabled
-// - The scheduling.k8s.io/v1beta1 API enabled via runtime-config
-// See hack/testing/kind-cluster-was.yaml.
+//   - A kind cluster running Kubernetes 1.37 or newer, either a release
+//     (make test-e2e-was) or k/k main (make test-e2e-k8s-main-was)
+//   - The GenericWorkload and WorkloadWithJob feature gates enabled
+//   - The scheduling.k8s.io/v1beta1 API enabled via runtime-config
+//
+// See patch_kind_config_for_was in hack/testing/e2e-common.sh.
 var _ = ginkgo.Describe("WorkloadAwareScheduling Job", ginkgo.Label("area:was", "feature:was", "feature:was-job"), func() {
 	var ns *corev1.Namespace
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area testing

#### What this PR does / why we need it:

The existing WAS e2e lane follows k/k main, which is useful for catching upstream breakage but gives Kueue no stable target for WAS feature development.

This PR adds `make test-e2e-was`, driven by `E2E_K8S_VERSION`, and registers Kubernetes 1.37 as the first released target. The existing k/k-main WAS lane is left unchanged.

It also adds a runnable Job/PodGroup spec for the new lane. The test creates a Job with explicit `spec.scheduling` and verifies that the field survives creation and that the Job controller compiles the expected gang `minCount` and `disruptionMode`.

The existing skipped spec stays skipped intentionally. It starts from a Job without `spec.scheduling`, so it is the acceptance test for Kueue defaulting in #14091 rather than for upstream Job compilation. That distinction is also discussed in #13533.

Verified locally with:

```
E2E_K8S_VERSION=1.37 make kind-image-build test-e2e-was
Ran 1 of 2 Specs — SUCCESS! 1 Passed | 0 Failed | 1 Pending
```

The matching optional Prow presubmit is in kubernetes/test-infra#37782

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #13728.
Related to #13533 and #14091.

#### Special notes for your reviewer:

The Job in the new spec is created as unstructured because Kueue's currently vendored `batch/v1` does not expose `Job.spec.scheduling`.

Parts of this change were drafted with an AI coding assistant

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end validation for WAS workloads on Kubernetes 1.37 and released Kubernetes versions.
  * Expanded coverage for gang scheduling and disruption settings, including admission, unsuspension, PodGroup creation, minimum counts, and preservation of scheduling fields.
  * Clarified compatibility requirements and test behavior for newer Kubernetes versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->