### PR TITLE
Retain topology domain affinity during preemption wait

### DIFF
--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -33,6 +33,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/component-helpers/scheduling/corev1/nodeaffinity"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -480,6 +481,23 @@ type topologyAssignmentParameters struct {
 	required              bool
 	unconstrained         bool
 	multiLayerConstraints []kueue.PodsetSliceRequiredTopologyConstraint
+	preferredDomains      sets.Set[string]
+}
+
+func (p *topologyAssignmentParameters) isPreferredDomain(d *domain) bool {
+	if p == nil || p.preferredDomains == nil || p.preferredDomains.Len() == 0 {
+		return false
+	}
+	key := strings.Join(d.levelValues, "/")
+	if p.preferredDomains.Has(key) {
+		return true
+	}
+	for pref := range p.preferredDomains {
+		if strings.HasPrefix(pref, key) || strings.HasSuffix(key, pref) || strings.HasSuffix(pref, key) {
+			return true
+		}
+	}
+	return false
 }
 
 // findTopologyAssignmentState stores the derived state for a single run of the
@@ -900,6 +918,15 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 		},
 		stats: &tasExclusionStats{},
 	}
+	if workersTasPodSetRequests.PreviousAssignment != nil {
+		internalPrev := utiltas.InternalFrom(workersTasPodSetRequests.PreviousAssignment)
+		if internalPrev != nil {
+			state.preferredDomains = sets.New[string]()
+			for _, d := range internalPrev.Domains {
+				state.preferredDomains.Insert(strings.Join(d.Values, "/"))
+			}
+		}
+	}
 	requirements.requests = workersTasPodSetRequests.SinglePodRequests.Clone()
 	requirements.requests.Add(resources.OnePodRequest)
 
@@ -1036,7 +1063,7 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 	for ; currentLevelIdx < min(len(s.domainsPerLevel)-1, state.sliceLevelIdx) && !useBalancedPlacement; currentLevelIdx++ {
 		// If we are "above" the requested slice topology level and we don't run the balanced placement algorithm,
 		// we're greedily assigning pods/slices to all domains without checking what we've assigned to parent domains.
-		sortedLowerDomains := s.sortedDomains(s.lowerLevelDomains(currFitDomain), state.unconstrained)
+		sortedLowerDomains := s.sortedDomains(s.lowerLevelDomains(currFitDomain), state.unconstrained, state)
 		currFitDomain = s.updateCountsToMinimumGeneric(sortedLowerDomains, state.count, state.leaderCount, state.sliceSize, state.unconstrained, true)
 	}
 
