### PR TITLE
Helm: make controller-manager affinity configurable

### DIFF
--- a/charts/kueue/README.md
+++ b/charts/kueue/README.md
@@ -112,6 +112,7 @@ The following table lists the configurable parameters of the kueue chart and the
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | certManager.issuerRef | object | `{}` | Override the default self-signed cert-manager issuer reference. When set, the chart skips creating its own Issuer and uses this reference for webhook, metrics, and visibility certificates. The referenced issuer must provide the CA data required by Kueue's cert-manager integration. |
+| controllerManager.affinity | object | `{}` | ControllerManager's affinity |
 | controllerManager.dnsPolicy | string | `""` | ControllerManager pod's dnsPolicy. Set to ClusterFirstWithHostNet when hostNetwork is enabled. |
 | controllerManager.featureGates | list | `[]` | ControllerManager's feature gates |
 | controllerManager.hostNetwork | bool | `false` | Run the ControllerManager pod on the host network. Needed where the API server reaches the webhook/visibility endpoints via node IPs rather than pod IPs. |

--- a/charts/kueue/templates/manager/manager.yaml
+++ b/charts/kueue/templates/manager/manager.yaml
@@ -126,6 +126,10 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.controllerManager.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
       - name: cert
         secret:

--- a/charts/kueue/tests/manager_test.yaml
+++ b/charts/kueue/tests/manager_test.yaml
@@ -133,6 +133,35 @@ tests:
     asserts:
       - notExists:
           path: spec.template.spec.tolerations
+  - it: should set affinity when provided
+    template: manager/manager.yaml
+    set:
+      controllerManager:
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - topologyKey: "kubernetes.io/hostname"
+                labelSelector:
+                  matchLabels:
+                    control-plane: "controller-manager"
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity
+          value:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - topologyKey: "kubernetes.io/hostname"
+                  labelSelector:
+                    matchLabels:
+                      control-plane: "controller-manager"
+  - it: should not render affinity if not set
+    template: manager/manager.yaml
+    set:
+      controllerManager:
+        affinity: {}
+    asserts:
+      - notExists:
+          path: spec.template.spec.affinity
   - it: should use default log level
     template: manager/manager.yaml
     asserts:

--- a/charts/kueue/values.yaml
+++ b/charts/kueue/values.yaml
@@ -107,6 +107,8 @@ controllerManager:
   tolerations: []
   # -- ControllerManager's topologySpreadConstraints
   topologySpreadConstraints: []
+  # -- ControllerManager's affinity
+  affinity: {}
   podDisruptionBudget:
     # -- Enable PodDisruptionBudget
     enabled: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
The Kueue chart already supports `nodeSelector`, `tolerations`, and `topologySpreadConstraints` for controlling where the controller-manager pod runs.

However, `affinity` is currently missing. A grep search confirms that it is not defined in the chart's templates or values.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Helm: Added support for setting `affinity` on the kueue-controller-manager Deployment via `controllerManager.affinity`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring pod affinity and anti-affinity for the controller manager through Helm chart values.
  - Affinity settings are applied to the deployed controller-manager pods when configured.

- **Documentation**
  - Documented the new controller-manager affinity option, including its type and default value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->