### PR TITLE
Fix: Refresh AdmissionCheck ObservedGeneration After Configuration Updates

### DIFF
--- a/pkg/controller/admissionchecks/provisioning/admissioncheck_reconciler.go
+++ b/pkg/controller/admissionchecks/provisioning/admissioncheck_reconciler.go
@@ -56,7 +56,7 @@ func (a *acReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 		newCondition.Message = err.Error()
 	}
 
-	if currentCondition.Status != newCondition.Status {
+	if currentCondition.Status != newCondition.Status || currentCondition.ObservedGeneration != newCondition.ObservedGeneration {
 		apimeta.SetStatusCondition(&ac.Status.Conditions, newCondition)
 		return reconcile.Result{}, client.IgnoreNotFound(a.client.Status().Update(ctx, ac))
 	}

--- a/pkg/controller/admissionchecks/provisioning/admissioncheck_reconciler_test.go
+++ b/pkg/controller/admissionchecks/provisioning/admissioncheck_reconciler_test.go
@@ -111,6 +111,28 @@ func TestReconcileAdmissionCheck(t *testing.T) {
 				ObservedGeneration: 1,
 			},
 		},
+		"active condition with stale observed generation": {
+			check: utiltestingapi.MakeAdmissionCheck("check1").
+				Parameters(kueue.SchemeGroupVersion.Group, ConfigKind, "config1").
+				ControllerName(kueue.ProvisioningRequestControllerName).
+				Generation(2).
+				Condition(metav1.Condition{
+					Type:               kueue.AdmissionCheckActive,
+					Status:             metav1.ConditionTrue,
+					Reason:             "Active",
+					Message:            "The admission check is active",
+					ObservedGeneration: 1,
+				}).
+				Obj(),
+			configs: []kueue.ProvisioningRequestConfig{*utiltestingapi.MakeProvisioningRequestConfig("config1").Obj()},
+			wantCondition: &metav1.Condition{
+				Type:               kueue.AdmissionCheckActive,
+				Status:             metav1.ConditionTrue,
+				Reason:             "Active",
+				Message:            "The admission check is active",
+				ObservedGeneration: 2,
+			},
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

```
kind: AdmissionCheck
metadata:
  generation: 1
  ...
spec:
  ...
status:
  conditions:
  - type: Active
    status: "True"
    reason: Active
    observedGeneration: 1
```

Provisioning AdmissionCheck controller incorrectly determines whether status needs updating by comparing only `Active` condition’s boolean value: `currentCondition.Status != newCondition.Status`

When AdmissionCheck configuration changes, `metadata.generation` increases from `1` to `2`. 
If both configuration generations remain `active`, controller successfully validates generation `2`, but `Active` remains `True`. 
Since boolean value does not change, controller skips status update, leaving `observedGeneration` permanently stuck at generation 1.

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
ProvisioningRequest: Fixed a bug where the `Active` condition's `observedGeneration` on a ProvisioningRequest AdmissionCheck was not updated when a configuration change kept the check healthy, leaving `observedGeneration` permanently behind `metadata.generation`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Admission check status now refreshes when its recorded generation is outdated.
  * Ensures the active status condition accurately reflects the latest resource generation.

* **Tests**
  * Added coverage for updating stale generation information during reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->