### PR TITLE
Fix kueuectl resource group validation

### DIFF
--- a/cmd/kueuectl/app/create/create_clusterqueue.go
+++ b/cmd/kueuectl/app/create/create_clusterqueue.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
@@ -37,7 +38,6 @@ import (
 	kueuev1beta2 "sigs.k8s.io/kueue/client-go/clientset/versioned/typed/kueue/v1beta2"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/clientgetter"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/dryrun"
-	utilslices "sigs.k8s.io/kueue/pkg/util/slices"
 )
 
 const (
@@ -462,40 +462,23 @@ func mergeResourceQuotas(rQuotas1, rQuotas2 []kueue.ResourceQuota) ([]kueue.Reso
 func mergeFlavorsByCoveredResources(resourceGroups []kueue.ResourceGroup) ([]kueue.ResourceGroup, error) {
 	var mergedResources []kueue.ResourceGroup
 
-	indexByResourceGroupID := make(map[string]int)
-	var index int
+	coveredResources := sets.New[corev1.ResourceName]()
 	for _, rg := range resourceGroups {
-		resourcesGroupID := getResourcesGroupID(rg.CoveredResources)
-		if idx, found := indexByResourceGroupID[resourcesGroupID]; found {
+		resourceGroupResources := sets.New(rg.CoveredResources...)
+		idx := slices.IndexFunc(mergedResources, func(existing kueue.ResourceGroup) bool {
+			return resourceGroupResources.Equal(sets.New(existing.CoveredResources...))
+		})
+		if idx != -1 {
 			mergedResources[idx].Flavors = append(mergedResources[idx].Flavors, rg.Flavors...)
 			continue
 		}
 
-		if !isResourceGroupValid(indexByResourceGroupID, resourcesGroupID) {
+		if coveredResources.HasAny(rg.CoveredResources...) {
 			return mergedResources, errInvalidResourceGroup
 		}
 		mergedResources = append(mergedResources, rg)
-		indexByResourceGroupID[resourcesGroupID] = index
-		index++
+		coveredResources.Insert(rg.CoveredResources...)
 	}
 
 	return mergedResources, nil
-}
-
-func getResourcesGroupID(coveredResources []corev1.ResourceName) string {
-	s := utilslices.Map(coveredResources, func(rn *corev1.ResourceName) string { return string(*rn) })
-	slices.Sort(s)
-
-	return strings.Join(s, ".")
-}
-
-func isResourceGroupValid(indexByResourceGroup map[string]int, newResourceGroup string) bool {
-	// check that new resource groups doesn't share resources with another group
-	for k := range indexByResourceGroup {
-		if strings.Contains(k, newResourceGroup) {
-			return false
-		}
-	}
-
-	return true
 }

--- a/cmd/kueuectl/app/create/create_clusterqueue_test.go
+++ b/cmd/kueuectl/app/create/create_clusterqueue_test.go
@@ -320,6 +320,54 @@ func TestParseResourceQuotas(t *testing.T) {
 			quotaArgs: []string{"alpha:cpu=1;memory=1", "beta:cpu=1"},
 			wantErr:   errInvalidResourceGroup,
 		},
+		"should fail to create when a resource is shared by a later larger resource group": {
+			quotaArgs: []string{"alpha:cpu=1", "beta:cpu=1;memory=1"},
+			wantErr:   errInvalidResourceGroup,
+		},
+		"should create separate resource groups for resource names with a common substring": {
+			quotaArgs: []string{"alpha:cpu.example=1", "beta:cpu=1"},
+			wantResourceGroups: []kueue.ResourceGroup{
+				{
+					CoveredResources: []corev1.ResourceName{"cpu.example"},
+					Flavors: []kueue.FlavorQuotas{
+						*utiltestingapi.MakeFlavorQuotas("alpha").
+							Resource("cpu.example", "1").
+							Obj(),
+					},
+				},
+				{
+					CoveredResources: []corev1.ResourceName{"cpu"},
+					Flavors: []kueue.FlavorQuotas{
+						*utiltestingapi.MakeFlavorQuotas("beta").
+							Resource("cpu", "1").
+							Obj(),
+					},
+				},
+			},
+		},
+		"should create separate resource groups whose resource names produce the same dotted string": {
+			quotaArgs: []string{"alpha:a.b=1;c=1", "beta:a=1;b.c=1"},
+			wantResourceGroups: []kueue.ResourceGroup{
+				{
+					CoveredResources: []corev1.ResourceName{"a.b", "c"},
+					Flavors: []kueue.FlavorQuotas{
+						*utiltestingapi.MakeFlavorQuotas("alpha").
+							Resource("a.b", "1").
+							Resource("c", "1").
+							Obj(),
+					},
+				},
+				{
+					CoveredResources: []corev1.ResourceName{"a", "b.c"},
+					Flavors: []kueue.FlavorQuotas{
+						*utiltestingapi.MakeFlavorQuotas("beta").
+							Resource("a", "1").
+							Resource("b.c", "1").
+							Obj(),
+					},
+				},
+			},
+		},
 		"should fail to create a resource group with an invalid flavor and multiple quotas set": {
 			quotaArgs:     []string{"alpha:cpu=1;memory=1"},
 			borrowingArgs: []string{"alpha:example.com/gpu=2"},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes `kueuectl create clusterqueue` resource-group validation to compare exact resource sets instead of dot-joined strings.

The previous string-based comparison was order-dependent, could miss resources shared by multiple groups, could reject distinct resource names with common substrings, and could merge different resource sets whose dotted serialization collided. The updated implementation uses set equality for group identity and exact set membership for overlap detection.

Regression tests cover:
- an overlapping resource in the previously missed argument order;
- distinct resource names with a common substring;
- distinct resource sets that previously produced the same dotted key.

#### Which issue(s) this PR fixes:

Fixes #14926

#### Special notes for your reviewer:

Tests run:
- `go test ./cmd/kueuectl/app/create -run TestParseResourceQuotas -count=1`
- `go test ./cmd/kueuectl/app/create -count=1`
- `go vet ./cmd/kueuectl/app/create`
- `git diff --check`

Some code was written by the human contributor; Codex helped with code drafting. The human contributor will review and finalize the changes.

#### Does this PR introduce a user-facing change?

```release-note
CLI: Fix kueuectl ClusterQueue resource-group validation to detect overlaps consistently and preserve distinct resource groups.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource-group validation to accurately detect overlapping resources.
  * Resource names that share substrings or dotted patterns are now handled as distinct resources.
  * Invalid configurations that reuse resources across groups are correctly rejected.

* **Tests**
  * Added coverage for overlapping resource groups and similar resource names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->