### PR TITLE
Stop retrying missing Docker manifests

### DIFF
--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -54,7 +54,7 @@ export KIND_VERSION="${E2E_KIND_VERSION#kindest/node:v}"
 
 # Non-retriable: missing image, denied access, or a full disk.
 # Shared by `e2e_docker_pull_if_needed` and `e2e_docker_manifest_available` below.
-export E2E_NON_RETRIABLE_IMAGE_ERRORS="manifest (unknown|for .* not found)|repository does not exist|not found|pull access denied|unauthorized|denied: requested access|no space left on device"
+export E2E_NON_RETRIABLE_IMAGE_ERRORS="no such manifest|manifest (unknown|for .* not found)|repository does not exist|not found|pull access denied|unauthorized|denied: requested access|no space left on device"
 
 function build_kind_node_image {
     if [[ "$E2E_KIND_VERSION" != kindest/node:v* ]]; then

--- a/hack/testing/e2e-common_test.sh
+++ b/hack/testing/e2e-common_test.sh
@@ -376,7 +376,7 @@ unset DOCKER_FAKE_MANIFEST_OK_AFTER DOCKER_FAKE_MANIFEST_ERROR
 : >"${DOCKER_FAKE_LOG}"
 printf '0' >"${DOCKER_FAKE_MANIFEST_STATE}"
 export DOCKER_FAKE_MANIFEST_OK_AFTER=99
-export DOCKER_FAKE_MANIFEST_ERROR="manifest for registry.example.com/kueue:missing not found"
+export DOCKER_FAKE_MANIFEST_ERROR="no such manifest: registry.example.com/kueue:missing"
 
 if e2e_docker_manifest_available "registry.example.com/kueue:missing"; then
   echo "expected e2e_docker_manifest_available to fail for a genuinely missing manifest" >&2


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind flake

#### What this PR does / why we need it:
Treat `no such manifest` as a non retryable error.
Since the image is unavailable in the registry, the retries only delay the e2e jobs by 2m making them exceed the 14m threshold.

https://storage.googleapis.com/kubernetes-ci-logs/logs/periodic-kueue-verify-ci-build-times-main/2094797923865858048/build-log.txt

```
[global] Runtime threshold exceeded: 3 job(s) have second_longest runtime above 14:00 (840s).
[global]  - pull-kueue-test-e2e-multikueue-sequential-shard-1-main: second_longest=15:16 builds=2094763776896143360, 2094630381352390656, 2094616301250023424, 2094604212980682752, 2094417984809340928 runtimes=11:59, 15:49, 13:34, 15:16, 11:00
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #15018


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing container image manifests so these errors are recognized as non-retriable during image pulls and manifest checks.
  * Updated validation to reflect Docker’s current missing-manifest error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->