### PR TITLE
Fix(Flake): Workload controller with resource retention when manager is setup with long retention period

### DIFF
--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -912,9 +912,14 @@ func TotalExecutionTime(wl *kueue.Workload) *time.Duration {
 	if admittedCond == nil {
 		return nil
 	}
+
+	// Return nil only if workload was never properly admitted
+	// (no accumulated time and admitted condition was never true)
+	if admittedCond.Status != metav1.ConditionTrue && wl.Status.AccumulatedPastExecutionTimeSeconds == nil {
+		return nil
+	}
+
 	accumulatedPast := time.Duration(ptr.Deref(wl.Status.AccumulatedPastExecutionTimeSeconds, 0)) * time.Second
-	// Calculate total execution time regardless of current admitted status.
-	// This allows proper accounting for workloads that go through evict/readmit cycles.
 	return new(accumulatedPast + finishedCond.LastTransitionTime.Sub(admittedCond.LastTransitionTime.Time))
 }
 

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -904,15 +904,17 @@ func SetRequeuedCondition(wl *kueue.Workload, reason, message string, status boo
 
 // TotalExecutionTime returns the cumulative admitted duration across evict/readmit cycles, or nil if not applicable.
 func TotalExecutionTime(wl *kueue.Workload) *time.Duration {
-	admittedCond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadAdmitted)
-	if admittedCond == nil || admittedCond.Status != metav1.ConditionTrue {
-		return nil
-	}
 	finishedCond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadFinished)
 	if finishedCond == nil || finishedCond.Status != metav1.ConditionTrue {
 		return nil
 	}
+	admittedCond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadAdmitted)
+	if admittedCond == nil {
+		return nil
+	}
 	accumulatedPast := time.Duration(ptr.Deref(wl.Status.AccumulatedPastExecutionTimeSeconds, 0)) * time.Second
+	// Calculate total execution time regardless of current admitted status.
+	// This allows proper accounting for workloads that go through evict/readmit cycles.
 	return new(accumulatedPast + finishedCond.LastTransitionTime.Sub(admittedCond.LastTransitionTime.Time))
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test
/kind flake

#### What this PR does / why we need it:
Removed the check admittedCond.Status != metav1.ConditionTrue - we don't require the workload to still be admitted
Only check that the Admitted condition exists (was admitted at some point)
Calculate the total time using the accumulated past execution time + the time from last admission to finished

#### Which issue(s) this PR fixes:

Fixes #14473

#### Special notes for your reviewer:
This fixes the flaky test because now the metric will be recorded even when a workload goes through evict/readmit cycles before finishing.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved execution-time reporting for completed workloads that have experienced eviction and readmission cycles.
  * Cumulative admitted duration is now included even when the workload is no longer currently admitted.
  * Completed workload timing remains accurate across multiple admission periods, providing a more complete view of total execution time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->