### PR TITLE
config: reject qualified names with more than one slash

### DIFF
--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -899,17 +899,12 @@ func validateQualifiedName(name resourcev1.QualifiedName, fldPath *field.Path) f
 		} else {
 			allErrs = append(allErrs, validateCIdentifier(parts[1], fldPath)...)
 		}
-		// TODO: This validation is incomplete. It should reject qualified names
-		// that contain more than one slash. Currently, names like "a/b/c" are not
-		// handled and are implicitly accepted.
-		//
-		// This needs to be fixed in two places:
-		// 1. Here in this function.
-		// 2. In the corresponding declarative validation utility `resourcesQualifiedName`
-		//    in `staging/src/k8s.io/apimachinery/pkg/api/validate/strfmt.go`.
-		//
-		// The fix should be introduced carefully, possibly using ratcheting to avoid
-		// breaking existing, non-compliant objects.
+		// TODO: The corresponding declarative validation utility
+		// `resourcesQualifiedName` in
+		// `staging/src/k8s.io/apimachinery/pkg/api/validate/strfmt.go` has the
+		// same gap and should be fixed upstream; not addressed here.
+	default:
+		allErrs = append(allErrs, field.Invalid(fldPath, string(name), "a qualified name must consist of at most one '/'"))
 	}
 
 	return allErrs

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -885,6 +885,10 @@ func validateDeviceClassSource(driver string, selector *resourcev1.DeviceSelecto
 func validateQualifiedName(name resourcev1.QualifiedName, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	parts := strings.Split(string(name), "/")
+	// Note: unlike validateLabelKey above, this cannot simply delegate to an
+	// upstream apimachinery helper — QualifiedName has different validation
+	// rules than a label key, and upstream's own equivalent helper has this
+	// same multi-slash gap (see TODO below).
 	switch len(parts) {
 	case 1:
 		allErrs = append(allErrs, validateCIdentifier(parts[0], fldPath)...)

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1921,6 +1921,35 @@ func TestValidate(t *testing.T) {
 				},
 			},
 		},
+		"capacity source with malformed qualified name (more than one slash)": {
+			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegrationConsumableCapacity: true},
+			cfg: &configapi.Configuration{
+				Integrations: defaultIntegrations,
+				Resources: &configapi.Resources{
+					DeviceClassMappings: []configapi.DeviceClassMapping{
+						{
+							Name:             "gpu.memory",
+							DeviceClassNames: []corev1.ResourceName{"vgpu.example.com"},
+							Sources: []configapi.DeviceClassSourceConfig{
+								{Capacity: &configapi.DeviceClassCapacitySource{
+									Name:   "a/b/c",
+									Driver: "gpu.example.com",
+									DeviceSelector: resourcev1.DeviceSelector{
+										CEL: &resourcev1.CELDeviceSelector{Expression: "device.driver == 'gpu.example.com'"},
+									},
+								}},
+							},
+						},
+					},
+				},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "resources.deviceClassMappings[0].sources[0].capacity.name",
+				},
+			},
+		},
 		"capacity source with CC gate disabled": {
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

`validateQualifiedName` (`pkg/config/validation.go`) is a port of upstream
Kubernetes' DRA resource validation. Its `switch` on the number of `/`-separated
parts only handled `len(parts) == 1` and `len(parts) == 2`; a name with more
than one slash (e.g. `"a/b/c"`) matched neither case, so `allErrs` stayed
empty and the value was silently accepted.

The only current caller validates `DeviceClassMapping.Sources[].Capacity.Name`
in Kueue's own `Configuration` file, re-validated fresh on every
controller-manager startup — not a live Kubernetes CRD field with persisted
cluster objects. So the ratcheting concern noted in the original TODO
(avoiding breaking existing non-compliant objects) doesn't apply here:
there's no persisted state to grandfather in, and failing fast on an invalid
config at startup is the correct behavior.

This adds a `default:` case rejecting names with more than one slash, mirroring
the existing `field.Invalid` style used for the empty-domain/empty-name cases
in the same function.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14846

#### Special notes for your reviewer:
Per discussion on #14846: the corresponding upstream gap in
`k8s.io/apimachinery`'s declarative-validation utility
(`resourcesQualifiedName` in `staging/.../strfmt.go`) is left to be fixed
upstream separately — this PR only addresses Kueue's local copy.

#### Does this PR introduce a user-facing change?
```release-note
DRA: Fixed config validation silently accepting capacity names with more than one slash, which produced a mapping that never matched any device.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid resource names containing multiple `/` characters are now rejected with a clear validation error.
  - Prevents malformed qualified names from being accepted during configuration validation.

- **Tests**
  - Added coverage to verify that malformed capacity source names are correctly reported as invalid.
  - Confirms validation identifies the affected configuration field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->