### PR TITLE
[release-0.19] WAS: Discard logs in simulator context to avoid race during teardown

### DIFF
--- a/pkg/cache/scheduler/was/scheduling_simulator.go
+++ b/pkg/cache/scheduler/was/scheduling_simulator.go
@@ -7,10 +7,12 @@ import (
 	"fmt"
 	"iter"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
 	schedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultbinder"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodeaffinity"
@@ -88,8 +90,10 @@ func NewWASSimulator(ctx context.Context, restConfig *rest.Config) (simulator.Sc
 
 // NewWASSimulatorForTest creates a WAS simulator backed by a fake client,
 // suitable for unit tests that need the full filter plugin pipeline.
+// It wraps ctx with a discard logger to prevent background informer goroutines
+// from racing with test teardown when t.Context() carries a test logger.
 func NewWASSimulatorForTest(ctx context.Context) (simulator.SchedulingSimulator, error) {
-	return NewWASSimulator(ctx, &rest.Config{})
+	return NewWASSimulator(klog.NewContext(ctx, logr.Discard()), &rest.Config{})
 }
 
 func (s *wasSimulator) NewFeasibilityChecker(ctx context.Context, nodes []*corev1.Node) (simulator.NodeFeasibilityChecker, error) {


### PR DESCRIPTION
This is a manual cherry-pick of #14908 onto `release-0.19`.

**What this PR does / why we need it:**

Fixes a data race in TestScheduleForTAS where background informer reflectors log stopping messages during context cancellation, racing with testing.T teardown. Wrapping the simulator context with logr.Discard() in NewWASSimulatorForTest prevents background teardown logging from racing with the unit test runner.

**Which issue(s) this PR fixes:**

Fixes #14903

**AI Usage:**

Assisted by AI tool.

**Special notes for your reviewer:**

Manual cherry-pick requested by @tenzen-y after automatic cherry-pick robot encountered a conflict.

**Does this PR introduce a user-facing change?**

NONE