### PR TITLE
ProvisioningRequest: append attempt after name truncation

### DIFF
--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -64,7 +64,9 @@ const (
 	objNameHashLength = 5
 	// 253 is the maximal length for a CRD name. We need to subtract one for '-', and the hash length.
 	objNameMaxPrefixLength = 252 - objNameHashLength
-	podTemplatesPrefix     = "ppt"
+	// attempt is int32; reserve enough digits so prefix+attempt stays within 253.
+	provisioningRequestAttemptMaxDigits = 10
+	podTemplatesPrefix                  = "ppt"
 )
 
 var (
@@ -917,13 +919,18 @@ func (c *Controller) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func limitObjectName(fullName string) string {
-	if len(fullName) <= objNameMaxPrefixLength {
+	return limitObjectNameWithReservedSuffix(fullName, 0)
+}
+
+func limitObjectNameWithReservedSuffix(fullName string, reservedSuffixLen int) string {
+	maxPrefixLen := objNameMaxPrefixLength - reservedSuffixLen
+	if len(fullName) <= maxPrefixLen {
 		return fullName
 	}
 	h := sha1.New()
 	h.Write([]byte(fullName))
 	hashBytes := hex.EncodeToString(h.Sum(nil))
-	return fmt.Sprintf("%s-%s", fullName[:objNameMaxPrefixLength], hashBytes[:objNameHashLength])
+	return fmt.Sprintf("%s-%s", fullName[:maxPrefixLen], hashBytes[:objNameHashLength])
 }
 
 type MergedPodSet struct {

--- a/pkg/controller/admissionchecks/provisioning/provisioning.go
+++ b/pkg/controller/admissionchecks/provisioning/provisioning.go
@@ -53,13 +53,13 @@ func isCapacityRevoked(pr *autoscaling.ProvisioningRequest) bool {
 }
 
 func ProvisioningRequestName(workloadName string, checkName kueue.AdmissionCheckReference, attempt int32) string {
-	fullName := fmt.Sprintf("%s-%s-%d", workloadName, checkName, int(attempt))
-	return limitObjectName(fullName)
+	// Limit the prefix first so the attempt stays a stable, matchable suffix.
+	return fmt.Sprintf("%s%d", getProvisioningRequestNamePrefix(workloadName, checkName), attempt)
 }
 
 func getProvisioningRequestNamePrefix(workloadName string, checkName kueue.AdmissionCheckReference) string {
 	fullName := fmt.Sprintf("%s-%s-", workloadName, checkName)
-	return limitObjectName(fullName)
+	return limitObjectNameWithReservedSuffix(fullName, provisioningRequestAttemptMaxDigits)
 }
 
 func getProvisioningRequestPodTemplateName(prName string, podsetName kueue.PodSetReference) string {

--- a/pkg/controller/admissionchecks/provisioning/provisioning_test.go
+++ b/pkg/controller/admissionchecks/provisioning/provisioning_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioning
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	autoscaling "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+)
+
+const objectNameMaxLength = 253
+
+func TestProvisioningRequestName(t *testing.T) {
+	longWorkload := strings.Repeat("w", 200)
+	longCheck := kueue.AdmissionCheckReference(strings.Repeat("c", 60))
+
+	cases := map[string]struct {
+		workloadName string
+		checkName    kueue.AdmissionCheckReference
+		attempt      int32
+		wantExact    string
+	}{
+		"short name keeps attempt as suffix": {
+			workloadName: "wl",
+			checkName:    "check",
+			attempt:      1,
+			wantExact:    "wl-check-1",
+		},
+		"short name with later attempt": {
+			workloadName: "wl",
+			checkName:    "check",
+			attempt:      12,
+			wantExact:    "wl-check-12",
+		},
+		"name longer than truncation threshold": {
+			workloadName: longWorkload,
+			checkName:    longCheck,
+			attempt:      1,
+		},
+		"name longer than truncation threshold with max attempt": {
+			workloadName: longWorkload,
+			checkName:    longCheck,
+			attempt:      math.MaxInt32,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := ProvisioningRequestName(tc.workloadName, tc.checkName, tc.attempt)
+			if tc.wantExact != "" && got != tc.wantExact {
+				t.Errorf("ProvisioningRequestName() = %q, want %q", got, tc.wantExact)
+			}
+			if len(got) > objectNameMaxLength {
+				t.Errorf("ProvisioningRequestName() length = %d, want <= %d (name=%q)", len(got), objectNameMaxLength, got)
+			}
+
+			prefix := getProvisioningRequestNamePrefix(tc.workloadName, tc.checkName)
+			if !strings.HasPrefix(got, prefix) {
+				t.Errorf("name %q does not start with prefix %q", got, prefix)
+			}
+
+			pr := &autoscaling.ProvisioningRequest{ObjectMeta: metav1.ObjectMeta{Name: got}}
+			if !matchesWorkloadAndCheck(pr, tc.workloadName, tc.checkName) {
+				t.Errorf("created name %q does not match workload %q check %q", got, tc.workloadName, tc.checkName)
+			}
+			if gotAttempt := getAttempt(logr.Discard(), pr, tc.workloadName, tc.checkName); gotAttempt != tc.attempt {
+				t.Errorf("getAttempt() = %d, want %d (name=%q)", gotAttempt, tc.attempt, got)
+			}
+		})
+	}
+}
+
+func TestProvisioningRequestNameStablePrefixAcrossAttempts(t *testing.T) {
+	workloadName := strings.Repeat("w", 200)
+	checkName := kueue.AdmissionCheckReference(strings.Repeat("c", 60))
+
+	name1 := ProvisioningRequestName(workloadName, checkName, 1)
+	name2 := ProvisioningRequestName(workloadName, checkName, 2)
+	prefix := getProvisioningRequestNamePrefix(workloadName, checkName)
+
+	if !strings.HasPrefix(name1, prefix) || !strings.HasPrefix(name2, prefix) {
+		t.Fatalf("attempts do not share prefix %q: got %q and %q", prefix, name1, name2)
+	}
+	if name1 == name2 {
+		t.Fatalf("different attempts produced the same name %q", name1)
+	}
+
+	pr1 := &autoscaling.ProvisioningRequest{ObjectMeta: metav1.ObjectMeta{Name: name1}}
+	pr2 := &autoscaling.ProvisioningRequest{ObjectMeta: metav1.ObjectMeta{Name: name2}}
+	if !matchesWorkloadAndCheck(pr1, workloadName, checkName) || !matchesWorkloadAndCheck(pr2, workloadName, checkName) {
+		t.Fatalf("long names were not recognized as belonging to the same workload and check: %q, %q", name1, name2)
+	}
+	if got := getAttempt(logr.Discard(), pr1, workloadName, checkName); got != 1 {
+		t.Errorf("getAttempt(name1) = %d, want 1", got)
+	}
+	if got := getAttempt(logr.Discard(), pr2, workloadName, checkName); got != 2 {
+		t.Errorf("getAttempt(name2) = %d, want 2", got)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`ProvisioningRequestName` hashed the full name including the attempt number. `getAttemptRegex` hashed only the workload+check prefix, so a long name produced two different hashes. `matchesWorkloadAndCheck` then missed the object, `deleteUnusedProvisioningRequests` deleted it, and `syncOwnedProvisionRequest` recreated it in a loop.

This change truncates the stable prefix first (reserving space for an int32 attempt), then appends the attempt so matching and naming stay consistent and the final name stays within 253 characters.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12542

#### Special notes for your reviewer:

- AI assistance was used to implement and test this change. The result was reviewed and is submitted by a human.
- The extra call sites named in the issue (`indexer.go`, `pkg/controller/jobframework/events.go`) do not use this name/hash path; they were left unchanged.
- Existing short names (`wl-check-1`) are unchanged. Long names that were already hashed with the attempt baked in will not match after upgrade; those objects were already being deleted in the loop, and the next create uses the stable prefix.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
ProvisioningRequest: Fix an infinite ProvisioningRequest create/delete loop for workloads whose generated request name needed truncation.
```

#### Test plan

- [x] `go test ./pkg/controller/admissionchecks/provisioning` (133 passed)
- [x] New unit tests: short names stay `wl-check-1`; long names match `matchesWorkloadAndCheck` / `getAttempt` across attempts; final name length <= 253 including `math.MaxInt32`
- [ ] Reviewers: consider whether a provisioning integration case with a long workload name is worth adding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provisioning request name generation for long workload and check names.
  * Names now reserve space for attempt numbers, remain within Kubernetes’ length limit, and preserve a stable prefix across attempts.

* **Tests**
  * Added coverage for name length limits, attempt-specific names, stable prefixes, and workload/check recognition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->