### PR TITLE
Helm: Render user-defined metricsService labels on the Service

### DIFF
--- a/charts/kueue/templates/manager/auth_proxy_service.yaml
+++ b/charts/kueue/templates/manager/auth_proxy_service.yaml
@@ -20,7 +20,8 @@ metadata:
   name: {{ include "kueue.fullname" . }}-controller-manager-metrics-service
   namespace: '{{ .Release.Namespace }}'
   labels:
-  {{- include "kueue.metricsService.labels" . | nindent 4 }}
+  {{- $labels := include "kueue.metricsService.labels" . | fromYaml }}
+  {{- toYaml (merge $labels (.Values.metricsService.labels | default dict)) | nindent 4 }}
   {{- if .Values.metricsService.annotations }}
   annotations:
   {{- toYaml .Values.metricsService.annotations | nindent 4 }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
The chart documented `metricsService.labels` in values.yaml, but the Service template `auth_proxy_service.yaml` only rendered the chart's own labels, so user-defined labels were ignored.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Helm: Fix a bug where user-defined metricsService labels are not propagated to the rendered manifests.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custom labels configured for the metrics Service are now applied correctly.
  * User-provided labels override default labels when both use the same key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->