### PR TITLE
[PoC] Default Kueue-managed Jobs to gang scheduling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.0
 
 require (
 	github.com/cert-manager/cert-manager v1.21.1
+	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-logr/logr v1.4.4
 	github.com/go-logr/zapr v1.3.0
@@ -26,6 +27,7 @@ require (
 	go.uber.org/mock v0.6.0
 	go.uber.org/zap v1.28.0
 	golang.org/x/sync v0.22.0
+	gomodules.xyz/jsonpatch/v2 v2.5.0
 	gopkg.in/inf.v0 v0.9.1
 	k8s.io/api v0.36.4
 	k8s.io/apiextensions-apiserver v0.36.4
@@ -70,7 +72,6 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
-	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.2 // indirect
@@ -150,7 +151,6 @@ require (
 	golang.org/x/text v0.41.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.49.0 // indirect
-	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260610212136-7ab31c22f7ad // indirect
 	google.golang.org/grpc v1.82.1 // indirect

--- a/hack/make/test.mk
+++ b/hack/make/test.mk
@@ -655,7 +655,7 @@ E2E_WAS_K8S_FULL_VERSION := $(or $(filter $(E2E_WAS_K8S_VERSION).%,$(E2E_K8S_VER
 # The Job specs assert the gang scheduling policy Kueue defaults, so the lane
 # turns its gate on. The script reads the environment, which a target-specific
 # variable does not reach, so the recipe passes it explicitly.
-E2E_WAS_KUEUE_FEATURE_GATES ?= GangSchedulingByDefault=true
+E2E_WAS_KUEUE_FEATURE_GATES ?= BatchJobGangSchedulingByDefault=true
 
 .PHONY: test-e2e-was
 test-e2e-was: setup-e2e-env run-test-e2e-was-$(E2E_WAS_K8S_FULL_VERSION) ## Run the WAS e2e test suite on a kind cluster of a released Kubernetes version (follows E2E_K8S_VERSION, defaults to 1.37).

--- a/hack/make/test.mk
+++ b/hack/make/test.mk
@@ -652,6 +652,11 @@ E2E_WAS_K8S_VERSION := $(E2E_K8S_VERSION)
 endif
 E2E_WAS_K8S_FULL_VERSION := $(or $(filter $(E2E_WAS_K8S_VERSION).%,$(E2E_K8S_VERSIONS)),$(E2E_WAS_K8S_VERSION).0)
 
+# The Job specs assert the gang scheduling policy Kueue defaults, so the lane
+# turns its gate on. The script reads the environment, which a target-specific
+# variable does not reach, so the recipe passes it explicitly.
+E2E_WAS_KUEUE_FEATURE_GATES ?= GangSchedulingByDefault=true
+
 .PHONY: test-e2e-was
 test-e2e-was: setup-e2e-env run-test-e2e-was-$(E2E_WAS_K8S_FULL_VERSION) ## Run the WAS e2e test suite on a kind cluster of a released Kubernetes version (follows E2E_K8S_VERSION, defaults to 1.37).
 
@@ -662,6 +667,7 @@ run-test-e2e-was-%:
 		ARTIFACTS="$(ARTIFACTS)/$@" IMAGE_TAG=$(IMAGE_TAG) GINKGO_ARGS="$(E2E_GINKGO_ARGS)" \
 		E2E_MODE=$(E2E_MODE) \
 		E2E_SKIP_REINSTALL=$(E2E_SKIP_REINSTALL) \
+		E2E_EXTRA_KUEUE_FEATURE_GATES="$(E2E_WAS_KUEUE_FEATURE_GATES)" \
 		KIND_CLUSTER_FILE="kind-cluster.yaml" E2E_TARGET_FOLDER="singlecluster/was" \
 		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
 		E2E_USE_HELM=$(E2E_USE_HELM) \

--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -230,6 +230,12 @@ type TopLevelJob interface {
 	IsTopLevel() bool
 }
 
+// JobWithDefaultedFieldCheck is implemented by jobs whose webhook defaults
+// fields the API server may discard. It runs before the Workload is created.
+type JobWithDefaultedFieldCheck interface {
+	CheckDefaultedFields(ctx context.Context, c client.Client, recorder events.EventRecorder) error
+}
+
 // JobWithCustomQueueNameChange is an optional interface that allows jobs
 // to provide custom queue-name change logic.
 type JobWithCustomQueueNameChange interface {

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -520,6 +520,11 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 	// 3. handle workload is nil.
 	if wl == nil {
 		log.V(3).Info("The workload is nil, handle job with no workload")
+		if jdc, ok := job.(JobWithDefaultedFieldCheck); ok {
+			if err := jdc.CheckDefaultedFields(ctx, r.client, r.record); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
 		err := r.handleJobWithNoWorkload(ctx, job, object)
 		if err != nil {
 			if apierrors.IsAlreadyExists(err) {

--- a/pkg/controller/jobs/job/gang_defaulting.go
+++ b/pkg/controller/jobs/job/gang_defaulting.go
@@ -77,7 +77,7 @@ type gangDefaultingHandler struct {
 
 func (h *gangDefaultingHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
 	resp := h.typed.Handle(ctx, req)
-	if !resp.Allowed || req.Operation != admissionv1.Create || !features.Enabled(features.GangSchedulingByDefault) {
+	if !resp.Allowed || req.Operation != admissionv1.Create || !features.Enabled(features.BatchJobGangSchedulingByDefault) {
 		return resp
 	}
 	log := ctrl.LoggerFrom(ctx).WithName("job-webhook")

--- a/pkg/controller/jobs/job/gang_defaulting.go
+++ b/pkg/controller/jobs/job/gang_defaulting.go
@@ -1,0 +1,199 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package job
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	jsonpatchapply "github.com/evanphx/json-patch/v5"
+	"gomodules.xyz/jsonpatch/v2"
+	admissionv1 "k8s.io/api/admission/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	versionutil "k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/workloadslicing"
+)
+
+const (
+	// GangDefaultedAnnotation marks a Job whose spec.scheduling Kueue set. It
+	// outlives the field, which the API server drops when WorkloadWithJob is off.
+	GangDefaultedAnnotation = "kueue.x-k8s.io/gang-defaulted"
+)
+
+// minKubeVersionForJobScheduling is the first release that serves
+// batch/v1 Job.spec.scheduling. Compared on major and minor only: a
+// distribution's 1.37.0-eks-... sorts below 1.37.0 under semver.
+var minKubeVersionForJobScheduling = versionutil.MajorMinor(1, 37)
+
+func gangSchedulingDefault() map[string]any {
+	return map[string]any{
+		"schedulingPolicy": map[string]any{"gang": map[string]any{}},
+		"disruptionMode":   map[string]any{"all": map[string]any{}},
+	}
+}
+
+type serverVersionGetter interface {
+	GetServerVersion() versionutil.Version
+}
+
+// gangDefaultingHandler wraps the typed Job defaulter, which cannot emit
+// spec.scheduling: the vendored batch/v1 Job has no such field, so it is lost
+// at decode. This works on the request JSON after the typed patches, so the
+// rules see the LocalQueue and suspend defaults.
+type gangDefaultingHandler struct {
+	typed   admission.Handler
+	webhook *JobWebhook
+}
+
+func (h *gangDefaultingHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
+	resp := h.typed.Handle(ctx, req)
+	if !resp.Allowed || req.Operation != admissionv1.Create || !features.Enabled(features.GangSchedulingByDefault) {
+		return resp
+	}
+	log := ctrl.LoggerFrom(ctx).WithName("job-webhook")
+
+	defaulted, err := applyJSONPatches(req.Object.Raw, resp.Patches)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+	mutated, reason, err := h.webhook.defaultGangScheduling(ctx, defaulted)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+	if mutated == nil {
+		log.V(3).Info("Skipping the gang scheduling default", "reason", reason)
+		return resp
+	}
+	patches, err := jsonpatch.CreatePatch(req.Object.Raw, mutated)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+	log.V(3).Info("Applied the gang scheduling default")
+	resp.Patches = patches
+	return resp
+}
+
+func applyJSONPatches(raw []byte, ops []jsonpatch.Operation) ([]byte, error) {
+	if len(ops) == 0 {
+		return raw, nil
+	}
+	encoded, err := json.Marshal(ops)
+	if err != nil {
+		return nil, err
+	}
+	patch, err := jsonpatchapply.DecodePatch(encoded)
+	if err != nil {
+		return nil, err
+	}
+	return patch.Apply(raw)
+}
+
+// defaultGangScheduling returns the Job JSON with the gang scheduling default
+// applied, or nil and the reason the default does not apply.
+func (w *JobWebhook) defaultGangScheduling(ctx context.Context, raw []byte) ([]byte, string, error) {
+	obj := &unstructured.Unstructured{}
+	if err := obj.UnmarshalJSON(raw); err != nil {
+		return nil, "", err
+	}
+	job := &batchv1.Job{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, job); err != nil {
+		return nil, "", err
+	}
+	if reason := gangDefaultSkipReason(job, obj.Object, w.serverVersion()); reason != "" {
+		return nil, reason, nil
+	}
+	managed, err := w.integrationManager.WorkloadShouldBeSuspended(ctx, job, w.client, w.manageJobsWithoutQueueName, w.managedJobsNamespaceSelector)
+	if err != nil {
+		return nil, "", err
+	}
+	if !managed {
+		return nil, "the Job is not managed by Kueue", nil
+	}
+
+	if err := unstructured.SetNestedMap(obj.Object, gangSchedulingDefault(), "spec", "scheduling"); err != nil {
+		return nil, "", err
+	}
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[GangDefaultedAnnotation] = "true"
+	obj.SetAnnotations(annotations)
+	mutated, err := obj.MarshalJSON()
+	if err != nil {
+		return nil, "", err
+	}
+	return mutated, "", nil
+}
+
+// gangDefaultSkipReason evaluates the rules that need no cluster state; the
+// managed-by-Kueue rule is evaluated by the caller. obj is the Job as JSON,
+// which is the only place spec.scheduling is visible.
+func gangDefaultSkipReason(job *batchv1.Job, obj map[string]any, serverVersion *versionutil.Version) string {
+	if serverVersion == nil {
+		return "the API server version is unknown"
+	}
+	if serverVersion.LessThan(minKubeVersionForJobScheduling) {
+		return fmt.Sprintf("the API server version %s does not serve batch/v1 Job.spec.scheduling", serverVersion)
+	}
+	if _, found := job.Labels[kueue.MultiKueueOriginLabel]; found {
+		return "the Job is a copy dispatched by a MultiKueue manager"
+	}
+	if _, found, _ := unstructured.NestedFieldNoCopy(obj, "spec", "scheduling"); found {
+		return "the Job sets spec.scheduling"
+	}
+	if _, found, _ := unstructured.NestedFieldNoCopy(obj, "spec", "template", "spec", "schedulingGroup"); found {
+		return "the Pod template sets schedulingGroup"
+	}
+	parallelism := ptr.Deref(job.Spec.Parallelism, 1)
+	if parallelism <= 1 {
+		return "parallelism is not greater than 1"
+	}
+	if job.Spec.Completions == nil {
+		return "completions is unset"
+	}
+	if *job.Spec.Completions != parallelism {
+		return fmt.Sprintf("completions (%d) differs from parallelism (%d)", *job.Spec.Completions, parallelism)
+	}
+	if features.Enabled(features.ElasticJobsViaWorkloadSlices) && workloadslicing.Enabled(job) {
+		return "the Job opts into workload slices"
+	}
+	return ""
+}
+
+func (w *JobWebhook) serverVersion() *versionutil.Version {
+	if w.kubeServerVersion == nil {
+		return nil
+	}
+	v := w.kubeServerVersion.GetServerVersion()
+	// A fetcher that has not completed a fetch holds a zero Version, whose
+	// Major and Minor accessors index an empty slice.
+	if len(v.Components()) < 2 || (v.Major() == 0 && v.Minor() == 0) {
+		return nil
+	}
+	return &v
+}

--- a/pkg/controller/jobs/job/gang_defaulting.go
+++ b/pkg/controller/jobs/job/gang_defaulting.go
@@ -26,11 +26,14 @@ import (
 	"gomodules.xyz/jsonpatch/v2"
 	admissionv1 "k8s.io/api/admission/v1"
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	versionutil "k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -42,6 +45,9 @@ const (
 	// GangDefaultedAnnotation marks a Job whose spec.scheduling Kueue set. It
 	// outlives the field, which the API server drops when WorkloadWithJob is off.
 	GangDefaultedAnnotation = "kueue.x-k8s.io/gang-defaulted"
+
+	ReasonGangSchedulingDefaulted      = "GangSchedulingDefaulted"
+	ReasonGangSchedulingDefaultDropped = "GangSchedulingDefaultDropped"
 )
 
 // minKubeVersionForJobScheduling is the first release that serves
@@ -196,4 +202,29 @@ func (w *JobWebhook) serverVersion() *versionutil.Version {
 		return nil
 	}
 	return &v
+}
+
+// CheckDefaultedFields reports, as an event on the Job, whether the API
+// server kept the spec.scheduling that Kueue set at admission.
+func (j *Job) CheckDefaultedFields(ctx context.Context, c client.Client, recorder events.EventRecorder) error {
+	if j.Annotations[GangDefaultedAnnotation] == "" {
+		return nil
+	}
+	stored := &unstructured.Unstructured{}
+	stored.SetGroupVersionKind(gvk)
+	if err := c.Get(ctx, client.ObjectKeyFromObject(j.Object()), stored); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	_, found, err := unstructured.NestedFieldNoCopy(stored.Object, "spec", "scheduling")
+	if err != nil {
+		return err
+	}
+	if !found {
+		recorder.Eventf(j.Object(), nil, corev1.EventTypeWarning, ReasonGangSchedulingDefaultDropped, "GangSchedulingDefaultDropped",
+			"Kueue set spec.scheduling at admission but the API server did not store it; the Job runs without gang scheduling. Check the WorkloadWithJob feature gate on the API server.")
+		return nil
+	}
+	recorder.Eventf(j.Object(), nil, corev1.EventTypeNormal, ReasonGangSchedulingDefaulted, "GangSchedulingDefaulted",
+		"Kueue set the gang scheduling policy with disruptionMode all")
+	return nil
 }

--- a/pkg/controller/jobs/job/gang_defaulting_test.go
+++ b/pkg/controller/jobs/job/gang_defaulting_test.go
@@ -1,0 +1,373 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package job
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"gomodules.xyz/jsonpatch/v2"
+	admissionv1 "k8s.io/api/admission/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	versionutil "k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/component-base/featuregate"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
+	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/util/kubeversion"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	testingutil "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
+	"sigs.k8s.io/kueue/pkg/workloadslicing"
+)
+
+type fakeServerVersion string
+
+func (v fakeServerVersion) GetServerVersion() versionutil.Version {
+	return *versionutil.MustParseSemantic(string(v))
+}
+
+func jobJSON(t *testing.T, job *batchv1.Job, scheduling map[string]any) []byte {
+	t.Helper()
+	content, err := runtime.DefaultUnstructuredConverter.ToUnstructured(job)
+	if err != nil {
+		t.Fatal(err)
+	}
+	u := &unstructured.Unstructured{Object: content}
+	u.SetGroupVersionKind(gvk)
+	if scheduling != nil {
+		if err := unstructured.SetNestedMap(u.Object, scheduling, "spec", "scheduling"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	raw, err := u.MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func eligibleJob() *testingutil.JobWrapper {
+	return testingutil.MakeJob("job", metav1.NamespaceDefault).Queue("queue").Parallelism(3).Completions(3)
+}
+
+func TestGangDefaultSkipReason(t *testing.T) {
+	v137 := versionutil.MustParseSemantic("1.37.0")
+	testcases := map[string]struct {
+		job           *batchv1.Job
+		mutate        func(*batchv1.Job)
+		scheduling    map[string]any
+		serverVersion *versionutil.Version
+		featureGates  map[featuregate.Feature]bool
+		wantSkipped   bool
+	}{
+		"eligible": {
+			job:           eligibleJob().Obj(),
+			serverVersion: v137,
+		},
+		"unknown server version": {
+			job:         eligibleJob().Obj(),
+			wantSkipped: true,
+		},
+		"server version below 1.37": {
+			job:           eligibleJob().Obj(),
+			serverVersion: versionutil.MustParseSemantic("1.36.4"),
+			wantSkipped:   true,
+		},
+		"1.37 release candidate": {
+			job:           eligibleJob().Obj(),
+			serverVersion: versionutil.MustParseSemantic("1.37.0-rc.1"),
+		},
+		"1.37 distribution build": {
+			job:           eligibleJob().Obj(),
+			serverVersion: versionutil.MustParseSemantic("1.37.0-eks-a1b2c3"),
+		},
+		"pre-release below 1.37": {
+			job:           eligibleJob().Obj(),
+			serverVersion: versionutil.MustParseSemantic("1.36.4-gke.100"),
+			wantSkipped:   true,
+		},
+		"MultiKueue dispatched copy": {
+			job:           eligibleJob().Label(kueue.MultiKueueOriginLabel, "manager").Obj(),
+			serverVersion: v137,
+			wantSkipped:   true,
+		},
+		"explicit gang": {
+			job:           eligibleJob().Obj(),
+			scheduling:    map[string]any{"schedulingPolicy": map[string]any{"gang": map[string]any{}}},
+			serverVersion: v137,
+			wantSkipped:   true,
+		},
+		"explicit basic": {
+			job:           eligibleJob().Obj(),
+			scheduling:    map[string]any{"schedulingPolicy": map[string]any{"basic": map[string]any{}}},
+			serverVersion: v137,
+			wantSkipped:   true,
+		},
+		"disruptionMode alone": {
+			job:           eligibleJob().Obj(),
+			scheduling:    map[string]any{"disruptionMode": map[string]any{"all": map[string]any{}}},
+			serverVersion: v137,
+			wantSkipped:   true,
+		},
+		"Pod template brings its own PodGroup": {
+			job: eligibleJob().Obj(),
+			mutate: func(job *batchv1.Job) {
+				job.Spec.Template.Spec.SchedulingGroup = &corev1.PodSchedulingGroup{
+					PodGroupName: new("byo-group"),
+				}
+			},
+			serverVersion: v137,
+			wantSkipped:   true,
+		},
+		"schedulingConstraints alone": {
+			job:           eligibleJob().Obj(),
+			scheduling:    map[string]any{"schedulingConstraints": map[string]any{}},
+			serverVersion: v137,
+			wantSkipped:   true,
+		},
+		"empty spec.scheduling": {
+			job:           eligibleJob().Obj(),
+			scheduling:    map[string]any{},
+			serverVersion: v137,
+			wantSkipped:   true,
+		},
+		"parallelism 1": {
+			job:           eligibleJob().Parallelism(1).Completions(1).Obj(),
+			serverVersion: v137,
+			wantSkipped:   true,
+		},
+		"completions unset": {
+			job:           testingutil.MakeJob("job", metav1.NamespaceDefault).Queue("queue").Parallelism(3).Obj(),
+			serverVersion: v137,
+			wantSkipped:   true,
+		},
+		"completions below parallelism": {
+			job:           eligibleJob().Completions(2).Obj(),
+			serverVersion: v137,
+			wantSkipped:   true,
+		},
+		"completions above parallelism": {
+			job:           eligibleJob().Completions(4).Obj(),
+			serverVersion: v137,
+			wantSkipped:   true,
+		},
+		"NonIndexed is eligible": {
+			job:           eligibleJob().Indexed(false).Obj(),
+			serverVersion: v137,
+		},
+		"workload slices": {
+			job:           eligibleJob().SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).Obj(),
+			serverVersion: v137,
+			featureGates:  map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			wantSkipped:   true,
+		},
+	}
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
+			if tc.mutate != nil {
+				tc.mutate(tc.job)
+			}
+			obj := &unstructured.Unstructured{}
+			if err := obj.UnmarshalJSON(jobJSON(t, tc.job, tc.scheduling)); err != nil {
+				t.Fatal(err)
+			}
+			reason := gangDefaultSkipReason(tc.job, obj.Object, tc.serverVersion)
+			if got := reason != ""; got != tc.wantSkipped {
+				t.Errorf("gangDefaultSkipReason() skipped=%t, want %t (reason %q)", got, tc.wantSkipped, reason)
+			}
+		})
+	}
+}
+
+func TestServerVersionUnknown(t *testing.T) {
+	testcases := map[string]serverVersionGetter{
+		"no getter":         nil,
+		"fetch not yet run": kubeversion.NewServerVersionFetcher(nil),
+	}
+	for name, getter := range testcases {
+		t.Run(name, func(t *testing.T) {
+			wh := &JobWebhook{kubeServerVersion: getter}
+			if got := wh.serverVersion(); got != nil {
+				t.Errorf("serverVersion() = %v, want nil", got)
+			}
+		})
+	}
+}
+
+func TestGangDefaultingHandler(t *testing.T) {
+	testcases := map[string]struct {
+		job           *batchv1.Job
+		scheduling    map[string]any
+		typedPatches  []jsonpatch.Operation
+		gateEnabled   bool
+		serverVersion string
+		wantDefaulted bool
+	}{
+		"defaults an eligible managed Job": {
+			job:           eligibleJob().Obj(),
+			gateEnabled:   true,
+			serverVersion: "1.37.0",
+			wantDefaulted: true,
+		},
+		"gate disabled": {
+			job:           eligibleJob().Obj(),
+			serverVersion: "1.37.0",
+		},
+		"not managed by Kueue": {
+			job:           testingutil.MakeJob("job", metav1.NamespaceDefault).Parallelism(3).Completions(3).Obj(),
+			gateEnabled:   true,
+			serverVersion: "1.37.0",
+		},
+		"queue name added by the typed defaulter counts": {
+			job: testingutil.MakeJob("job", metav1.NamespaceDefault).Parallelism(3).Completions(3).Obj(),
+			typedPatches: []jsonpatch.Operation{
+				jsonpatch.NewOperation("add", "/metadata/labels", map[string]any{"kueue.x-k8s.io/queue-name": "queue"}),
+			},
+			gateEnabled:   true,
+			serverVersion: "1.37.0",
+			wantDefaulted: true,
+		},
+		"user-set spec.scheduling is left alone": {
+			job:           eligibleJob().Obj(),
+			scheduling:    map[string]any{"schedulingPolicy": map[string]any{"basic": map[string]any{}}},
+			gateEnabled:   true,
+			serverVersion: "1.37.0",
+		},
+		"server below 1.37": {
+			job:           eligibleJob().Obj(),
+			gateEnabled:   true,
+			serverVersion: "1.36.4",
+		},
+	}
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.GangSchedulingByDefault, tc.gateEnabled)
+			ctx, _ := utiltesting.ContextWithLog(t)
+			cl := utiltesting.NewClientBuilder().WithObjects(utiltesting.MakeNamespace(metav1.NamespaceDefault)).Build()
+			cqCache := schdcache.New(cl)
+			integrationManager := newTestIntegrationManager(t)
+			t.Cleanup(integrationManager.EnableIntegrationsForTest(t, "batch/job"))
+			wh := &JobWebhook{
+				integrationManager:           integrationManager,
+				client:                       cl,
+				managedJobsNamespaceSelector: labels.Everything(),
+				queues:                       qcache.NewManagerForUnitTests(cl, cqCache),
+				cache:                        cqCache,
+				kubeServerVersion:            fakeServerVersion(tc.serverVersion),
+			}
+			typed := admission.HandlerFunc(func(context.Context, admission.Request) admission.Response {
+				return admission.Patched("", tc.typedPatches...)
+			})
+			handler := &gangDefaultingHandler{typed: typed, webhook: wh}
+
+			raw := jobJSON(t, tc.job, tc.scheduling)
+			req := admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Create,
+				Object:    runtime.RawExtension{Raw: raw},
+			}}
+			resp := handler.Handle(ctx, req)
+			if !resp.Allowed {
+				t.Fatalf("request denied: %v", resp.Result)
+			}
+			got, err := applyJSONPatches(raw, resp.Patches)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want, err := applyJSONPatches(raw, tc.typedPatches)
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantObj := &unstructured.Unstructured{}
+			if err := wantObj.UnmarshalJSON(want); err != nil {
+				t.Fatal(err)
+			}
+			if tc.wantDefaulted {
+				// Spelled out rather than taken from gangSchedulingDefault(), so
+				// that a change to the policy Kueue writes fails here.
+				want := map[string]any{
+					"schedulingPolicy": map[string]any{"gang": map[string]any{}},
+					"disruptionMode":   map[string]any{"all": map[string]any{}},
+				}
+				if err := unstructured.SetNestedMap(wantObj.Object, want, "spec", "scheduling"); err != nil {
+					t.Fatal(err)
+				}
+				annotations := wantObj.GetAnnotations()
+				if annotations == nil {
+					annotations = map[string]string{}
+				}
+				annotations[GangDefaultedAnnotation] = "true"
+				wantObj.SetAnnotations(annotations)
+			}
+			gotObj := &unstructured.Unstructured{}
+			if err := gotObj.UnmarshalJSON(got); err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(wantObj.Object, gotObj.Object); diff != "" {
+				t.Errorf("unexpected Job after admission (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGangDefaultingHandlerIsIdempotent(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.GangSchedulingByDefault, true)
+	ctx, _ := utiltesting.ContextWithLog(t)
+	cl := utiltesting.NewClientBuilder().WithObjects(utiltesting.MakeNamespace(metav1.NamespaceDefault)).Build()
+	cqCache := schdcache.New(cl)
+	integrationManager := newTestIntegrationManager(t)
+	t.Cleanup(integrationManager.EnableIntegrationsForTest(t, "batch/job"))
+	wh := &JobWebhook{
+		integrationManager:           integrationManager,
+		client:                       cl,
+		managedJobsNamespaceSelector: labels.Everything(),
+		queues:                       qcache.NewManagerForUnitTests(cl, cqCache),
+		cache:                        cqCache,
+		kubeServerVersion:            fakeServerVersion("1.37.0"),
+	}
+	handler := &gangDefaultingHandler{
+		typed: admission.HandlerFunc(func(context.Context, admission.Request) admission.Response {
+			return admission.Allowed("")
+		}),
+		webhook: wh,
+	}
+	raw := jobJSON(t, eligibleJob().Obj(), nil)
+	first := handler.Handle(ctx, admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+		Operation: admissionv1.Create, Object: runtime.RawExtension{Raw: raw},
+	}})
+	defaulted, err := applyJSONPatches(raw, first.Patches)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second := handler.Handle(ctx, admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+		Operation: admissionv1.Create, Object: runtime.RawExtension{Raw: defaulted},
+	}})
+	if len(second.Patches) != 0 {
+		encoded, _ := json.Marshal(second.Patches)
+		t.Errorf("reinvocation produced patches: %s", encoded)
+	}
+}

--- a/pkg/controller/jobs/job/gang_defaulting_test.go
+++ b/pkg/controller/jobs/job/gang_defaulting_test.go
@@ -266,7 +266,7 @@ func TestGangDefaultingHandler(t *testing.T) {
 	}
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.GangSchedulingByDefault, tc.gateEnabled)
+			features.SetFeatureGateDuringTest(t, features.BatchJobGangSchedulingByDefault, tc.gateEnabled)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			cl := utiltesting.NewClientBuilder().WithObjects(utiltesting.MakeNamespace(metav1.NamespaceDefault)).Build()
 			cqCache := schdcache.New(cl)
@@ -335,7 +335,7 @@ func TestGangDefaultingHandler(t *testing.T) {
 }
 
 func TestGangDefaultingHandlerIsIdempotent(t *testing.T) {
-	features.SetFeatureGateDuringTest(t, features.GangSchedulingByDefault, true)
+	features.SetFeatureGateDuringTest(t, features.BatchJobGangSchedulingByDefault, true)
 	ctx, _ := utiltesting.ContextWithLog(t)
 	cl := utiltesting.NewClientBuilder().WithObjects(utiltesting.MakeNamespace(metav1.NamespaceDefault)).Build()
 	cqCache := schdcache.New(cl)

--- a/pkg/controller/jobs/job/gang_defaulting_test.go
+++ b/pkg/controller/jobs/job/gang_defaulting_test.go
@@ -19,19 +19,26 @@ package job
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"gomodules.xyz/jsonpatch/v2"
 	admissionv1 "k8s.io/api/admission/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	versionutil "k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/component-base/featuregate"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -214,6 +221,93 @@ func TestServerVersionUnknown(t *testing.T) {
 			wh := &JobWebhook{kubeServerVersion: getter}
 			if got := wh.serverVersion(); got != nil {
 				t.Errorf("serverVersion() = %v, want nil", got)
+			}
+		})
+	}
+}
+
+func TestCheckDefaultedFields(t *testing.T) {
+	const (
+		droppedNote = "Kueue set spec.scheduling at admission but the API server did not store it; " +
+			"the Job runs without gang scheduling. Check the WorkloadWithJob feature gate on the API server."
+		keptNote = "Kueue set the gang scheduling policy with disruptionMode all"
+	)
+	readErr := errors.New("read failed")
+	jobKey := types.NamespacedName{Namespace: metav1.NamespaceDefault, Name: "job"}
+
+	// injectScheduling makes the stored Job look like one the API server kept the
+	// field on. The vendored batch/v1 Job has no spec.scheduling, so the fake
+	// client cannot store it.
+	injectScheduling := func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+		if err := c.Get(ctx, key, obj, opts...); err != nil {
+			return err
+		}
+		u, isUnstructured := obj.(*unstructured.Unstructured)
+		if !isUnstructured {
+			return nil
+		}
+		return unstructured.SetNestedMap(u.Object, gangSchedulingDefault(), "spec", "scheduling")
+	}
+
+	testcases := map[string]struct {
+		annotated  bool
+		get        func(context.Context, client.WithWatch, client.ObjectKey, client.Object, ...client.GetOption) error
+		wantEvents []utiltesting.EventRecord
+		wantErr    error
+	}{
+		"Job Kueue never defaulted is not read at all": {
+			get: func(context.Context, client.WithWatch, client.ObjectKey, client.Object, ...client.GetOption) error {
+				t.Errorf("unexpected read for a Job without the annotation")
+				return nil
+			},
+		},
+		"field dropped by the API server": {
+			annotated: true,
+			wantEvents: []utiltesting.EventRecord{
+				{Key: jobKey, EventType: corev1.EventTypeWarning, Reason: ReasonGangSchedulingDefaultDropped, Message: droppedNote},
+			},
+		},
+		"field kept by the API server": {
+			annotated: true,
+			get:       injectScheduling,
+			wantEvents: []utiltesting.EventRecord{
+				{Key: jobKey, EventType: corev1.EventTypeNormal, Reason: ReasonGangSchedulingDefaulted, Message: keptNote},
+			},
+		},
+		"Job deleted before the check": {
+			annotated: true,
+			get: func(_ context.Context, _ client.WithWatch, key client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+				return apierrors.NewNotFound(schema.GroupResource{Group: "batch", Resource: "jobs"}, key.Name)
+			},
+		},
+		"read fails": {
+			annotated: true,
+			get: func(context.Context, client.WithWatch, client.ObjectKey, client.Object, ...client.GetOption) error {
+				return readErr
+			},
+			wantErr: readErr,
+		},
+	}
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			ctx, _ := utiltesting.ContextWithLog(t)
+			jobWrapper := eligibleJob()
+			if tc.annotated {
+				jobWrapper = jobWrapper.SetAnnotation(GangDefaultedAnnotation, "true")
+			}
+			job := jobWrapper.Obj()
+			cl := utiltesting.NewClientBuilder().
+				WithObjects(job).
+				WithInterceptorFuncs(interceptor.Funcs{Get: tc.get}).
+				Build()
+			recorder := &utiltesting.EventRecorder{}
+
+			gotErr := fromObject(job).CheckDefaultedFields(ctx, cl, recorder)
+			if diff := cmp.Diff(tc.wantErr, gotErr, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("unexpected error (-want,+got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantEvents, recorder.RecordedEvents); diff != "" {
+				t.Errorf("unexpected events (-want,+got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/controller/jobs/job/job_controller.go
+++ b/pkg/controller/jobs/job/job_controller.go
@@ -144,6 +144,7 @@ var _ jobframework.GenericJob = (*Job)(nil)
 var _ jobframework.JobWithReclaimablePods = (*Job)(nil)
 var _ jobframework.JobWithCustomStop = (*Job)(nil)
 var _ jobframework.JobWithManagedBy = (*Job)(nil)
+var _ jobframework.JobWithDefaultedFieldCheck = (*Job)(nil)
 
 func (j *Job) Object() client.Object {
 	return (*batchv1.Job)(j)

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -1209,6 +1209,46 @@ func TestReconciler(t *testing.T) {
 				},
 			},
 		},
+		"a Job the API server stripped spec.scheduling from still gets its Workload": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
+			},
+			job: baseJobWrapper.Clone().
+				SetAnnotation(GangDefaultedAnnotation, "true").
+				UID("test-uid").
+				Obj(),
+			wantJob: *baseJobWrapper.Clone().
+				SetAnnotation(GangDefaultedAnnotation, "true").
+				UID("test-uid").
+				Suspend(true).
+				Obj(),
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("job", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 10).Request(corev1.ResourceCPU, "1").Obj()).
+					Queue(localQueueName).
+					Priority(0).
+					Labels(map[string]string{controllerconsts.JobUIDLabel: "test-uid"}).
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: "job", Namespace: "ns"},
+					EventType: "Warning",
+					Reason:    ReasonGangSchedulingDefaultDropped,
+					Message: "Kueue set spec.scheduling at admission but the API server did not store it; " +
+						"the Job runs without gang scheduling. Check the WorkloadWithJob feature gate on the API server.",
+				},
+				{
+					Key:       types.NamespacedName{Name: "job", Namespace: "ns"},
+					EventType: "Normal",
+					Reason:    "CreatedWorkload",
+					Message:   "Created Workload: ns/" + GetWorkloadNameForJob(baseJobWrapper.Name, "test-uid"),
+				},
+			},
+		},
 		"when workload is created, it has its owner ProvReq annotations": {
 			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling: false,

--- a/pkg/controller/jobs/job/job_webhook.go
+++ b/pkg/controller/jobs/job/job_webhook.go
@@ -94,7 +94,7 @@ func SetupWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 		return webhook.SetupNoopWebhook(mgr, obj)
 	}
 	logConstructor := jobframework.WebhookLogConstructor(fromObject(obj).GVK(), options.RoleTracker)
