### PR TITLE
Refactor RayCluster test wantErr bool fields to expected error values

### DIFF
--- a/pkg/controller/jobs/raycluster/common.go
+++ b/pkg/controller/jobs/raycluster/common.go
@@ -58,6 +58,22 @@ const (
 	RayClusterGenerationAnnotation = "kueue.x-k8s.io/raycluster-generation"
 )
 
+var (
+	// ErrRedisCleanupMissingRayContainer is returned when GCS fault tolerance is
+	// enabled but the head Pod template does not include the Ray container needed
+	// to account for the Redis cleanup Job's resource requests.
+	ErrRedisCleanupMissingRayContainer = errors.New("cannot account for Redis cleanup resources: head pod template must include the Ray container")
+	// ErrPodSetNameMismatch is returned when a RayCluster's worker group has no
+	// matching PodSet in the Ray object's spec.
+	ErrPodSetNameMismatch = errors.New("PodSet name mismatch")
+	// ErrGetRayCluster is returned when fetching the RayCluster fails for a reason
+	// other than it not existing.
+	ErrGetRayCluster = errors.New("failed to get RayCluster")
+	// ErrUnmarshalPodSetReplicaSizes is returned when the
+	// RayClusterPodsetReplicaSizesAnnotation value cannot be parsed.
+	ErrUnmarshalPodSetReplicaSizes = errors.New("failed to unmarshal podset replica sizes annotation")
+)
+
 // effectiveWorkerCount returns the effective worker pod count for a worker
 // group: Replicas scaled by NumOfHosts, with Replicas defaulting to 1 when
 // unset. BuildPodSets, UpdatePodSets, and the MultiKueue elastic replica sync
