### PR TITLE
Copy limits into missing requests before applying LimitRange defaults

### DIFF
--- a/pkg/workload/resources.go
+++ b/pkg/workload/resources.go
@@ -146,10 +146,15 @@ func AdjustResources(ctx context.Context, cl client.Client, wl *kueue.Workload) 
 	for _, err := range handlePodOverhead(ctx, cl, wl) {
 		log.Error(err, "Failures adjusting requests for pod overhead")
 	}
+	// Copy limits into missing requests before applying the LimitRange
+	// defaults, mirroring the API server, where requests default from limits
+	// at object defaulting, before the LimitRanger admission plugin runs.
+	// The Pods created after admission request their limits, so the Workload
+	// must be accounted the same way.
+	handleLimitsToRequests(wl)
 	if err := handlePodLimitRange(ctx, cl, wl); err != nil {
 		log.Error(err, "Failed adjusting requests for LimitRanges")
 	}
-	handleLimitsToRequests(wl)
 }
 
 // ValidateResources validates that requested resources are less or equal

--- a/pkg/workload/resources_test.go
+++ b/pkg/workload/resources_test.go
@@ -229,7 +229,10 @@ func TestAdjustResources(t *testing.T) {
 						Obj(),
 					*utiltestingapi.MakePodSet("b", 1).
 						Limit(corev1.ResourceCPU, "6").
-						Request(corev1.ResourceCPU, "3").
+						// The limits are copied into the missing requests before
+						// the LimitRange defaultRequest applies, mirroring the
+						// requests the created Pods will carry.
+						Request(corev1.ResourceCPU, "6").
 						InitContainers(corev1.Container{
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
@@ -332,7 +335,9 @@ func TestAdjustResources(t *testing.T) {
 						PodLevelLimit(corev1.ResourceCPU, "4").
 						PodLevelLimit(corev1.ResourceMemory, "2Gi").
 						PodLevelRequest(corev1.ResourceCPU, "3").
-						PodLevelRequest(corev1.ResourceMemory, "512Mi").
+						// The user-set memory limit is copied into the missing
+						// request before the LimitRange defaultRequest applies.
+						PodLevelRequest(corev1.ResourceMemory, "2Gi").
 						Obj(),
 					*utiltestingapi.MakePodSet("b", 1).
 						PodLevelLimit(corev1.ResourceCPU, "6").

--- a/test/integration/singlecluster/scheduler/limits_default_order_probe_test.go
+++ b/test/integration/singlecluster/scheduler/limits_default_order_probe_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/pkg/workload"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+// Probe for: when a namespace LimitRange sets defaultRequest and a container
+// declares only limits, the real Pod will request its limits (requests default
+// from limits at the API level, before the LimitRange admission plugin runs),
+// so Kueue must account the limits value, not the LimitRange default.
+var _ = ginkgo.Describe("LimitRange default vs limits-only accounting probe", func() {
+	var (
+		ns             *corev1.Namespace
+		onDemandFlavor *kueue.ResourceFlavor
+		clusterQueue   *kueue.ClusterQueue
+		localQueue     *kueue.LocalQueue
+	)
+
+	ginkgo.BeforeEach(func() {
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "lr-order-probe-")
+		onDemandFlavor = utiltestingapi.MakeResourceFlavor("on-demand").Obj()
+		util.MustCreate(ctx, k8sClient, onDemandFlavor)
+		clusterQueue = utiltestingapi.MakeClusterQueue("cq-lr-order").
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas(onDemandFlavor.Name).
+				Resource(corev1.ResourceCPU, "10").Obj()).
+			Obj()
+		util.MustCreate(ctx, k8sClient, clusterQueue)
+		localQueue = utiltestingapi.MakeLocalQueue("queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+		util.MustCreate(ctx, k8sClient, localQueue)
+
+		limitRange := utiltesting.MakeLimitRange("limits", ns.Name).
+			WithValue("DefaultRequest", corev1.ResourceCPU, "1").Obj()
+		util.MustCreate(ctx, k8sClient, limitRange)
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, onDemandFlavor, true)
+	})
+
+	ginkgo.It("accounts a limits-only workload by its limits, matching pod semantics", func() {
+		wl := utiltestingapi.MakeWorkload("limits-only", ns.Name).
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			Limit(corev1.ResourceCPU, "3").
+			Obj()
+		util.MustCreate(ctx, k8sClient, wl)
+
+		ginkgo.By("waiting for admission", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				read := kueue.Workload{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &read)).To(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(&read)).To(gomega.BeTrue())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("checking the queue books the limits value, not the LimitRange default", func() {
+			updatedCQ := kueue.ClusterQueue{}
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &updatedCQ)).To(gomega.Succeed())
+				g.Expect(updatedCQ.Status.FlavorsReservation).Should(gomega.BeComparableTo([]kueue.FlavorUsage{{
+					Name: kueue.ResourceFlavorReference(onDemandFlavor.Name),
+					Resources: []kueue.ResourceUsage{{
+						Name:  corev1.ResourceCPU,
+						Total: resource.MustParse("3"),
+					}},
+				}}, cmpopts.IgnoreFields(kueue.ResourceUsage{}, "Borrowed")))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+})

--- a/test/integration/singlecluster/scheduler/limits_default_order_probe_test.go
+++ b/test/integration/singlecluster/scheduler/limits_default_order_probe_test.go
@@ -52,8 +52,10 @@ var _ = ginkgo.Describe("LimitRange default vs limits-only accounting probe", fu
 				Resource(corev1.ResourceCPU, "10").Obj()).
 			Obj()
 		util.MustCreate(ctx, k8sClient, clusterQueue)
+		util.ExpectClusterQueuesToBeActive(ctx, k8sClient, clusterQueue)
 		localQueue = utiltestingapi.MakeLocalQueue("queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
 		util.MustCreate(ctx, k8sClient, localQueue)
+		util.ExpectLocalQueuesToBeActive(ctx, k8sClient, localQueue)
 
 		limitRange := utiltesting.MakeLimitRange("limits", ns.Name).
 			WithValue("DefaultRequest", corev1.ResourceCPU, "1").Obj()


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`AdjustResources` applied the namespace LimitRange defaults before copying
limits into missing requests. When a container (or pod-level resources)
declares only limits and the namespace has a LimitRange with
`defaultRequest`, the default filled the empty requests first and the limits
copy found the slot occupied, so the Workload was accounted by the default.

The real Pod resolves the same situation in the opposite order: requests
default from limits at the API level, before the LimitRanger admission
plugin runs — a limits-only container always requests its limits. Kueue
therefore admitted by a smaller number than the created Pods actually
request, overcommitting the quota (with `defaultRequest: cpu=1` and a
limits-only `cpu=3` container, the ClusterQueue booked 1 while the Pods
request 3).

The fix swaps the order: copy limits into missing requests first, then apply
the LimitRange defaults to whatever is still unset, mirroring the API server
where object defaulting runs before admission plugins.

Two unit-test expectations pinned the old order and are updated to the
Pod-mirroring semantics; the new integration spec reproduces the
under-accounting (red on main, green with the fix).

#### Which issue(s) this PR fixes:

Fixes #15020

#### Special notes for your reviewer:

Another instance of the `AdjustResources` fragility tracked in #14964.

#### Does this PR introduce a user-facing change?

```release-note
Scheduling: Fixed a bug which would charge the quota based on the LimitRange (if specified) for workloads
with only limits specified. That could create a mismatch between the charged quota and the resources actually
used by the running Pods.
```

---

The investigation, reproduction, and fix were done with AI assistance
(Claude); I reviewed and verified the ordering semantics against the API
server behavior and the red/green test results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resource accounting now matches Kubernetes behavior when workloads specify limits without requests.
  * Limits are copied to missing requests before namespace defaults are applied, ensuring accurate quota reservations.

* **Tests**
  * Updated resource accounting expectations for limit-range scenarios.
  * Added integration coverage confirming that a limits-only workload is accounted for using its declared limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->