-	if features.Enabled(features.GangSchedulingByDefault) {
+	if features.Enabled(features.BatchJobGangSchedulingByDefault) {
 		// Register the mutating path first so the builder below keeps only
 		// the validating webhook for it; the typed defaulter runs inside.
 		mgr.GetWebhookServer().Register("/mutate-batch-v1-job", &admission.Webhook{

--- a/pkg/controller/jobs/job/job_webhook.go
+++ b/pkg/controller/jobs/job/job_webhook.go
@@ -72,6 +72,7 @@ type JobWebhook struct {
 	managedJobsNamespaceSelector labels.Selector
 	queues                       *qcache.Manager
 	cache                        *schdcache.Cache
+	kubeServerVersion            serverVersionGetter
 }
 
 // SetupWebhook configures the webhook for batchJob.
@@ -85,14 +86,29 @@ func SetupWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 		queues:                       options.Queues,
 		cache:                        options.Cache,
 	}
+	if options.KubeServerVersion != nil {
+		wh.kubeServerVersion = options.KubeServerVersion
+	}
 	obj := &batchv1.Job{}
 	if options.NoopWebhook {
 		return webhook.SetupNoopWebhook(mgr, obj)
 	}
+	logConstructor := jobframework.WebhookLogConstructor(fromObject(obj).GVK(), options.RoleTracker)
+	if features.Enabled(features.GangSchedulingByDefault) {
+		// Register the mutating path first so the builder below keeps only
+		// the validating webhook for it; the typed defaulter runs inside.
+		mgr.GetWebhookServer().Register("/mutate-batch-v1-job", &admission.Webhook{
+			Handler: &gangDefaultingHandler{
+				typed:   admission.WithDefaulter(mgr.GetScheme(), wh).Handler,
+				webhook: wh,
+			},
+			LogConstructor: logConstructor,
+		})
+	}
 	return ctrl.NewWebhookManagedBy(mgr, obj).
 		WithDefaulter(wh).
 		WithValidator(wh).
-		WithLogConstructor(jobframework.WebhookLogConstructor(fromObject(obj).GVK(), options.RoleTracker)).
+		WithLogConstructor(logConstructor).
 		Complete()
 }
 

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -619,7 +619,7 @@ const (
 	//
 	// Defaults eligible Kueue-managed batch/v1 Jobs to upstream gang scheduling
 	// by setting spec.scheduling at admission.
-	GangSchedulingByDefault featuregate.Feature = "GangSchedulingByDefault"
+	BatchJobGangSchedulingByDefault featuregate.Feature = "BatchJobGangSchedulingByDefault"
 )
 
 func init() {
@@ -957,7 +957,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 		{Version: version.MustParse("0.20"), Default: false, PreRelease: featuregate.Alpha},
 	},
 
-	GangSchedulingByDefault: {
+	BatchJobGangSchedulingByDefault: {
 		{Version: version.MustParse("0.21"), Default: false, PreRelease: featuregate.Alpha},
 	},
 }

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -613,6 +613,13 @@ const (
 	// Note: This feature can be promoted to "beta" once https://github.com/kubernetes-sigs/kueue/issues/14543
 	// is fixed because it might boost chances for issue #14543 to appear.
 	FairSharingReevaluatePreemptionCandidates featuregate.Feature = "FairSharingReevaluatePreemptionCandidates"
+
+	// owner: @apullo777
+	// kep: https://github.com/kubernetes-sigs/kueue/issues/13715
+	//
+	// Defaults eligible Kueue-managed batch/v1 Jobs to upstream gang scheduling
+	// by setting spec.scheduling at admission.
+	GangSchedulingByDefault featuregate.Feature = "GangSchedulingByDefault"
 )
 
 func init() {
@@ -948,6 +955,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 
 	FairSharingReevaluatePreemptionCandidates: {
 		{Version: version.MustParse("0.20"), Default: false, PreRelease: featuregate.Alpha},
+	},
+
+	GangSchedulingByDefault: {
+		{Version: version.MustParse("0.21"), Default: false, PreRelease: featuregate.Alpha},
 	},
 }
 

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -27,6 +27,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.17"
+- name: BatchJobGangSchedulingByDefault
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.21"
 - name: CleanupProvisioningRequestsOnEviction
   versionedSpecs:
   - default: true
@@ -121,12 +127,6 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.20"
-- name: GangSchedulingByDefault
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: "0.21"
 - name: KueueDRAIntegration
   versionedSpecs:
   - default: true

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -121,6 +121,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.20"
+- name: GangSchedulingByDefault
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.21"
 - name: KueueDRAIntegration
   versionedSpecs:
   - default: true

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -27,6 +27,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.17"
+- name: BatchJobGangSchedulingByDefault
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.21"
 - name: CleanupProvisioningRequestsOnEviction
   versionedSpecs:
   - default: true
@@ -121,12 +127,6 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.20"
-- name: GangSchedulingByDefault
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: "0.21"
 - name: KueueDRAIntegration
   versionedSpecs:
   - default: true

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -121,6 +121,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.20"
+- name: GangSchedulingByDefault
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.21"
 - name: KueueDRAIntegration
   versionedSpecs:
   - default: true

--- a/test/e2e/singlecluster/was/job_test.go
+++ b/test/e2e/singlecluster/was/job_test.go
@@ -22,8 +22,10 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -43,6 +45,9 @@ import (
 //     (make test-e2e-was) or k/k main (make test-e2e-k8s-main-was)
 //   - The GenericWorkload and WorkloadWithJob feature gates enabled
 //   - The scheduling.k8s.io/v1beta1 API enabled via runtime-config
+//
+// The specs asserting the policy Kueue defaults skip unless Kueue runs with
+// GangSchedulingByDefault, so the lane tracking k/k main still runs the rest.
 //
 // See patch_kind_config_for_was in hack/testing/e2e-common.sh.
 var _ = ginkgo.Describe("WorkloadAwareScheduling Job", ginkgo.Label("area:was", "feature:was", "feature:was-job"), func() {
@@ -91,14 +96,12 @@ var _ = ginkgo.Describe("WorkloadAwareScheduling Job", ginkgo.Label("area:was", 
 			util.ExpectAllPodsInNamespaceDeleted(ctx, k8sClient, ns)
 		})
 
-		ginkgo.XIt("Should create a Workload with PodSet count matching Job parallelism", func() {
+		ginkgo.It("Should create a Workload with PodSet count matching Job parallelism", func() {
+			skipUnlessGangDefaulting()
 			const parallelism int32 = 3
 
-			// This job is being skipped because in 1.37 the job controller has an
-			// api to control gang scheduling.
-			// The default behavior is not have gang scheduling so PodSet will not match podgroup mincount
-			// unless we bring in 1.37 apis to create the right job.
-			// Skipping for now but will reenable once we have 1.37 apis.
+			// This Job sets no spec.scheduling; the gang policy asserted below
+			// is the one Kueue defaults (KEP-13715).
 			job := testingjob.MakeJob("was-test-job", ns.Name).
 				Queue("main").
 				Parallelism(parallelism).
@@ -152,8 +155,111 @@ var _ = ginkgo.Describe("WorkloadAwareScheduling Job", ginkgo.Label("area:was", 
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
+
+		ginkgo.It("Should compile the gang minCount from the parallelism reduced by partial admission", func() {
+			skipUnlessGangDefaulting()
+			const parallelism int32 = 5
+			const admitted int32 = 4
+			// The ClusterQueue has 4 CPUs, so five one-CPU Pods are admitted partially.
+			job := testingjob.MakeJob("was-partial-job", ns.Name).
+				Queue("main").
+				Parallelism(parallelism).
+				Completions(parallelism).
+				Indexed(true).
+				SetAnnotation(workloadjob.JobMinParallelismAnnotation, "2").
+				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+				RequestAndLimit(corev1.ResourceCPU, "1").
+				RequestAndLimit(corev1.ResourceMemory, "20Mi").
+				TerminationGracePeriod(1).
+				Obj()
+			jobKey := client.ObjectKeyFromObject(job)
+			util.MustCreate(ctx, k8sClient, job)
+
+			ginkgo.By("verifying the Job is admitted with the reduced parallelism and unchanged completions", func() {
+				createdJob := &batchv1.Job{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, jobKey, createdJob)).Should(gomega.Succeed())
+					g.Expect(*createdJob.Spec.Suspend).Should(gomega.BeFalse())
+					g.Expect(*createdJob.Spec.Parallelism).Should(gomega.Equal(admitted))
+					g.Expect(*createdJob.Spec.Completions).Should(gomega.Equal(parallelism))
+				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("verifying the compiled gang minCount follows the admitted count", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					createdWorkload := workloadForJob(g, jobKey)
+					// Partial admission keeps spec.podSets[].count at the requested
+					// size and records the admitted size in the admission.
+					g.Expect(createdWorkload.Status.Admission).ShouldNot(gomega.BeNil())
+					g.Expect(createdWorkload.Status.Admission.PodSetAssignments).Should(gomega.HaveLen(1))
+					g.Expect(ptr.Deref(createdWorkload.Status.Admission.PodSetAssignments[0].Count, 0)).Should(gomega.Equal(admitted))
+
+					minCount, found, err := gangMinCountForJob(ns.Name, job.Name)
+					g.Expect(err).ShouldNot(gomega.HaveOccurred())
+					g.Expect(found).Should(gomega.BeTrue(), "expected a PodGroup owned by the Job with a gang scheduling policy")
+					g.Expect(minCount).Should(gomega.Equal(int64(admitted)))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
+		ginkgo.It("Should leave a Job that opts out with an explicit basic policy alone", func() {
+			job := testingjob.MakeJob("was-basic-job", ns.Name).
+				Queue("main").
+				Parallelism(3).
+				Completions(3).
+				Indexed(true).
+				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+				RequestAndLimit(corev1.ResourceCPU, "200m").
+				RequestAndLimit(corev1.ResourceMemory, "20Mi").
+				TerminationGracePeriod(1).
+				Obj()
+			jobKey := client.ObjectKeyFromObject(job)
+			util.MustCreate(ctx, k8sClient, jobWithScheduling(job, map[string]any{
+				"schedulingPolicy": map[string]any{"basic": map[string]any{}},
+			}))
+
+			ginkgo.By("verifying Kueue did not mark the Job as defaulted", func() {
+				createdJob := &batchv1.Job{}
+				gomega.Expect(k8sClient.Get(ctx, jobKey, createdJob)).Should(gomega.Succeed())
+				gomega.Expect(createdJob.Annotations).ShouldNot(gomega.HaveKey(workloadjob.GangDefaultedAnnotation))
+			})
+
+			ginkgo.By("verifying the PodGroup keeps the basic policy and the single disruption mode", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					podGroup, err := podGroupForJob(ns.Name, job.Name)
+					g.Expect(err).ShouldNot(gomega.HaveOccurred())
+					g.Expect(podGroup).ShouldNot(gomega.BeNil(), "expected a PodGroup owned by the Job")
+
+					_, found, err := unstructured.NestedMap(podGroup.Object, "spec", "schedulingPolicy", "basic")
+					g.Expect(err).ShouldNot(gomega.HaveOccurred())
+					g.Expect(found).Should(gomega.BeTrue(), "expected the PodGroup to keep the basic scheduling policy")
+
+					_, found, err = unstructured.NestedMap(podGroup.Object, "spec", "disruptionMode", "single")
+					g.Expect(err).ShouldNot(gomega.HaveOccurred())
+					g.Expect(found).Should(gomega.BeTrue(), "expected the PodGroup disruptionMode to stay single")
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
 	})
 })
+
+func skipUnlessGangDefaulting() {
+	ginkgo.GinkgoHelper()
+	if !gangDefaultingEnabled {
+		ginkgo.Skip("Kueue does not run with the GangSchedulingByDefault feature gate")
+	}
+}
+
+// jobWithScheduling converts a typed Job to unstructured data and sets
+// spec.scheduling, which batch/v1 in the vendored k8s.io/api does not have.
+func jobWithScheduling(job *batchv1.Job, scheduling map[string]any) *unstructured.Unstructured {
+	content, err := runtime.DefaultUnstructuredConverter.ToUnstructured(job)
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	u := &unstructured.Unstructured{Object: content}
+	u.SetGroupVersionKind(batchv1.SchemeGroupVersion.WithKind("Job"))
+	gomega.Expect(unstructured.SetNestedMap(u.Object, scheduling, "spec", "scheduling")).Should(gomega.Succeed())
+	return u
+}
 
 // podGroupListGVK identifies the upstream scheduling.k8s.io/v1beta1 PodGroup
 // list kind. We deliberately query it as unstructured data (instead of
@@ -185,22 +291,32 @@ func workloadForJob(g gomega.Gomega, jobKey types.NamespacedName) *kueue.Workloa
 	return createdWorkload
 }
 
-// gangMinCountForJob returns the gang scheduling minCount of the upstream
-// PodGroup owned by the given Job name, if one exists.
-func gangMinCountForJob(namespace, jobName string) (int64, bool, error) {
+// podGroupForJob returns the upstream PodGroup owned by the given Job name,
+// or nil if there is none.
+func podGroupForJob(namespace, jobName string) (*unstructured.Unstructured, error) {
 	podGroupList := &unstructured.UnstructuredList{}
 	podGroupList.SetGroupVersionKind(podGroupListGVK)
 	if err := k8sClient.List(ctx, podGroupList, client.InNamespace(namespace)); err != nil {
-		return 0, false, err
+		return nil, err
 	}
 
 	for i := range podGroupList.Items {
 		pg := &podGroupList.Items[i]
 		for _, ownerRef := range pg.GetOwnerReferences() {
 			if ownerRef.Kind == "Job" && ownerRef.Name == jobName {
-				return unstructured.NestedInt64(pg.Object, "spec", "schedulingPolicy", "gang", "minCount")
+				return pg, nil
 			}
 		}
 	}
-	return 0, false, nil
+	return nil, nil
+}
+
+// gangMinCountForJob returns the gang scheduling minCount of the upstream
+// PodGroup owned by the given Job name, if one exists.
+func gangMinCountForJob(namespace, jobName string) (int64, bool, error) {
+	pg, err := podGroupForJob(namespace, jobName)
+	if err != nil || pg == nil {
+		return 0, false, err
+	}
+	return unstructured.NestedInt64(pg.Object, "spec", "schedulingPolicy", "gang", "minCount")
 }

--- a/test/e2e/singlecluster/was/job_test.go
+++ b/test/e2e/singlecluster/was/job_test.go
@@ -47,7 +47,7 @@ import (
 //   - The scheduling.k8s.io/v1beta1 API enabled via runtime-config
 //
 // The specs asserting the policy Kueue defaults skip unless Kueue runs with
-// GangSchedulingByDefault, so the lane tracking k/k main still runs the rest.
+// BatchJobGangSchedulingByDefault, so the lane tracking k/k main still runs the rest.
 //
 // See patch_kind_config_for_was in hack/testing/e2e-common.sh.
 var _ = ginkgo.Describe("WorkloadAwareScheduling Job", ginkgo.Label("area:was", "feature:was", "feature:was-job"), func() {
@@ -246,7 +246,7 @@ var _ = ginkgo.Describe("WorkloadAwareScheduling Job", ginkgo.Label("area:was", 
 func skipUnlessGangDefaulting() {
 	ginkgo.GinkgoHelper()
 	if !gangDefaultingEnabled {
-		ginkgo.Skip("Kueue does not run with the GangSchedulingByDefault feature gate")
+		ginkgo.Skip("Kueue does not run with the BatchJobGangSchedulingByDefault feature gate")
 	}
 }
 

--- a/test/e2e/singlecluster/was/suite_test.go
+++ b/test/e2e/singlecluster/was/suite_test.go
@@ -60,5 +60,5 @@ var _ = ginkgo.BeforeSuite(func() {
 	)
 
 	gangDefaultingEnabled = util.GetKueueConfiguration(ctx, k8sClient).
-		FeatureGates[string(features.GangSchedulingByDefault)]
+		FeatureGates[string(features.BatchJobGangSchedulingByDefault)]
 })

--- a/test/e2e/singlecluster/was/suite_test.go
+++ b/test/e2e/singlecluster/was/suite_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/test/util"
 )
 
@@ -33,6 +34,10 @@ var (
 	k8sClient client.WithWatch
 	cfg       *rest.Config
 	ctx       context.Context
+
+	// gangDefaultingEnabled gates the specs that assert a scheduling policy
+	// Kueue writes itself rather than one the Job carries.
+	gangDefaultingEnabled bool
 )
 
 func TestAPIs(t *testing.T) {
@@ -53,4 +58,7 @@ var _ = ginkgo.BeforeSuite(func() {
 		"Kueue and all required operators are available in the cluster",
 		"waitingTime", time.Since(waitForAvailableStart),
 	)
+
+	gangDefaultingEnabled = util.GetKueueConfiguration(ctx, k8sClient).
+		FeatureGates[string(features.GangSchedulingByDefault)]
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Draft PoC for KEP-13715 (#14091), opened to make the proposed behavior concrete and validate it on Kubernetes 1.37. Not intended to merge as-is.

Kueue still vendors `k8s.io/api` 0.36, where `batch/v1`.Job has no `spec.scheduling`, so the typed admission defaulter cannot write the field. For this PoC only, the existing Job defaulter is wrapped on the same webhook path and the scheduling fields are added through an unstructured JSON patch.

The PoC is mainly useful for reviewing three behaviors:

- Partial admission: the admitted Job `parallelism` and compiled PodGroup `minCount` follow the admitted count. This also exposed a small correction needed in the KEP Test Plan: the Workload PodSet spec keeps its original count; the admitted count lives in `status.admission`.
- Field loss: if the API server drops `spec.scheduling`, the defaulting annotation survives, allowing the reconciler to detect and report it.
- TAS × gang: in the cases tested, Kueue makes the topology placement decision first and gang scheduling operates within that choice.

The KEP-level findings and remaining open questions are summarized here: https://github.com/kubernetes-sigs/kueue/pull/14091#issuecomment-5473409786

The unstructured patch is intentionally a pre-vendor workaround, not the proposed alpha implementation. Once #14905 lands, this path can use the typed Kubernetes 1.37 API instead.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #13715. Related to #13533 (re-enables the skipped defaulting test)

#### Special notes for your reviewer:

The three commits are split by review surface:

- Job defaulting and feature gate
- detection of a dropped scheduling field
- WAS e2e coverage

Local validation:

`make kind-image-build test-e2e-was`

Known PoC limitations:

- `managedJobsNamespaceSelector` is not applied consistently to defaulting.
- The field-loss check is not feature-gated and currently performs an uncached read.
- A MultiKueue worker copy can inherit the annotation after the scheduling field has been lost.
- The opposite component-gate skew, `disruptionMode: all`, and skip observability are not covered yet.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional default gang scheduling for eligible Jobs through the `GangSchedulingByDefault` feature gate.
  - Jobs with multiple parallel completions can automatically receive scheduling settings when managed by Kueue.
  - Added safeguards for unsupported configurations, explicit scheduling choices, and incompatible API server versions.
  - Added event reporting when scheduling settings are applied or discarded.

- **Tests**
  - Expanded end-to-end and unit test coverage for defaulting behavior, opt-outs, partial admission, and compatibility scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->