### PR TITLE
Automated cherry pick of #14565: Skip priority transitions the API server refuses while quota is reserved

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1246,11 +1246,7 @@ func updateWorkloadPriorities(ctx context.Context, c client.Client, r events.Eve
 		if priorityStateEqual(wl, priorityClassRef, priority) {
 			continue
 		}
-		if !priorityRefTransitionAllowed(wl, priorityClassRef) {
-			// The API server would refuse this write for as long as the reservation
-			// is held, so issuing it would only fail the reconcile and be retried
-			// forever. Leaving this workload behind keeps the rest of the batch
-			// moving instead of stopping on the first rejection.
+		if workload.HasQuotaReservation(wl) && !hasSameOrEmptyPriorityClass(wl.Spec.PriorityClassRef, priorityClassRef) {
 			log.V(2).Info("Leaving a workload that reserved quota on its current priority class, since the transition the owner asks for is immutable while quota is reserved",
 				"workload", klog.KObj(wl))
 			continue
@@ -1306,34 +1302,21 @@ func classifyWorkloadsForPriorityUpdate(log logr.Logger, jobPriorityClassName st
 	return sameClassName, needsClassChange
 }
 
-// priorityRefTransitionAllowed reports whether the API server will accept moving
-// wl onto the resolved ref. Once a workload has reserved quota the Workload CEL
-// rules freeze the priorityClassRef: it cannot be added or removed, its group and
-// kind cannot change, and for a Pod PriorityClass the name cannot change either.
-// A workload without a reservation is unconstrained.
-//
-// The classifier upstream cannot make this call, because it only sees the class
-// name; the group and kind of the target are not known until ExtractPriority has
-// resolved the ref.
-func priorityRefTransitionAllowed(wl *kueue.Workload, ref *kueue.PriorityClassRef) bool {
-	if !workload.HasQuotaReservation(wl) {
-		return true
-	}
-	current := wl.Spec.PriorityClassRef
-	// Adding or removing the ref. The addition half is already skipped by the
-	// classifier; the removal half reaches here when the owner's class stops
-	// resolving to anything.
-	if (current == nil) != (ref == nil) {
+// hasSameOrEmptyPriorityClass reports whether cur and ref agree on everything the
+// Workload CEL rules freeze while quota is reserved: presence, group and kind, and
+// for a Pod PriorityClass the name as well.
+func hasSameOrEmptyPriorityClass(cur, ref *kueue.PriorityClassRef) bool {
+	if (cur == nil) != (ref == nil) {
 		return false
 	}
-	if current == nil {
+	if cur == nil {
 		return true
 	}
-	if current.Group != ref.Group || current.Kind != ref.Kind {
+	if cur.Group != ref.Group || cur.Kind != ref.Kind {
 		return false
 	}
 	if ref.Group == kueue.PodPriorityClassGroup && ref.Kind == kueue.PodPriorityClassKind {
-		return current.Name == ref.Name
+		return cur.Name == ref.Name
 	}
 	return true
 }

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1241,8 +1241,18 @@ func updateWorkloadPriorities(ctx context.Context, c client.Client, r events.Eve
 	targets := make([]*kueue.Workload, 0, len(sameClassName)+len(needsClassChange))
 	targets = append(targets, sameClassName...)
 	targets = append(targets, needsClassChange...)
+	log := ctrl.LoggerFrom(ctx)
 	for _, wl := range targets {
 		if priorityStateEqual(wl, priorityClassRef, priority) {
+			continue
+		}
+		if !priorityRefTransitionAllowed(wl, priorityClassRef) {
+			// The API server would refuse this write for as long as the reservation
+			// is held, so issuing it would only fail the reconcile and be retried
+			// forever. Leaving this workload behind keeps the rest of the batch
+			// moving instead of stopping on the first rejection.
+			log.V(2).Info("Leaving a workload that reserved quota on its current priority class, since the transition the owner asks for is immutable while quota is reserved",
+				"workload", klog.KObj(wl))
 			continue
 		}
 		wl.Spec.PriorityClassRef = priorityClassRef.DeepCopy()
@@ -1294,6 +1304,38 @@ func classifyWorkloadsForPriorityUpdate(log logr.Logger, jobPriorityClassName st
 		}
 	}
 	return sameClassName, needsClassChange
+}
+
+// priorityRefTransitionAllowed reports whether the API server will accept moving
+// wl onto the resolved ref. Once a workload has reserved quota the Workload CEL
+// rules freeze the priorityClassRef: it cannot be added or removed, its group and
+// kind cannot change, and for a Pod PriorityClass the name cannot change either.
+// A workload without a reservation is unconstrained.
+//
+// The classifier upstream cannot make this call, because it only sees the class
+// name; the group and kind of the target are not known until ExtractPriority has
+// resolved the ref.
+func priorityRefTransitionAllowed(wl *kueue.Workload, ref *kueue.PriorityClassRef) bool {
+	if !workload.HasQuotaReservation(wl) {
+		return true
+	}
+	current := wl.Spec.PriorityClassRef
+	// Adding or removing the ref. The addition half is already skipped by the
+	// classifier; the removal half reaches here when the owner's class stops
+	// resolving to anything.
+	if (current == nil) != (ref == nil) {
+		return false
+	}
+	if current == nil {
+		return true
+	}
+	if current.Group != ref.Group || current.Kind != ref.Kind {
+		return false
+	}
+	if ref.Group == kueue.PodPriorityClassGroup && ref.Kind == kueue.PodPriorityClassKind {
+		return current.Name == ref.Name
+	}
+	return true
 }
 
 // priorityStateEqual reports whether the workload's priority already matches the

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -31,6 +31,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -89,6 +90,9 @@ func TestReconcileGenericJob(t *testing.T) {
 		Queue(testLocalQueueName).
 		PodSets(basePodSets...).
 		Priority(0)
+	// No pod set assignments, so equivalence compares against the workload spec.
+	reservedIn := &kueue.Admission{ClusterQueue: "cq"}
+	reservedAt := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
 
 	testCases := map[string]struct {
 		featureGates  map[featuregate.Feature]bool
@@ -408,6 +412,66 @@ func TestReconcileGenericJob(t *testing.T) {
 					Tolerations:     nil,
 					SchedulingGates: nil,
 				},
+			},
+		},
+		// Group and kind are frozen while quota is reserved.
+		"quota-reserved workload is not moved onto a pod priority class": {
+			req: baseReq,
+			job: baseJob.DeepCopy(),
+			podSets: []kueue.PodSet{
+				*utiltestingapi.MakePodSet("main", 1).PriorityClass("podpc").Obj(),
+			},
+			objs: []client.Object{
+				&schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: "podpc"}, Value: 50},
+				baseWl.Clone().Name("job-test-job-1").
+					PodSets(*utiltestingapi.MakePodSet("main", 1).PriorityClass("podpc").Obj()).
+					WorkloadPriorityClassRef("high").Priority(100).
+					ReserveQuotaAt(reservedIn, reservedAt).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*baseWl.Clone().Name("job-test-job-1").
+					PodSets(*utiltestingapi.MakePodSet("main", 1).PriorityClass("podpc").Obj()).
+					WorkloadPriorityClassRef("high").Priority(100).
+					ReserveQuotaAt(reservedIn, reservedAt).
+					Obj(),
+			},
+		},
+		// A nil resolved ref is a removal, frozen while quota is reserved.
+		"quota-reserved workload keeps its priority class when the owner's stops resolving": {
+			req:     baseReq,
+			job:     baseJob.DeepCopy(),
+			podSets: basePodSets,
+			objs: []client.Object{
+				baseWl.Clone().Name("job-test-job-1").
+					WorkloadPriorityClassRef("high").Priority(100).
+					ReserveQuotaAt(reservedIn, reservedAt).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*baseWl.Clone().Name("job-test-job-1").
+					WorkloadPriorityClassRef("high").Priority(100).
+					ReserveQuotaAt(reservedIn, reservedAt).
+					Obj(),
+			},
+		},
+		// Same group and kind, so the rename is legal while reserved.
+		"quota-reserved workload follows the owner to another workload priority class": {
+			req:     baseReq,
+			job:     baseJob.Clone().WorkloadPriorityClass("low").Obj(),
+			podSets: basePodSets,
+			objs: []client.Object{
+				utiltestingapi.MakeWorkloadPriorityClass("low").PriorityValue(10).Obj(),
+				baseWl.Clone().Name("job-test-job-1").
+					WorkloadPriorityClassRef("high").Priority(100).
+					ReserveQuotaAt(reservedIn, reservedAt).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*baseWl.Clone().Name("job-test-job-1").ResourceVersion("2").
+					WorkloadPriorityClassRef("low").Priority(10).
+					ReserveQuotaAt(reservedIn, reservedAt).
+					Obj(),
 			},
 		},
 	}

--- a/pkg/controller/jobframework/workload_priority_test.go
+++ b/pkg/controller/jobframework/workload_priority_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	batchv1 "k8s.io/api/batch/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -54,8 +55,14 @@ func TestUpdateWorkloadPriority(t *testing.T) {
 	}
 
 	cases := map[string]struct {
-		class        *kueue.WorkloadPriorityClass
-		workloads    []*kueue.Workload
+		class     *kueue.WorkloadPriorityClass
+		workloads []*kueue.Workload
+		// Defaults to a job carrying the "high" WorkloadPriorityClass label. Set it
+		// where the case needs the owner to resolve somewhere else, or nowhere.
+		job *batchv1.Job
+		// Extra objects the case needs in the cluster, such as a Pod PriorityClass
+		// the owner falls back to.
+		extraObjs    []client.Object
 		interceptors func(s *priorityStats) interceptor.Funcs
 		steps        []step
 		want         map[string]wantWorkload
@@ -121,6 +128,119 @@ func TestUpdateWorkloadPriority(t *testing.T) {
 				"reserved": {refName: new("")},
 			},
 			wantWorkloadWrites: new(0),
+		},
+
+		// Dropping the WorkloadPriorityClass label from the owner leaves a Pod
+		// PriorityClass to fall back to, which is a different group and kind. The
+		// Workload CEL rules freeze both while quota is reserved, so the write would
+		// be refused for as long as the reservation is held and retried forever.
+		// The fake client does not evaluate those rules, so a regression shows up
+		// here as a write that the API server would never have accepted.
+		"leaves a quota-reserved workload alone when the owner falls back to a pod priority class": {
+			job: testingjob.MakeJob("job", "ns").PriorityClass("podpc").Obj(),
+			extraObjs: []client.Object{
+				&schedulingv1.PriorityClass{
+					ObjectMeta: metav1.ObjectMeta{Name: "podpc"},
+					Value:      50,
+				},
+			},
+			workloads: []*kueue.Workload{
+				utiltestingapi.MakeWorkload("reserved", "ns").
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).PriorityClass("podpc").Obj()).
+					WorkloadPriorityClassRef("low").Priority(10).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionTrue,
+						Reason:             "AdmittedByTest",
+						Message:            "reserved",
+						LastTransitionTime: metav1.Now(),
+					}).Obj(),
+			},
+			interceptors: countingWrites,
+			steps:        []step{{}},
+			want: map[string]wantWorkload{
+				"reserved": {refName: new("low"), priority: new(int32(10))},
+			},
+			wantWorkloadWrites: new(0),
+		},
+
+		// With nothing left to fall back to, the resolved ref is nil, which is a
+		// removal. Rule 1 refuses that while quota is reserved.
+		"leaves a quota-reserved workload alone when the owner's class stops resolving": {
+			job: testingjob.MakeJob("job", "ns").Obj(),
+			workloads: []*kueue.Workload{
+				utiltestingapi.MakeWorkload("reserved", "ns").
+					WorkloadPriorityClassRef("low").Priority(10).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionTrue,
+						Reason:             "AdmittedByTest",
+						Message:            "reserved",
+						LastTransitionTime: metav1.Now(),
+					}).Obj(),
+			},
+			interceptors: countingWrites,
+			steps:        []step{{}},
+			want: map[string]wantWorkload{
+				"reserved": {refName: new("low"), priority: new(int32(10))},
+			},
+			wantWorkloadWrites: new(0),
+		},
+
+		// The guard is about the reservation, not the transition, so a workload that
+		// has not reserved still follows its owner onto a Pod PriorityClass.
+		"still moves a workload without a reservation onto a pod priority class": {
+			job: testingjob.MakeJob("job", "ns").PriorityClass("podpc").Obj(),
+			extraObjs: []client.Object{
+				&schedulingv1.PriorityClass{
+					ObjectMeta: metav1.ObjectMeta{Name: "podpc"},
+					Value:      50,
+				},
+			},
+			workloads: []*kueue.Workload{
+				utiltestingapi.MakeWorkload("free", "ns").
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).PriorityClass("podpc").Obj()).
+					WorkloadPriorityClassRef("low").Priority(10).Obj(),
+			},
+			steps: []step{{}},
+			want: map[string]wantWorkload{
+				"free": {refName: new("podpc"), priority: new(int32(50))},
+			},
+		},
+
+		// A batch is not all-or-nothing. The component that can take the transition
+		// is still written, and the reserved one is skipped deliberately rather than
+		// failing the whole reconcile on the first rejection.
+		"writes the unreserved half of a batch and skips the reserved half": {
+			job: testingjob.MakeJob("job", "ns").PriorityClass("podpc").Obj(),
+			extraObjs: []client.Object{
+				&schedulingv1.PriorityClass{
+					ObjectMeta: metav1.ObjectMeta{Name: "podpc"},
+					Value:      50,
+				},
+			},
+			workloads: []*kueue.Workload{
+				utiltestingapi.MakeWorkload("reserved", "ns").
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).PriorityClass("podpc").Obj()).
+					WorkloadPriorityClassRef("low").Priority(10).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionTrue,
+						Reason:             "AdmittedByTest",
+						Message:            "reserved",
+						LastTransitionTime: metav1.Now(),
+					}).Obj(),
+				utiltestingapi.MakeWorkload("free", "ns").
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).PriorityClass("podpc").Obj()).
+					WorkloadPriorityClassRef("low").Priority(10).Obj(),
+			},
+			interceptors: countingWrites,
+			steps:        []step{{}},
+			want: map[string]wantWorkload{
+				"reserved": {refName: new("low"), priority: new(int32(10))},
+				"free":     {refName: new("podpc"), priority: new(int32(50))},
+			},
+			wantWorkloadWrites: new(1),
 		},
 
 		// A workload that already carries the right class name but a stale value is
