### PR TITLE
[release-0.19] Refactor RayCluster test wantErr bool fields to expected error values

### DIFF
--- a/pkg/controller/jobs/raycluster/common.go
+++ b/pkg/controller/jobs/raycluster/common.go
@@ -57,6 +57,19 @@ const (
 	RayClusterGenerationAnnotation = "kueue.x-k8s.io/raycluster-generation"
 )
 
+var (
+	// errRedisCleanupMissingRayContainer is returned when GCS fault tolerance is
+	// enabled but the head Pod template does not include the Ray container needed
+	// to account for the Redis cleanup Job's resource requests.
+	errRedisCleanupMissingRayContainer = errors.New("cannot account for Redis cleanup resources: head pod template must include the Ray container")
+	// errPodSetNameMismatch is returned when a RayCluster's worker group has no
+	// matching PodSet in the Ray object's spec.
+	errPodSetNameMismatch = errors.New("PodSet name mismatch")
+	// errUnmarshalPodSetReplicaSizes is returned when the
+	// RayClusterPodsetReplicaSizesAnnotation value cannot be parsed.
+	errUnmarshalPodSetReplicaSizes = fmt.Errorf("failed to unmarshal %s annotation", RayClusterPodsetReplicaSizesAnnotation)
+)
+
 // effectiveWorkerCount returns the effective worker pod count for a worker
 // group: Replicas scaled by NumOfHosts, with Replicas defaulting to 1 when
 // unset. BuildPodSets, UpdatePodSets, and the MultiKueue elastic replica sync
