### PR TITLE
Validate Kubeflow Trainer TrainJob CRD compatibility at setup and document v2.2.0 minimum

### DIFF
--- a/pkg/controller/jobs/trainjob/crd_validation.go
+++ b/pkg/controller/jobs/trainjob/crd_validation.go
@@ -1,0 +1,102 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package trainjob
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ValidateTrainJobCRDVersion validates that the installed TrainJob CRD is v2.2.0 or later.
+// Returns nil if CRD is not found (it might be installed later).
+func ValidateTrainJobCRDVersion(ctx context.Context, c client.Client) error {
+	crd := &unstructured.Unstructured{}
+	crd.SetAPIVersion("apiextensions.k8s.io/v1")
+	crd.SetKind("CustomResourceDefinition")
+
+	crdKey := client.ObjectKey{Name: "trainjobs.trainer.kubeflow.org"}
+	if err := c.Get(ctx, crdKey, crd); err != nil {
+		// If CRD not found, it might be installed later - that's OK for now
+		if apierrors.IsNotFound(err) {
+			return nil // Don't fail - CRD might not be installed yet
+		}
+		return fmt.Errorf(
+			"unable to fetch TrainJob CRD. "+
+				"Ensure Kubeflow Trainer is installed and v2.2.0 or later. "+
+				"Error: %w",
+			err,
+		)
+	}
+
+	// Check if the CRD schema has the runtimePatches field in TrainJobSpec
+	if !hasRuntimePatchesField(crd) {
+		return errors.New(
+			"TrainJob CRD does not support the 'runtimePatches' field. " +
+				"This field is required by Kueue and was added in Kubeflow Trainer v2.2.0. " +
+				"Currently installed TrainJob CRD appears to be v2.1 or earlier. " +
+				"Please upgrade Kubeflow Trainer to v2.2.0 or later. " +
+				"See: https://github.com/kubeflow/trainer/releases/tag/v2.2.0",
+		)
+	}
+
+	return nil
+}
+
+// hasRuntimePatchesField checks if the CRD schema contains the runtimePatches field
+// in the TrainJobSpec by inspecting the OpenAPI v3 schema definition.
+// Only checks the SERVED version of the CRD.
+func hasRuntimePatchesField(crd *unstructured.Unstructured) bool {
+	versions, found, err := unstructured.NestedSlice(crd.Object, "spec", "versions")
+	if err != nil || !found || len(versions) == 0 {
+		return false
+	}
+
+	// Check ONLY the served versions
+	for _, v := range versions {
+		versionMap, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		// SKIP if this version is not served
+		served, found, err := unstructured.NestedBool(versionMap, "served")
+		if err != nil || !found || !served {
+			continue // Skip unserved versions
+		}
+
+		// Navigate to the schema properties
+		schemaProps, found, err := unstructured.NestedMap(
+			versionMap,
+			"schema", "openAPIV3Schema", "properties", "spec", "properties",
+		)
+		if err != nil || !found {
+			continue
+		}
+
+		// Check if runtimePatches exists in spec.properties (v2.2.0+ marker)
+		if _, exists := schemaProps["runtimePatches"]; exists {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/controller/jobs/trainjob/crd_validation_integration_test.go
+++ b/pkg/controller/jobs/trainjob/crd_validation_integration_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package trainjob
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// TestSetupTrainJobWebhook_ValidatesCRD verifies that SetupTrainJobWebhook validates the CRD
+func TestSetupTrainJobWebhook_ValidatesCRD(t *testing.T) {
+	tests := []struct {
+		name      string
+		crd       *unstructured.Unstructured
+		wantError bool
+	}{
+		{
+			name:      "v2.2.0 compatible CRD should pass",
+			crd:       createMockTrainJobCRDv22(),
+			wantError: false,
+		},
+		{
+			name:      "v2.1 incompatible CRD should fail",
+			crd:       createMockTrainJobCRDv21(),
+			wantError: true,
+		},
+		{
+			name:      "missing CRD should NOT fail (graceful)",
+			crd:       nil,
+			wantError: false, // Changed from true to false - missing is OK
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var objects []client.Object
+			if tt.crd != nil {
+				objects = []client.Object{tt.crd}
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithObjects(objects...).
+				Build()
+
+			ctx := t.Context()
+			err := ValidateTrainJobCRDVersion(ctx, fakeClient)
+
+			if (err != nil) != tt.wantError {
+				t.Errorf("ValidateTrainJobCRDVersion() error = %v, wantError %v", err, tt.wantError)
+			}
+		})
+	}
+}

--- a/pkg/controller/jobs/trainjob/crd_validation_test.go
+++ b/pkg/controller/jobs/trainjob/crd_validation_test.go
@@ -1,0 +1,254 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package trainjob
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// TestValidateTrainJobCRDVersion_V2_2_Compatible tests validation with v2.2.0 compatible CRD
+func TestValidateTrainJobCRDVersion_V2_2_Compatible(t *testing.T) {
+	crd := createMockTrainJobCRDv22()
+	client := fake.NewClientBuilder().WithObjects(crd).Build()
+	ctx := t.Context()
+
+	err := ValidateTrainJobCRDVersion(ctx, client)
+	if err != nil {
+		t.Errorf("ValidateTrainJobCRDVersion() with v2.2.0 CRD should not error, got: %v", err)
+	}
+}
+
+// TestValidateTrainJobCRDVersion_V2_1_Incompatible tests validation with v2.1 incompatible CRD
+func TestValidateTrainJobCRDVersion_V2_1_Incompatible(t *testing.T) {
+	crd := createMockTrainJobCRDv21()
+	client := fake.NewClientBuilder().WithObjects(crd).Build()
+	ctx := t.Context()
+
+	err := ValidateTrainJobCRDVersion(ctx, client)
+	if err == nil {
+		t.Error("ValidateTrainJobCRDVersion() with v2.1 CRD should error, got nil")
+	}
+
+	if err != nil {
+		errMsg := err.Error()
+		if !containsSubstring(errMsg, "v2.2.0") {
+			t.Errorf("Error should mention v2.2.0, got: %v", err)
+		}
+		if !containsSubstring(errMsg, "runtimePatches") {
+			t.Errorf("Error should mention runtimePatches, got: %v", err)
+		}
+	}
+}
+
+// TestValidateTrainJobCRDVersion_NotInstalled tests validation when CRD is not installed
+// When CRD is not found, it's OK - it might be installed later
+func TestValidateTrainJobCRDVersion_NotInstalled(t *testing.T) {
+	client := fake.NewClientBuilder().Build()
+	ctx := t.Context()
+
+	err := ValidateTrainJobCRDVersion(ctx, client)
+
+	// Missing CRD is OK - return nil, don't fail
+	if err != nil {
+		t.Errorf("ValidateTrainJobCRDVersion() with missing CRD should return nil (graceful), got: %v", err)
+	}
+}
+
+// TestHasRuntimePatchesField tests the field detection logic
+func TestHasRuntimePatchesField(t *testing.T) {
+	tests := []struct {
+		name     string
+		crd      *unstructured.Unstructured
+		expected bool
+	}{
+		{
+			name:     "v2.2.0 CRD with runtimePatches",
+			crd:      createMockTrainJobCRDv22(),
+			expected: true,
+		},
+		{
+			name:     "v2.1 CRD without runtimePatches",
+			crd:      createMockTrainJobCRDv21(),
+			expected: false,
+		},
+		{
+			name:     "empty CRD",
+			crd:      &unstructured.Unstructured{},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasRuntimePatchesField(tt.crd)
+			if result != tt.expected {
+				t.Errorf("hasRuntimePatchesField() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+// Helper functions
+
+func createMockTrainJobCRDv22() *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "apiextensions.k8s.io/v1",
+			"kind":       "CustomResourceDefinition",
+			"metadata": map[string]any{
+				"name": "trainjobs.trainer.kubeflow.org",
+			},
+			"spec": map[string]any{
+				"versions": []any{
+					map[string]any{
+						"name":    "v1",
+						"served":  true,
+						"storage": true,
+						"schema": map[string]any{
+							"openAPIV3Schema": map[string]any{
+								"type": "object",
+								"properties": map[string]any{
+									"spec": map[string]any{
+										"type": "object",
+										"properties": map[string]any{
+											"runtimePatches": map[string]any{
+												"type": "array",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func createMockTrainJobCRDv21() *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "apiextensions.k8s.io/v1",
+			"kind":       "CustomResourceDefinition",
+			"metadata": map[string]any{
+				"name": "trainjobs.trainer.kubeflow.org",
+			},
+			"spec": map[string]any{
+				"versions": []any{
+					map[string]any{
+						"name":    "v1",
+						"served":  true,
+						"storage": true,
+						"schema": map[string]any{
+							"openAPIV3Schema": map[string]any{
+								"type": "object",
+								"properties": map[string]any{
+									"spec": map[string]any{
+										"type": "object",
+										"properties": map[string]any{
+											"suspend": map[string]any{
+												"type": "boolean",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func containsSubstring(text, substring string) bool {
+	for i := 0; i <= len(text)-len(substring); i++ {
+		if text[i:i+len(substring)] == substring {
+			return true
+		}
+	}
+	return false
+}
+
+// TestHasRuntimePatchesField_MixedVersions tests with both served and unserved versions
+func TestHasRuntimePatchesField_MixedVersions(t *testing.T) {
+	// Create CRD with unserved v1alpha1 (has runtimePatches) and served v1 (no runtimePatches)
+	crd := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "apiextensions.k8s.io/v1",
+			"kind":       "CustomResourceDefinition",
+			"metadata": map[string]any{
+				"name": "trainjobs.trainer.kubeflow.org",
+			},
+			"spec": map[string]any{
+				"versions": []any{
+					// Unserved version with runtimePatches
+					map[string]any{
+						"name":    "v1alpha1",
+						"served":  false, // NOT SERVED
+						"storage": false,
+						"schema": map[string]any{
+							"openAPIV3Schema": map[string]any{
+								"type": "object",
+								"properties": map[string]any{
+									"spec": map[string]any{
+										"type": "object",
+										"properties": map[string]any{
+											"runtimePatches": map[string]any{
+												"type": "array",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					// Served version WITHOUT runtimePatches
+					map[string]any{
+						"name":    "v1",
+						"served":  true, // SERVED
+						"storage": true,
+						"schema": map[string]any{
+							"openAPIV3Schema": map[string]any{
+								"type": "object",
+								"properties": map[string]any{
+									"spec": map[string]any{
+										"type": "object",
+										"properties": map[string]any{
+											"suspend": map[string]any{
+												"type": "boolean",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := hasRuntimePatchesField(crd)
+	if result {
+		t.Errorf("hasRuntimePatchesField() should return false for CRD with unserved runtimePatches and served without it, got true")
+	}
+}

--- a/pkg/controller/jobs/trainjob/trainjob_webhook.go
+++ b/pkg/controller/jobs/trainjob/trainjob_webhook.go
@@ -45,6 +45,7 @@ type TrainJobWebhook struct {
 // SetupTrainJobWebhook configures the webhook for kubeflow TrainJob.
 func SetupTrainJobWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 	options := jobframework.ProcessOptions(opts...)
+
 	wh := &TrainJobWebhook{
 		integrationManager:           options.IntegrationManager,
 		client:                       mgr.GetClient(),

--- a/site/content/en/docs/tasks/run/multikueue/trainjob.md
+++ b/site/content/en/docs/tasks/run/multikueue/trainjob.md
@@ -11,7 +11,7 @@ description: >
 
 Check the [MultiKueue installation guide](/docs/tasks/manage/setup_multikueue) on how to properly setup MultiKueue clusters.
 
-For the ease of setup and use we recommend using at least Kueue v0.11.0 and for Kubeflow Trainer at least v2.0.0.
+For the ease of setup and use we recommend using at least Kueue v0.11.0 and for Kubeflow Trainer at least v2.2.0.
 
 See [Trainer Installation](https://www.kubeflow.org/docs/components/trainer/operator-guides/installation/) for installation and configuration details of Kubeflow Trainer v2.
 

--- a/site/content/en/docs/tasks/run/trainjobs.md
+++ b/site/content/en/docs/tasks/run/trainjobs.md
@@ -24,7 +24,7 @@ This guide is for [batch users](/docs/tasks#batch-user) that have a basic unders
 
 2. Install Kubeflow Trainer v2. Check [the Trainer installation guide](https://www.kubeflow.org/docs/components/trainer/operator-guides/installation/).
 
-   **Note**: The minimum required Trainer version is v2.0.0.
+   **Note**: The minimum required Trainer version is v2.2.0. Earlier versions (v2.1 and earlier) do not support the `runtimePatches` field required by Kueue integration.
 
 3. Enable TrainJob integration in Kueue. You can [modify kueue configurations from installed releases](/docs/installation#install-a-custom-configured-released-version) to include TrainJobs as an allowed workload.
 

--- a/site/content/en/v0.18/docs/tasks/run/multikueue/trainjob.md
+++ b/site/content/en/v0.18/docs/tasks/run/multikueue/trainjob.md
@@ -11,7 +11,7 @@ description: >
 
 Check the [MultiKueue installation guide](/v0.18/docs/tasks/manage/setup_multikueue) on how to properly setup MultiKueue clusters.
 
-For the ease of setup and use we recommend using at least Kueue v0.11.0 and for Kubeflow Trainer at least v2.0.0.
+For the ease of setup and use we recommend using at least Kueue v0.11.0 and for Kubeflow Trainer at least v2.2.0.
 
 See [Trainer Installation](https://www.kubeflow.org/docs/components/trainer/operator-guides/installation/) for installation and configuration details of Kubeflow Trainer v2.
 

--- a/site/content/en/v0.18/docs/tasks/run/trainjobs.md
+++ b/site/content/en/v0.18/docs/tasks/run/trainjobs.md
@@ -24,7 +24,7 @@ This guide is for [batch users](/v0.18/docs/tasks#batch-user) that have a basic 
 
 2. Install Kubeflow Trainer v2. Check [the Trainer installation guide](https://www.kubeflow.org/docs/components/trainer/operator-guides/installation/).
 
-   **Note**: The minimum required Trainer version is v2.0.0.
+   **Note**: The minimum required Trainer version is v2.2.0.
 
 3. Enable TrainJob integration in Kueue. You can [modify kueue configurations from installed releases](/v0.18/docs/installation#install-a-custom-configured-released-version) to include TrainJobs as an allowed workload.
 

--- a/site/content/en/v0.19/docs/tasks/run/multikueue/trainjob.md
+++ b/site/content/en/v0.19/docs/tasks/run/multikueue/trainjob.md
@@ -11,7 +11,7 @@ description: >
 
 Check the [MultiKueue installation guide](/v0.19/docs/tasks/manage/setup_multikueue) on how to properly setup MultiKueue clusters.
 
-For the ease of setup and use we recommend using at least Kueue v0.11.0 and for Kubeflow Trainer at least v2.0.0.
+For the ease of setup and use we recommend using at least Kueue v0.11.0 and for Kubeflow Trainer at least v2.2.0.
 
 See [Trainer Installation](https://www.kubeflow.org/docs/components/trainer/operator-guides/installation/) for installation and configuration details of Kubeflow Trainer v2.
 

--- a/site/content/en/v0.19/docs/tasks/run/trainjobs.md
+++ b/site/content/en/v0.19/docs/tasks/run/trainjobs.md
@@ -24,7 +24,7 @@ This guide is for [batch users](/v0.19/docs/tasks#batch-user) that have a basic 
 
 2. Install Kubeflow Trainer v2. Check [the Trainer installation guide](https://www.kubeflow.org/docs/components/trainer/operator-guides/installation/).
 
-   **Note**: The minimum required Trainer version is v2.0.0.
+   **Note**: The minimum required Trainer version is v2.2.0.
 
 3. Enable TrainJob integration in Kueue. You can [modify kueue configurations from installed releases](/v0.19/docs/installation#install-a-custom-configured-released-version) to include TrainJobs as an allowed workload.
 

--- a/site/content/zh-CN/docs/tasks/run/multikueue/trainjob.md
+++ b/site/content/zh-CN/docs/tasks/run/multikueue/trainjob.md
@@ -12,7 +12,7 @@ description: >
 查阅 [MultiKueue 安装指南](/docs/tasks/manage/setup_multikueue)以了解如何正确设置 MultiKueue 集群。
 
 为了简化设置和使用，我们建议至少使用 Kueue v0.11.0 版本以及
-Kubeflow Trainer 至少 v2.0.0 版本。
+Kubeflow Trainer 至少 v2.2.0 版本。
 
 查看 [Trainer 安装](https://www.kubeflow.org/zh/docs/components/trainer/operator-guides/installation/)获取
 Kubeflow Trainer v2 的安装和配置详情。

--- a/site/content/zh-CN/v0.18/docs/tasks/run/multikueue/trainjob.md
+++ b/site/content/zh-CN/v0.18/docs/tasks/run/multikueue/trainjob.md
@@ -12,7 +12,7 @@ description: >
 查阅 [MultiKueue 安装指南](/v0.18/docs/tasks/manage/setup_multikueue)以了解如何正确设置 MultiKueue 集群。
 
 为了简化设置和使用，我们建议至少使用 Kueue v0.11.0 版本以及
-Kubeflow Trainer 至少 v2.0.0 版本。
+Kubeflow Trainer 至少 v2.2.0 版本。
 
 查看 [Trainer 安装](https://www.kubeflow.org/zh/docs/components/trainer/operator-guides/installation/)获取
 Kubeflow Trainer v2 的安装和配置详情。

--- a/site/content/zh-CN/v0.19/docs/tasks/run/multikueue/trainjob.md
+++ b/site/content/zh-CN/v0.19/docs/tasks/run/multikueue/trainjob.md
@@ -12,7 +12,7 @@ description: >
 查阅 [MultiKueue 安装指南](/v0.19/docs/tasks/manage/setup_multikueue)以了解如何正确设置 MultiKueue 集群。
 
 为了简化设置和使用，我们建议至少使用 Kueue v0.11.0 版本以及
-Kubeflow Trainer 至少 v2.0.0 版本。
+Kubeflow Trainer 至少 v2.2.0 版本。
 
 查看 [Trainer 安装](https://www.kubeflow.org/zh/docs/components/trainer/operator-guides/installation/)获取
 Kubeflow Trainer v2 的安装和配置详情。


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/kind feature
/area multikueue
/area testing

#### What this PR does / why we need it:
Kueue already uses v2.3.0 (with breaking API changes)
Decision: Implement BOTH v2.2.0 AND v2.3.0 validation
This PR covers v2.2.0 validation

#### Which issue(s) this PR fixes:

Part of #14819

#### Special notes for your reviewer:
v2.2.0 Validation (for older/released branches)
Validate that TrainJob CRD has runtimePatches field (v2.2.0+ marker)
Reject v2.1 and earlier
Can be cherry-picked to older branches
Update docs to say "v2.2.0 minimum"

#### Does this PR introduce a user-facing change?

```release-note
Yes - I have updates Docs
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated TrainJob and MultiKueue guidance to require Kubeflow Trainer v2.2.0 or later.
  * Clarified that earlier Trainer versions do not support the required `runtimePatches` integration feature.
  * Updated guidance consistently across current, legacy, and Chinese documentation.
* **Bug Fixes**
  * Improved TrainJob CRD compatibility checks by validating served versions.
  * Missing CRDs no longer prevent setup, allowing them to be installed later.
* **Tests**
  * Added coverage for compatible, incompatible, missing, and mixed-version CRDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->