### PR TITLE
Retry transient docker manifest inspect failures in e2e prepare_docker_images

### DIFF
--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -52,6 +52,10 @@ export E2E_SKIP_IMAGE_RELOAD="${E2E_SKIP_IMAGE_RELOAD:-false}"
 
 export KIND_VERSION="${E2E_KIND_VERSION#kindest/node:v}"
 
+# Non-retriable: missing image, denied access, or a full disk.
+# Shared by `e2e_docker_pull_if_needed` and `e2e_docker_manifest_available` below.
+export E2E_NON_RETRIABLE_IMAGE_ERRORS="manifest (unknown|for .* not found)|repository does not exist|not found|pull access denied|unauthorized|denied: requested access|no space left on device"
+
 function build_kind_node_image {
     if [[ "$E2E_KIND_VERSION" != kindest/node:v* ]]; then
         echo "Skipping kind node image build for non-standard image: $E2E_KIND_VERSION"
@@ -91,12 +95,21 @@ function e2e_docker_pull_if_needed {
         return 0
     fi
 
-    local non_retriable_errors="manifest (unknown|for .* not found)|repository does not exist|not found|pull access denied|unauthorized|denied: requested access|no space left on device"
-
     "${ROOT_DIR}/hack/testing/retry.sh" \
         --attempts 7 --delay 2 --exponential --stream \
-        --continue-if "! grep -qiE '${non_retriable_errors}' {output}" \
+        --continue-if "! grep -qiE '${E2E_NON_RETRIABLE_IMAGE_ERRORS}' {output}" \
         -- docker pull "$image"
+}
+
+# $1 image reference
+function e2e_docker_manifest_available {
+    local image="$1"
+
+    # shellcheck disable=SC2016 # the $1 expansion is evaluated by the inner bash -c
+    "${ROOT_DIR}/hack/testing/retry.sh" \
+        --attempts 7 --delay 2 --exponential --stream \
+        --continue-if "! grep -qiE '${E2E_NON_RETRIABLE_IMAGE_ERRORS}' {output}" \
+        -- bash -c 'docker manifest inspect "$1" 2>&1 >/dev/null' _ "$image"
 }
 
 function e2e_download_url {
@@ -636,14 +649,12 @@ function prepare_docker_images {
 
     # When using a pre-built Kueue image (released or staging), ensure it's available for kind load.
     # Check remote first; if not found remotely, use local image if present; otherwise error.
-    local manifest_error
-    if manifest_error=$(docker manifest inspect "$IMAGE_TAG" 2>&1 >/dev/null); then
+    if e2e_docker_manifest_available "$IMAGE_TAG"; then
         # E2E_SKIP_IMAGE_RELOAD covers dependency images only: the Kueue image may
         # have been rebuilt with the same tag, so it is always pulled.
         E2E_SKIP_IMAGE_RELOAD=false e2e_docker_pull_if_needed "$IMAGE_TAG"
     elif ! docker image inspect "$IMAGE_TAG" >/dev/null 2>&1; then
         echo "ERROR: Image '$IMAGE_TAG' is not available remotely or locally." >&2
-        echo "$manifest_error" >&2
         return 1
     fi
 
@@ -670,7 +681,7 @@ function prepare_docker_images {
         determine_kuberay_ray_image
         if [[ "${USE_RAY_FOR_TESTS:-}" == "ray" ]]; then
             e2e_docker_pull_if_needed "${KUBERAY_RAY_IMAGE}"
-        elif docker manifest inspect "${KUBERAY_RAY_IMAGE}" >/dev/null 2>&1; then
+        elif e2e_docker_manifest_available "${KUBERAY_RAY_IMAGE}"; then
             e2e_docker_pull_if_needed "${KUBERAY_RAY_IMAGE}"
         else
             echo "Raymini image not available in registry, building locally..."

--- a/hack/testing/e2e-common_test.sh
+++ b/hack/testing/e2e-common_test.sh
@@ -150,6 +150,17 @@ case "$*" in
   "image inspect "*)
     exit "${DOCKER_FAKE_IMAGE_PRESENT:-1}"
     ;;
+  "manifest inspect "*)
+    attempts=$(cat "${DOCKER_FAKE_MANIFEST_STATE:?}")
+    attempts=$((attempts + 1))
+    printf '%s' "${attempts}" >"${DOCKER_FAKE_MANIFEST_STATE}"
+    if [[ "${attempts}" -lt "${DOCKER_FAKE_MANIFEST_OK_AFTER:-1}" ]]; then
+      printf '%s\n' "${DOCKER_FAKE_MANIFEST_ERROR:?}" >&2
+      exit 1
+    fi
+    printf '{"fake":"manifest"}\n'
+    exit 0
+    ;;
 esac
 
 printf 'unexpected docker call: %s\n' "$*" >&2
@@ -338,5 +349,46 @@ if [[ "${pull_attempts}" != "1" ]]; then
   echo "expected a cached image to be pulled when E2E_SKIP_IMAGE_RELOAD is off; got ${pull_attempts} pull(s)" >&2
   exit 1
 fi
+
+# e2e_docker_manifest_available retries a transient manifest-inspect failure until it succeeds.
+DOCKER_FAKE_LOG="${test_dir}/docker.log"
+DOCKER_FAKE_MANIFEST_STATE="${test_dir}/docker-manifest-state"
+export DOCKER_FAKE_LOG DOCKER_FAKE_MANIFEST_STATE
+: >"${DOCKER_FAKE_LOG}"
+printf '0' >"${DOCKER_FAKE_MANIFEST_STATE}"
+export DOCKER_FAKE_MANIFEST_OK_AFTER=2
+export DOCKER_FAKE_MANIFEST_ERROR="net/http: TLS handshake timeout"
+
+if ! e2e_docker_manifest_available "registry.example.com/kueue:transient"; then
+  echo "expected a transient manifest-inspect failure to be retried until success" >&2
+  exit 1
+fi
+
+manifest_attempts=$(grep -c "^manifest inspect " "${DOCKER_FAKE_LOG}" || true)
+if [[ "${manifest_attempts}" != "2" ]]; then
+  echo "expected manifest inspect to be retried once after a transient failure; got ${manifest_attempts} attempt(s)" >&2
+  exit 1
+fi
+
+unset DOCKER_FAKE_MANIFEST_OK_AFTER DOCKER_FAKE_MANIFEST_ERROR
+
+# e2e_docker_manifest_available fails fast without retrying when the manifest is genuinely missing.
+: >"${DOCKER_FAKE_LOG}"
+printf '0' >"${DOCKER_FAKE_MANIFEST_STATE}"
+export DOCKER_FAKE_MANIFEST_OK_AFTER=99
+export DOCKER_FAKE_MANIFEST_ERROR="manifest for registry.example.com/kueue:missing not found"
+
+if e2e_docker_manifest_available "registry.example.com/kueue:missing"; then
+  echo "expected e2e_docker_manifest_available to fail for a genuinely missing manifest" >&2
+  exit 1
+fi
+
+manifest_attempts=$(grep -c "^manifest inspect " "${DOCKER_FAKE_LOG}" || true)
+if [[ "${manifest_attempts}" != "1" ]]; then
+  echo "expected a non-retriable manifest-inspect failure to fail fast without retrying; got ${manifest_attempts} attempt(s)" >&2
+  exit 1
+fi
+
+unset DOCKER_FAKE_MANIFEST_OK_AFTER DOCKER_FAKE_MANIFEST_ERROR
 
 echo "e2e-common tests passed"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

/kind flake

#### What this PR does / why we need it:
`prepare_docker_images` probes the registry with a single unretried `docker manifest inspect` at both of its call sites, checking `$IMAGE_TAG` and the KubeRay image. That single attempt has no retry, so a transient registry or TLS failure looks identical to a genuinely missing manifest. `prepare_docker_images` then falls back to a local image if one is cached, or fails outright, without ever giving the probe a chance to succeed on retry the way `docker pull` already does.

Both call sites now go through `e2e_docker_manifest_available`, which wraps the probe in `retry.sh` the same way `e2e_docker_pull_if_needed` already wraps the pull, reusing the same non-retriable-error classification so a genuinely missing manifest still fails fast.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14834
Fixes #14924

#### Special notes for your reviewer:
- Follow-up to the review comment on #14823 (https://github.com/kubernetes-sigs/kueue/pull/14823#discussion_r3865644147), which asked for the same retry treatment already given to the pull in that PR.
- `hack/testing/e2e-common_test.sh` now stubs `docker manifest inspect` and asserts a transient TLS handshake timeout is retried until it succeeds, and a genuinely missing manifest fails fast without retrying.
- This PR was written in part with the assistance of generative AI.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end test reliability when checking Docker image manifests by retrying transient registry or network failures.
  * Fails quickly for permanent issues such as missing images, unauthorized access, or unavailable repositories.
  * Docker image preparation now handles temporary registry errors more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->