@@ -1057,7 +1084,7 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 		}
 		newCurrFitDomain := make([]*domain, 0)
 		for _, domain := range currFitDomain {
-			sortedLowerDomains := s.sortedDomains(domain.children, state.unconstrained)
+			sortedLowerDomains := s.sortedDomains(domain.children, state.unconstrained, state)
 
 			if sliceSizeOnLevel > 1 {
 				// For inner slice layers, recompute sliceCount on the
@@ -1342,7 +1369,7 @@ func (s *TASFlavorSnapshot) findLevelWithFitDomains(
 		return 0, nil, fmt.Sprintf("no topology domains at level: %s", s.levelKeys[searchLevelIdx])
 	}
 	levelDomains := slices.Collect(maps.Values(domains))
-	sortedDomain := s.sortedDomainsWithLeader(levelDomains, state.unconstrained)
+	sortedDomain := s.sortedDomainsWithLeader(levelDomains, state.unconstrained, state)
 	topDomain := sortedDomain[0]
 
 	sliceCount := state.count / state.sliceSize
@@ -1421,7 +1448,7 @@ func (s *TASFlavorSnapshot) findLevelWithFitDomains(
 
 		// At this point we have assigned all leaders, so we sort remaining domains based on worker capacity
 		// and assign remaining workers.
-		sortedDomain = s.sortedDomains(sortedDomain[idx:], state.unconstrained)
+		sortedDomain = s.sortedDomains(sortedDomain[idx:], state.unconstrained, state)
 		for idx := 0; remainingSliceCount > 0 && idx < len(sortedDomain); idx++ {
 			domain := sortedDomain[idx]
 			if useBestFitAlgorithm(state.unconstrained) && s.domainStateOf(sortedDomain[idx]).sliceCount >= remainingSliceCount {
@@ -1728,7 +1755,11 @@ func compareDomainLevelValues(a, b *domain) int {
 	return slices.CompareFunc(a.levelValues, b.levelValues, strings.Compare)
 }
 
-func (s *TASFlavorSnapshot) sortedDomainsWithLeader(domains []*domain, unconstrained bool) []*domain {
+func (s *TASFlavorSnapshot) sortedDomainsWithLeader(domains []*domain, unconstrained bool, state ...*findTopologyAssignmentState) []*domain {
+	var st *findTopologyAssignmentState
+	if len(state) > 0 {
+		st = state[0]
+	}
 	isLeastFreeCapacity := useLeastFreeCapacityAlgorithm(unconstrained)
 	respectNodeAffinityPreferred := features.Enabled(features.TASRespectNodeAffinityPreferred)
 	result := slices.Clone(domains)
@@ -1755,6 +1786,16 @@ func (s *TASFlavorSnapshot) sortedDomainsWithLeader(domains []*domain, unconstra
 			return cmp.Compare(aDomainState.podCountWithLeader, bDomainState.podCountWithLeader)
 		}
 
+		if st != nil {
+			aPref, bPref := st.isPreferredDomain(a), st.isPreferredDomain(b)
+			if aPref != bPref {
+				if aPref {
+					return -1
+				}
+				return 1
+			}
+		}
+
 		return s.compareDomainLevelValues(a, b)
 	})
 	return result
@@ -1767,7 +1808,11 @@ func (s *TASFlavorSnapshot) sortedDomainsWithLeader(domains []*domain, unconstra
 // - **LeastFreeCapacity**: `sliceCount` (ascending), `podCount` (ascending), `levelValues` (ascending)
 //
 // `podCount` is always sorted ascending. This prioritizes domains that can accommodate slices with minimal leftover pod capacity.
-func (s *TASFlavorSnapshot) sortedDomains(domains []*domain, unconstrained bool) []*domain {
+func (s *TASFlavorSnapshot) sortedDomains(domains []*domain, unconstrained bool, state ...*findTopologyAssignmentState) []*domain {
+	var st *findTopologyAssignmentState
+	if len(state) > 0 {
+		st = state[0]
+	}
 	isLeastFreeCapacity := useLeastFreeCapacityAlgorithm(unconstrained)
 	respectNodeAffinityPreferred := features.Enabled(features.TASRespectNodeAffinityPreferred)
 	result := slices.Clone(domains)
@@ -1788,6 +1833,16 @@ func (s *TASFlavorSnapshot) sortedDomains(domains []*domain, unconstrained bool)
 
 		if aDomainState.podCount != bDomainState.podCount {
 			return cmp.Compare(aDomainState.podCount, bDomainState.podCount)
+		}
+
+		if st != nil {
+			aPref, bPref := st.isPreferredDomain(a), st.isPreferredDomain(b)
+			if aPref != bPref {
+				if aPref {
+					return -1
+				}
+				return 1
+			}
 		}
 
 		return s.compareDomainLevelValues(a, b)

--- a/pkg/scheduler/flavorassigner/tas_flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/tas_flavorassigner.go
@@ -69,6 +69,9 @@ func (a *Assignment) WorkloadsTopologyRequests(log logr.Logger, wl *workload.Inf
 				}
 				previousAssignment = getPreviousTopologyAssignment(a.replaceWorkloadSlice, podSet.Name)
 			}
+			if previousAssignment == nil && wl.LastAssignment != nil && wl.LastAssignment.PreemptionTopologyAssignments != nil {
+				previousAssignment = wl.LastAssignment.PreemptionTopologyAssignments[podSet.Name]
+			}
 
 			psTASRequest, err := podSetTopologyRequest(psAssignment, wl, cq, isTASImplied, i, previousAssignment)
 			if err != nil {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -59,6 +59,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/util/resourcegroups"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	"sigs.k8s.io/kueue/pkg/util/routine"
+	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 	"sigs.k8s.io/kueue/pkg/util/wait"
 	"sigs.k8s.io/kueue/pkg/workload"
 	"sigs.k8s.io/kueue/pkg/workload/concurrentadmission"
@@ -493,6 +494,14 @@ func (s *Scheduler) processEntry(
 
 	if mode == flavorassigner.Preempt {
 		e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads
+		if e.LastAssignment != nil {
+			e.LastAssignment.PreemptionTopologyAssignments = make(map[kueue.PodSetReference]*kueue.TopologyAssignment)
+			for _, ps := range e.assignment.PodSets {
+				if ps.TopologyAssignment != nil {
+					e.LastAssignment.PreemptionTopologyAssignments[ps.Name] = utiltas.V1Beta2From(ps.TopologyAssignment)
+				}
+			}
+		}
 		s.issuePreemptions(ctx, log, e, preemptionTargets)
 		return
 	}
@@ -828,7 +837,14 @@ func (s *Scheduler) getAssignments(ctx context.Context, wl *workload.Info, snap 
 		log.FromContext(ctx).V(6).Info("Clearing Workload's last assignment because it was outdated",
 			"cq.AllocatableResourceGeneration", cq.AllocatableResourceGeneration,
 			"wl.LastAssignment.ClusterQueueGeneration", wl.LastAssignment.ClusterQueueGeneration)
-		wl.LastAssignment = nil
+		if wl.LastAssignment.PreemptionTopologyAssignments != nil && wl.LastAssignment.MatchesSchedulingShape(wl.SchedulingHash) {
+			wl.LastAssignment = &workload.AssignmentClusterQueueState{
+				PreemptionTopologyAssignments: wl.LastAssignment.PreemptionTopologyAssignments,
+				SchedulingHash:                 wl.SchedulingHash,
+			}
+		} else {
+			wl.LastAssignment = nil
+		}
 	}
 	assignment, targets := s.getInitialAssignments(ctx, wl, snap)
 	updateAssignmentForTAS(ctx, snap, cq, wl, &assignment, targets)

--- a/pkg/scheduler/scheduler_tas_test.go
+++ b/pkg/scheduler/scheduler_tas_test.go
@@ -3886,6 +3886,9 @@ type tasScheduleTestCase struct {
 	// eventCmpOpts are the comparison options for the events
 	eventCmpOpts cmp.Options
 
+	// lastAssignments sets the LastAssignment on pending workloads in queue manager before scheduling.
+	lastAssignments map[workload.Reference]*workload.AssignmentClusterQueueState
+
 	featureGates map[featuregate.Feature]bool
 }
 
@@ -4033,6 +4036,15 @@ func runTASScheduleTestCases(t *testing.T, cfg tasScheduleTestConfig, cases map[
 					for _, w := range testWls {
 						if workload.IsAdmitted(&w) {
 							initiallyAdmittedWorkloads.Insert(workload.Key(&w))
+						}
+					}
+					for wlKey, la := range tc.lastAssignments {
+						for _, cq := range tc.clusterQueues {
+							for _, info := range qManager.PendingWorkloadsInfo(kueue.ClusterQueueReference(cq.Name)) {
+								if workload.Key(info.Obj) == wlKey {
+									info.LastAssignment = la.Clone()
+								}
+							}
 						}
 					}
 					scheduler := New(qManager, cqCache, cl, recorder, WithClock(t, testingclock.NewFakeClock(cfg.now)), WithPreemptionExpectations(preemptexpectations.New()))
@@ -5937,6 +5949,174 @@ func TestScheduleForTASPreemption(t *testing.T) {
 				utiltesting.MakeEventRecord("default", "wl-high-1", kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads, corev1.EventTypeWarning).Obj(),
 				utiltesting.MakeEventRecord("default", "wl-high-2", "PreemptedWorkload", corev1.EventTypeNormal).Obj(),
 				utiltesting.MakeEventRecord("default", "wl-high-2", kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads, corev1.EventTypeWarning).Obj(),
+			},
+			eventCmpOpts: cmp.Options{eventIgnoreMessage},
+		},
+		"sticky preemption topology assignment retains targeted domain across cycles": {
+			nodes:           defaultTwoNodes,
+			topologies:      []kueue.Topology{defaultSingleLevelTopology},
+			resourceFlavors: []kueue.ResourceFlavor{defaultTASFlavor},
+			clusterQueues:   []kueue.ClusterQueue{defaultClusterQueueWithPreemption},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-low-x1", "default").
+					UID("wl-low-x1-uid").
+					Queue("tas-main").
+					Priority(1).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("tas-main").
+							PodSets(utiltestingapi.MakePodSetAssignment("one").
+								Assignment(corev1.ResourceCPU, "tas-default", "5000m").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(),
+						now,
+					).
+					AdmittedAt(true, now).
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "5").
+						Obj()).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-low-y1", "default").
+					UID("wl-low-y1-uid").
+					Queue("tas-main").
+					Priority(1).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("tas-main").
+							PodSets(utiltestingapi.MakePodSetAssignment("one").
+								Assignment(corev1.ResourceCPU, "tas-default", "5000m").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(),
+						now,
+					).
+					AdmittedAt(true, now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadEvicted,
+						Status:             metav1.ConditionTrue,
+						Reason:             kueue.WorkloadEvictedByPreemption,
+						Message:            "Preempted to accommodate a workload (UID: wl-preemptor-uid, JobUID: ) due to within-ClusterQueue preemption",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Preempted", Count: 1}).
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "5").
+						Obj()).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-preemptor", "default").
+					UID("wl-preemptor-uid").
+					Queue("tas-main").
+					Priority(10).
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "5").
+						Obj()).
+					Obj(),
+			},
+			lastAssignments: map[workload.Reference]*workload.AssignmentClusterQueueState{
+				"default/wl-preemptor": {
+					PreemptionTopologyAssignments: map[kueue.PodSetReference]*kueue.TopologyAssignment{
+						"one": utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+							Obj(),
+					},
+				},
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-low-x1", "default").
+					UID("wl-low-x1-uid").
+					Queue("tas-main").
+					Priority(1).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("tas-main").
+							PodSets(utiltestingapi.MakePodSetAssignment("one").
+								Assignment(corev1.ResourceCPU, "tas-default", "5000m").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(),
+						now,
+					).
+					AdmittedAt(true, now).
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "5").
+						Obj()).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-low-y1", "default").
+					UID("wl-low-y1-uid").
+					Queue("tas-main").
+					Priority(1).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("tas-main").
+							PodSets(utiltestingapi.MakePodSetAssignment("one").
+								Assignment(corev1.ResourceCPU, "tas-default", "5000m").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(),
+						now,
+					).
+					AdmittedAt(true, now).
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "5").
+						Obj()).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadEvicted,
+						Status:             metav1.ConditionTrue,
+						Reason:             kueue.WorkloadEvictedByPreemption,
+						Message:            "Preempted to accommodate a workload (UID: wl-preemptor-uid, JobUID: ) due to within-ClusterQueue preemption",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Preempted", Count: 1}).
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "5").
+						Obj()).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-preemptor", "default").
+					UID("wl-preemptor-uid").
+					Queue("tas-main").
+					Priority(10).
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "5").
+						Obj()).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads,
+						Message:            "couldn't assign flavors to pod set one: topology \"tas-single-level\" doesn't allow to fit any of 1 pod(s). Total nodes: 2; excluded: resource \"cpu\": 2. Pending the preemption of 1 workload(s)",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadAdmittedReasonNoReservation,
+						Message:            "The workload has no reservation",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "one",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("5"),
+						},
+					}).
+					Obj(),
+			},
+			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+				"tas-main": {"default/wl-preemptor"},
+			},
+			wantEvents: []utiltesting.EventRecord{
+				utiltesting.MakeEventRecord("default", "wl-preemptor", kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads, corev1.EventTypeWarning).Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 		},

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -124,6 +124,9 @@ type AssignmentClusterQueueState struct {
 	// for a particular set of requests, so it only carries meaning while the Workload keeps
 	// the shape it had then.
 	SchedulingHash EquivalenceHash
+
+	// PreemptionTopologyAssignments records the topology assignments chosen when preemption was initiated.
+	PreemptionTopologyAssignments map[kueue.PodSetReference]*kueue.TopologyAssignment
 }
 
 type dra struct {
@@ -180,10 +183,11 @@ func WithPreprocessedDRAResources(
 
 func (s *AssignmentClusterQueueState) Clone() *AssignmentClusterQueueState {
 	c := AssignmentClusterQueueState{
-		LastTriedFlavorIdx:     make([]map[corev1.ResourceName]int, len(s.LastTriedFlavorIdx)),
-		ClusterQueueGeneration: s.ClusterQueueGeneration,
-		SchedulingCycle:        s.SchedulingCycle,
-		SchedulingHash:         s.SchedulingHash,
+		LastTriedFlavorIdx:             make([]map[corev1.ResourceName]int, len(s.LastTriedFlavorIdx)),
+		ClusterQueueGeneration:         s.ClusterQueueGeneration,
+		SchedulingCycle:                s.SchedulingCycle,
+		SchedulingHash:                 s.SchedulingHash,
+		PreemptionTopologyAssignments: maps.Clone(s.PreemptionTopologyAssignments),
 	}
 	for ps, flavorIdx := range s.LastTriedFlavorIdx {
 		c.LastTriedFlavorIdx[ps] = maps.Clone(flavorIdx)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area tas

#### What this PR does / why we need it:

When a preemptor workload targets a set of topology domains and begins evictions, subsequent scheduling cycles previously evaluated topology domains using purely lexicographical order. If another preemptor evicted workloads in lexicographically earlier domains that also satisfied the first preemptor, the first preemptor could switch domains across scheduling cycles. This resulted in wasted evictions in the previously targeted domains and potential admission latency inflation.

This PR introduces sticky preemption topology domain affinity:
1. When a workload is waiting for preemption targets to be evicted (`mode == flavorassigner.Preempt`), the targeted topology assignments are recorded in `LastAssignment.PreemptionTopologyAssignments`.
2. When flavor assignment and TAS snapshots evaluate candidate domains in subsequent cycles, the preemptor's previously targeted topology domains are prioritized over non-targeted domains during tie-breaking.
3. This ensures the preemptor remains committed to its targeted topology domains until the evicted victims terminate, preventing domain reassignment and wasted evictions.

#### Which issue(s) this PR fixes:

Fixes #14723

#### Special notes for your reviewer:

- Includes unit tests in `pkg/scheduler/scheduler_tas_test.go` verifying sticky preemption topology assignment across cycles without unnecessary victim evictions or domain flipping.
- AI assistance disclosure: Implementation and evaluation developed with AI assistance per the Kubernetes AI Tool Usage Policy.

#### Does this PR introduce a user-facing change?

```release-note
Fix topology-domain reassignment during ongoing preemptions across scheduling cycles for Topology-Aware Scheduling (TAS).
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scheduling now prioritizes previously selected topology domains when assigning workloads.
  * Preemption placement information is preserved across scheduling cycles, helping workloads remain targeted to the same topology domains.

* **Bug Fixes**
  * Improved recovery of topology assignments when workloads are replaced or prior assignments become outdated.
  * Scheduling now retains relevant placement decisions while recalculating other assignment details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->