@@ -129,7 +142,7 @@ func BuildPodSets(rayClusterSpec *rayv1.RayClusterSpec, annotations map[string]s
 
 func accountForRedisCleanupInHeadPodSet(headPodSet *kueue.PodSet) error {
 	if len(headPodSet.Template.Spec.Containers) <= rayutils.RayContainerIndex {
-		return errors.New("cannot account for Redis cleanup resources: head pod template must include the Ray container")
+		return errRedisCleanupMissingRayContainer
 	}
 
 	headContainer := &headPodSet.Template.Spec.Containers[rayutils.RayContainerIndex]
@@ -224,7 +237,7 @@ func UpdatePodSets(ctx context.Context, podSets []kueue.PodSet, c client.Client,
 
 					podSet, exists := podSetMap[podSetName]
 					if !exists {
-						return nil, fmt.Errorf("PodSet name mismatch: RayCluster %s has worker group %s which is not found in Ray object %s spec", rayClusterName, wgs.GroupName, object.GetName())
+						return nil, fmt.Errorf("%w: RayCluster %s has worker group %s which is not found in Ray object %s spec", errPodSetNameMismatch, rayClusterName, wgs.GroupName, object.GetName())
 					}
 
 					if wgs.Replicas == nil {
@@ -409,7 +422,7 @@ func ParsePodSetReplicaSizes(annotation string) (map[kueue.PodSetReference]int32
 	}
 	var podSets []jobframework.PodSetReplicaSize
 	if err := json.Unmarshal([]byte(annotation), &podSets); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal %s annotation: %w", RayClusterPodsetReplicaSizesAnnotation, err)
+		return nil, fmt.Errorf("%w: %w", errUnmarshalPodSetReplicaSizes, err)
 	}
 	for _, ps := range podSets {
 		counts[ps.Name] = ps.Count

--- a/pkg/controller/jobs/raycluster/common_test.go
+++ b/pkg/controller/jobs/raycluster/common_test.go
@@ -50,7 +50,6 @@ func TestBuildPodSets(t *testing.T) {
 	testCases := map[string]struct {
 		rayClusterSpec              *rayv1.RayClusterSpec
 		annotations                 map[string]string
-		enablePartialScaleUpFeature bool
 		wantPodSets                 []kueue.PodSet
 		wantErr                     error
 	}{

--- a/pkg/controller/jobs/raycluster/common_test.go
+++ b/pkg/controller/jobs/raycluster/common_test.go
@@ -48,10 +48,10 @@ import (
 
 func TestBuildPodSets(t *testing.T) {
 	testCases := map[string]struct {
-		rayClusterSpec              *rayv1.RayClusterSpec
-		annotations                 map[string]string
-		wantPodSets                 []kueue.PodSet
-		wantErr                     error
+		rayClusterSpec *rayv1.RayClusterSpec
+		annotations    map[string]string
+		wantPodSets    []kueue.PodSet
+		wantErr        error
 	}{
 		"basic spec with head and single worker group": {
 			rayClusterSpec: &rayv1.RayClusterSpec{

--- a/pkg/controller/jobs/raycluster/common_test.go
+++ b/pkg/controller/jobs/raycluster/common_test.go
@@ -48,10 +48,11 @@ import (
 
 func TestBuildPodSets(t *testing.T) {
 	testCases := map[string]struct {
-		rayClusterSpec *rayv1.RayClusterSpec
-		annotations    map[string]string
-		wantPodSets    []kueue.PodSet
-		wantErr        bool
+		rayClusterSpec              *rayv1.RayClusterSpec
+		annotations                 map[string]string
+		enablePartialScaleUpFeature bool
+		wantPodSets                 []kueue.PodSet
+		wantErr                     error
 	}{
 		"basic spec with head and single worker group": {
 			rayClusterSpec: &rayv1.RayClusterSpec{
@@ -305,7 +306,7 @@ func TestBuildPodSets(t *testing.T) {
 					Template: corev1.PodTemplateSpec{},
 				},
 			},
-			wantErr: true,
+			wantErr: errRedisCleanupMissingRayContainer,
 		},
 		"autoscaler sidecar added to head podSet with default resources when in-tree autoscaling is enabled": {
 			rayClusterSpec: &rayv1.RayClusterSpec{
@@ -401,16 +402,8 @@ func TestBuildPodSets(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			gotPodSets, err := BuildPodSets(tc.rayClusterSpec, tc.annotations)
 
-			if tc.wantErr {
-				if err == nil {
-					t.Error("Expected error but got none")
-				}
-				return
-			}
-
-			if err != nil {
-				t.Errorf("Unexpected error: %v", err)
-				return
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("Unexpected error (-want +got):\n%s", diff)
 			}
 
 			if diff := cmp.Diff(tc.wantPodSets, gotPodSets, cmpopts.IgnoreFields(kueue.PodSet{}, "TopologyRequest")); diff != "" {
@@ -428,7 +421,7 @@ func TestUpdatePodSets(t *testing.T) {
 		rayClusterName          string
 		rayClusterInClient      *rayv1.RayCluster
 		wantPodSets             []kueue.PodSet
-		wantErr                 bool
+		wantErr                 error
 	}{
 		"workload slicing disabled - no update": {
 			podSets: []kueue.PodSet{
@@ -547,7 +540,7 @@ func TestUpdatePodSets(t *testing.T) {
 			rayClusterInClient: testingrayutil.MakeCluster("target-raycluster", "ns").
 				ScaleFirstWorkerGroup(5).
 				Obj(),
-			wantErr: true,
+			wantErr: errPodSetNameMismatch,
 		},
 	}
 
@@ -570,16 +563,8 @@ func TestUpdatePodSets(t *testing.T) {
 
 			gotPodSets, err := UpdatePodSets(t.Context(), tc.podSets, c, tc.object, tc.enableInTreeAutoscaling, tc.rayClusterName)
 
-			if tc.wantErr {
-				if err == nil {
-					t.Error("Expected error but got none")
-				}
-				return
-			}
-
-			if err != nil {
-				t.Errorf("Unexpected error: %v", err)
-				return
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("Unexpected error (-want +got):\n%s", diff)
 			}
 
 			if diff := cmp.Diff(tc.wantPodSets, gotPodSets, cmpopts.IgnoreFields(kueue.PodSet{}, "Template")); diff != "" {
@@ -594,7 +579,7 @@ func TestUpdateRayClusterSpecToRunWithPodSetsInfo(t *testing.T) {
 		rayClusterSpec *rayv1.RayClusterSpec
 		podSetsInfo    []podset.PodSetInfo
 		wantSpec       *rayv1.RayClusterSpec
-		wantErr        bool
+		wantErr        error
 	}{
 		"basic update with node selector": {
 			rayClusterSpec: &rayv1.RayClusterSpec{
@@ -808,16 +793,8 @@ func TestUpdateRayClusterSpecToRunWithPodSetsInfo(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			err := UpdateRayClusterSpecToRunWithPodSetsInfo(utiltesting.NewLogger(t), tc.rayClusterSpec, tc.podSetsInfo)
 
-			if tc.wantErr {
-				if err == nil {
-					t.Error("Expected error but got none")
-				}
-				return
-			}
-
-			if err != nil {
-				t.Errorf("Unexpected error: %v", err)
-				return
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("UpdateRayClusterSpecToRunWithPodSetsInfo() error mismatch (-want +got):\n%s", diff)
 			}
 
 			if diff := cmp.Diff(tc.wantSpec, tc.rayClusterSpec); diff != "" {
@@ -1243,7 +1220,7 @@ func TestParsePodSetReplicaSizes(t *testing.T) {
 	testCases := map[string]struct {
 		annotation string
 		wantCounts map[kueue.PodSetReference]int32
-		wantErr    bool
+		wantErr    error
 	}{
 		"empty annotation": {
 			annotation: "",
@@ -1264,20 +1241,18 @@ func TestParsePodSetReplicaSizes(t *testing.T) {
 		},
 		"invalid json": {
 			annotation: `invalid`,
-			wantErr:    true,
+			wantErr:    errUnmarshalPodSetReplicaSizes,
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			got, err := ParsePodSetReplicaSizes(tc.annotation)
-			if (err != nil) != tc.wantErr {
-				t.Fatalf("ParsePodSetReplicaSizes() error = %v, wantErr %v", err, tc.wantErr)
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("ParsePodSetReplicaSizes() error mismatch (-want +got):\n%s", diff)
 			}
-			if !tc.wantErr {
-				if diff := cmp.Diff(tc.wantCounts, got); diff != "" {
-					t.Errorf("ParsePodSetReplicaSizes() mismatch (-want +got):\n%s", diff)
-				}
+			if diff := cmp.Diff(tc.wantCounts, got); diff != "" {
+				t.Errorf("ParsePodSetReplicaSizes() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -1321,6 +1296,8 @@ func TestSerializePodSetCounts(t *testing.T) {
 }
 
 func TestGetWorkloadslicingCustomAnnotations(t *testing.T) {
+	rayClusterGetErr := errors.New("failed to get RayCluster")
+
 	testCases := map[string]struct {
 		annotations      map[string]string
 		podSets          []kueue.PodSet
@@ -1329,7 +1306,7 @@ func TestGetWorkloadslicingCustomAnnotations(t *testing.T) {
 		createRayCluster bool
 		standalone       bool
 		wantAnnotation   map[string]string
-		wantErr          bool
+		wantErr          error
 	}{
 		"workload slicing disabled returns nil": {
 			annotations: map[string]string{},
@@ -1430,7 +1407,7 @@ func TestGetWorkloadslicingCustomAnnotations(t *testing.T) {
 				{Name: "head", Count: 1},
 			},
 			rayClusterName: "test-raycluster",
-			wantErr:        true,
+			wantErr:        rayClusterGetErr,
 		},
 	}
 
@@ -1445,7 +1422,16 @@ func TestGetWorkloadslicingCustomAnnotations(t *testing.T) {
 				_ = rayv1.AddToScheme(scheme)
 			}
 
-			builder := fake.NewClientBuilder().WithScheme(scheme)
+			builder := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						if _, ok := obj.(*rayv1.RayCluster); ok && errors.Is(tc.wantErr, rayClusterGetErr) {
+							return rayClusterGetErr
+						}
+						return c.Get(ctx, key, obj, opts...)
+					},
+				})
 
 			var jobObject client.Object
 			if tc.createRayCluster {
@@ -1470,14 +1456,8 @@ func TestGetWorkloadslicingCustomAnnotations(t *testing.T) {
 			}
 
 			got, err := GetWorkloadslicingRayClusterCustomAnnotations(t.Context(), c, jobObject, tc.podSets, tc.rayClusterName)
-			if tc.wantErr {
-				if err == nil {
-					t.Fatalf("GetWorkloadslicingCustomAnnotations() expected error but got nil")
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("GetWorkloadslicingCustomAnnotations() unexpected error: %v", err)
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("GetWorkloadslicingCustomAnnotations() error mismatch (-want +got):\n%s", diff)
 			}
 			if diff := cmp.Diff(tc.wantAnnotation, got); diff != "" {
 				t.Errorf("GetWorkloadslicingCustomAnnotations() mismatch (-want +got):\n%s", diff)


### PR DESCRIPTION
This is a manual cherry-pick of #14930

/assign tenzen-y

```release-note
NONE
```

/kind cleanup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency and reliability of error handling in RayCluster operations.
  * Error conditions such as missing containers, PodSet mismatches, and invalid replica-size data are now reported more precisely.

* **Tests**
  * Expanded validation to confirm specific errors are returned for expected failure scenarios.
  * Added coverage for RayCluster retrieval failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->