### PR TITLE
[release-0.18] Requeue popped heads when the scheduling snapshot fails

### DIFF
--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -64,6 +64,7 @@ const (
 	RequeueReasonPreemptionFailed       RequeueReason = "PreemptionFailed"
 	RequeueReasonNoFit                  RequeueReason = "NoFit"
 	RequeueReasonPreemptionNoCandidates RequeueReason = "PreemptionNoCandidates"
+	RequeueReasonSnapshotFailed         RequeueReason = "SnapshotFailed"
 )
 
 // QuotaReservedReason represents the reason for the WorkloadQuotaReserved condition
@@ -169,7 +170,7 @@ type ClusterQueue struct {
 
 	// inadmissibleWorkloads are workloads that have been tried at least once and couldn't be admitted.
 	//
-	// Invariant: a pending workload is tracked in exactly one of heap,
+	// Invariant: a pending workload is tracked in at most one of heap,
 	// inadmissibleWorkloads, or inflight at any time, and contributes to
 	// pendingResourcesTotal exactly once while in heap or inadmissibleWorkloads.
 	// All transitions between these places must go through the helpers next to
@@ -192,7 +193,8 @@ type ClusterQueue struct {
 	popCycle int64
 
 	// inflight is non-nil when a workload has been popped by the scheduler but
-	// not yet requeued or deleted.
+	// not yet requeued, deleted, or released because it could not be placed
+	// back into a queue.
 	inflight *workload.Info
 
 	// queueInadmissibleCycle stores the popId at the time when
@@ -715,6 +717,14 @@ func (c *ClusterQueue) forgetInflightByKey(key workload.Reference) {
 	}
 }
 
+// forgetInflight releases the claim on a popped workload. Only correct under the
+// Manager lock, which orders it against the other transitions of the claim.
+func (c *ClusterQueue) forgetInflight(key workload.Reference) {
+	c.rwm.Lock()
+	defer c.rwm.Unlock()
+	c.forgetInflightByKey(key)
+}
+
 // handleInadmissibleHash bulk-moves all heap workloads matching the given
 // scheduling hash to inadmissibleWorkloads. Returns the number moved.
 // Only applies to BestEffortFIFO queues; in StrictFIFO the head workload
@@ -1050,6 +1060,7 @@ func (c *ClusterQueue) RequeueIfNotPresent(ctx context.Context, wInfo *workload.
 		immediate = reason != RequeueReasonNamespaceMismatch
 	} else {
 		immediate = reason == RequeueReasonFailedAfterNomination ||
+			reason == RequeueReasonSnapshotFailed ||
 			reason == RequeueReasonPendingPreemption ||
 			reason == RequeueReasonPendingMigration ||
 			reason == RequeueReasonPreemptionFailed

--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -735,12 +735,20 @@ func (m *Manager) AddOrUpdateWorkloadWithoutLock(log logr.Logger, w *kueue.Workl
 // RequeueWorkload requeues the workload ensuring that the queue and the
 // workload still exist in the client cache and not admitted. It won't
 // requeue if the workload is already in the queue (possible if the workload was updated).
+// Either way the workload is no longer inflight in the ClusterQueue it was popped from.
 // The quotaReservedReason parameter represents the WorkloadQuotaReserved condition reason
 // computed by the scheduler during this cycle. It must be passed explicitly because info.Obj
 // has not yet been patched with the updated condition when RequeueWorkload is called.
 func (m *Manager) RequeueWorkload(ctx context.Context, info *workload.Info, reason RequeueReason, quotaReservedReason QuotaReservedReason) bool {
 	m.Lock()
 	defer m.Unlock()
+
+	// This call decides where the workload goes, so the claim taken by Pop does
+	// not survive it. Releasing it up front also covers the returns below that
+	// never reach the ClusterQueue: a claim left behind makes PushOrUpdate a
+	// no-op, keeping the workload out of the queues even once it could be added
+	// again. Read before info.Update, which resets info.ClusterQueue.
+	m.forgetInflight(info.ClusterQueue, workload.Key(info.Obj))
 
 	var w kueue.Workload
 	// Always get the newest workload to avoid requeuing the out-of-date obj.
@@ -778,6 +786,17 @@ func (m *Manager) RequeueWorkload(ctx context.Context, info *workload.Info, reas
 		m.Broadcast()
 	}
 	return added
+}
+
+// forgetInflight releases the claim that Pop took on a workload in the given
+// ClusterQueue. Must be called with the lock held.
+func (m *Manager) forgetInflight(cqName kueue.ClusterQueueReference, key workload.Reference) {
+	cq := m.hm.ClusterQueue(cqName)
+	if cq == nil {
+		return
+	}
+	cq.forgetInflight(key)
+	reportCQPendingWorkloads(m, cq)
 }
 
 // Delete the workload from queue or cluster queue.

--- a/pkg/cache/queue/manager_test.go
+++ b/pkg/cache/queue/manager_test.go
@@ -1196,18 +1196,40 @@ func TestStatus(t *testing.T) {
 	}
 }
 
-func TestRequeueWorkloadStrictFIFO(t *testing.T) {
+// hasInflight reports whether the ClusterQueue still claims the popped workload.
+func hasInflight(c *ClusterQueue, key workload.Reference) bool {
+	c.rwm.RLock()
+	defer c.rwm.RUnlock()
+	return c.inflight != nil && workload.Key(c.inflight.Obj) == key
+}
+
+func TestRequeueWorkload(t *testing.T) {
 	now := time.Now()
-	cq := utiltestingapi.MakeClusterQueue("cq").Obj()
+	clusterQueues := []*kueue.ClusterQueue{
+		utiltestingapi.MakeClusterQueue("cq").Obj(),
+		utiltestingapi.MakeClusterQueue("other-cq").Obj(),
+	}
 	queues := []*kueue.LocalQueue{
 		utiltestingapi.MakeLocalQueue("foo", "").ClusterQueue("cq").Obj(),
 		utiltestingapi.MakeLocalQueue("bar", "").Obj(),
+		utiltestingapi.MakeLocalQueue("moved", "").ClusterQueue("other-cq").Obj(),
 	}
 	cases := map[string]struct {
-		workload     *kueue.Workload
-		inClient     bool
-		inQueue      bool
-		wantRequeued bool
+		workload *kueue.Workload
+		inClient bool
+		inQueue  bool
+		popped   bool
+		// requeueWorkload is what the cluster holds by the time of the requeue,
+		// when it changed after the pop. Defaults to workload.
+		requeueWorkload *kueue.Workload
+		wantRequeued    bool
+		// wantTrackedClusterQueue is where the workload ends up right after the
+		// requeue.
+		wantTrackedClusterQueue kueue.ClusterQueueReference
+		// wantRecoveredClusterQueue is where the original workload must land when
+		// it is added back: the ClusterQueue it was popped from must have let go
+		// of it by then.
+		wantRecoveredClusterQueue kueue.ClusterQueueReference
 	}{
 		"existing queue and obj": {
 			workload: utiltestingapi.MakeWorkload("wl", "").
@@ -1241,7 +1263,7 @@ func TestRequeueWorkloadStrictFIFO(t *testing.T) {
 		"has no quota reservation": {
 			workload: utiltestingapi.MakeWorkload("wl", "").
 				Queue("foo").
-				ReserveQuotaAt(&kueue.Admission{ClusterQueue: kueue.ClusterQueueReference(cq.Name)}, now).
+				ReserveQuotaAt(&kueue.Admission{ClusterQueue: "cq"}, now).
 				Obj(),
 			inClient:     true,
 			inQueue:      true,
@@ -1282,15 +1304,82 @@ func TestRequeueWorkloadStrictFIFO(t *testing.T) {
 			inQueue:      true,
 			wantRequeued: false,
 		},
+		"workload deleted between the pop and the requeue": {
+			workload: utiltestingapi.MakeWorkload("wl", "").
+				Queue("foo").
+				Obj(),
+			inClient:                  false,
+			inQueue:                   true,
+			popped:                    true,
+			wantRequeued:              false,
+			wantRecoveredClusterQueue: "cq",
+		},
+		"workload deactivated between the pop and the requeue": {
+			workload: utiltestingapi.MakeWorkload("wl", "").
+				Queue("foo").
+				Obj(),
+			inClient: true,
+			inQueue:  true,
+			popped:   true,
+			requeueWorkload: utiltestingapi.MakeWorkload("wl", "").
+				Queue("foo").
+				Active(false).
+				Obj(),
+			wantRequeued:              false,
+			wantRecoveredClusterQueue: "cq",
+		},
+		"queue name points at a missing LocalQueue": {
+			workload: utiltestingapi.MakeWorkload("wl", "").
+				Queue("foo").
+				Obj(),
+			inClient: true,
+			inQueue:  true,
+			popped:   true,
+			requeueWorkload: utiltestingapi.MakeWorkload("wl", "").
+				Queue("baz").
+				Obj(),
+			wantRequeued:              false,
+			wantRecoveredClusterQueue: "cq",
+		},
+		"queue name points at a LocalQueue without a ClusterQueue": {
+			workload: utiltestingapi.MakeWorkload("wl", "").
+				Queue("foo").
+				Obj(),
+			inClient: true,
+			inQueue:  true,
+			popped:   true,
+			requeueWorkload: utiltestingapi.MakeWorkload("wl", "").
+				Queue("bar").
+				Obj(),
+			wantRequeued:              false,
+			wantRecoveredClusterQueue: "cq",
+		},
+		"queue name points at another ClusterQueue": {
+			workload: utiltestingapi.MakeWorkload("wl", "").
+				Queue("foo").
+				Obj(),
+			inClient: true,
+			inQueue:  true,
+			popped:   true,
+			requeueWorkload: utiltestingapi.MakeWorkload("wl", "").
+				Queue("moved").
+				Obj(),
+			wantRequeued:            true,
+			wantTrackedClusterQueue: "other-cq",
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			cl := utiltesting.NewFakeClient()
 			ctx, log := utiltesting.ContextWithLog(t)
+			ctx, cancel := context.WithTimeout(ctx, headsTimeout)
+			defer cancel()
 			queueOptions := []Option{WithPreemptionExpectations(preemptexpectations.New())}
 			manager := NewManagerForUnitTests(cl, nil, queueOptions...)
-			if err := manager.AddClusterQueue(ctx, cq); err != nil {
-				t.Fatalf("Failed adding cluster queue %s: %v", cq.Name, err)
+			for _, cq := range clusterQueues {
+				if err := manager.AddClusterQueue(ctx, cq); err != nil {
+					t.Fatalf("Failed adding cluster queue %s: %v", cq.Name, err)
+				}
 			}
 			for _, q := range queues {
 				if err := manager.AddLocalQueue(ctx, q); err != nil {
@@ -1300,7 +1389,11 @@ func TestRequeueWorkloadStrictFIFO(t *testing.T) {
 			// Adding workload to client after the queues are created, otherwise it
 			// will be in the queue.
 			if tc.inClient {
-				if err := cl.Create(ctx, tc.workload); err != nil {
+				cliWl := tc.requeueWorkload
+				if cliWl == nil {
+					cliWl = tc.workload
+				}
+				if err := cl.Create(ctx, cliWl); err != nil {
 					t.Fatalf("Failed adding workload to client: %v", err)
 				}
 			}
@@ -1308,8 +1401,33 @@ func TestRequeueWorkloadStrictFIFO(t *testing.T) {
 				_ = manager.AddOrUpdateWorkload(log, tc.workload)
 			}
 			info := workload.NewInfo(tc.workload)
+			if tc.popped {
+				go manager.CleanUpOnContext(ctx)
+				heads := manager.Heads(ctx)
+				if len(heads) != 1 {
+					t.Fatalf("Heads returned %d workloads, want 1", len(heads))
+				}
+				info = &heads[0].Info
+				if !hasInflight(manager.hm.ClusterQueue("cq"), workload.Key(tc.workload)) {
+					t.Fatalf("ClusterQueue %q does not claim %q after the pop", "cq", workload.Key(tc.workload))
+				}
+			}
 			if requeued := manager.RequeueWorkload(ctx, info, RequeueReasonGeneric, ""); requeued != tc.wantRequeued {
 				t.Errorf("RequeueWorkload returned %t, want %t", requeued, tc.wantRequeued)
+			}
+			if tc.popped && hasInflight(manager.hm.ClusterQueue("cq"), workload.Key(tc.workload)) {
+				t.Errorf("ClusterQueue %q still claims %q", "cq", workload.Key(tc.workload))
+			}
+			if tc.wantTrackedClusterQueue != "" && manager.hm.ClusterQueue(tc.wantTrackedClusterQueue).trackedInfo(workload.Key(tc.workload)) == nil {
+				t.Errorf("ClusterQueue %q does not track %q", tc.wantTrackedClusterQueue, workload.Key(tc.workload))
+			}
+			if tc.wantRecoveredClusterQueue != "" {
+				if err := manager.AddOrUpdateWorkload(log, tc.workload); err != nil {
+					t.Fatalf("Failed re-adding workload: %v", err)
+				}
+				if manager.hm.ClusterQueue(tc.wantRecoveredClusterQueue).Info(workload.Key(tc.workload)) == nil {
+					t.Errorf("ClusterQueue %q does not hold %q on the heap once the workload is added back", tc.wantRecoveredClusterQueue, workload.Key(tc.workload))
+				}
 			}
 		})
 	}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -316,6 +316,7 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 	snapshot, err := s.cache.Snapshot(ctx, snapshotOpts...)
 	if err != nil {
 		log.Error(err, "failed to build snapshot for scheduling")
+		s.requeueHeadsAfterSnapshotError(ctx, heads)
 		return wait.SlowDown
 	}
 	logSnapshotIfVerbose(log, snapshot)
@@ -365,6 +366,24 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 		return wait.SlowDown
 	}
 	return wait.KeepGoing
+}
+
+// requeueHeadsAfterSnapshotError puts back the workloads popped by Heads, which
+// nothing else does. The failure is transient, so they are requeued to be retried
+// rather than parked as inadmissible; second-pass workloads return after a backoff
+// step, as they do on the other failure paths of a cycle.
+func (s *Scheduler) requeueHeadsAfterSnapshotError(ctx context.Context, heads []qcache.Head) {
+	log := ctrl.LoggerFrom(ctx)
+	for i := range heads {
+		wl := &heads[i].Info
+		if s.queues.QueueSecondPassIfNeeded(ctx, wl.Obj, wl.SecondPassIteration) {
+			continue
+		}
+		if !s.queues.RequeueWorkload(ctx, wl, qcache.RequeueReasonSnapshotFailed, "") {
+			log.V(2).Info("Popped head was not requeued after a failed snapshot",
+				"workload", klog.KObj(wl.Obj), "clusterQueue", klog.KRef("", string(wl.ClusterQueue)))
+		}
+	}
 }
 
 // processEntry runs the admission pipeline for a single entry: TAS replacement,

--- a/pkg/scheduler/scheduler_afs_test.go
+++ b/pkg/scheduler/scheduler_afs_test.go
@@ -18,6 +18,7 @@ package scheduler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -30,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
@@ -82,12 +84,18 @@ func TestScheduleForAFS(t *testing.T) {
 			Obj(),
 	}
 
+	snapshotErr := errors.New("snapshot failed")
+
 	cases := map[string]struct {
 		featureGates  map[featuregate.Feature]bool
 		initialUsage  map[string]corev1.ResourceList
 		workloads     []kueue.Workload
 		wantWorkloads []kueue.Workload
 		deleteQueue   string
+		wantLeft      map[kueue.ClusterQueueReference][]workload.Reference
+		// wantErr fails every LocalQueue lookup made to resolve a fair-sharing
+		// weight, so the cycles of the case run with a failing snapshot.
+		wantErr error
 	}{
 		"admits workload from less active localqueue": {
 			featureGates: map[featuregate.Feature]bool{features.AdmissionFairSharing: true},
@@ -824,6 +832,61 @@ func TestScheduleForAFS(t *testing.T) {
 					Obj(),
 			},
 		},
+		// Nothing but the scheduler puts a popped head back, so wl-a2 is only
+		// still queued at the end if every failed cycle requeued it.
+		"snapshot fails; the popped head is requeued": {
+			featureGates: map[featuregate.Feature]bool{features.AdmissionFairSharing: true},
+			wantErr:      snapshotErr,
+			workloads: []kueue.Workload{
+				// Admitted so that the snapshot resolves a LocalQueue
+				// weight, and a second entry so the harness runs two cycles.
+				*utiltestingapi.MakeWorkload("wl-a1", "default").
+					Queue("lq-a").
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						Request(corev1.ResourceCPU, "4").
+						Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("cq1").
+							PodSets(utiltestingapi.MakePodSetAssignment("one").
+								Assignment(corev1.ResourceCPU, "default", "4").
+								Count(1).
+								Obj()).
+							Obj(), now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-a2", "default").
+					Queue("lq-a").
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						Request(corev1.ResourceCPU, "4").
+						Obj()).
+					Creation(now).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-a1", "default").
+					Queue("lq-a").
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						Request(corev1.ResourceCPU, "4").
+						Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("cq1").
+							PodSets(utiltestingapi.MakePodSetAssignment("one").
+								Assignment(corev1.ResourceCPU, "default", "4").
+								Count(1).
+								Obj()).
+							Obj(), now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-a2", "default").
+					Queue("lq-a").
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						Request(corev1.ResourceCPU, "4").
+						Obj()).
+					Creation(now).
+					Obj(),
+			},
+			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+				"cq1": {"default/wl-a2"},
+			},
+		},
 	}
 
 	scenarios := []map[featuregate.Feature]bool{
@@ -870,7 +933,15 @@ func TestScheduleForAFS(t *testing.T) {
 							utiltesting.MakeNamespace("default"),
 						).
 						WithStatusSubresource(&kueue.Workload{}).
-						WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})
+						WithInterceptorFuncs(interceptor.Funcs{
+							SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge,
+							Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+								if _, isLocalQueue := obj.(*kueue.LocalQueue); isLocalQueue && errors.Is(tc.wantErr, snapshotErr) {
+									return tc.wantErr
+								}
+								return c.Get(ctx, key, obj, opts...)
+							},
+						})
 					cl := clientBuilder.Build()
 
 					cqCache := schdcache.New(cl, schdcache.WithFairSharing(tc.featureGates[features.AdmissionFairSharing]), schdcache.WithAdmissionFairSharing(afsConfig))
@@ -936,6 +1007,10 @@ func TestScheduleForAFS(t *testing.T) {
 
 					if diff := cmp.Diff(wantWorkloads, gotWorkloads.Items, defaultWorkloadCmpOpts); diff != "" {
 						t.Errorf("Unexpected workloads (-want,+got):\n%s", diff)
+					}
+
+					if diff := cmp.Diff(tc.wantLeft, qManager.Dump(), cmpDump...); diff != "" {
+						t.Errorf("Unexpected elements left in the queue (-want,+got):\n%s", diff)
 					}
 				},
 			)

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -23,6 +23,7 @@ import (
 	"maps"
 	"reflect"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -54,6 +55,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/util/limitrange"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	"sigs.k8s.io/kueue/pkg/util/routine"
+	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -9837,5 +9839,131 @@ func TestFitsDedupsOverlappingVictims(t *testing.T) {
 	got := fits(snapshot, cq, &incomingUsage, preempted, targets)
 	if got != schdcache.FitsCheckNoQuota {
 		t.Fatalf("fits() = %v, want %v (overlapping victim must be subtracted once)", got, schdcache.FitsCheckNoQuota)
+	}
+}
+
+// TestRequeueHeadsAfterSnapshotError covers the heads popped by a cycle whose
+// snapshot failed: nothing else puts them back, so they are lost unless the
+// scheduler requeues them. Regular heads return to the ClusterQueue right away,
+// second-pass heads after a backoff step.
+func TestRequeueHeadsAfterSnapshotError(t *testing.T) {
+	// The LocalQueue weight lookup is the only client call a snapshot makes, so
+	// admission fair sharing is what a test has to enable to fail one.
+	features.SetFeatureGateDuringTest(t, features.AdmissionFairSharing, true)
+	afsConfig := &config.AdmissionFairSharing{
+		UsageHalfLifeTime:     metav1.Duration{Duration: 10 * time.Second},
+		UsageSamplingInterval: metav1.Duration{Duration: 1 * time.Second},
+	}
+	now := time.Now().Truncate(time.Second)
+	ctx, log := utiltesting.ContextWithLog(t)
+
+	ns := utiltesting.MakeNamespaceWrapper(metav1.NamespaceDefault).Obj()
+	rf := utiltestingapi.MakeResourceFlavor("rf").Obj()
+	cq := utiltestingapi.MakeClusterQueue("cq").
+		ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas(rf.Name).
+				Resource(corev1.ResourceCPU, "1").
+				Obj(),
+		).
+		AdmissionMode(kueue.UsageBasedAdmissionFairSharing).
+		Obj()
+	lq := utiltestingapi.MakeLocalQueue("lq", metav1.NamespaceDefault).ClusterQueue(cq.Name).Obj()
+	pending := utiltestingapi.MakeWorkload("pending", metav1.NamespaceDefault).
+		Queue(kueue.LocalQueueName(lq.Name)).
+		PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+			Request(corev1.ResourceCPU, "1").
+			Obj()).
+		Creation(now).
+		Obj()
+	// A workload whose topology assignment is still delayed is what the queue
+	// manager hands over as a second-pass head.
+	secondPass := utiltestingapi.MakeWorkload("second-pass", metav1.NamespaceDefault).
+		Queue(kueue.LocalQueueName(lq.Name)).
+		PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+			RequiredTopologyRequest(corev1.LabelHostname).
+			Request(corev1.ResourceCPU, "1").
+			Obj()).
+		ReserveQuotaAt(
+			utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(cq.Name)).
+				PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name), "1").
+					DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
+					Obj()).
+				Obj(), now).
+		AdmissionCheck(kueue.AdmissionCheckState{Name: "check", State: kueue.CheckStateReady}).
+		Obj()
+
+	var snapshotToFail atomic.Bool
+	cl := utiltesting.NewClientBuilder().
+		WithObjects(ns, rf, cq, lq, pending, secondPass).
+		WithStatusSubresource(&kueue.Workload{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, isLocalQueue := obj.(*kueue.LocalQueue); isLocalQueue && snapshotToFail.CompareAndSwap(true, false) {
+					return errors.New("injected LocalQueue get failure")
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	fakeClock := testingclock.NewFakeClock(now)
+	cqCache := schdcache.New(cl, schdcache.WithFairSharing(true), schdcache.WithAdmissionFairSharing(afsConfig))
+	qManager := qcache.NewManagerForUnitTests(cl, cqCache,
+		qcache.WithClock(fakeClock), qcache.WithAdmissionFairSharing(afsConfig))
+
+	cqCache.AddOrUpdateResourceFlavor(log, rf)
+	if err := cqCache.AddClusterQueue(ctx, cq); err != nil {
+		t.Fatalf("Inserting clusterQueue %s in cache: %v", cq.Name, err)
+	}
+	if err := qManager.AddClusterQueue(ctx, cq); err != nil {
+		t.Fatalf("Inserting clusterQueue %s in manager: %v", cq.Name, err)
+	}
+	if err := qManager.AddLocalQueue(ctx, lq); err != nil {
+		t.Fatalf("Inserting queue %s/%s in manager: %v", lq.Namespace, lq.Name, err)
+	}
+
+	scheduler := New(qManager, cqCache, cl, &utiltesting.EventRecorder{},
+		WithClock(t, fakeClock), WithPreemptionExpectations(preemptexpectations.New()))
+
+	ctx, cancel := context.WithTimeout(ctx, queueingTimeout)
+	// Heads blocks on a condition variable, which CleanUpOnContext wakes up so
+	// the assertions below fail on a timeout instead of hanging.
+	go qManager.CleanUpOnContext(ctx)
+	defer cancel()
+
+	if !qManager.QueueSecondPassIfNeeded(ctx, secondPass, 0) {
+		t.Fatalf("Failed queueing %q for the second pass", secondPass.Name)
+	}
+	fakeClock.Step(time.Second)
+	if fakeClock.HasWaiters() {
+		t.Fatalf("The second pass pre-queue left a timer behind")
+	}
+
+	// Armed here rather than at build time so that only a scheduling cycle can
+	// consume it.
+	snapshotToFail.Store(true)
+	scheduler.schedule(ctx)
+	if snapshotToFail.Load() {
+		t.Fatal("No snapshot read a LocalQueue, so none of them failed")
+	}
+
+	// One iteration in, the second pass backoff is two seconds.
+	fakeClock.Step(2*time.Second - time.Nanosecond)
+	if !fakeClock.HasWaiters() {
+		t.Fatalf("The second pass head didn't come back with a two second backoff")
+	}
+	fakeClock.Step(time.Nanosecond)
+	gotHeads := qManager.Heads(ctx)
+	gotHeadKeys := slices.Map(gotHeads, func(h *qcache.Head) workload.Reference { return workload.Key(h.Obj) })
+	wantHeadKeys := []workload.Reference{workload.Key(pending), workload.Key(secondPass)}
+	sortRefs := cmpopts.SortSlices(func(a, b workload.Reference) bool { return a < b })
+	if diff := cmp.Diff(wantHeadKeys, gotHeadKeys, sortRefs); diff != "" {
+		t.Fatalf("Unexpected heads after the second pass backoff (-want,+got):\n%s", diff)
+	}
+	for _, head := range gotHeads {
+		if workload.Key(head.Obj) == workload.Key(secondPass) && head.SecondPassIteration != 2 {
+			t.Errorf("Unexpected second pass iteration: want 2, got %d", head.SecondPassIteration)
+		}
 	}
 }


### PR DESCRIPTION
(cherry picked from commit 86edfeb1b69e4bf577d98cbd1a59bd6e47a581f0)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

cheery-pick of https://github.com/kubernetes-sigs/kueue/pull/13885

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Scheduling: Fix workloads becoming stranded after scheduling snapshot failures, and stale pending accounting when a LocalQueue moves to another ClusterQueue.
```