@@ -207,9 +327,16 @@ func TestUpdateWorkloadPriority(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			ctx, _ := utiltesting.ContextWithLog(t)
-			job := testingjob.MakeJob("job", "ns").WorkloadPriorityClass("high").Obj()
+			job := tc.job
+			if job == nil {
+				job = testingjob.MakeJob("job", "ns").WorkloadPriorityClass("high").Obj()
+			}
 
-			objs := []client.Object{job, tc.class}
+			objs := []client.Object{job}
+			if tc.class != nil {
+				objs = append(objs, tc.class)
+			}
+			objs = append(objs, tc.extraObjs...)
 			names := make([]string, 0, len(tc.workloads))
 			for _, wl := range tc.workloads {
 				objs = append(objs, wl)

--- a/pkg/controller/jobframework/workload_priority_test.go
+++ b/pkg/controller/jobframework/workload_priority_test.go
@@ -55,17 +55,13 @@ func TestUpdateWorkloadPriority(t *testing.T) {
 	}
 
 	cases := map[string]struct {
-		class     *kueue.WorkloadPriorityClass
-		workloads []*kueue.Workload
-		// Defaults to a job carrying the "high" WorkloadPriorityClass label. Set it
-		// where the case needs the owner to resolve somewhere else, or nowhere.
-		job *batchv1.Job
-		// Extra objects the case needs in the cluster, such as a Pod PriorityClass
-		// the owner falls back to.
-		extraObjs    []client.Object
-		interceptors func(s *priorityStats) interceptor.Funcs
-		steps        []step
-		want         map[string]wantWorkload
+		class            *kueue.WorkloadPriorityClass
+		workloads        []*kueue.Workload
+		job              *batchv1.Job
+		podPriorityClass []schedulingv1.PriorityClass
+		interceptors     func(s *priorityStats) interceptor.Funcs
+		steps            []step
+		want             map[string]wantWorkload
 		// Nil where the count is not part of what the case pins.
 		wantClassReads     *int
 		wantWorkloadWrites *int
@@ -130,19 +126,11 @@ func TestUpdateWorkloadPriority(t *testing.T) {
 			wantWorkloadWrites: new(0),
 		},
 
-		// Dropping the WorkloadPriorityClass label from the owner leaves a Pod
-		// PriorityClass to fall back to, which is a different group and kind. The
-		// Workload CEL rules freeze both while quota is reserved, so the write would
-		// be refused for as long as the reservation is held and retried forever.
-		// The fake client does not evaluate those rules, so a regression shows up
-		// here as a write that the API server would never have accepted.
+		// Group and kind are frozen while quota is reserved.
 		"leaves a quota-reserved workload alone when the owner falls back to a pod priority class": {
 			job: testingjob.MakeJob("job", "ns").PriorityClass("podpc").Obj(),
-			extraObjs: []client.Object{
-				&schedulingv1.PriorityClass{
-					ObjectMeta: metav1.ObjectMeta{Name: "podpc"},
-					Value:      50,
-				},
+			podPriorityClass: []schedulingv1.PriorityClass{
+				{ObjectMeta: metav1.ObjectMeta{Name: "podpc"}, Value: 50},
 			},
 			workloads: []*kueue.Workload{
 				utiltestingapi.MakeWorkload("reserved", "ns").
@@ -164,8 +152,7 @@ func TestUpdateWorkloadPriority(t *testing.T) {
 			wantWorkloadWrites: new(0),
 		},
 
-		// With nothing left to fall back to, the resolved ref is nil, which is a
-		// removal. Rule 1 refuses that while quota is reserved.
+		// A nil resolved ref is a removal, frozen while quota is reserved.
 		"leaves a quota-reserved workload alone when the owner's class stops resolving": {
 			job: testingjob.MakeJob("job", "ns").Obj(),
 			workloads: []*kueue.Workload{
@@ -187,15 +174,33 @@ func TestUpdateWorkloadPriority(t *testing.T) {
 			wantWorkloadWrites: new(0),
 		},
 
-		// The guard is about the reservation, not the transition, so a workload that
-		// has not reserved still follows its owner onto a Pod PriorityClass.
+		// Same group and kind, so the rename is legal while reserved.
+		"moves a quota-reserved workload between workload priority classes": {
+			class: utiltestingapi.MakeWorkloadPriorityClass("low").PriorityValue(10).Obj(),
+			job:   testingjob.MakeJob("job", "ns").WorkloadPriorityClass("low").Obj(),
+			workloads: []*kueue.Workload{
+				utiltestingapi.MakeWorkload("reserved", "ns").
+					WorkloadPriorityClassRef("high").Priority(100).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionTrue,
+						Reason:             "AdmittedByTest",
+						Message:            "reserved",
+						LastTransitionTime: metav1.Now(),
+					}).Obj(),
+			},
+			interceptors: countingWrites,
+			steps:        []step{{}},
+			want: map[string]wantWorkload{
+				"reserved": {refName: new("low"), priority: new(int32(10))},
+			},
+			wantWorkloadWrites: new(1),
+		},
+
 		"still moves a workload without a reservation onto a pod priority class": {
 			job: testingjob.MakeJob("job", "ns").PriorityClass("podpc").Obj(),
-			extraObjs: []client.Object{
-				&schedulingv1.PriorityClass{
-					ObjectMeta: metav1.ObjectMeta{Name: "podpc"},
-					Value:      50,
-				},
+			podPriorityClass: []schedulingv1.PriorityClass{
+				{ObjectMeta: metav1.ObjectMeta{Name: "podpc"}, Value: 50},
 			},
 			workloads: []*kueue.Workload{
 				utiltestingapi.MakeWorkload("free", "ns").
@@ -208,16 +213,10 @@ func TestUpdateWorkloadPriority(t *testing.T) {
 			},
 		},
 
-		// A batch is not all-or-nothing. The component that can take the transition
-		// is still written, and the reserved one is skipped deliberately rather than
-		// failing the whole reconcile on the first rejection.
 		"writes the unreserved half of a batch and skips the reserved half": {
 			job: testingjob.MakeJob("job", "ns").PriorityClass("podpc").Obj(),
-			extraObjs: []client.Object{
-				&schedulingv1.PriorityClass{
-					ObjectMeta: metav1.ObjectMeta{Name: "podpc"},
-					Value:      50,
-				},
+			podPriorityClass: []schedulingv1.PriorityClass{
+				{ObjectMeta: metav1.ObjectMeta{Name: "podpc"}, Value: 50},
 			},
 			workloads: []*kueue.Workload{
 				utiltestingapi.MakeWorkload("reserved", "ns").
@@ -336,7 +335,9 @@ func TestUpdateWorkloadPriority(t *testing.T) {
 			if tc.class != nil {
 				objs = append(objs, tc.class)
 			}
-			objs = append(objs, tc.extraObjs...)
+			for i := range tc.podPriorityClass {
+				objs = append(objs, &tc.podPriorityClass[i])
+			}
 			names := make([]string, 0, len(tc.workloads))
 			for _, wl := range tc.workloads {
 				objs = append(objs, wl)
@@ -453,85 +454,5 @@ func raiseClassTo(value int32) func(t *testing.T, ctx context.Context, cl client
 		if err := cl.Update(ctx, class); err != nil {
 			t.Fatalf("updating class: %v", err)
 		}
-	}
-}
-
-// TestPriorityRefTransitionAllowed covers the rules directly, including the Pod
-// PriorityClass name case. That one is not reachable through
-// UpdateWorkloadPriority today, because the classifier already drops workloads
-// that are on a Pod PriorityClass, so it is guarded here rather than through the
-// reconciler.
-func TestPriorityRefTransitionAllowed(t *testing.T) {
-	reserved := func(ref *kueue.PriorityClassRef) *kueue.Workload {
-		wl := utiltestingapi.MakeWorkload("wl", "ns").
-			Condition(metav1.Condition{
-				Type:               kueue.WorkloadQuotaReserved,
-				Status:             metav1.ConditionTrue,
-				Reason:             "AdmittedByTest",
-				Message:            "reserved",
-				LastTransitionTime: metav1.Now(),
-			}).Obj()
-		wl.Spec.PriorityClassRef = ref
-		return wl
-	}
-	free := func(ref *kueue.PriorityClassRef) *kueue.Workload {
-		wl := utiltestingapi.MakeWorkload("wl", "ns").Obj()
-		wl.Spec.PriorityClassRef = ref
-		return wl
-	}
-
-	cases := map[string]struct {
-		wl   *kueue.Workload
-		ref  *kueue.PriorityClassRef
-		want bool
-	}{
-		"no reservation, anything goes": {
-			wl:   free(kueue.NewWorkloadPriorityClassRef("high")),
-			ref:  kueue.NewPodPriorityClassRef("system-node-critical"),
-			want: true,
-		},
-		"reserved, unchanged": {
-			wl:   reserved(kueue.NewWorkloadPriorityClassRef("high")),
-			ref:  kueue.NewWorkloadPriorityClassRef("high"),
-			want: true,
-		},
-		"reserved, workload priority class renamed": {
-			wl:   reserved(kueue.NewWorkloadPriorityClassRef("high")),
-			ref:  kueue.NewWorkloadPriorityClassRef("low"),
-			want: true,
-		},
-		"reserved, pod priority class renamed": {
-			wl:   reserved(kueue.NewPodPriorityClassRef("high")),
-			ref:  kueue.NewPodPriorityClassRef("low"),
-			want: false,
-		},
-		"reserved, group and kind change": {
-			wl:   reserved(kueue.NewWorkloadPriorityClassRef("high")),
-			ref:  kueue.NewPodPriorityClassRef("high"),
-			want: false,
-		},
-		"reserved, ref removed": {
-			wl:   reserved(kueue.NewWorkloadPriorityClassRef("high")),
-			ref:  nil,
-			want: false,
-		},
-		"reserved, ref added": {
-			wl:   reserved(nil),
-			ref:  kueue.NewWorkloadPriorityClassRef("high"),
-			want: false,
-		},
-		"reserved, no ref either side": {
-			wl:   reserved(nil),
-			ref:  nil,
-			want: true,
-		},
-	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			if got := priorityRefTransitionAllowed(tc.wl, tc.ref); got != tc.want {
-				t.Errorf("priorityRefTransitionAllowed() = %v, want %v", got, tc.want)
-			}
-		})
 	}
 }

--- a/pkg/controller/jobframework/workload_priority_test.go
+++ b/pkg/controller/jobframework/workload_priority_test.go
@@ -455,3 +455,83 @@ func raiseClassTo(value int32) func(t *testing.T, ctx context.Context, cl client
 		}
 	}
 }
+
+// TestPriorityRefTransitionAllowed covers the rules directly, including the Pod
+// PriorityClass name case. That one is not reachable through
+// UpdateWorkloadPriority today, because the classifier already drops workloads
+// that are on a Pod PriorityClass, so it is guarded here rather than through the
+// reconciler.
+func TestPriorityRefTransitionAllowed(t *testing.T) {
+	reserved := func(ref *kueue.PriorityClassRef) *kueue.Workload {
+		wl := utiltestingapi.MakeWorkload("wl", "ns").
+			Condition(metav1.Condition{
+				Type:               kueue.WorkloadQuotaReserved,
+				Status:             metav1.ConditionTrue,
+				Reason:             "AdmittedByTest",
+				Message:            "reserved",
+				LastTransitionTime: metav1.Now(),
+			}).Obj()
+		wl.Spec.PriorityClassRef = ref
+		return wl
+	}
+	free := func(ref *kueue.PriorityClassRef) *kueue.Workload {
+		wl := utiltestingapi.MakeWorkload("wl", "ns").Obj()
+		wl.Spec.PriorityClassRef = ref
+		return wl
+	}
+
+	cases := map[string]struct {
+		wl   *kueue.Workload
+		ref  *kueue.PriorityClassRef
+		want bool
+	}{
+		"no reservation, anything goes": {
+			wl:   free(kueue.NewWorkloadPriorityClassRef("high")),
+			ref:  kueue.NewPodPriorityClassRef("system-node-critical"),
+			want: true,
+		},
+		"reserved, unchanged": {
+			wl:   reserved(kueue.NewWorkloadPriorityClassRef("high")),
+			ref:  kueue.NewWorkloadPriorityClassRef("high"),
+			want: true,
+		},
+		"reserved, workload priority class renamed": {
+			wl:   reserved(kueue.NewWorkloadPriorityClassRef("high")),
+			ref:  kueue.NewWorkloadPriorityClassRef("low"),
+			want: true,
+		},
+		"reserved, pod priority class renamed": {
+			wl:   reserved(kueue.NewPodPriorityClassRef("high")),
+			ref:  kueue.NewPodPriorityClassRef("low"),
+			want: false,
+		},
+		"reserved, group and kind change": {
+			wl:   reserved(kueue.NewWorkloadPriorityClassRef("high")),
+			ref:  kueue.NewPodPriorityClassRef("high"),
+			want: false,
+		},
+		"reserved, ref removed": {
+			wl:   reserved(kueue.NewWorkloadPriorityClassRef("high")),
+			ref:  nil,
+			want: false,
+		},
+		"reserved, ref added": {
+			wl:   reserved(nil),
+			ref:  kueue.NewWorkloadPriorityClassRef("high"),
+			want: false,
+		},
+		"reserved, no ref either side": {
+			wl:   reserved(nil),
+			ref:  nil,
+			want: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := priorityRefTransitionAllowed(tc.wl, tc.ref); got != tc.want {
+				t.Errorf("priorityRefTransitionAllowed() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/onsi/gomega"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	schedulingv1 "k8s.io/api/scheduling/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -1530,128 +1529,6 @@ var _ = ginkgo.Describe("Interacting with scheduler", ginkgo.Ordered, ginkgo.Con
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, onDemandFlavor, true)
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, spotTaintedFlavor, true)
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, spotUntaintedFlavor, true)
-	})
-
-	// These specs pin the API server behaviour the guard in UpdateWorkloadPriority
-	// exists for. The unit tests cover the guard itself, by asserting no write is
-	// attempted; they cannot cover this, because they build their client with
-	// utiltesting.NewClientBuilder, which does not evaluate CEL. If these rules are
-	// ever relaxed, these specs fail and the guard can be revisited.
-	ginkgo.When("A workload has reserved quota", func() {
-		var (
-			reservedWPC        *kueue.WorkloadPriorityClass
-			reservedPodPC      *schedulingv1.PriorityClass
-			reservedOtherPodPC *schedulingv1.PriorityClass
-		)
-
-		ginkgo.BeforeEach(func() {
-			reservedWPC = utiltestingapi.MakeWorkloadPriorityClass("reserved-wpc").PriorityValue(100).Obj()
-			util.MustCreate(ctx, k8sClient, reservedWPC)
-
-			reservedPodPC = &schedulingv1.PriorityClass{
-				ObjectMeta: metav1.ObjectMeta{Name: "reserved-podpc"},
-				Value:      50,
-			}
-			util.MustCreate(ctx, k8sClient, reservedPodPC)
-
-			reservedOtherPodPC = &schedulingv1.PriorityClass{
-				ObjectMeta: metav1.ObjectMeta{Name: "reserved-podpc-other"},
-				Value:      25,
-			}
-			util.MustCreate(ctx, k8sClient, reservedOtherPodPC)
-		})
-
-		ginkgo.AfterEach(func() {
-			gomega.Expect(k8sClient.Delete(ctx, reservedWPC)).To(gomega.Succeed())
-			gomega.Expect(k8sClient.Delete(ctx, reservedPodPC)).To(gomega.Succeed())
-			gomega.Expect(k8sClient.Delete(ctx, reservedOtherPodPC)).To(gomega.Succeed())
-		})
-
-		// Returns a workload that carries reservedWPC and has reserved quota.
-		reservedWorkload := func(jobName string) (*kueue.Workload, types.NamespacedName) {
-			job := testingjob.MakeJob(jobName, ns.Name).
-				WorkloadPriorityClass(reservedWPC.Name).
-				Queue(kueue.LocalQueueName(devLocalQ.Name)).
-				Request(corev1.ResourceCPU, "1").
-				Obj()
-			util.MustCreate(ctx, k8sClient, job)
-
-			wlKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: ns.Name}
-			util.ExpectWorkloadsWithWorkloadPriority(ctx, k8sClient, reservedWPC.Name, reservedWPC.Value, wlKey)
-			util.SetQuotaReservation(ctx, k8sClient, wlKey, utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(devClusterQ.Name)).Obj())
-
-			createdWl := &kueue.Workload{}
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, wlKey, createdWl)).To(gomega.Succeed())
-				g.Expect(createdWl.Status.Conditions).To(utiltesting.HaveConditionStatusTrue(kueue.WorkloadQuotaReserved))
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			return createdWl, wlKey
-		}
-
-		// What the owner dropping its WorkloadPriorityClass label resolves to when a
-		// Pod PriorityClass is left on the template. Different group and kind.
-		ginkgo.It("refuses to move its priorityClassRef to a pod priority class", func() {
-			createdWl, wlKey := reservedWorkload("reserved-group-kind")
-
-			createdWl.Spec.PriorityClassRef = kueue.NewPodPriorityClassRef(reservedPodPC.Name)
-			createdWl.Spec.Priority = new(reservedPodPC.Value)
-			err := k8sClient.Update(ctx, createdWl)
-			gomega.Expect(err).To(gomega.HaveOccurred())
-			gomega.Expect(err.Error()).To(gomega.ContainSubstring("priorityClassRef.group is immutable while workload quota reserved"))
-
-			gomega.Expect(k8sClient.Get(ctx, wlKey, createdWl)).To(gomega.Succeed())
-			gomega.Expect(createdWl.Spec.PriorityClassRef.Name).To(gomega.Equal(reservedWPC.Name))
-		})
-
-		// What it resolves to when there is nothing to fall back to at all.
-		ginkgo.It("refuses to remove its priorityClassRef", func() {
-			createdWl, wlKey := reservedWorkload("reserved-removal")
-
-			createdWl.Spec.PriorityClassRef = nil
-			createdWl.Spec.Priority = new(int32(0))
-			err := k8sClient.Update(ctx, createdWl)
-			gomega.Expect(err).To(gomega.HaveOccurred())
-			gomega.Expect(err.Error()).To(gomega.ContainSubstring("priorityClassRef is immutable while workload quota reserved"))
-
-			gomega.Expect(k8sClient.Get(ctx, wlKey, createdWl)).To(gomega.Succeed())
-			gomega.Expect(createdWl.Spec.PriorityClassRef).ToNot(gomega.BeNil())
-		})
-
-		// The remaining rule the guard implements. A workload on a pod priority
-		// class cannot be renamed onto another one. It is not reachable through
-		// UpdateWorkloadPriority, since the classifier drops these before the write,
-		// so the guard is defensive and this is what justifies keeping it.
-		ginkgo.It("refuses to rename its pod priority class", func() {
-			job := testingjob.MakeJob("reserved-podpc-rename", ns.Name).
-				PriorityClass(reservedPodPC.Name).
-				Queue(kueue.LocalQueueName(devLocalQ.Name)).
-				Request(corev1.ResourceCPU, "1").
-				Obj()
-			util.MustCreate(ctx, k8sClient, job)
-
-			wlKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: ns.Name}
-			createdWl := &kueue.Workload{}
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, wlKey, createdWl)).To(gomega.Succeed())
-				g.Expect(createdWl.Spec.PriorityClassRef).ToNot(gomega.BeNil())
-				g.Expect(createdWl.Spec.PriorityClassRef.Kind).To(gomega.Equal(kueue.PodPriorityClassKind))
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-			util.SetQuotaReservation(ctx, k8sClient, wlKey, utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(devClusterQ.Name)).Obj())
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, wlKey, createdWl)).To(gomega.Succeed())
-				g.Expect(createdWl.Status.Conditions).To(utiltesting.HaveConditionStatusTrue(kueue.WorkloadQuotaReserved))
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-			createdWl.Spec.PriorityClassRef = kueue.NewPodPriorityClassRef(reservedOtherPodPC.Name)
-			createdWl.Spec.Priority = new(reservedOtherPodPC.Value)
-			err := k8sClient.Update(ctx, createdWl)
-			gomega.Expect(err).To(gomega.HaveOccurred())
-			gomega.Expect(err.Error()).To(gomega.ContainSubstring("priorityClassRef.name is immutable for scheduling.k8s.io/priorityclass while workload quota reserved"))
-
-			gomega.Expect(k8sClient.Get(ctx, wlKey, createdWl)).To(gomega.Succeed())
-			gomega.Expect(createdWl.Spec.PriorityClassRef.Name).To(gomega.Equal(reservedPodPC.Name))
-		})
 	})
 
 	ginkgo.When("Substitute WorkloadPriorityClass", func() {

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/onsi/gomega"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -1529,6 +1530,84 @@ var _ = ginkgo.Describe("Interacting with scheduler", ginkgo.Ordered, ginkgo.Con
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, onDemandFlavor, true)
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, spotTaintedFlavor, true)
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, spotUntaintedFlavor, true)
+	})
+
+	// These specs pin the API server behaviour the guard in UpdateWorkloadPriority
+	// exists for. The unit tests cover the guard itself, by asserting no write is
+	// attempted; they cannot cover this, because they build their client with
+	// utiltesting.NewClientBuilder, which does not evaluate CEL. If these rules are
+	// ever relaxed, these specs fail and the guard can be revisited.
+	ginkgo.When("A workload has reserved quota", func() {
+		var (
+			reservedWPC   *kueue.WorkloadPriorityClass
+			reservedPodPC *schedulingv1.PriorityClass
+		)
+
+		ginkgo.BeforeEach(func() {
+			reservedWPC = utiltestingapi.MakeWorkloadPriorityClass("reserved-wpc").PriorityValue(100).Obj()
+			util.MustCreate(ctx, k8sClient, reservedWPC)
+
+			reservedPodPC = &schedulingv1.PriorityClass{
+				ObjectMeta: metav1.ObjectMeta{Name: "reserved-podpc"},
+				Value:      50,
+			}
+			util.MustCreate(ctx, k8sClient, reservedPodPC)
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(k8sClient.Delete(ctx, reservedWPC)).To(gomega.Succeed())
+			gomega.Expect(k8sClient.Delete(ctx, reservedPodPC)).To(gomega.Succeed())
+		})
+
+		// Returns a workload that carries reservedWPC and has reserved quota.
+		reservedWorkload := func(jobName string) (*kueue.Workload, types.NamespacedName) {
+			job := testingjob.MakeJob(jobName, ns.Name).
+				WorkloadPriorityClass(reservedWPC.Name).
+				Queue(kueue.LocalQueueName(devLocalQ.Name)).
+				Request(corev1.ResourceCPU, "1").
+				Obj()
+			util.MustCreate(ctx, k8sClient, job)
+
+			wlKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: ns.Name}
+			util.ExpectWorkloadsWithWorkloadPriority(ctx, k8sClient, reservedWPC.Name, reservedWPC.Value, wlKey)
+			util.SetQuotaReservation(ctx, k8sClient, wlKey, utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(devClusterQ.Name)).Obj())
+
+			createdWl := &kueue.Workload{}
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlKey, createdWl)).To(gomega.Succeed())
+				g.Expect(createdWl.Status.Conditions).To(utiltesting.HaveConditionStatusTrue(kueue.WorkloadQuotaReserved))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			return createdWl, wlKey
+		}
+
+		// What the owner dropping its WorkloadPriorityClass label resolves to when a
+		// Pod PriorityClass is left on the template. Different group and kind.
+		ginkgo.It("refuses to move its priorityClassRef to a pod priority class", func() {
+			createdWl, wlKey := reservedWorkload("reserved-group-kind")
+
+			createdWl.Spec.PriorityClassRef = kueue.NewPodPriorityClassRef(reservedPodPC.Name)
+			createdWl.Spec.Priority = ptr.To(reservedPodPC.Value)
+			err := k8sClient.Update(ctx, createdWl)
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("priorityClassRef.group is immutable while workload quota reserved"))
+
+			gomega.Expect(k8sClient.Get(ctx, wlKey, createdWl)).To(gomega.Succeed())
+			gomega.Expect(createdWl.Spec.PriorityClassRef.Name).To(gomega.Equal(reservedWPC.Name))
+		})
+
+		// What it resolves to when there is nothing to fall back to at all.
+		ginkgo.It("refuses to remove its priorityClassRef", func() {
+			createdWl, wlKey := reservedWorkload("reserved-removal")
+
+			createdWl.Spec.PriorityClassRef = nil
+			createdWl.Spec.Priority = ptr.To(int32(0))
+			err := k8sClient.Update(ctx, createdWl)
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("priorityClassRef is immutable while workload quota reserved"))
+
+			gomega.Expect(k8sClient.Get(ctx, wlKey, createdWl)).To(gomega.Succeed())
+			gomega.Expect(createdWl.Spec.PriorityClassRef).ToNot(gomega.BeNil())
+		})
 	})
 
 	ginkgo.When("Substitute WorkloadPriorityClass", func() {

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -1586,7 +1586,7 @@ var _ = ginkgo.Describe("Interacting with scheduler", ginkgo.Ordered, ginkgo.Con
 			createdWl, wlKey := reservedWorkload("reserved-group-kind")
 
 			createdWl.Spec.PriorityClassRef = kueue.NewPodPriorityClassRef(reservedPodPC.Name)
-			createdWl.Spec.Priority = ptr.To(reservedPodPC.Value)
+			createdWl.Spec.Priority = new(reservedPodPC.Value)
 			err := k8sClient.Update(ctx, createdWl)
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).To(gomega.ContainSubstring("priorityClassRef.group is immutable while workload quota reserved"))
@@ -1600,7 +1600,7 @@ var _ = ginkgo.Describe("Interacting with scheduler", ginkgo.Ordered, ginkgo.Con
 			createdWl, wlKey := reservedWorkload("reserved-removal")
 
 			createdWl.Spec.PriorityClassRef = nil
-			createdWl.Spec.Priority = ptr.To(int32(0))
+			createdWl.Spec.Priority = new(int32(0))
 			err := k8sClient.Update(ctx, createdWl)
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).To(gomega.ContainSubstring("priorityClassRef is immutable while workload quota reserved"))

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -1539,8 +1539,9 @@ var _ = ginkgo.Describe("Interacting with scheduler", ginkgo.Ordered, ginkgo.Con
 	// ever relaxed, these specs fail and the guard can be revisited.
 	ginkgo.When("A workload has reserved quota", func() {
 		var (
-			reservedWPC   *kueue.WorkloadPriorityClass
-			reservedPodPC *schedulingv1.PriorityClass
+			reservedWPC        *kueue.WorkloadPriorityClass
+			reservedPodPC      *schedulingv1.PriorityClass
+			reservedOtherPodPC *schedulingv1.PriorityClass
 		)
 
 		ginkgo.BeforeEach(func() {
@@ -1552,11 +1553,18 @@ var _ = ginkgo.Describe("Interacting with scheduler", ginkgo.Ordered, ginkgo.Con
 				Value:      50,
 			}
 			util.MustCreate(ctx, k8sClient, reservedPodPC)
+
+			reservedOtherPodPC = &schedulingv1.PriorityClass{
+				ObjectMeta: metav1.ObjectMeta{Name: "reserved-podpc-other"},
+				Value:      25,
+			}
+			util.MustCreate(ctx, k8sClient, reservedOtherPodPC)
 		})
 
 		ginkgo.AfterEach(func() {
 			gomega.Expect(k8sClient.Delete(ctx, reservedWPC)).To(gomega.Succeed())
 			gomega.Expect(k8sClient.Delete(ctx, reservedPodPC)).To(gomega.Succeed())
+			gomega.Expect(k8sClient.Delete(ctx, reservedOtherPodPC)).To(gomega.Succeed())
 		})
 
 		// Returns a workload that carries reservedWPC and has reserved quota.
@@ -1607,6 +1615,42 @@ var _ = ginkgo.Describe("Interacting with scheduler", ginkgo.Ordered, ginkgo.Con
 
 			gomega.Expect(k8sClient.Get(ctx, wlKey, createdWl)).To(gomega.Succeed())
 			gomega.Expect(createdWl.Spec.PriorityClassRef).ToNot(gomega.BeNil())
+		})
+
+		// The remaining rule the guard implements. A workload on a pod priority
+		// class cannot be renamed onto another one. It is not reachable through
+		// UpdateWorkloadPriority, since the classifier drops these before the write,
+		// so the guard is defensive and this is what justifies keeping it.
+		ginkgo.It("refuses to rename its pod priority class", func() {
+			job := testingjob.MakeJob("reserved-podpc-rename", ns.Name).
+				PriorityClass(reservedPodPC.Name).
+				Queue(kueue.LocalQueueName(devLocalQ.Name)).
+				Request(corev1.ResourceCPU, "1").
+				Obj()
+			util.MustCreate(ctx, k8sClient, job)
+
+			wlKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: ns.Name}
+			createdWl := &kueue.Workload{}
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlKey, createdWl)).To(gomega.Succeed())
+				g.Expect(createdWl.Spec.PriorityClassRef).ToNot(gomega.BeNil())
+				g.Expect(createdWl.Spec.PriorityClassRef.Kind).To(gomega.Equal(kueue.PodPriorityClassKind))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			util.SetQuotaReservation(ctx, k8sClient, wlKey, utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(devClusterQ.Name)).Obj())
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlKey, createdWl)).To(gomega.Succeed())
+				g.Expect(createdWl.Status.Conditions).To(utiltesting.HaveConditionStatusTrue(kueue.WorkloadQuotaReserved))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			createdWl.Spec.PriorityClassRef = kueue.NewPodPriorityClassRef(reservedOtherPodPC.Name)
+			createdWl.Spec.Priority = new(reservedOtherPodPC.Value)
+			err := k8sClient.Update(ctx, createdWl)
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("priorityClassRef.name is immutable for scheduling.k8s.io/priorityclass while workload quota reserved"))
+
+			gomega.Expect(k8sClient.Get(ctx, wlKey, createdWl)).To(gomega.Succeed())
+			gomega.Expect(createdWl.Spec.PriorityClassRef.Name).To(gomega.Equal(reservedPodPC.Name))
 		})
 	})
 


### PR DESCRIPTION
Cherry pick of #14565 on release-0.18.

#14565: Skip priority transitions the API server refuses while quota is reserved

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
WorkloadPriorityClass: Fixed a bug where a Workload that had reserved quota was repeatedly written with
a priorityClassRef the API server rejects, when its owner's WorkloadPriorityClass label was removed.
```