### PR TITLE
[WIP] MultiKueue: Prevent worker JobSet TTL cleanup

### DIFF
--- a/pkg/controller/jobs/jobset/jobset_multikueue_adapter.go
+++ b/pkg/controller/jobs/jobset/jobset_multikueue_adapter.go
@@ -31,6 +31,7 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/api"
 	clientutil "sigs.k8s.io/kueue/pkg/util/client"
 )
@@ -63,6 +64,14 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 	remoteJob = jobset.JobSet{
 		ObjectMeta: api.CloneObjectMetaForCreation(&localJob.ObjectMeta),
 		Spec:       *localJob.Spec.DeepCopy(),
+	}
+
+	if features.Enabled(features.MultiKueueJobSetClearingTTLSecondsAfterFinishedOnWorkerCluster) {
+		// The manager cluster is the source of truth for JobSet lifecycle. Propagating
+		// the TTL to the worker can delete the remote JobSet before its terminal status
+		// is synchronized back to the manager, causing the completed JobSet to be
+		// dispatched again.
+		remoteJob.Spec.TTLSecondsAfterFinished = nil
 	}
 
 	// Add prebuilt workload name and multikueue origin

--- a/pkg/controller/jobs/jobset/jobset_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/jobset/jobset_multikueue_adapter_test.go
@@ -82,6 +82,61 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 		},
+		"sync does not propagate ttl seconds after finished to remote jobset when clearing is enabled": {
+			featureGates: map[featuregate.Feature]bool{
+				features.MultiKueueJobSetClearingTTLSecondsAfterFinishedOnWorkerCluster: true,
+				features.WorkloadIdentifierAnnotations:                                  false,
+			},
+			managersJobSets: []jobsetapi.JobSet{
+				*baseJobSetManagedByKueueBuilder.Clone().
+					TTLSecondsAfterFinished(0).
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "jobset1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
+			},
+
+			wantManagersJobSets: []jobsetapi.JobSet{
+				*baseJobSetManagedByKueueBuilder.Clone().
+					TTLSecondsAfterFinished(0).
+					Obj(),
+			},
+			wantWorkerJobSets: []jobsetapi.JobSet{
+				*baseJobSetBuilder.Clone().
+					PrebuiltWorkloadLabel("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					Obj(),
+			},
+		},
+		"sync propagates ttl seconds after finished to remote jobset when clearing is disabled": {
+			featureGates: map[featuregate.Feature]bool{
+				features.MultiKueueJobSetClearingTTLSecondsAfterFinishedOnWorkerCluster: false,
+				features.WorkloadIdentifierAnnotations:                                  false,
+			},
+			managersJobSets: []jobsetapi.JobSet{
+				*baseJobSetManagedByKueueBuilder.Clone().
+					TTLSecondsAfterFinished(0).
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multiKueueAdapter, managerClient, workerClient client.Client) error {
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "jobset1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
+			},
+
+			wantManagersJobSets: []jobsetapi.JobSet{
+				*baseJobSetManagedByKueueBuilder.Clone().
+					TTLSecondsAfterFinished(0).
+					Obj(),
+			},
+			wantWorkerJobSets: []jobsetapi.JobSet{
+				*baseJobSetBuilder.Clone().
+					TTLSecondsAfterFinished(0).
+					PrebuiltWorkloadLabel("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					Obj(),
+			},
+		},
 		"sync status from remote jobset": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersJobSets: []jobsetapi.JobSet{

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -88,6 +88,12 @@ const (
 	// Enables clearing ttlSecondsAfterFinished when creating remote batch Jobs.
 	MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster featuregate.Feature = "MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster"
 
+	// owner: @kevin85421
+	// issue: https://github.com/kubernetes-sigs/kueue/issues/14779
+	//
+	// Enables clearing ttlSecondsAfterFinished when creating remote JobSets.
+	MultiKueueJobSetClearingTTLSecondsAfterFinishedOnWorkerCluster featuregate.Feature = "MultiKueueJobSetClearingTTLSecondsAfterFinishedOnWorkerCluster"
+
 	// owner: @mimowo
 	//
 	// Enable Topology Aware Scheduling allowing to optimize placement of Pods
@@ -685,6 +691,9 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 		{Version: version.MustParse("0.9"), Default: true, PreRelease: featuregate.Beta},
 	},
 	MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster: {
+		{Version: version.MustParse("0.20"), Default: true, PreRelease: featuregate.Beta},
+	},
+	MultiKueueJobSetClearingTTLSecondsAfterFinishedOnWorkerCluster: {
 		{Version: version.MustParse("0.20"), Default: true, PreRelease: featuregate.Beta},
 	},
 	TopologyAwareScheduling: {

--- a/pkg/util/testingjobs/jobset/wrappers.go
+++ b/pkg/util/testingjobs/jobset/wrappers.go
@@ -233,6 +233,12 @@ func (j *JobSetWrapper) ManagedBy(c string) *JobSetWrapper {
 	return j
 }
 
+// TTLSecondsAfterFinished sets the JobSet cleanup TTL.
+func (j *JobSetWrapper) TTLSecondsAfterFinished(seconds int32) *JobSetWrapper {
+	j.Spec.TTLSecondsAfterFinished = &seconds
+	return j
+}
+
 // TerminationGracePeriod sets the termination grace period for all replicated jobs.
 func (j *JobSetWrapper) TerminationGracePeriod(seconds int64) *JobSetWrapper {
 	for i := range j.Spec.ReplicatedJobs {

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -251,6 +251,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.19"
+- name: MultiKueueJobSetClearingTTLSecondsAfterFinishedOnWorkerCluster
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.20"
 - name: MultiKueueKubeConfigPathValidation
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -245,6 +245,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.19"
+- name: MultiKueueJobSetClearingTTLSecondsAfterFinishedOnWorkerCluster
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.20"
 - name: MultiKueueKubeConfigPathValidation
   versionedSpecs:
   - default: false

--- a/test/e2e/multikueue/extended/e2e_test.go
+++ b/test/e2e/multikueue/extended/e2e_test.go
@@ -522,6 +522,55 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			})
 		})
 
+		ginkgo.It("Should not propagate JobSet TTL and should clean up the completed manager JobSet", ginkgo.Label("feature:jobset"), func() {
+			jobSet := testingjobset.MakeJobSet("job-set-with-ttl", managerNs.Name).
+				Queue(managerLq.Name).
+				TTLSecondsAfterFinished(0).
+				ReplicatedJobs(
+					testingjobset.ReplicatedJobRequirements{
+						Name:        "replicated-job",
+						Replicas:    1,
+						Parallelism: 1,
+						Completions: 1,
+						Image:       util.GetAgnHostImage(),
+						Args:        util.BehaviorWaitForDeletion,
+					},
+				).
+				RequestAndLimit("replicated-job", corev1.ResourceCPU, "100m").
+				RequestAndLimit("replicated-job", corev1.ResourceMemory, "100M").
+				TerminationGracePeriod(1).
+				Obj()
+
+			ginkgo.By("Creating the JobSet with immediate TTL cleanup", func() {
+				util.MustCreate(ctx, k8sManagerClient, jobSet)
+			})
+
+			wlLookupKey := types.NamespacedName{Name: workloadjobset.GetWorkloadNameForJobSet(jobSet.Name, jobSet.UID), Namespace: managerNs.Name}
+			admittedWorkerName := util.ExpectWorkloadsToBeAdmittedAndGetWorkerName(ctx, k8sManagerClient, wlLookupKey, multiKueueAc.Name)
+			admittedWorker := kubernetesClients[admittedWorkerName]
+
+			ginkgo.By("Checking that the remote JobSet does not inherit the manager JobSet TTL", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					remoteJobSet := &jobset.JobSet{}
+					g.Expect(admittedWorker.client.Get(ctx, client.ObjectKeyFromObject(jobSet), remoteJobSet)).To(gomega.Succeed())
+					g.Expect(remoteJobSet.Spec.TTLSecondsAfterFinished).To(gomega.BeNil())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Finishing the remote JobSet", func() {
+				listOpts := util.GetListOptsFromLabel(fmt.Sprintf("jobset.sigs.k8s.io/jobset-name=%s", jobSet.Name))
+				util.WaitForActivePodsAndTerminate(ctx, admittedWorker.client, admittedWorker.restClient, admittedWorker.cfg, jobSet.Namespace, 1, 0, listOpts)
+			})
+
+			ginkgo.By("Waiting for the completed manager JobSet to be deleted by the TTL controller", func() {
+				util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sManagerClient, jobSet, false, util.MediumTimeout)
+			})
+
+			ginkgo.By("Checking that the remote JobSets are cleaned up", func() {
+				util.ExpectObjectToBeDeletedOnClusters(ctx, jobSet, k8sWorker1Client, k8sWorker2Client)
+			})
+		})
+
 		ginkgo.It("Should run an appwrapper containing a job on worker if admitted", ginkgo.Label("feature:appwrapper"), func() {
 			jobName := "job-1"
 			aw := testingaw.MakeAppWrapper("aw", managerNs.Name).


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area multikueue

#### What this PR does / why we need it:

MultiKueue currently copies `spec.ttlSecondsAfterFinished` from a manager JobSet to its remote worker JobSet. The worker JobSet controller can delete a completed remote JobSet before MultiKueue synchronizes its terminal status back to the manager, causing the completed JobSet to be dispatched again.

Following the Batch Job fix in #14734, this change keeps the manager cluster authoritative for JobSet lifecycle cleanup by omitting `spec.ttlSecondsAfterFinished` when creating a remote JobSet. Existing remote JobSets are not modified. The behavior is controlled by the `MultiKueueJobSetClearingTTLSecondsAfterFinishedOnWorkerCluster` feature gate. It is Beta and enabled by default in v0.20; disabling it restores the previous TTL propagation behavior.

With the feature gate enabled, JobSet completion and cleanup work as follows:

1. The manager JobSet retains its configured `spec.ttlSecondsAfterFinished`.
2. MultiKueue creates the remote worker JobSet without `spec.ttlSecondsAfterFinished`.
3. When the remote JobSet completes, the worker JobSet controller does not delete it, allowing MultiKueue to synchronize its terminal status back to the manager JobSet.
4. The manager JobSet becomes complete and is deleted according to its own TTL policy.
5. MultiKueue cleans up the remote JobSet as part of the manager-side cleanup flow.

#### Which issue(s) this PR fixes:

Part of #14779.

#### Special notes for your reviewer:

This PR was developed with assistance from AI tooling.

The main-branch feature-gate rollout follows #14734. If this fix is backported to release-0.18 or release-0.19, the gate should be Alpha/default-off and the focused E2E should enable it per spec and wait for remote-client reconnection, following #14827 and #14828.

Tests:
- `go test ./pkg/controller/jobs/jobset ./pkg/features ./pkg/util/testingjobs/jobset -count=1`
- `go test ./test/e2e/multikueue/extended -run '^$' -count=1`
- Focused MultiKueue extended E2E: `Should not propagate JobSet TTL and should clean up the completed manager JobSet`

#### Does this PR introduce a user-facing change?

```release-note
MultiKueue no longer propagates JobSet `spec.ttlSecondsAfterFinished` to newly created worker JobSets by default, preventing completed JobSets from being dispatched again before their terminal status is synchronized. The previous behavior can be restored by disabling the `MultiKueueJobSetClearingTTLSecondsAfterFinishedOnWorkerCluster` feature gate.
```
