### PR TITLE
FIx: Skip MultiKueue Remote Workloads During Local Priority Synchronization

### DIFF
--- a/pkg/controller/core/workloadpriorityclass_controller.go
+++ b/pkg/controller/core/workloadpriorityclass_controller.go
@@ -95,6 +95,11 @@ func (r *WorkloadPriorityClassReconciler) Reconcile(ctx context.Context, req ctr
 		wl := &workloads.Items[i]
 		wlLog := log.WithValues("workload", klog.KObj(wl))
 
+		if _, isMultiKueueRemote := wl.Labels[kueue.MultiKueueOriginLabel]; isMultiKueueRemote {
+			wlLog.V(3).Info("Skipping MultiKueue remote workload")
+			return nil
+		}
+
 		// Skip if priority is already up to date
 		if wl.Spec.Priority != nil && *wl.Spec.Priority == wpc.Value {
 			wlLog.V(3).Info("Workload priority already up to date")

--- a/pkg/controller/core/workloadpriorityclass_controller_test.go
+++ b/pkg/controller/core/workloadpriorityclass_controller_test.go
@@ -146,6 +146,31 @@ func TestWorkloadPriorityClassReconcile(t *testing.T) {
 					Obj(),
 			},
 		},
+		"reconcile updates local workload and skips MultiKueue remote workload": {
+			wpc: utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(1000).Obj(),
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("local", "default").
+					Priority(100).
+					WorkloadPriorityClassRef("high").
+					Obj(),
+				*utiltestingapi.MakeWorkload("remote", "default").
+					Label(kueue.MultiKueueOriginLabel, "manager").
+					Priority(100).
+					WorkloadPriorityClassRef("high").
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("local", "default").
+					Priority(1000).
+					WorkloadPriorityClassRef("high").
+					Obj(),
+				*utiltestingapi.MakeWorkload("remote", "default").
+					Label(kueue.MultiKueueOriginLabel, "manager").
+					Priority(100).
+					WorkloadPriorityClassRef("high").
+					Obj(),
+			},
+		},
 		"reconcile skips workloads with up-to-date priority": {
 			wpc: utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(1000).Obj(),
 			workloads: []kueue.Workload{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

Management and worker clusters are independent Kubernetes clusters. Each cluster can define a `WorkloadPriorityClass` with same name but different value. For example:

```
apiVersion: kueue.x-k8s.io/v1beta2
kind: WorkloadPriorityClass
metadata:
  name: high
value: 100
```

• Management cluster: `high = 100`
• Worker cluster: `high = 999`

When management cluster dispatches a Workload through MultiKueue, it copies both `priorityClassRef: high` and resolved `priority: 100` to worker cluster. It also adds `kueue.x-k8s.io/multikueue-origin` label. Management cluster therefore owns priority decision for this remote Workload.

Problem occurs when worker cluster creates, recreates, or modifies its local `high` WorkloadPriorityClass. Existing controller scans every Workload referencing `high` without distinguishing locally owned Workloads from MultiKueue remote Workloads. 

As result, it incorrectly changes remote Workload priority from management-cluster value `100` to worker-cluster value `999`.

More appropriate behavior is to skip remote Workloads carrying `kueue.x-k8s.io/multikueue-origin`. Their `spec.priority` has already been resolved and synchronized by management cluster. Worker cluster must not manage it through a local WorkloadPriorityClass with same name, because doing so creates conflicting ownership between management and worker clusters.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
MultiKueue: Fixed a bug where the WorkloadPriorityClass controller incorrectly updated the priority of MultiKueue remote workloads when a WorkloadPriorityClass value changed. Remote workloads are now skipped during priority synchronization.
```