@@ -136,7 +152,7 @@ func BuildPodSets(rayClusterSpec *rayv1.RayClusterSpec, annotations map[string]s
 
 func accountForRedisCleanupInHeadPodSet(headPodSet *kueue.PodSet) error {
 	if len(headPodSet.Template.Spec.Containers) <= rayutils.RayContainerIndex {
-		return errors.New("cannot account for Redis cleanup resources: head pod template must include the Ray container")
+		return ErrRedisCleanupMissingRayContainer
 	}
 
 	headContainer := &headPodSet.Template.Spec.Containers[rayutils.RayContainerIndex]
@@ -215,7 +231,7 @@ func UpdatePodSets(ctx context.Context, podSets []kueue.PodSet, c client.Client,
 					log.V(2).Info("RayCluster does not exist, do not update podsets",
 						"rayCluster", rayClusterName)
 				} else {
-					return nil, fmt.Errorf("failed to get RayCluster %s: %w", rayClusterName, err)
+					return nil, fmt.Errorf("%w %s: %w", ErrGetRayCluster, rayClusterName, err)
 				}
 			} else {
 				// Create a map of podSets from Ray object spec for quick lookup by name
@@ -231,7 +247,7 @@ func UpdatePodSets(ctx context.Context, podSets []kueue.PodSet, c client.Client,
 
 					podSet, exists := podSetMap[podSetName]
 					if !exists {
-						return nil, fmt.Errorf("PodSet name mismatch: RayCluster %s has worker group %s which is not found in Ray object %s spec", rayClusterName, wgs.GroupName, object.GetName())
+						return nil, fmt.Errorf("%w: RayCluster %s has worker group %s which is not found in Ray object %s spec", ErrPodSetNameMismatch, rayClusterName, wgs.GroupName, object.GetName())
 					}
 
 					if wgs.Replicas == nil {
@@ -416,7 +432,7 @@ func ParsePodSetReplicaSizes(annotation string) (map[kueue.PodSetReference]int32
 	}
 	var podSets []jobframework.PodSetReplicaSize
 	if err := json.Unmarshal([]byte(annotation), &podSets); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal %s annotation: %w", RayClusterPodsetReplicaSizesAnnotation, err)
+		return nil, fmt.Errorf("%w %s: %w", ErrUnmarshalPodSetReplicaSizes, RayClusterPodsetReplicaSizesAnnotation, err)
 	}
 	for _, ps := range podSets {
 		counts[ps.Name] = ps.Count
@@ -440,7 +456,7 @@ func GetWorkloadslicingRayClusterCustomAnnotations(ctx context.Context, c client
 			if apierrors.IsNotFound(err) {
 				log.V(3).Info("RayCluster not found, skipping generation annotation", "rayCluster", rayClusterName)
 			} else {
-				return nil, fmt.Errorf("failed to get RayCluster %s: %w", rayClusterName, err)
+				return nil, fmt.Errorf("%w %s: %w", ErrGetRayCluster, rayClusterName, err)
 			}
 		} else {
 			if isStandaloneRayCluster(jobObject, rayClusterName) {

--- a/pkg/controller/jobs/raycluster/common.go
+++ b/pkg/controller/jobs/raycluster/common.go
@@ -228,7 +228,7 @@ func UpdatePodSets(ctx context.Context, podSets []kueue.PodSet, c client.Client,
 					log.V(2).Info("RayCluster does not exist, do not update podsets",
 						"rayCluster", rayClusterName)
 				} else {
-					return nil, fmt.Errorf("%w %s: %w", errGetRayCluster, rayClusterName, err)
+					return nil, fmt.Errorf("failed to get RayCluster %s: %w", rayClusterName, err)
 				}
 			} else {
 				// Create a map of podSets from Ray object spec for quick lookup by name

--- a/pkg/controller/jobs/raycluster/common.go
+++ b/pkg/controller/jobs/raycluster/common.go
@@ -66,9 +66,6 @@ var (
 	// errPodSetNameMismatch is returned when a RayCluster's worker group has no
 	// matching PodSet in the Ray object's spec.
 	errPodSetNameMismatch = errors.New("PodSet name mismatch")
-	// errGetRayCluster is returned when fetching the RayCluster fails for a reason
-	// other than it not existing.
-	errGetRayCluster = errors.New("failed to get RayCluster")
 	// errUnmarshalPodSetReplicaSizes is returned when the
 	// RayClusterPodsetReplicaSizesAnnotation value cannot be parsed.
 	errUnmarshalPodSetReplicaSizes = fmt.Errorf("failed to unmarshal %s annotation", RayClusterPodsetReplicaSizesAnnotation)
@@ -456,7 +453,7 @@ func GetWorkloadslicingRayClusterCustomAnnotations(ctx context.Context, c client
 			if apierrors.IsNotFound(err) {
 				log.V(3).Info("RayCluster not found, skipping generation annotation", "rayCluster", rayClusterName)
 			} else {
-				return nil, fmt.Errorf("%w %s: %w", errGetRayCluster, rayClusterName, err)
+				return nil, fmt.Errorf("failed to get RayCluster %s: %w", rayClusterName, err)
 			}
 		} else {
 			if isStandaloneRayCluster(jobObject, rayClusterName) {

--- a/pkg/controller/jobs/raycluster/common.go
+++ b/pkg/controller/jobs/raycluster/common.go
@@ -59,17 +59,17 @@ const (
 )
 
 var (
-	// ErrRedisCleanupMissingRayContainer is returned when GCS fault tolerance is
+	// errRedisCleanupMissingRayContainer is returned when GCS fault tolerance is
 	// enabled but the head Pod template does not include the Ray container needed
 	// to account for the Redis cleanup Job's resource requests.
 	errRedisCleanupMissingRayContainer = errors.New("cannot account for Redis cleanup resources: head pod template must include the Ray container")
-	// ErrPodSetNameMismatch is returned when a RayCluster's worker group has no
+	// errPodSetNameMismatch is returned when a RayCluster's worker group has no
 	// matching PodSet in the Ray object's spec.
-	ErrPodSetNameMismatch = errors.New("PodSet name mismatch")
-	// ErrGetRayCluster is returned when fetching the RayCluster fails for a reason
+	errPodSetNameMismatch = errors.New("PodSet name mismatch")
+	// errGetRayCluster is returned when fetching the RayCluster fails for a reason
 	// other than it not existing.
-	ErrGetRayCluster = errors.New("failed to get RayCluster")
-	// ErrUnmarshalPodSetReplicaSizes is returned when the
+	errGetRayCluster = errors.New("failed to get RayCluster")
+	// errUnmarshalPodSetReplicaSizes is returned when the
 	// RayClusterPodsetReplicaSizesAnnotation value cannot be parsed.
 	errUnmarshalPodSetReplicaSizes = fmt.Errorf("failed to unmarshal %s annotation", RayClusterPodsetReplicaSizesAnnotation)
 )
@@ -152,7 +152,7 @@ func BuildPodSets(rayClusterSpec *rayv1.RayClusterSpec, annotations map[string]s
 
 func accountForRedisCleanupInHeadPodSet(headPodSet *kueue.PodSet) error {
 	if len(headPodSet.Template.Spec.Containers) <= rayutils.RayContainerIndex {
-		return ErrRedisCleanupMissingRayContainer
+		return errRedisCleanupMissingRayContainer
 	}
 
 	headContainer := &headPodSet.Template.Spec.Containers[rayutils.RayContainerIndex]
@@ -231,7 +231,7 @@ func UpdatePodSets(ctx context.Context, podSets []kueue.PodSet, c client.Client,
 					log.V(2).Info("RayCluster does not exist, do not update podsets",
 						"rayCluster", rayClusterName)
 				} else {
-					return nil, fmt.Errorf("%w %s: %w", ErrGetRayCluster, rayClusterName, err)
+					return nil, fmt.Errorf("%w %s: %w", errGetRayCluster, rayClusterName, err)
 				}
 			} else {
 				// Create a map of podSets from Ray object spec for quick lookup by name
@@ -247,7 +247,7 @@ func UpdatePodSets(ctx context.Context, podSets []kueue.PodSet, c client.Client,
 
 					podSet, exists := podSetMap[podSetName]
 					if !exists {
-						return nil, fmt.Errorf("%w: RayCluster %s has worker group %s which is not found in Ray object %s spec", ErrPodSetNameMismatch, rayClusterName, wgs.GroupName, object.GetName())
+						return nil, fmt.Errorf("%w: RayCluster %s has worker group %s which is not found in Ray object %s spec", errPodSetNameMismatch, rayClusterName, wgs.GroupName, object.GetName())
 					}
 
 					if wgs.Replicas == nil {
@@ -432,7 +432,7 @@ func ParsePodSetReplicaSizes(annotation string) (map[kueue.PodSetReference]int32
 	}
 	var podSets []jobframework.PodSetReplicaSize
 	if err := json.Unmarshal([]byte(annotation), &podSets); err != nil {
-		return nil, fmt.Errorf("%w %s: %w", ErrUnmarshalPodSetReplicaSizes, RayClusterPodsetReplicaSizesAnnotation, err)
+		return nil, fmt.Errorf("%w: %w", errUnmarshalPodSetReplicaSizes, err)
 	}
 	for _, ps := range podSets {
 		counts[ps.Name] = ps.Count
@@ -456,7 +456,7 @@ func GetWorkloadslicingRayClusterCustomAnnotations(ctx context.Context, c client
 			if apierrors.IsNotFound(err) {
 				log.V(3).Info("RayCluster not found, skipping generation annotation", "rayCluster", rayClusterName)
 			} else {
-				return nil, fmt.Errorf("%w %s: %w", ErrGetRayCluster, rayClusterName, err)
+				return nil, fmt.Errorf("%w %s: %w", errGetRayCluster, rayClusterName, err)
 			}
 		} else {
 			if isStandaloneRayCluster(jobObject, rayClusterName) {

--- a/pkg/controller/jobs/raycluster/common.go
+++ b/pkg/controller/jobs/raycluster/common.go
@@ -62,7 +62,7 @@ var (
 	// ErrRedisCleanupMissingRayContainer is returned when GCS fault tolerance is
 	// enabled but the head Pod template does not include the Ray container needed
 	// to account for the Redis cleanup Job's resource requests.
-	ErrRedisCleanupMissingRayContainer = errors.New("cannot account for Redis cleanup resources: head pod template must include the Ray container")
+	errRedisCleanupMissingRayContainer = errors.New("cannot account for Redis cleanup resources: head pod template must include the Ray container")
 	// ErrPodSetNameMismatch is returned when a RayCluster's worker group has no
 	// matching PodSet in the Ray object's spec.
 	ErrPodSetNameMismatch = errors.New("PodSet name mismatch")
@@ -71,7 +71,7 @@ var (
 	ErrGetRayCluster = errors.New("failed to get RayCluster")
 	// ErrUnmarshalPodSetReplicaSizes is returned when the
 	// RayClusterPodsetReplicaSizesAnnotation value cannot be parsed.
-	ErrUnmarshalPodSetReplicaSizes = errors.New("failed to unmarshal podset replica sizes annotation")
+	errUnmarshalPodSetReplicaSizes = fmt.Errorf("failed to unmarshal %s annotation", RayClusterPodsetReplicaSizesAnnotation)
 )
 
 // effectiveWorkerCount returns the effective worker pod count for a worker

--- a/pkg/controller/jobs/raycluster/common_test.go
+++ b/pkg/controller/jobs/raycluster/common_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -53,7 +54,7 @@ func TestBuildPodSets(t *testing.T) {
 		annotations                 map[string]string
 		enablePartialScaleUpFeature bool
 		wantPodSets                 []kueue.PodSet
-		wantErr                     bool
+		wantErr                     error
 	}{
 		"basic spec with head and single worker group": {
 			rayClusterSpec: &rayv1.RayClusterSpec{
@@ -307,7 +308,7 @@ func TestBuildPodSets(t *testing.T) {
 					Template: corev1.PodTemplateSpec{},
 				},
 			},
-			wantErr: true,
+			wantErr: errors.New("cannot account for Redis cleanup resources: head pod template must include the Ray container"),
 		},
 		"autoscaler sidecar added to head podSet with default resources when in-tree autoscaling is enabled": {
 			rayClusterSpec: &rayv1.RayClusterSpec{
@@ -558,9 +559,9 @@ func TestBuildPodSets(t *testing.T) {
 			features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlicesWithPartialReplicaScaleUp, tc.enablePartialScaleUpFeature)
 			gotPodSets, err := BuildPodSets(tc.rayClusterSpec, tc.annotations)
 
-			if tc.wantErr {
-				if err == nil {
-					t.Error("Expected error but got none")
+			if tc.wantErr != nil {
+				if err == nil || err.Error() != tc.wantErr.Error() {
+					t.Errorf("Expected error %q, got %v", tc.wantErr, err)
 				}
 				return
 			}
@@ -585,7 +586,7 @@ func TestUpdatePodSets(t *testing.T) {
 		rayClusterName          string
 		rayClusterInClient      *rayv1.RayCluster
 		wantPodSets             []kueue.PodSet
-		wantErr                 bool
+		wantErr                 error
 	}{
 		"workload slicing disabled - no update": {
 			podSets: []kueue.PodSet{
@@ -704,7 +705,7 @@ func TestUpdatePodSets(t *testing.T) {
 			rayClusterInClient: testingrayutil.MakeCluster("target-raycluster", "ns").
 				ScaleFirstWorkerGroup(5).
 				Obj(),
-			wantErr: true,
+			wantErr: errors.New("PodSet name mismatch: RayCluster target-raycluster has worker group workers-group-0 which is not found in Ray object raycluster spec"),
 		},
 	}
 
@@ -727,9 +728,9 @@ func TestUpdatePodSets(t *testing.T) {
 
 			gotPodSets, err := UpdatePodSets(t.Context(), tc.podSets, c, tc.object, tc.enableInTreeAutoscaling, tc.rayClusterName)
 
-			if tc.wantErr {
-				if err == nil {
-					t.Error("Expected error but got none")
+			if tc.wantErr != nil {
+				if err == nil || err.Error() != tc.wantErr.Error() {
+					t.Errorf("Expected error %q, got %v", tc.wantErr, err)
 				}
 				return
 			}
@@ -751,7 +752,6 @@ func TestUpdateRayClusterSpecToRunWithPodSetsInfo(t *testing.T) {
 		rayClusterSpec *rayv1.RayClusterSpec
 		podSetsInfo    []podset.PodSetInfo
 		wantSpec       *rayv1.RayClusterSpec
-		wantErr        bool
 	}{
 		"basic update with node selector": {
 			rayClusterSpec: &rayv1.RayClusterSpec{
@@ -964,13 +964,6 @@ func TestUpdateRayClusterSpecToRunWithPodSetsInfo(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			err := UpdateRayClusterSpecToRunWithPodSetsInfo(utiltesting.NewLogger(t), tc.rayClusterSpec, tc.podSetsInfo)
-
-			if tc.wantErr {
-				if err == nil {
-					t.Error("Expected error but got none")
-				}
-				return
-			}
 
 			if err != nil {
 				t.Errorf("Unexpected error: %v", err)
@@ -1400,7 +1393,7 @@ func TestParsePodSetReplicaSizes(t *testing.T) {
 	testCases := map[string]struct {
 		annotation string
 		wantCounts map[kueue.PodSetReference]int32
-		wantErr    bool
+		wantErr    error
 	}{
 		"empty annotation": {
 			annotation: "",
@@ -1421,20 +1414,24 @@ func TestParsePodSetReplicaSizes(t *testing.T) {
 		},
 		"invalid json": {
 			annotation: `invalid`,
-			wantErr:    true,
+			wantErr:    fmt.Errorf("failed to unmarshal %s annotation: invalid character 'i' looking for beginning of value", RayClusterPodsetReplicaSizesAnnotation),
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			got, err := ParsePodSetReplicaSizes(tc.annotation)
-			if (err != nil) != tc.wantErr {
-				t.Fatalf("ParsePodSetReplicaSizes() error = %v, wantErr %v", err, tc.wantErr)
-			}
-			if !tc.wantErr {
-				if diff := cmp.Diff(tc.wantCounts, got); diff != "" {
-					t.Errorf("ParsePodSetReplicaSizes() mismatch (-want +got):\n%s", diff)
+			if tc.wantErr != nil {
+				if err == nil || err.Error() != tc.wantErr.Error() {
+					t.Fatalf("ParsePodSetReplicaSizes() error = %v, wantErr %v", err, tc.wantErr)
 				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParsePodSetReplicaSizes() unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.wantCounts, got); diff != "" {
+				t.Errorf("ParsePodSetReplicaSizes() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -1449,7 +1446,7 @@ func TestGetWorkloadslicingCustomAnnotations(t *testing.T) {
 		createRayCluster bool
 		standalone       bool
 		wantAnnotation   map[string]string
-		wantErr          bool
+		wantErr          error
 	}{
 		"workload slicing disabled returns nil": {
 			annotations: map[string]string{},
@@ -1542,7 +1539,7 @@ func TestGetWorkloadslicingCustomAnnotations(t *testing.T) {
 				{Name: "head", Count: 1},
 			},
 			rayClusterName: "test-raycluster",
-			wantErr:        true,
+			wantErr:        errors.New("failed to get RayCluster test-raycluster:"),
 		},
 	}
 
@@ -1582,9 +1579,9 @@ func TestGetWorkloadslicingCustomAnnotations(t *testing.T) {
 			}
 
 			got, err := GetWorkloadslicingRayClusterCustomAnnotations(t.Context(), c, jobObject, tc.rayClusterName)
-			if tc.wantErr {
-				if err == nil {
-					t.Fatalf("GetWorkloadslicingCustomAnnotations() expected error but got nil")
+			if tc.wantErr != nil {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr.Error()) {
+					t.Fatalf("GetWorkloadslicingCustomAnnotations() expected error containing %q, got %v", tc.wantErr, err)
 				}
 				return
 			}

--- a/pkg/controller/jobs/raycluster/common_test.go
+++ b/pkg/controller/jobs/raycluster/common_test.go
@@ -307,7 +307,7 @@ func TestBuildPodSets(t *testing.T) {
 					Template: corev1.PodTemplateSpec{},
 				},
 			},
-			wantErr: ErrRedisCleanupMissingRayContainer,
+			wantErr: errRedisCleanupMissingRayContainer,
 		},
 		"autoscaler sidecar added to head podSet with default resources when in-tree autoscaling is enabled": {
 			rayClusterSpec: &rayv1.RayClusterSpec{
@@ -699,7 +699,7 @@ func TestUpdatePodSets(t *testing.T) {
 			rayClusterInClient: testingrayutil.MakeCluster("target-raycluster", "ns").
 				ScaleFirstWorkerGroup(5).
 				Obj(),
-			wantErr: ErrPodSetNameMismatch,
+			wantErr: errPodSetNameMismatch,
 		},
 	}
 
@@ -1403,7 +1403,7 @@ func TestParsePodSetReplicaSizes(t *testing.T) {
 		},
 		"invalid json": {
 			annotation: `invalid`,
-			wantErr:    ErrUnmarshalPodSetReplicaSizes,
+			wantErr:    errUnmarshalPodSetReplicaSizes,
 		},
 	}
 
@@ -1525,7 +1525,7 @@ func TestGetWorkloadslicingCustomAnnotations(t *testing.T) {
 				{Name: "head", Count: 1},
 			},
 			rayClusterName: "test-raycluster",
-			wantErr:        ErrGetRayCluster,
+			wantErr:        errGetRayCluster,
 		},
 	}
 

--- a/pkg/controller/jobs/raycluster/common_test.go
+++ b/pkg/controller/jobs/raycluster/common_test.go
@@ -725,9 +725,6 @@ func TestUpdatePodSets(t *testing.T) {
 			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("Unexpected error (-want +got):\n%s", diff)
 			}
-			if tc.wantErr != nil {
-				return
-			}
 
 			if diff := cmp.Diff(tc.wantPodSets, gotPodSets, cmpopts.IgnoreFields(kueue.PodSet{}, "Template")); diff != "" {
 				t.Errorf("Unexpected podSets (-want +got):\n%s", diff)
@@ -1424,6 +1421,8 @@ func TestParsePodSetReplicaSizes(t *testing.T) {
 }
 
 func TestGetWorkloadslicingCustomAnnotations(t *testing.T) {
+	rayClusterGetErr := errors.New("failed to get RayCluster")
+
 	testCases := map[string]struct {
 		annotations      map[string]string
 		podSets          []kueue.PodSet
@@ -1525,7 +1524,7 @@ func TestGetWorkloadslicingCustomAnnotations(t *testing.T) {
 				{Name: "head", Count: 1},
 			},
 			rayClusterName: "test-raycluster",
-			wantErr:        errGetRayCluster,
+			wantErr:       rayClusterGetErr,
 		},
 	}
 
@@ -1540,7 +1539,16 @@ func TestGetWorkloadslicingCustomAnnotations(t *testing.T) {
 				_ = rayv1.AddToScheme(scheme)
 			}
 
-			builder := fake.NewClientBuilder().WithScheme(scheme)
+			builder := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						if _, ok := obj.(*rayv1.RayCluster); ok && errors.Is(tc.wantErr, rayClusterGetErr) {
+							return rayClusterGetErr
+						}
+						return c.Get(ctx, key, obj, opts...)
+					},
+				})
 
 			var jobObject client.Object
 			if tc.createRayCluster {
@@ -1566,10 +1574,7 @@ func TestGetWorkloadslicingCustomAnnotations(t *testing.T) {
 
 			got, err := GetWorkloadslicingRayClusterCustomAnnotations(t.Context(), c, jobObject, tc.rayClusterName)
 			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
-				t.Fatalf("GetWorkloadslicingCustomAnnotations() error mismatch (-want +got):\n%s", diff)
-			}
-			if tc.wantErr != nil {
-				return
+				t.Errorf("GetWorkloadslicingCustomAnnotations() error mismatch (-want +got):\n%s", diff)
 			}
 			if diff := cmp.Diff(tc.wantAnnotation, got); diff != "" {
 				t.Errorf("GetWorkloadslicingCustomAnnotations() mismatch (-want +got):\n%s", diff)

--- a/pkg/controller/jobs/raycluster/common_test.go
+++ b/pkg/controller/jobs/raycluster/common_test.go
@@ -561,9 +561,6 @@ func TestBuildPodSets(t *testing.T) {
 			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("Unexpected error (-want +got):\n%s", diff)
 			}
-			if tc.wantErr != nil {
-				return
-			}
 
 			if diff := cmp.Diff(tc.wantPodSets, gotPodSets, cmpopts.IgnoreFields(kueue.PodSet{}, "TopologyRequest")); diff != "" {
 				t.Errorf("Unexpected podSets (-want +got):\n%s", diff)
@@ -1409,9 +1406,6 @@ func TestParsePodSetReplicaSizes(t *testing.T) {
 			got, err := ParsePodSetReplicaSizes(tc.annotation)
 			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("ParsePodSetReplicaSizes() error mismatch (-want +got):\n%s", diff)
-			}
-			if tc.wantErr != nil {
-				return
 			}
 			if diff := cmp.Diff(tc.wantCounts, got); diff != "" {
 				t.Errorf("ParsePodSetReplicaSizes() mismatch (-want +got):\n%s", diff)

--- a/pkg/controller/jobs/raycluster/common_test.go
+++ b/pkg/controller/jobs/raycluster/common_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -308,7 +307,7 @@ func TestBuildPodSets(t *testing.T) {
 					Template: corev1.PodTemplateSpec{},
 				},
 			},
-			wantErr: errors.New("cannot account for Redis cleanup resources: head pod template must include the Ray container"),
+			wantErr: ErrRedisCleanupMissingRayContainer,
 		},
 		"autoscaler sidecar added to head podSet with default resources when in-tree autoscaling is enabled": {
 			rayClusterSpec: &rayv1.RayClusterSpec{
@@ -559,15 +558,10 @@ func TestBuildPodSets(t *testing.T) {
 			features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlicesWithPartialReplicaScaleUp, tc.enablePartialScaleUpFeature)
 			gotPodSets, err := BuildPodSets(tc.rayClusterSpec, tc.annotations)
 
-			if tc.wantErr != nil {
-				if err == nil || err.Error() != tc.wantErr.Error() {
-					t.Errorf("Expected error %q, got %v", tc.wantErr, err)
-				}
-				return
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("Unexpected error (-want +got):\n%s", diff)
 			}
-
-			if err != nil {
-				t.Errorf("Unexpected error: %v", err)
+			if tc.wantErr != nil {
 				return
 			}
 
@@ -705,7 +699,7 @@ func TestUpdatePodSets(t *testing.T) {
 			rayClusterInClient: testingrayutil.MakeCluster("target-raycluster", "ns").
 				ScaleFirstWorkerGroup(5).
 				Obj(),
-			wantErr: errors.New("PodSet name mismatch: RayCluster target-raycluster has worker group workers-group-0 which is not found in Ray object raycluster spec"),
+			wantErr: ErrPodSetNameMismatch,
 		},
 	}
 
@@ -728,15 +722,10 @@ func TestUpdatePodSets(t *testing.T) {
 
 			gotPodSets, err := UpdatePodSets(t.Context(), tc.podSets, c, tc.object, tc.enableInTreeAutoscaling, tc.rayClusterName)
 
-			if tc.wantErr != nil {
-				if err == nil || err.Error() != tc.wantErr.Error() {
-					t.Errorf("Expected error %q, got %v", tc.wantErr, err)
-				}
-				return
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("Unexpected error (-want +got):\n%s", diff)
 			}
-
-			if err != nil {
-				t.Errorf("Unexpected error: %v", err)
+			if tc.wantErr != nil {
 				return
 			}
 
@@ -1414,21 +1403,18 @@ func TestParsePodSetReplicaSizes(t *testing.T) {
 		},
 		"invalid json": {
 			annotation: `invalid`,
-			wantErr:    fmt.Errorf("failed to unmarshal %s annotation:", RayClusterPodsetReplicaSizesAnnotation),
+			wantErr:    ErrUnmarshalPodSetReplicaSizes,
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			got, err := ParsePodSetReplicaSizes(tc.annotation)
-			if tc.wantErr != nil {
-				if err == nil || !strings.Contains(err.Error(), tc.wantErr.Error()) {
-					t.Fatalf("ParsePodSetReplicaSizes() error = %v, wantErr %v", err, tc.wantErr)
-				}
-				return
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("ParsePodSetReplicaSizes() error mismatch (-want +got):\n%s", diff)
 			}
-			if err != nil {
-				t.Fatalf("ParsePodSetReplicaSizes() unexpected error: %v", err)
+			if tc.wantErr != nil {
+				return
 			}
 			if diff := cmp.Diff(tc.wantCounts, got); diff != "" {
 				t.Errorf("ParsePodSetReplicaSizes() mismatch (-want +got):\n%s", diff)
@@ -1539,7 +1525,7 @@ func TestGetWorkloadslicingCustomAnnotations(t *testing.T) {
 				{Name: "head", Count: 1},
 			},
 			rayClusterName: "test-raycluster",
-			wantErr:        errors.New("failed to get RayCluster test-raycluster:"),
+			wantErr:        ErrGetRayCluster,
 		},
 	}
 
@@ -1579,14 +1565,11 @@ func TestGetWorkloadslicingCustomAnnotations(t *testing.T) {
 			}
 
 			got, err := GetWorkloadslicingRayClusterCustomAnnotations(t.Context(), c, jobObject, tc.rayClusterName)
-			if tc.wantErr != nil {
-				if err == nil || !strings.Contains(err.Error(), tc.wantErr.Error()) {
-					t.Fatalf("GetWorkloadslicingCustomAnnotations() expected error containing %q, got %v", tc.wantErr, err)
-				}
-				return
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Fatalf("GetWorkloadslicingCustomAnnotations() error mismatch (-want +got):\n%s", diff)
 			}
-			if err != nil {
-				t.Fatalf("GetWorkloadslicingCustomAnnotations() unexpected error: %v", err)
+			if tc.wantErr != nil {
+				return
 			}
 			if diff := cmp.Diff(tc.wantAnnotation, got); diff != "" {
 				t.Errorf("GetWorkloadslicingCustomAnnotations() mismatch (-want +got):\n%s", diff)

--- a/pkg/controller/jobs/raycluster/common_test.go
+++ b/pkg/controller/jobs/raycluster/common_test.go
@@ -1524,7 +1524,7 @@ func TestGetWorkloadslicingCustomAnnotations(t *testing.T) {
 				{Name: "head", Count: 1},
 			},
 			rayClusterName: "test-raycluster",
-			wantErr:       rayClusterGetErr,
+			wantErr:        rayClusterGetErr,
 		},
 	}
 

--- a/pkg/controller/jobs/raycluster/common_test.go
+++ b/pkg/controller/jobs/raycluster/common_test.go
@@ -735,6 +735,7 @@ func TestUpdateRayClusterSpecToRunWithPodSetsInfo(t *testing.T) {
 		rayClusterSpec *rayv1.RayClusterSpec
 		podSetsInfo    []podset.PodSetInfo
 		wantSpec       *rayv1.RayClusterSpec
+		wantErr        error
 	}{
 		"basic update with node selector": {
 			rayClusterSpec: &rayv1.RayClusterSpec{
@@ -948,9 +949,8 @@ func TestUpdateRayClusterSpecToRunWithPodSetsInfo(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			err := UpdateRayClusterSpecToRunWithPodSetsInfo(utiltesting.NewLogger(t), tc.rayClusterSpec, tc.podSetsInfo)
 
-			if err != nil {
-				t.Errorf("Unexpected error: %v", err)
-				return
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("UpdateRayClusterSpecToRunWithPodSetsInfo() error mismatch (-want +got):\n%s", diff)
 			}
 
 			if diff := cmp.Diff(tc.wantSpec, tc.rayClusterSpec); diff != "" {

--- a/pkg/controller/jobs/raycluster/common_test.go
+++ b/pkg/controller/jobs/raycluster/common_test.go
@@ -1414,7 +1414,7 @@ func TestParsePodSetReplicaSizes(t *testing.T) {
 		},
 		"invalid json": {
 			annotation: `invalid`,
-			wantErr:    fmt.Errorf("failed to unmarshal %s annotation: invalid character 'i' looking for beginning of value", RayClusterPodsetReplicaSizesAnnotation),
+			wantErr:    fmt.Errorf("failed to unmarshal %s annotation:", RayClusterPodsetReplicaSizesAnnotation),
 		},
 	}
 
@@ -1422,7 +1422,7 @@ func TestParsePodSetReplicaSizes(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			got, err := ParsePodSetReplicaSizes(tc.annotation)
 			if tc.wantErr != nil {
-				if err == nil || err.Error() != tc.wantErr.Error() {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr.Error()) {
 					t.Fatalf("ParsePodSetReplicaSizes() error = %v, wantErr %v", err, tc.wantErr)
 				}
 				return


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Refactors `TestBuildPodSets`, `TestUpdatePodSets`, `TestParsePodSetReplicaSizes`, and `TestGetWorkloadslicingCustomAnnotations` in `pkg/controller/jobs/raycluster/common_test.go` to store an expected `error` value instead of a `wantErr bool`, so assertions verify the actual error condition rather than just its presence. Also removes the `wantErr bool` field in `TestUpdateRayClusterSpecToRunWithPodSetsInfo`, which was never exercised by any test case.

The affected error paths in `pkg/controller/jobs/raycluster/common.go` now return package-level sentinel errors (`ErrRedisCleanupMissingRayContainer`, `ErrPodSetNameMismatch`, `ErrGetRayCluster`, `ErrUnmarshalPodSetReplicaSizes`), wrapped via `%w`. Tests compare against these sentinels using `cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors())`, matching the pattern used in `pkg/controller/jobs/job/job_controller_test.go` (`wantRunError` vs. `podset.ErrInvalidPodSetUpdate`), rather than asserting on exact or partial error strings.

Disclosure: AI assistance (Claude Code) was used to draft this change.

#### Which issue(s) this PR fixes:

Fixes #14928

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for Ray cluster configuration, pod set mismatches, invalid settings, cleanup issues, and cluster retrieval failures.
  * Preserved actionable error messages while improving consistency when identifying specific failure conditions.

* **Tests**
  * Strengthened validation to check both returned errors and resulting pod-set or annotation updates.
  * Added coverage for failures encountered while retrieving Ray cluster information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->