### PR TITLE
multikueue: reset admission check for remote OwnerNotFound finish instead of finishing manager workload

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -396,18 +396,21 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 
 	// 3. Finish the local workload when the remote workload is finished.
 	if remoteFinishedCond, remote := group.bestMatchByCondition(kueue.WorkloadFinished); remoteFinishedCond != nil {
-		// A remote OutOfSync finish is a sync failure, not a job completion: reset to Retry to
-		// re-dispatch rather than finishing (which would strand the manager Job). Always return so
-		// it never falls through to Finish; patch only while still Ready so a re-reconcile can't
-		// see Retry and wrongly finish. Elastic workloads use OutOfSync for slice replacement.
-		if remoteFinishedCond.Reason == kueue.WorkloadFinishedReasonOutOfSync && !group.IsElasticWorkload() {
+		// A remote OutOfSync or OwnerNotFound finish is a sync failure, not a job completion:
+		// reset to Retry to re-dispatch rather than finishing (which would strand the manager
+		// Job/Pod). Always return so it never falls through to Finish; patch only while still
+		// Ready so a re-reconcile can't see Retry and wrongly finish. Elastic workloads use
+		// OutOfSync for slice replacement, so they are excluded from that reason's reset.
+		isSyncFailure := (remoteFinishedCond.Reason == kueue.WorkloadFinishedReasonOutOfSync && !group.IsElasticWorkload()) ||
+			remoteFinishedCond.Reason == kueue.WorkloadFinishedReasonOwnerNotFound
+		if isSyncFailure {
 			if acs == nil || acs.State != kueue.CheckStateReady {
-				log.V(3).Info("Skipping remote OutOfSync reset, admission check is not Ready", "workerCluster", remote)
+				log.V(3).Info("Skipping remote sync-failure reset, admission check is not Ready", "workerCluster", remote, "reason", remoteFinishedCond.Reason)
 				return reconcile.Result{}, nil
 			}
 			msg := fmt.Sprintf("Remote workload on worker cluster %q is out of sync with its user job, resetting for re-dispatch", remote)
 			if err := w.updateACS(ctx, group.local, acs, kueue.CheckStateRetry, msg); err != nil {
-				log.Error(err, "Resetting admission check after remote OutOfSync", "workerCluster", remote)
+				log.Error(err, "Resetting admission check after remote sync failure", "workerCluster", remote, "reason", remoteFinishedCond.Reason)
 				return reconcile.Result{}, err
 			}
 			w.recorder.Eventf(group.local, nil, corev1.EventTypeWarning, "MultiKueue", "MultiKueue", api.TruncateEventMessage(acs.Message))

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -223,6 +223,61 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 		})
 	})
 
+	ginkgo.It("Should retry a Job whose remote workload finishes OwnerNotFound instead of finishing the manager workload", func() {
+		job := testingjob.MakeJob("job-owner-not-found", f.managerNs.Name).
+			Queue(kueue.LocalQueueName(f.managerLq.Name)).
+			Obj()
+		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, job)).Should(gomega.Succeed())
+
+		wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: f.managerNs.Name}
+		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).
+			PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()).
+			Obj()
+
+		ginkgo.By("setting workload reservation on the manager and worker1, AC becomes Ready", func() {
+			util.SetQuotaReservation(managerTestCluster.ctx, managerTestCluster.client, wlLookupKey, admission)
+			gomega.Eventually(func(g gomega.Gomega) {
+				createdWorkload := &kueue.Workload{}
+				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			util.SetQuotaReservation(worker1TestCluster.ctx, worker1TestCluster.client, wlLookupKey, admission)
+			util.ExpectAdmissionCheckStateWithMessage(
+				managerTestCluster.ctx, managerTestCluster.client, wlLookupKey,
+				f.multiKueueAC.Name, kueue.CheckStateReady, `The workload was admitted on "worker1"`,
+			)
+		})
+
+		ginkgo.By("finishing the remote workload OwnerNotFound (simulating a worker-side orphan-detection race)", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				remoteWl := &kueue.Workload{}
+				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, wlLookupKey, remoteWl)).To(gomega.Succeed())
+				apimeta.SetStatusCondition(&remoteWl.Status.Conditions, metav1.Condition{
+					Type:    kueue.WorkloadFinished,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueue.WorkloadFinishedReasonOwnerNotFound,
+					Message: "The workload's owner no longer exists",
+				})
+				g.Expect(worker1TestCluster.client.Status().Update(worker1TestCluster.ctx, remoteWl)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("the manager emits a reset event and does not finish the manager workload", func() {
+			resetMsg := `Remote workload on worker cluster "worker1" is out of sync with its user job, resetting for re-dispatch, Previously: "Ready"`
+			util.ExpectEventAppeared(managerTestCluster.ctx, managerTestCluster.client, eventsv1.Event{
+				Reason: "MultiKueue",
+				Type:   corev1.EventTypeWarning,
+				Note:   resetMsg,
+			})
+			gomega.Consistently(func(g gomega.Gomega) {
+				createdWorkload := &kueue.Workload{}
+				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+				if finished := apimeta.FindStatusCondition(createdWorkload.Status.Conditions, kueue.WorkloadFinished); finished != nil {
+					g.Expect(finished.Reason).NotTo(gomega.Equal(kueue.WorkloadFinishedReasonOwnerNotFound))
+				}
+			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+		})
+	})
+
 	ginkgo.It("Should run a job on worker if admitted (ManagedBy)", func() {
 		job := testingjob.MakeJob("job", f.managerNs.Name).
 			ManagedBy(kueue.MultiKueueControllerName).


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

A remote MultiKueue worker workload finishing with reason `OwnerNotFound` is a
sync failure (a race between the worker's Pod reconciler and its Workload
reconciler can incorrectly conclude the workload is orphaned), not a genuine
job completion. Previously only `OutOfSync` was treated this way; `OwnerNotFound`
fell through to a verbatim `Finish` on the manager side, which:
- terminally finished the local Workload, so it was never re-dispatched,
- left the manager Pod's scheduling gates in place forever (ungating only
  happens for an admitted, non-finished Workload), permanently stranding it,
- gave no indication that this was a sync failure rather than completion.

This extends the existing `OutOfSync` guard in `reconcileGroup` to also treat
`OwnerNotFound` as a sync failure, resetting the admission check to `Retry`
for re-dispatch instead of finishing the manager Workload — reusing the exact
same reset path already used for `OutOfSync`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14935

#### Special notes for your reviewer:
Per @mimowo's approval on #14935 of the minimal-fix approach (narrow guard
extension, mirroring the existing `OutOfSync` precedent) plus a request for
an integration test.

Added an integration test (`test/integration/multikueue/jobs_test.go`)
mirroring the existing `OutOfSync` test case, covering an admitted
MultiKueue workload whose remote copy finishes with `OwnerNotFound`:
verifies the manager emits the reset event and does not finish the local
Workload. Both this test and the existing `OutOfSync` test pass together
(`2 Passed | 0 Failed`). `golangci-lint --new-from-rev=main` reports 0 new
issues.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
MultiKueue: Fixed a bug where a remote workload finishing with reason
OwnerNotFound was mirrored back verbatim, permanently finishing the manager
Workload and leaving the manager Pod's scheduling gates stuck. Such finishes
are now treated as a sync failure and reset for re-dispatch, matching
existing OutOfSync handling.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Jobs whose remote workload finishes because its owner cannot be found are now retried instead of incorrectly being marked as finished.
  * Admission checks are reset for redispatch when remote workload synchronization fails.

* **Tests**
  * Added integration coverage to verify retry behavior and ensure the manager workload remains unfinished.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->