### PR TITLE
Cleanup WorkloadPriorityClass reconcile error assertions

### DIFF
--- a/pkg/controller/core/workloadpriorityclass_controller_test.go
+++ b/pkg/controller/core/workloadpriorityclass_controller_test.go
@@ -18,13 +18,14 @@ package core
 
 import (
 	"context"
-	stderrors "errors"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"k8s.io/apimachinery/pkg/api/errors"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -100,11 +101,12 @@ func TestWorkloadPriorityClassPredicates(t *testing.T) {
 }
 
 func TestWorkloadPriorityClassReconcile(t *testing.T) {
+	errTest := errors.New("test error")
 	cases := map[string]struct {
 		wpc             *kueue.WorkloadPriorityClass
 		workloads       []kueue.Workload
 		wantWorkloads   []kueue.Workload
-		wantError       bool
+		wantError       error
 		wantSingleError bool
 		clientFuncs     *interceptor.Funcs
 	}{
@@ -201,7 +203,7 @@ func TestWorkloadPriorityClassReconcile(t *testing.T) {
 			},
 			clientFuncs: &interceptor.Funcs{
 				Update: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
-					return errors.NewNotFound(kueue.Resource("workload"), "wl1")
+					return apierrors.NewNotFound(kueue.Resource("workload"), "wl1")
 				},
 			},
 			wantWorkloads: []kueue.Workload{
@@ -221,10 +223,10 @@ func TestWorkloadPriorityClassReconcile(t *testing.T) {
 			},
 			clientFuncs: &interceptor.Funcs{
 				Update: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
-					return stderrors.New("update failed")
+					return errTest
 				},
 			},
-			wantError: true,
+			wantError: errTest,
 			wantWorkloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("wl1", "default").
 					Priority(100).
@@ -248,12 +250,12 @@ func TestWorkloadPriorityClassReconcile(t *testing.T) {
 				Update: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
 					wl := obj.(*kueue.Workload)
 					if wl.Name == "wl2" {
-						return stderrors.New("update failed for wl2")
+						return errTest
 					}
 					return client.Update(ctx, obj, opts...)
 				},
 			},
-			wantError: true,
+			wantError: errTest,
 			wantWorkloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("wl1", "default").
 					Priority(1000).
@@ -287,10 +289,10 @@ func TestWorkloadPriorityClassReconcile(t *testing.T) {
 			},
 			clientFuncs: &interceptor.Funcs{
 				Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
-					return fmt.Errorf("update failed for %s", obj.GetName())
+					return fmt.Errorf("%w: update failed for %s", errTest, obj.GetName())
 				},
 			},
-			wantError:       true,
+			wantError:       errTest,
 			wantSingleError: true,
 			wantWorkloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("wl1", "default").
@@ -313,7 +315,7 @@ func TestWorkloadPriorityClassReconcile(t *testing.T) {
 			wantWorkloads: []kueue.Workload{},
 			clientFuncs: &interceptor.Funcs{
 				Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-					return errors.NewNotFound(kueue.Resource("workloadpriorityclass"), key.Name)
+					return apierrors.NewNotFound(kueue.Resource("workloadpriorityclass"), key.Name)
 				},
 			},
 		},
@@ -343,11 +345,8 @@ func TestWorkloadPriorityClassReconcile(t *testing.T) {
 			}
 
 			_, gotErr := reconciler.Reconcile(ctx, req)
-
-			if tc.wantError && gotErr == nil {
-				t.Errorf("expected error but got nil")
-			} else if !tc.wantError && gotErr != nil {
-				t.Errorf("unexpected error: %v", gotErr)
+			if diff := cmp.Diff(tc.wantError, gotErr, cmpopts.EquateErrors()); len(diff) != 0 {
+				t.Errorf("Unexpected error (-want/+got):\n%s", diff)
 			}
 			if tc.wantSingleError && gotErr != nil {
 				named := 0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/area testing

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Cleanup WorkloadPriorityClass reconcile error assertions

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14979

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reconciliation test coverage by validating specific error values and wrapped errors.
  * Updated not-found error handling in tests to use Kubernetes API error types consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->