### PR TITLE
Move the snapshot error requeue test to scheduler_afs_test.go

### DIFF
--- a/pkg/scheduler/scheduler_afs_test.go
+++ b/pkg/scheduler/scheduler_afs_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -42,6 +43,7 @@ import (
 	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
 	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
 	"sigs.k8s.io/kueue/pkg/util/routine"
+	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -1090,5 +1092,131 @@ func TestShouldApplyEntryPenalty(t *testing.T) {
 				t.Errorf("shouldApplyEntryPenalty() = %t, want %t", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestRequeueHeadsAfterSnapshotError covers the heads popped by a cycle whose
+// snapshot failed: nothing else puts them back, so they are lost unless the
+// scheduler requeues them. Regular heads return to the ClusterQueue right away,
+// second-pass heads after a backoff step.
+func TestRequeueHeadsAfterSnapshotError(t *testing.T) {
+	// The LocalQueue weight lookup is the only client call a snapshot makes, so
+	// admission fair sharing is what a test has to enable to fail one.
+	features.SetFeatureGateDuringTest(t, features.AdmissionFairSharing, true)
+	afsConfig := &config.AdmissionFairSharing{
+		UsageHalfLifeTime:     metav1.Duration{Duration: 10 * time.Second},
+		UsageSamplingInterval: metav1.Duration{Duration: 1 * time.Second},
+	}
+	now := time.Now().Truncate(time.Second)
+	ctx, log := utiltesting.ContextWithLog(t)
+
+	ns := utiltesting.MakeNamespaceWrapper(metav1.NamespaceDefault).Obj()
+	rf := utiltestingapi.MakeResourceFlavor("rf").Obj()
+	cq := utiltestingapi.MakeClusterQueue("cq").
+		ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas(rf.Name).
+				Resource(corev1.ResourceCPU, "1").
+				Obj(),
+		).
+		AdmissionMode(kueue.UsageBasedAdmissionFairSharing).
+		Obj()
+	lq := utiltestingapi.MakeLocalQueue("lq", metav1.NamespaceDefault).ClusterQueue(cq.Name).Obj()
+	pending := utiltestingapi.MakeWorkload("pending", metav1.NamespaceDefault).
+		Queue(kueue.LocalQueueName(lq.Name)).
+		PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+			Request(corev1.ResourceCPU, "1").
+			Obj()).
+		Creation(now).
+		Obj()
+	// A workload whose topology assignment is still delayed is what the queue
+	// manager hands over as a second-pass head.
+	secondPass := utiltestingapi.MakeWorkload("second-pass", metav1.NamespaceDefault).
+		Queue(kueue.LocalQueueName(lq.Name)).
+		PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+			RequiredTopologyRequest(corev1.LabelHostname).
+			Request(corev1.ResourceCPU, "1").
+			Obj()).
+		ReserveQuotaAt(
+			utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(cq.Name)).
+				PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name), "1").
+					DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
+					Obj()).
+				Obj(), now).
+		AdmissionCheck(kueue.AdmissionCheckState{Name: "check", State: kueue.CheckStateReady}).
+		Obj()
+
+	var snapshotToFail atomic.Bool
+	cl := utiltesting.NewClientBuilder().
+		WithObjects(ns, rf, cq, lq, pending, secondPass).
+		WithStatusSubresource(&kueue.Workload{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, isLocalQueue := obj.(*kueue.LocalQueue); isLocalQueue && snapshotToFail.CompareAndSwap(true, false) {
+					return errors.New("injected LocalQueue get failure")
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	fakeClock := testingclock.NewFakeClock(now)
+	cqCache := schdcache.New(cl, schdcache.WithFairSharing(true), schdcache.WithAdmissionFairSharing(afsConfig))
+	qManager := qcache.NewManagerForUnitTests(cl, cqCache,
+		qcache.WithClock(fakeClock), qcache.WithAdmissionFairSharing(afsConfig))
+
+	cqCache.AddOrUpdateResourceFlavor(log, rf)
+	if err := cqCache.AddClusterQueue(ctx, cq); err != nil {
+		t.Fatalf("Inserting clusterQueue %s in cache: %v", cq.Name, err)
+	}
+	if err := qManager.AddClusterQueue(ctx, cq); err != nil {
+		t.Fatalf("Inserting clusterQueue %s in manager: %v", cq.Name, err)
+	}
+	if err := qManager.AddLocalQueue(ctx, lq); err != nil {
+		t.Fatalf("Inserting queue %s/%s in manager: %v", lq.Namespace, lq.Name, err)
+	}
+
+	scheduler := New(qManager, cqCache, cl, &utiltesting.EventRecorder{},
+		WithClock(t, fakeClock), WithPreemptionExpectations(preemptexpectations.New()))
+
+	ctx, cancel := context.WithTimeout(ctx, queueingTimeout)
+	// Heads blocks on a condition variable, which CleanUpOnContext wakes up so
+	// the assertions below fail on a timeout instead of hanging.
+	go qManager.CleanUpOnContext(ctx)
+	defer cancel()
+
+	if !qManager.QueueSecondPassIfNeeded(ctx, secondPass, 0) {
+		t.Fatalf("Failed queueing %q for the second pass", secondPass.Name)
+	}
+	fakeClock.Step(time.Second)
+	if fakeClock.HasWaiters() {
+		t.Fatalf("The second pass pre-queue left a timer behind")
+	}
+
+	// Armed here rather than at build time so that only a scheduling cycle can
+	// consume it.
+	snapshotToFail.Store(true)
+	scheduler.schedule(ctx)
+	if snapshotToFail.Load() {
+		t.Fatal("No snapshot read a LocalQueue, so none of them failed")
+	}
+
+	// One iteration in, the second pass backoff is two seconds.
+	fakeClock.Step(2*time.Second - time.Nanosecond)
+	if !fakeClock.HasWaiters() {
+		t.Fatalf("The second pass head didn't come back with a two second backoff")
+	}
+	fakeClock.Step(time.Nanosecond)
+	gotHeads := qManager.Heads(ctx)
+	gotHeadKeys := slices.Map(gotHeads, func(h *qcache.Head) workload.Reference { return workload.Key(h.Obj) })
+	wantHeadKeys := []workload.Reference{workload.Key(pending), workload.Key(secondPass)}
+	sortRefs := cmpopts.SortSlices(func(a, b workload.Reference) bool { return a < b })
+	if diff := cmp.Diff(wantHeadKeys, gotHeadKeys, sortRefs); diff != "" {
+		t.Fatalf("Unexpected heads after the second pass backoff (-want,+got):\n%s", diff)
+	}
+	for _, head := range gotHeads {
+		if workload.Key(head.Obj) == workload.Key(secondPass) && head.SecondPassIteration != 2 {
+			t.Errorf("Unexpected second pass iteration: want 2, got %d", head.SecondPassIteration)
+		}
 	}
 }

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -23,7 +23,6 @@ import (
 	"maps"
 	"reflect"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -54,7 +53,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/util/limitrange"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	"sigs.k8s.io/kueue/pkg/util/routine"
-	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -9857,131 +9855,5 @@ func TestFitsDedupsOverlappingVictims(t *testing.T) {
 	got := fits(snapshot, cq, &incomingUsage, preempted, targets)
 	if got != schdcache.FitsCheckNoQuota {
 		t.Fatalf("fits() = %v, want %v (overlapping victim must be subtracted once)", got, schdcache.FitsCheckNoQuota)
-	}
-}
-
-// TestRequeueHeadsAfterSnapshotError covers the heads popped by a cycle whose
-// snapshot failed: nothing else puts them back, so they are lost unless the
-// scheduler requeues them. Regular heads return to the ClusterQueue right away,
-// second-pass heads after a backoff step.
-func TestRequeueHeadsAfterSnapshotError(t *testing.T) {
-	// The LocalQueue weight lookup is the only client call a snapshot makes, so
-	// admission fair sharing is what a test has to enable to fail one.
-	features.SetFeatureGateDuringTest(t, features.AdmissionFairSharing, true)
-	afsConfig := &config.AdmissionFairSharing{
-		UsageHalfLifeTime:     metav1.Duration{Duration: 10 * time.Second},
-		UsageSamplingInterval: metav1.Duration{Duration: 1 * time.Second},
-	}
-	now := time.Now().Truncate(time.Second)
-	ctx, log := utiltesting.ContextWithLog(t)
-
-	ns := utiltesting.MakeNamespaceWrapper(metav1.NamespaceDefault).Obj()
-	rf := utiltestingapi.MakeResourceFlavor("rf").Obj()
-	cq := utiltestingapi.MakeClusterQueue("cq").
-		ResourceGroup(
-			*utiltestingapi.MakeFlavorQuotas(rf.Name).
-				Resource(corev1.ResourceCPU, "1").
-				Obj(),
-		).
-		AdmissionMode(kueue.UsageBasedAdmissionFairSharing).
-		Obj()
-	lq := utiltestingapi.MakeLocalQueue("lq", metav1.NamespaceDefault).ClusterQueue(cq.Name).Obj()
-	pending := utiltestingapi.MakeWorkload("pending", metav1.NamespaceDefault).
-		Queue(kueue.LocalQueueName(lq.Name)).
-		PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
-			Request(corev1.ResourceCPU, "1").
-			Obj()).
-		Creation(now).
-		Obj()
-	// A workload whose topology assignment is still delayed is what the queue
-	// manager hands over as a second-pass head.
-	secondPass := utiltestingapi.MakeWorkload("second-pass", metav1.NamespaceDefault).
-		Queue(kueue.LocalQueueName(lq.Name)).
-		PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
-			RequiredTopologyRequest(corev1.LabelHostname).
-			Request(corev1.ResourceCPU, "1").
-			Obj()).
-		ReserveQuotaAt(
-			utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(cq.Name)).
-				PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
-					Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name), "1").
-					DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-					Obj()).
-				Obj(), now).
-		AdmissionCheck(kueue.AdmissionCheckState{Name: "check", State: kueue.CheckStateReady}).
-		Obj()
-
-	var snapshotToFail atomic.Bool
-	cl := utiltesting.NewClientBuilder().
-		WithObjects(ns, rf, cq, lq, pending, secondPass).
-		WithStatusSubresource(&kueue.Workload{}).
-		WithInterceptorFuncs(interceptor.Funcs{
-			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-				if _, isLocalQueue := obj.(*kueue.LocalQueue); isLocalQueue && snapshotToFail.CompareAndSwap(true, false) {
-					return errors.New("injected LocalQueue get failure")
-				}
-				return c.Get(ctx, key, obj, opts...)
-			},
-		}).
-		Build()
-
-	fakeClock := testingclock.NewFakeClock(now)
-	cqCache := schdcache.New(cl, schdcache.WithFairSharing(true), schdcache.WithAdmissionFairSharing(afsConfig))
-	qManager := qcache.NewManagerForUnitTests(cl, cqCache,
-		qcache.WithClock(fakeClock), qcache.WithAdmissionFairSharing(afsConfig))
-
-	cqCache.AddOrUpdateResourceFlavor(log, rf)
-	if err := cqCache.AddClusterQueue(ctx, cq); err != nil {
-		t.Fatalf("Inserting clusterQueue %s in cache: %v", cq.Name, err)
-	}
-	if err := qManager.AddClusterQueue(ctx, cq); err != nil {
-		t.Fatalf("Inserting clusterQueue %s in manager: %v", cq.Name, err)
-	}
-	if err := qManager.AddLocalQueue(ctx, lq); err != nil {
-		t.Fatalf("Inserting queue %s/%s in manager: %v", lq.Namespace, lq.Name, err)
-	}
-
-	scheduler := New(qManager, cqCache, cl, &utiltesting.EventRecorder{},
-		WithClock(t, fakeClock), WithPreemptionExpectations(preemptexpectations.New()))
-
-	ctx, cancel := context.WithTimeout(ctx, queueingTimeout)
-	// Heads blocks on a condition variable, which CleanUpOnContext wakes up so
-	// the assertions below fail on a timeout instead of hanging.
-	go qManager.CleanUpOnContext(ctx)
-	defer cancel()
-
-	if !qManager.QueueSecondPassIfNeeded(ctx, secondPass, 0) {
-		t.Fatalf("Failed queueing %q for the second pass", secondPass.Name)
-	}
-	fakeClock.Step(time.Second)
-	if fakeClock.HasWaiters() {
-		t.Fatalf("The second pass pre-queue left a timer behind")
-	}
-
-	// Armed here rather than at build time so that only a scheduling cycle can
-	// consume it.
-	snapshotToFail.Store(true)
-	scheduler.schedule(ctx)
-	if snapshotToFail.Load() {
-		t.Fatal("No snapshot read a LocalQueue, so none of them failed")
-	}
-
-	// One iteration in, the second pass backoff is two seconds.
-	fakeClock.Step(2*time.Second - time.Nanosecond)
-	if !fakeClock.HasWaiters() {
-		t.Fatalf("The second pass head didn't come back with a two second backoff")
-	}
-	fakeClock.Step(time.Nanosecond)
-	gotHeads := qManager.Heads(ctx)
-	gotHeadKeys := slices.Map(gotHeads, func(h *qcache.Head) workload.Reference { return workload.Key(h.Obj) })
-	wantHeadKeys := []workload.Reference{workload.Key(pending), workload.Key(secondPass)}
-	sortRefs := cmpopts.SortSlices(func(a, b workload.Reference) bool { return a < b })
-	if diff := cmp.Diff(wantHeadKeys, gotHeadKeys, sortRefs); diff != "" {
-		t.Fatalf("Unexpected heads after the second pass backoff (-want,+got):\n%s", diff)
-	}
-	for _, head := range gotHeads {
-		if workload.Key(head.Obj) == workload.Key(secondPass) && head.SecondPassIteration != 2 {
-			t.Errorf("Unexpected second pass iteration: want 2, got %d", head.SecondPassIteration)
-		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/area testing

#### What this PR does / why we need it:

Moves `TestRequeueHeadsAfterSnapshotError` from `scheduler_test.go` to `scheduler_afs_test.go`

The test enables Admission Fair Sharing because its snapshot failure is triggered through the AFS LocalQueue lookup. Keeping it with the other AFS scheduler tests makes that dependency clearer.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14920

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for scheduler recovery when a snapshot fails.
  * Verified that regular items are requeued immediately, while second-pass items return after the appropriate backoff.
  * Confirmed iteration tracking and timer cleanup behave correctly after recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->