### PR TITLE
MultiKueue: truncate quota automation condition messages

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/clusterqueue.go
+++ b/pkg/controller/admissionchecks/multikueue/clusterqueue.go
@@ -44,6 +44,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/util/admissioncheck"
+	"sigs.k8s.io/kueue/pkg/util/api"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 )
 
@@ -246,7 +247,7 @@ func (r *cqReconciler) updateQuotaAutomationCondition(ctx context.Context, cq *k
 		Type:               kueue.MultiKueueManagerQuotaAutomation,
 		Status:             status,
 		Reason:             reason,
-		Message:            message,
+		Message:            api.TruncateConditionMessage(message),
 		ObservedGeneration: cq.Generation,
 	}
 

--- a/pkg/controller/admissionchecks/multikueue/clusterqueue_test.go
+++ b/pkg/controller/admissionchecks/multikueue/clusterqueue_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package multikueue
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -35,6 +36,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/jobs"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/admissioncheck"
+	"sigs.k8s.io/kueue/pkg/util/api"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 )
@@ -521,6 +523,30 @@ func TestCQReconcile(t *testing.T) {
 				t.Errorf("Unexpected status condition (-want/+got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestCQReconciler_UpdateQuotaAutomationCondition(t *testing.T) {
+	cq := utiltestingapi.MakeClusterQueue("cq1").Obj()
+	c := utiltesting.NewClientBuilder().WithObjects(cq).WithStatusSubresource(cq).Build()
+	reconciler := &cqReconciler{client: c}
+	message := strings.Repeat("a", 32*1024+1)
+	ctx, _ := utiltesting.ContextWithLog(t)
+
+	if err := reconciler.updateQuotaAutomationCondition(ctx, cq, metav1.ConditionFalse, "UnsupportedConfiguration", message); err != nil {
+		t.Fatalf("updating quota automation condition: %v", err)
+	}
+
+	gotCQ := &kueue.ClusterQueue{}
+	if err := c.Get(ctx, client.ObjectKeyFromObject(cq), gotCQ); err != nil {
+		t.Fatalf("getting ClusterQueue: %v", err)
+	}
+	gotCondition := apimeta.FindStatusCondition(gotCQ.Status.Conditions, kueue.MultiKueueManagerQuotaAutomation)
+	if gotCondition == nil {
+		t.Fatal("expected quota automation condition")
+	}
+	if diff := cmp.Diff(api.TruncateConditionMessage(message), gotCondition.Message); diff != "" {
+		t.Errorf("unexpected condition message (-want/+got):\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/area multikueue

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Truncates MultiKueue manager quota automation condition messages before updating ClusterQueue status. When a manager ClusterQueue does not cover resources configured on related worker ClusterQueues, the controller reports an UnsupportedConfiguration condition. With enough distinct worker resources, that message exceeded the 32 KiB CRD limit, causing the status update to be rejected and hiding the configuration error.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
MultiKueue: Truncate quota automation condition messages so unsupported manager/worker resource configurations can be reported successfully.
```
