### PR TITLE
Requeue pending workloads when LimitRange constraints are relaxed

### DIFF
--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -1674,11 +1674,8 @@ func (h *resourceUpdatesHandler) Update(ctx context.Context, e event.UpdateEvent
 	log.V(5).Info("Update event")
 	h.handle(ctx, e.ObjectNew, q)
 	if oldLr, isLr := e.ObjectOld.(*corev1.LimitRange); isLr {
-		if newLr, isNewLr := e.ObjectNew.(*corev1.LimitRange); isNewLr && limitRangeConstraintsChanged(oldLr, newLr) {
-			log.V(3).Info("LimitRange constraint fields changed",
-				"limitRange", klog.KObj(newLr),
-				"oldLimits", oldLr.Spec.Limits, "newLimits", newLr.Spec.Limits)
-			h.retryInadmissibleForNamespace(ctx, newLr.Namespace)
+		if newLr, isNewLr := e.ObjectNew.(*corev1.LimitRange); isNewLr {
+			h.notifyForLimitRangeConstraintsChange(ctx, oldLr, newLr)
 		}
 	}
 }
@@ -1688,14 +1685,29 @@ func (h *resourceUpdatesHandler) Delete(ctx context.Context, e event.DeleteEvent
 	ctx = ctrl.LoggerInto(ctx, log)
 	log.V(5).Info("Delete event")
 	h.handle(ctx, e.Object, q)
-	if lr, isLr := e.Object.(*corev1.LimitRange); isLr && limitRangeHasConstraints(lr) {
-		log.V(3).Info("LimitRange with constraint fields deleted",
-			"limitRange", klog.KObj(lr), "limits", lr.Spec.Limits)
-		h.retryInadmissibleForNamespace(ctx, lr.Namespace)
+	if lr, isLr := e.Object.(*corev1.LimitRange); isLr {
+		h.notifyForLimitRangeConstraintsChange(ctx, lr, nil)
 	}
 }
 
 func (h *resourceUpdatesHandler) Generic(_ context.Context, _ event.GenericEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+}
+
+// notifyForLimitRangeConstraintsChange requeues the inadmissible workloads of
+// the LimitRange's namespace when the constraint fields changed. A deletion is
+// passed as a nil newLr.
+func (h *resourceUpdatesHandler) notifyForLimitRangeConstraintsChange(ctx context.Context, oldLr, newLr *corev1.LimitRange) {
+	if !limitRangeConstraintsChanged(oldLr, newLr) {
+		return
+	}
+	var newLimits []corev1.LimitRangeItem
+	if newLr != nil {
+		newLimits = newLr.Spec.Limits
+	}
+	ctrl.LoggerFrom(ctx).V(3).Info("LimitRange constraint fields changed",
+		"limitRange", klog.KObj(oldLr),
+		"oldLimits", oldLr.Spec.Limits, "newLimits", newLimits)
+	h.retryInadmissibleForNamespace(ctx, oldLr.Namespace)
 }
 
 // limitRangeConstraintsChanged reports whether any of the LimitRange spec
@@ -1703,8 +1715,15 @@ func (h *resourceUpdatesHandler) Generic(_ context.Context, _ event.GenericEvent
 // maxLimitRequestRatio) changed. Unlike default and defaultRequest, these
 // fields do not alter the workloads' adjusted resources, so a change to them
 // is invisible to the spec-diff based requeue in queueReconcileForPending.
+// A nil LimitRange stands for the object not existing (deletion).
 func limitRangeConstraintsChanged(oldLr, newLr *corev1.LimitRange) bool {
-	oldItems, newItems := oldLr.Spec.Limits, newLr.Spec.Limits
+	var oldItems, newItems []corev1.LimitRangeItem
+	if oldLr != nil {
+		oldItems = oldLr.Spec.Limits
+	}
+	if newLr != nil {
+		newItems = newLr.Spec.Limits
+	}
 	if len(oldItems) != len(newItems) {
 		return true
 	}
@@ -1713,16 +1732,6 @@ func limitRangeConstraintsChanged(oldLr, newLr *corev1.LimitRange) bool {
 			!equality.Semantic.DeepEqual(oldItems[i].Max, newItems[i].Max) ||
 			!equality.Semantic.DeepEqual(oldItems[i].Min, newItems[i].Min) ||
 			!equality.Semantic.DeepEqual(oldItems[i].MaxLimitRequestRatio, newItems[i].MaxLimitRequestRatio) {
-			return true
-		}
-	}
-	return false
-}
-
-func limitRangeHasConstraints(lr *corev1.LimitRange) bool {
-	for i := range lr.Spec.Limits {
-		item := &lr.Spec.Limits[i]
-		if len(item.Max) > 0 || len(item.Min) > 0 || len(item.MaxLimitRequestRatio) > 0 {
 			return true
 		}
 	}

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -1673,6 +1673,14 @@ func (h *resourceUpdatesHandler) Update(ctx context.Context, e event.UpdateEvent
 	ctx = ctrl.LoggerInto(ctx, log)
 	log.V(5).Info("Update event")
 	h.handle(ctx, e.ObjectNew, q)
+	if oldLr, isLr := e.ObjectOld.(*corev1.LimitRange); isLr {
+		if newLr, isNewLr := e.ObjectNew.(*corev1.LimitRange); isNewLr && limitRangeConstraintsChanged(oldLr, newLr) {
+			log.V(3).Info("LimitRange constraint fields changed",
+				"limitRange", klog.KObj(newLr),
+				"oldLimits", oldLr.Spec.Limits, "newLimits", newLr.Spec.Limits)
+			h.retryInadmissibleForNamespace(ctx, newLr.Namespace)
+		}
+	}
 }
 
 func (h *resourceUpdatesHandler) Delete(ctx context.Context, e event.DeleteEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
@@ -1680,9 +1688,69 @@ func (h *resourceUpdatesHandler) Delete(ctx context.Context, e event.DeleteEvent
 	ctx = ctrl.LoggerInto(ctx, log)
 	log.V(5).Info("Delete event")
 	h.handle(ctx, e.Object, q)
+	if lr, isLr := e.Object.(*corev1.LimitRange); isLr && limitRangeHasConstraints(lr) {
+		log.V(3).Info("LimitRange with constraint fields deleted",
+			"limitRange", klog.KObj(lr), "limits", lr.Spec.Limits)
+		h.retryInadmissibleForNamespace(ctx, lr.Namespace)
+	}
 }
 
 func (h *resourceUpdatesHandler) Generic(_ context.Context, _ event.GenericEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+}
+
+// limitRangeConstraintsChanged reports whether any of the LimitRange spec
+// fields the admission-time validation consults (max, min,
+// maxLimitRequestRatio) changed. Unlike default and defaultRequest, these
+// fields do not alter the workloads' adjusted resources, so a change to them
+// is invisible to the spec-diff based requeue in queueReconcileForPending.
+func limitRangeConstraintsChanged(oldLr, newLr *corev1.LimitRange) bool {
+	oldItems, newItems := oldLr.Spec.Limits, newLr.Spec.Limits
+	if len(oldItems) != len(newItems) {
+		return true
+	}
+	for i := range oldItems {
+		if oldItems[i].Type != newItems[i].Type ||
+			!equality.Semantic.DeepEqual(oldItems[i].Max, newItems[i].Max) ||
+			!equality.Semantic.DeepEqual(oldItems[i].Min, newItems[i].Min) ||
+			!equality.Semantic.DeepEqual(oldItems[i].MaxLimitRequestRatio, newItems[i].MaxLimitRequestRatio) {
+			return true
+		}
+	}
+	return false
+}
+
+func limitRangeHasConstraints(lr *corev1.LimitRange) bool {
+	for i := range lr.Spec.Limits {
+		item := &lr.Spec.Limits[i]
+		if len(item.Max) > 0 || len(item.Min) > 0 || len(item.MaxLimitRequestRatio) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// retryInadmissibleForNamespace requeues the inadmissible workloads of every
+// ClusterQueue that has pending workloads in the given namespace. A workload
+// rejected against the previous LimitRange constraints keeps a byte-identical
+// spec when only the constraints change, so it has to be retried explicitly.
+func (h *resourceUpdatesHandler) retryInadmissibleForNamespace(ctx context.Context, namespace string) {
+	log := ctrl.LoggerFrom(ctx)
+	lst := kueue.WorkloadList{}
+	err := h.r.client.List(ctx, &lst, client.InNamespace(namespace),
+		client.MatchingFields{indexer.WorkloadQuotaReservedKey: string(metav1.ConditionFalse)})
+	if err != nil {
+		log.Error(err, "Could not list pending workloads")
+		return
+	}
+	cqNames := sets.New[kueue.ClusterQueueReference]()
+	for i := range lst.Items {
+		if cqName, ok := h.r.queues.ClusterQueueForWorkload(&lst.Items[i]); ok {
+			cqNames.Insert(cqName)
+		}
+	}
+	if len(cqNames) > 0 {
+		qcache.NotifyRetryInadmissible(h.r.queues, cqNames)
+	}
 }
 
 func (h *resourceUpdatesHandler) handle(ctx context.Context, obj client.Object, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {

--- a/pkg/controller/core/workload_controller_limitrange_test.go
+++ b/pkg/controller/core/workload_controller_limitrange_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+)
+
+func TestLimitRangeConstraintsChanged(t *testing.T) {
+	base := func() *corev1.LimitRange {
+		return utiltesting.MakeLimitRange("limits", "ns").
+			WithValue("Max", corev1.ResourceCPU, "2").
+			WithValue("Min", corev1.ResourceCPU, "1").
+			WithValue("DefaultRequest", corev1.ResourceCPU, "1").
+			Obj()
+	}
+	cases := map[string]struct {
+		mutate func(*corev1.LimitRange)
+		want   bool
+	}{
+		"no change": {
+			mutate: func(*corev1.LimitRange) {},
+			want:   false,
+		},
+		"max changed": {
+			mutate: func(lr *corev1.LimitRange) {
+				lr.Spec.Limits[0].Max[corev1.ResourceCPU] = resource.MustParse("8")
+			},
+			want: true,
+		},
+		"min changed": {
+			mutate: func(lr *corev1.LimitRange) {
+				lr.Spec.Limits[0].Min[corev1.ResourceCPU] = resource.MustParse("500m")
+			},
+			want: true,
+		},
+		"maxLimitRequestRatio changed": {
+			mutate: func(lr *corev1.LimitRange) {
+				lr.Spec.Limits[0].MaxLimitRequestRatio[corev1.ResourceCPU] = resource.MustParse("2")
+			},
+			want: true,
+		},
+		"only defaultRequest changed": {
+			mutate: func(lr *corev1.LimitRange) {
+				lr.Spec.Limits[0].DefaultRequest[corev1.ResourceCPU] = resource.MustParse("2")
+			},
+			want: false,
+		},
+		"item type changed": {
+			mutate: func(lr *corev1.LimitRange) {
+				lr.Spec.Limits[0].Type = corev1.LimitTypePod
+			},
+			want: true,
+		},
+		"item added": {
+			mutate: func(lr *corev1.LimitRange) {
+				lr.Spec.Limits = append(lr.Spec.Limits, corev1.LimitRangeItem{Type: corev1.LimitTypePod})
+			},
+			want: true,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			oldLr := base()
+			newLr := base()
+			tc.mutate(newLr)
+			if got := limitRangeConstraintsChanged(oldLr, newLr); got != tc.want {
+				t.Errorf("limitRangeConstraintsChanged() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLimitRangeHasConstraints(t *testing.T) {
+	cases := map[string]struct {
+		lr   *corev1.LimitRange
+		want bool
+	}{
+		"defaults only": {
+			lr: utiltesting.MakeLimitRange("limits", "ns").
+				WithValue("DefaultRequest", corev1.ResourceCPU, "1").Obj(),
+			want: false,
+		},
+		"max set": {
+			lr: utiltesting.MakeLimitRange("limits", "ns").
+				WithValue("Max", corev1.ResourceCPU, "2").Obj(),
+			want: true,
+		},
+		"min set": {
+			lr: utiltesting.MakeLimitRange("limits", "ns").
+				WithValue("Min", corev1.ResourceCPU, "1").Obj(),
+			want: true,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := limitRangeHasConstraints(tc.lr); got != tc.want {
+				t.Errorf("limitRangeHasConstraints() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/core/workload_controller_limitrange_test.go
+++ b/pkg/controller/core/workload_controller_limitrange_test.go
@@ -90,32 +90,19 @@ func TestLimitRangeConstraintsChanged(t *testing.T) {
 	}
 }
 
-func TestLimitRangeHasConstraints(t *testing.T) {
-	cases := map[string]struct {
-		lr   *corev1.LimitRange
-		want bool
-	}{
-		"defaults only": {
-			lr: utiltesting.MakeLimitRange("limits", "ns").
-				WithValue("DefaultRequest", corev1.ResourceCPU, "1").Obj(),
-			want: false,
-		},
-		"max set": {
-			lr: utiltesting.MakeLimitRange("limits", "ns").
-				WithValue("Max", corev1.ResourceCPU, "2").Obj(),
-			want: true,
-		},
-		"min set": {
-			lr: utiltesting.MakeLimitRange("limits", "ns").
-				WithValue("Min", corev1.ResourceCPU, "1").Obj(),
-			want: true,
-		},
+func TestLimitRangeConstraintsChangedOnDeletion(t *testing.T) {
+	withConstraints := utiltesting.MakeLimitRange("limits", "ns").
+		WithValue("Max", corev1.ResourceCPU, "2").Obj()
+	defaultsOnly := utiltesting.MakeLimitRange("limits", "ns").
+		WithValue("DefaultRequest", corev1.ResourceCPU, "1").Obj()
+
+	if !limitRangeConstraintsChanged(withConstraints, nil) {
+		t.Error("limitRangeConstraintsChanged(withConstraints, nil) = false, want true")
 	}
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			if got := limitRangeHasConstraints(tc.lr); got != tc.want {
-				t.Errorf("limitRangeHasConstraints() = %v, want %v", got, tc.want)
-			}
-		})
+	if !limitRangeConstraintsChanged(defaultsOnly, nil) {
+		t.Error("limitRangeConstraintsChanged(defaultsOnly, nil) = false, want true")
+	}
+	if limitRangeConstraintsChanged(nil, nil) {
+		t.Error("limitRangeConstraintsChanged(nil, nil) = true, want false")
 	}
 }

--- a/test/integration/singlecluster/scheduler/limitrange_wakeup_probe_test.go
+++ b/test/integration/singlecluster/scheduler/limitrange_wakeup_probe_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/pkg/workload"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+// Probe for: a Workload rejected for exceeding a LimitRange max is never
+// requeued when that LimitRange is relaxed or deleted, because the
+// LimitRange event handler only recomputes defaults and the queue's
+// PushOrUpdate guard sees an unchanged spec.
+var _ = ginkgo.Describe("LimitRange constraint relaxation wake-up probe", func() {
+	var (
+		ns             *corev1.Namespace
+		onDemandFlavor *kueue.ResourceFlavor
+		clusterQueue   *kueue.ClusterQueue
+		localQueue     *kueue.LocalQueue
+		limitRange     *corev1.LimitRange
+		wl             *kueue.Workload
+	)
+
+	ginkgo.BeforeEach(func() {
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "lr-max-probe-")
+		onDemandFlavor = utiltestingapi.MakeResourceFlavor("on-demand").Obj()
+		util.MustCreate(ctx, k8sClient, onDemandFlavor)
+		clusterQueue = utiltestingapi.MakeClusterQueue("cq-lr-max").
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas(onDemandFlavor.Name).
+				Resource(corev1.ResourceCPU, "10").Obj()).
+			Obj()
+		util.MustCreate(ctx, k8sClient, clusterQueue)
+		localQueue = utiltestingapi.MakeLocalQueue("queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+		util.MustCreate(ctx, k8sClient, localQueue)
+
+		limitRange = utiltesting.MakeLimitRange("limits", ns.Name).
+			WithValue("Max", corev1.ResourceCPU, "2").Obj()
+		util.MustCreate(ctx, k8sClient, limitRange)
+
+		wl = utiltestingapi.MakeWorkload("over-max", ns.Name).
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			RequestAndLimit(corev1.ResourceCPU, "3").
+			Obj()
+		util.MustCreate(ctx, k8sClient, wl)
+
+		ginkgo.By("Waiting for the workload to be rejected by the LimitRange, not by quota", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				read := kueue.Workload{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &read)).To(gomega.Succeed())
+				cond := apimeta.FindStatusCondition(read.Status.Conditions, kueue.WorkloadQuotaReserved)
+				g.Expect(cond).NotTo(gomega.BeNil())
+				g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionFalse))
+				g.Expect(cond.Message).To(gomega.ContainSubstring("LimitRange"))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, onDemandFlavor, true)
+	})
+
+	ginkgo.It("admits the workload after the LimitRange max is raised above its request", func() {
+		ginkgo.By("Raising the LimitRange max", func() {
+			updatedLr := corev1.LimitRange{}
+			gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(limitRange), &updatedLr)).To(gomega.Succeed())
+			updatedLr.Spec.Limits[0].Max[corev1.ResourceCPU] = resource.MustParse("8")
+			gomega.Expect(k8sClient.Update(ctx, &updatedLr)).To(gomega.Succeed())
+		})
+
+		ginkgo.By("Expecting the workload to be admitted", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				read := kueue.Workload{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &read)).To(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(&read)).To(gomega.BeTrue())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+
+	ginkgo.It("admits the workload after the LimitRange is deleted", func() {
+		ginkgo.By("Deleting the LimitRange", func() {
+			gomega.Expect(k8sClient.Delete(ctx, limitRange)).To(gomega.Succeed())
+		})
+
+		ginkgo.By("Expecting the workload to be admitted", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				read := kueue.Workload{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &read)).To(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(&read)).To(gomega.BeTrue())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+})

--- a/test/integration/singlecluster/scheduler/limitrange_wakeup_probe_test.go
+++ b/test/integration/singlecluster/scheduler/limitrange_wakeup_probe_test.go
@@ -86,34 +86,26 @@ var _ = ginkgo.Describe("LimitRange constraint relaxation wake-up probe", func()
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, onDemandFlavor, true)
 	})
 
-	ginkgo.It("admits the workload after the LimitRange max is raised above its request", func() {
-		ginkgo.By("Raising the LimitRange max", func() {
+	ginkgo.DescribeTable("admits the workload after the LimitRange constraints are relaxed",
+		func(relax func()) {
+			relax()
+
+			ginkgo.By("Expecting the workload to be admitted", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					read := kueue.Workload{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &read)).To(gomega.Succeed())
+					g.Expect(workload.HasQuotaReservation(&read)).To(gomega.BeTrue())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		},
+		ginkgo.Entry("when the max is raised above its request", func() {
 			updatedLr := corev1.LimitRange{}
 			gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(limitRange), &updatedLr)).To(gomega.Succeed())
 			updatedLr.Spec.Limits[0].Max[corev1.ResourceCPU] = resource.MustParse("8")
 			gomega.Expect(k8sClient.Update(ctx, &updatedLr)).To(gomega.Succeed())
-		})
-
-		ginkgo.By("Expecting the workload to be admitted", func() {
-			gomega.Eventually(func(g gomega.Gomega) {
-				read := kueue.Workload{}
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &read)).To(gomega.Succeed())
-				g.Expect(workload.HasQuotaReservation(&read)).To(gomega.BeTrue())
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-		})
-	})
-
-	ginkgo.It("admits the workload after the LimitRange is deleted", func() {
-		ginkgo.By("Deleting the LimitRange", func() {
+		}),
+		ginkgo.Entry("when the LimitRange is deleted", func() {
 			gomega.Expect(k8sClient.Delete(ctx, limitRange)).To(gomega.Succeed())
-		})
-
-		ginkgo.By("Expecting the workload to be admitted", func() {
-			gomega.Eventually(func(g gomega.Gomega) {
-				read := kueue.Workload{}
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &read)).To(gomega.Succeed())
-				g.Expect(workload.HasQuotaReservation(&read)).To(gomega.BeTrue())
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-		})
-	})
+		}),
+	)
 })

--- a/test/integration/singlecluster/scheduler/limitrange_wakeup_probe_test.go
+++ b/test/integration/singlecluster/scheduler/limitrange_wakeup_probe_test.go
@@ -86,26 +86,34 @@ var _ = ginkgo.Describe("LimitRange constraint relaxation wake-up probe", func()
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, onDemandFlavor, true)
 	})
 
-	ginkgo.DescribeTable("admits the workload after the LimitRange constraints are relaxed",
-		func(relax func()) {
-			relax()
-
-			ginkgo.By("Expecting the workload to be admitted", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					read := kueue.Workload{}
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &read)).To(gomega.Succeed())
-					g.Expect(workload.HasQuotaReservation(&read)).To(gomega.BeTrue())
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
-		},
-		ginkgo.Entry("when the max is raised above its request", func() {
+	ginkgo.It("admits the workload after the LimitRange max is raised above its request", func() {
+		ginkgo.By("Raising the LimitRange max", func() {
 			updatedLr := corev1.LimitRange{}
 			gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(limitRange), &updatedLr)).To(gomega.Succeed())
 			updatedLr.Spec.Limits[0].Max[corev1.ResourceCPU] = resource.MustParse("8")
 			gomega.Expect(k8sClient.Update(ctx, &updatedLr)).To(gomega.Succeed())
-		}),
-		ginkgo.Entry("when the LimitRange is deleted", func() {
+		})
+
+		ginkgo.By("Expecting the workload to be admitted", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				read := kueue.Workload{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &read)).To(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(&read)).To(gomega.BeTrue())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+
+	ginkgo.It("admits the workload after the LimitRange is deleted", func() {
+		ginkgo.By("Deleting the LimitRange", func() {
 			gomega.Expect(k8sClient.Delete(ctx, limitRange)).To(gomega.Succeed())
-		}),
-	)
+		})
+
+		ginkgo.By("Expecting the workload to be admitted", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				read := kueue.Workload{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &read)).To(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(&read)).To(gomega.BeTrue())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
 })


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The workload controller watches LimitRange, but the event path only recomputes
what `AdjustResources` consumes (`default`/`defaultRequest`). A change to the
validation-only fields (`max`, `min`, `maxLimitRequestRatio`) leaves the
recomputed spec byte-identical, so `PushOrUpdate` keeps the Workload parked in
`inadmissibleWorkloads` and a relaxed constraint never revives the Workloads it
rejected. Under BestEffortFIFO they stay pending until an unrelated cluster
event happens to requeue the ClusterQueue. StrictFIFO is unaffected.

This PR notifies the ClusterQueues that have pending Workloads in the
LimitRange's namespace whenever its constraint fields change, or a
constraint-carrying LimitRange is deleted — the same shape as the
ResourceFlavor scheduling-fields requeue: compare old/new on the fields the
admission-time validation consults, and retry the inadmissible Workloads
explicitly instead of relying on the spec diff.

Two notes refining the issue's analysis:

- Deletion sometimes appeared to work, but only for Workloads without explicit
  limits: the API server defaults `default := max` on container items, so while
  the LimitRange existed `AdjustResources` materialized those defaults into the
  Workload copy, and deletion changed the recomputed spec — a by-design
  diff-based wake-up. A Workload that sets explicit limits leaves no such trace
  and stayed stuck forever even after deletion; the new integration spec pins
  that case.
- The same API-server defaulting means a `max`-only LimitRange also carries
  `default == max`, which is why the integration specs use Workloads with
  explicit limits: they are immune to defaulting and make both specs
  deterministically red without the fix.

#### Which issue(s) this PR fixes:

Fixes #14965

#### Does this PR introduce a user-facing change?

```release-note
Pending Workloads rejected by a LimitRange are requeued when the LimitRange's max, min, or maxLimitRequestRatio change, or the LimitRange is deleted.
```

---

The investigation, reproduction, and implementation were done with AI
assistance (Claude); I reviewed and verified the analysis, the code, and the
red/green test results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Workloads rejected by resource limits are now automatically rechecked when those limits are relaxed or removed.
  - Changes to minimum, maximum, limit-to-request ratio, item type, and item count constraints now correctly trigger workload reprocessing.

- **Tests**
  - Added coverage for constraint updates, additions, deletions, and missing limits.
  - Added integration tests verifying that workloads can be admitted after restrictive limits are changed or removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->