### PR TITLE
Add a restart regression spec for effective-resource accounting

### DIFF
--- a/test/integration/singlecluster/controller/core/workload_accounting_restart_test.go
+++ b/test/integration/singlecluster/controller/core/workload_accounting_restart_test.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/metrics"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -72,6 +73,7 @@ var _ = ginkgo.Describe("Workload accounting across a manager restart", func() {
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, onDemandFlavor, true)
 		gomega.Expect(util.DeleteObject(ctx, k8sClient, runtimeClass)).To(gomega.Succeed())
 		fwk.StopManager(ctx)
+		metrics.InitMetricVectors(nil)
 	})
 
 	expectReservedCPU := func(total string) {

--- a/test/integration/singlecluster/controller/core/workload_accounting_restart_test.go
+++ b/test/integration/singlecluster/controller/core/workload_accounting_restart_test.go
@@ -35,7 +35,7 @@ import (
 // requests, RuntimeClass overhead) survives a manager restart, when every
 // workload's in-memory state is rebuilt from the raw objects. Guards the
 // AdjustResources migration tracked in kueue#14964.
-var _ = ginkgo.Describe("Workload accounting across a manager restart", ginkgo.Ordered, func() {
+var _ = ginkgo.Describe("Workload accounting across a manager restart", func() {
 	var (
 		ns             *corev1.Namespace
 		onDemandFlavor *kueue.ResourceFlavor

--- a/test/integration/singlecluster/controller/core/workload_accounting_restart_test.go
+++ b/test/integration/singlecluster/controller/core/workload_accounting_restart_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	nodev1 "k8s.io/api/node/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/pkg/workload"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+// Pins that the effective-resource accounting (limits copied into missing
+// requests, RuntimeClass overhead) survives a manager restart, when every
+// workload's in-memory state is rebuilt from the raw objects. Guards the
+// AdjustResources migration tracked in kueue#14964.
+var _ = ginkgo.Describe("Workload accounting across a manager restart", ginkgo.Ordered, func() {
+	var (
+		ns             *corev1.Namespace
+		onDemandFlavor *kueue.ResourceFlavor
+		runtimeClass   *nodev1.RuntimeClass
+		clusterQueue   *kueue.ClusterQueue
+		localQueue     *kueue.LocalQueue
+	)
+
+	ginkgo.BeforeEach(func() {
+		fwk.StartManager(ctx, cfg, managerAndSchedulerSetup)
+
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "restart-accounting-")
+		onDemandFlavor = utiltestingapi.MakeResourceFlavor("on-demand").Obj()
+		util.MustCreate(ctx, k8sClient, onDemandFlavor)
+		runtimeClass = utiltesting.MakeRuntimeClass("kata-restart", "bar-handler").
+			PodOverhead(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")}).
+			Obj()
+		util.MustCreate(ctx, k8sClient, runtimeClass)
+		clusterQueue = utiltestingapi.MakeClusterQueue("cq-restart").
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas(onDemandFlavor.Name).
+				Resource(corev1.ResourceCPU, "10").Obj()).
+			Obj()
+		util.MustCreate(ctx, k8sClient, clusterQueue)
+		util.ExpectClusterQueuesToBeActive(ctx, k8sClient, clusterQueue)
+		localQueue = utiltestingapi.MakeLocalQueue("queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+		util.MustCreate(ctx, k8sClient, localQueue)
+		util.ExpectLocalQueuesToBeActive(ctx, k8sClient, localQueue)
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, onDemandFlavor, true)
+		gomega.Expect(util.DeleteObject(ctx, k8sClient, runtimeClass)).To(gomega.Succeed())
+		fwk.StopManager(ctx)
+	})
+
+	expectReservedCPU := func(total string) {
+		gomega.Eventually(func(g gomega.Gomega) {
+			updatedCQ := kueue.ClusterQueue{}
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &updatedCQ)).To(gomega.Succeed())
+			g.Expect(updatedCQ.Status.FlavorsReservation).To(gomega.HaveLen(1))
+			g.Expect(updatedCQ.Status.FlavorsReservation[0].Resources).To(gomega.HaveLen(1))
+			g.Expect(updatedCQ.Status.FlavorsReservation[0].Resources[0].Total.Equal(resource.MustParse(total))).To(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+	}
+
+	ginkgo.It("keeps the effective-resource accounting after a restart", func() {
+		wl := utiltestingapi.MakeWorkload("adjusted", ns.Name).
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			Limit(corev1.ResourceCPU, "3").
+			RuntimeClass(runtimeClass.Name).
+			Obj()
+
+		ginkgo.By("admitting a workload whose accounting depends on adjustments", func() {
+			util.MustCreate(ctx, k8sClient, wl)
+			gomega.Eventually(func(g gomega.Gomega) {
+				read := kueue.Workload{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &read)).To(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(&read)).To(gomega.BeTrue())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			// 3 CPU copied from limits + 2 CPU RuntimeClass overhead.
+			expectReservedCPU("5")
+		})
+
+		ginkgo.By("restarting the manager", func() {
+			fwk.StopManager(ctx)
+			fwk.StartManager(ctx, cfg, managerAndSchedulerSetup)
+		})
+
+		ginkgo.By("verifying the workload stays admitted with unchanged accounting", func() {
+			gomega.Consistently(func(g gomega.Gomega) {
+				read := kueue.Workload{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &read)).To(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(&read)).To(gomega.BeTrue())
+			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+			expectReservedCPU("5")
+		})
+
+		ginkgo.By("verifying the rebuilt books gate new admissions correctly", func() {
+			// 10 - 5 = 5 free; a raw 6 CPU workload must stay pending.
+			wl2 := utiltestingapi.MakeWorkload("too-big", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				Request(corev1.ResourceCPU, "6").
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl2)
+			gomega.Consistently(func(g gomega.Gomega) {
+				read := kueue.Workload{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl2), &read)).To(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(&read)).To(gomega.BeFalse())
+			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+		})
+	})
+})

--- a/test/integration/singlecluster/controller/core/workload_hash_freshness_test.go
+++ b/test/integration/singlecluster/controller/core/workload_hash_freshness_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/pkg/workload"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+// Pins that the scheduling equivalence hash follows the effective resources:
+// two workloads with an identical raw spec must not share a scheduling
+// outcome when a LimitRange change altered the effective resources between
+// their admissions. Guards the AdjustResources migration tracked in
+// kueue#14964 and the hash-reuse work in kueue#14958.
+var _ = ginkgo.Describe("Scheduling hash freshness across LimitRange changes", ginkgo.Ordered, func() {
+	var (
+		ns           *corev1.Namespace
+		smallFlavor  *kueue.ResourceFlavor
+		largeFlavor  *kueue.ResourceFlavor
+		clusterQueue *kueue.ClusterQueue
+		localQueue   *kueue.LocalQueue
+		limitRange   *corev1.LimitRange
+	)
+
+	ginkgo.BeforeEach(func() {
+		fwk.StartManager(ctx, cfg, managerAndSchedulerSetup)
+
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "hash-freshness-")
+		smallFlavor = utiltestingapi.MakeResourceFlavor("small").Obj()
+		util.MustCreate(ctx, k8sClient, smallFlavor)
+		largeFlavor = utiltestingapi.MakeResourceFlavor("large").Obj()
+		util.MustCreate(ctx, k8sClient, largeFlavor)
+		// The small flavor fits only effective requests of up to 2 CPU in
+		// total; the large one has room for everything.
+		clusterQueue = utiltestingapi.MakeClusterQueue("cq-hash-freshness").
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas(smallFlavor.Name).Resource(corev1.ResourceCPU, "2").Obj(),
+				*utiltestingapi.MakeFlavorQuotas(largeFlavor.Name).Resource(corev1.ResourceCPU, "10").Obj(),
+			).
+			Obj()
+		util.MustCreate(ctx, k8sClient, clusterQueue)
+		util.ExpectClusterQueuesToBeActive(ctx, k8sClient, clusterQueue)
+		localQueue = utiltestingapi.MakeLocalQueue("queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+		util.MustCreate(ctx, k8sClient, localQueue)
+		util.ExpectLocalQueuesToBeActive(ctx, k8sClient, localQueue)
+
+		limitRange = utiltesting.MakeLimitRange("limits", ns.Name).
+			WithValue("DefaultRequest", corev1.ResourceCPU, "1").Obj()
+		util.MustCreate(ctx, k8sClient, limitRange)
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, largeFlavor, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, smallFlavor, true)
+		fwk.StopManager(ctx)
+	})
+
+	expectAdmittedOnFlavor := func(wl *kueue.Workload, flavorName string) {
+		gomega.Eventually(func(g gomega.Gomega) {
+			read := kueue.Workload{}
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &read)).To(gomega.Succeed())
+			g.Expect(workload.HasQuotaReservation(&read)).To(gomega.BeTrue())
+			g.Expect(read.Status.Admission.PodSetAssignments).To(gomega.HaveLen(1))
+			g.Expect(read.Status.Admission.PodSetAssignments[0].Flavors[corev1.ResourceCPU]).To(
+				gomega.Equal(kueue.ResourceFlavorReference(flavorName)))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+	}
+
+	ginkgo.It("places a raw-identical workload by its new effective resources after a defaultRequest change", func() {
+		wl1 := utiltestingapi.MakeWorkload("one", ns.Name).
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			Obj()
+		ginkgo.By("admitting the first raw workload on the small flavor (effective 1 CPU)", func() {
+			util.MustCreate(ctx, k8sClient, wl1)
+			expectAdmittedOnFlavor(wl1, smallFlavor.Name)
+		})
+
+		ginkgo.By("raising the LimitRange defaultRequest to 3 CPU", func() {
+			updatedLr := corev1.LimitRange{}
+			gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(limitRange), &updatedLr)).To(gomega.Succeed())
+			updatedLr.Spec.Limits[0].DefaultRequest[corev1.ResourceCPU] = resource.MustParse("3")
+			gomega.Expect(k8sClient.Update(ctx, &updatedLr)).To(gomega.Succeed())
+		})
+
+		ginkgo.By("admitting a raw-identical second workload on the large flavor (effective 3 CPU)", func() {
+			// If the scheduling equivalence hash were not refreshed from the
+			// new effective resources, the second workload could reuse the
+			// first one's assignment and land on the small flavor.
+			wl2 := utiltestingapi.MakeWorkload("two", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl2)
+			expectAdmittedOnFlavor(wl2, largeFlavor.Name)
+		})
+
+		ginkgo.By("verifying the first workload keeps its original assignment", func() {
+			expectAdmittedOnFlavor(wl1, smallFlavor.Name)
+		})
+	})
+})

--- a/test/integration/singlecluster/controller/core/workload_hash_freshness_test.go
+++ b/test/integration/singlecluster/controller/core/workload_hash_freshness_test.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/metrics"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -79,6 +80,7 @@ var _ = ginkgo.Describe("Scheduling hash freshness across LimitRange changes", f
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, largeFlavor, true)
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, smallFlavor, true)
 		fwk.StopManager(ctx)
+		metrics.InitMetricVectors(nil)
 	})
 
 	expectAdmittedOnFlavor := func(wl *kueue.Workload, flavorName string) {
@@ -189,6 +191,7 @@ var _ = ginkgo.Describe("Pending scheduling hashes under differing LimitRange de
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, flavor, true)
 		fwk.StopManager(ctx)
+		metrics.InitMetricVectors(nil)
 	})
 
 	ginkgo.It("reports two distinct hashes for raw-identical workloads under different defaults", func() {

--- a/test/integration/singlecluster/controller/core/workload_hash_freshness_test.go
+++ b/test/integration/singlecluster/controller/core/workload_hash_freshness_test.go
@@ -35,7 +35,7 @@ import (
 // outcome when a LimitRange change altered the effective resources between
 // their admissions. Guards the AdjustResources migration tracked in
 // kueue#14964 and the hash-reuse work in kueue#14958.
-var _ = ginkgo.Describe("Scheduling hash freshness across LimitRange changes", ginkgo.Ordered, func() {
+var _ = ginkgo.Describe("Scheduling hash freshness across LimitRange changes", func() {
 	var (
 		ns           *corev1.Namespace
 		smallFlavor  *kueue.ResourceFlavor
@@ -92,6 +92,15 @@ var _ = ginkgo.Describe("Scheduling hash freshness across LimitRange changes", g
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	}
 
+	setStopPolicy := func(p kueue.StopPolicy) {
+		gomega.Eventually(func(g gomega.Gomega) {
+			updatedCq := kueue.ClusterQueue{}
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &updatedCq)).To(gomega.Succeed())
+			updatedCq.Spec.StopPolicy = &p
+			g.Expect(k8sClient.Update(ctx, &updatedCq)).To(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+	}
+
 	ginkgo.It("places a raw-identical workload by its new effective resources after a defaultRequest change", func() {
 		wl1 := utiltestingapi.MakeWorkload("one", ns.Name).
 			Queue(kueue.LocalQueueName(localQueue.Name)).
@@ -101,6 +110,17 @@ var _ = ginkgo.Describe("Scheduling hash freshness across LimitRange changes", g
 			expectAdmittedOnFlavor(wl1, smallFlavor.Name)
 		})
 
+		wl2 := utiltestingapi.MakeWorkload("two", ns.Name).
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			Obj()
+		ginkgo.By("creating a raw-identical second workload while the ClusterQueue is held", func() {
+			// Holding the ClusterQueue makes the ordering between the
+			// LimitRange update and the second workload's admission
+			// deterministic: the workload is only evaluated after release.
+			setStopPolicy(kueue.Hold)
+			util.MustCreate(ctx, k8sClient, wl2)
+		})
+
 		ginkgo.By("raising the LimitRange defaultRequest to 3 CPU", func() {
 			updatedLr := corev1.LimitRange{}
 			gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(limitRange), &updatedLr)).To(gomega.Succeed())
@@ -108,19 +128,81 @@ var _ = ginkgo.Describe("Scheduling hash freshness across LimitRange changes", g
 			gomega.Expect(k8sClient.Update(ctx, &updatedLr)).To(gomega.Succeed())
 		})
 
-		ginkgo.By("admitting a raw-identical second workload on the large flavor (effective 3 CPU)", func() {
+		ginkgo.By("releasing the ClusterQueue and admitting the second workload on the large flavor (effective 3 CPU)", func() {
 			// If the scheduling equivalence hash were not refreshed from the
 			// new effective resources, the second workload could reuse the
 			// first one's assignment and land on the small flavor.
-			wl2 := utiltestingapi.MakeWorkload("two", ns.Name).
-				Queue(kueue.LocalQueueName(localQueue.Name)).
-				Obj()
-			util.MustCreate(ctx, k8sClient, wl2)
+			setStopPolicy(kueue.None)
 			expectAdmittedOnFlavor(wl2, largeFlavor.Name)
 		})
 
 		ginkgo.By("verifying the first workload keeps its original assignment", func() {
 			expectAdmittedOnFlavor(wl1, smallFlavor.Name)
 		})
+	})
+})
+
+// Direct observation of the hash layer, without involving the scheduler
+// outcome: two raw-identical pending workloads under different namespace
+// LimitRange defaults must carry two distinct scheduling hashes.
+var _ = ginkgo.Describe("Pending scheduling hashes under differing LimitRange defaults", func() {
+	var (
+		nsSmall      *corev1.Namespace
+		nsLarge      *corev1.Namespace
+		flavor       *kueue.ResourceFlavor
+		clusterQueue *kueue.ClusterQueue
+		lqSmall      *kueue.LocalQueue
+		lqLarge      *kueue.LocalQueue
+	)
+
+	ginkgo.BeforeEach(func() {
+		fwk.StartManager(ctx, cfg, managerAndSchedulerSetup)
+
+		nsSmall = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "hash-defaults-small-")
+		nsLarge = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "hash-defaults-large-")
+		flavor = utiltestingapi.MakeResourceFlavor("default").Obj()
+		util.MustCreate(ctx, k8sClient, flavor)
+		// Zero quota keeps both workloads pending as inadmissible.
+		clusterQueue = utiltestingapi.MakeClusterQueue("cq-hash-defaults").
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas(flavor.Name).
+				Resource(corev1.ResourceCPU, "0").Obj()).
+			Obj()
+		util.MustCreate(ctx, k8sClient, clusterQueue)
+		util.ExpectClusterQueuesToBeActive(ctx, k8sClient, clusterQueue)
+		lqSmall = utiltestingapi.MakeLocalQueue("queue", nsSmall.Name).ClusterQueue(clusterQueue.Name).Obj()
+		util.MustCreate(ctx, k8sClient, lqSmall)
+		lqLarge = utiltestingapi.MakeLocalQueue("queue", nsLarge.Name).ClusterQueue(clusterQueue.Name).Obj()
+		util.MustCreate(ctx, k8sClient, lqLarge)
+		util.ExpectLocalQueuesToBeActive(ctx, k8sClient, lqSmall, lqLarge)
+
+		util.MustCreate(ctx, k8sClient, utiltesting.MakeLimitRange("limits", nsSmall.Name).
+			WithValue("DefaultRequest", corev1.ResourceCPU, "1").Obj())
+		util.MustCreate(ctx, k8sClient, utiltesting.MakeLimitRange("limits", nsLarge.Name).
+			WithValue("DefaultRequest", corev1.ResourceCPU, "3").Obj())
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, nsSmall)).To(gomega.Succeed())
+		gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, nsLarge)).To(gomega.Succeed())
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, nsSmall)).To(gomega.Succeed())
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, nsLarge)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, flavor, true)
+		fwk.StopManager(ctx)
+	})
+
+	ginkgo.It("reports two distinct hashes for raw-identical workloads under different defaults", func() {
+		wlSmall := utiltestingapi.MakeWorkload("one", nsSmall.Name).
+			Queue(kueue.LocalQueueName(lqSmall.Name)).
+			Obj()
+		wlLarge := utiltestingapi.MakeWorkload("two", nsLarge.Name).
+			Queue(kueue.LocalQueueName(lqLarge.Name)).
+			Obj()
+		util.MustCreate(ctx, k8sClient, wlSmall)
+		util.MustCreate(ctx, k8sClient, wlLarge)
+
+		// The hashes must follow the effective requests (1 vs 3 CPU), not the
+		// identical raw spec.
+		util.ExpectPendingSchedulingHashesMetric(clusterQueue, 0, 2)
 	})
 })


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

First step of the phasing agreed in #14964: tighten the test net around the
current effective-resource behaviors before moving any code.

The spec pins that a workload whose accounting depends on the adjustments
(limits copied into missing requests, RuntimeClass overhead) keeps its
admission and its booked usage across a manager restart — the path where all
in-memory state is rebuilt from the raw objects, and the one the migration
will rewrite. The ordering interaction between the LimitRange defaults and
the limits copy is already pinned by the spec added in #15023.

#### Which issue(s) this PR fixes:

Part of #14964

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

---

Written with AI assistance (Claude); I reviewed the spec design and verified
it against the full controller/core suite (82/82).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration coverage verifying that workload resource accounting remains accurate after a manager restart.
  * Added validation for pod overhead accounting and continued admission behavior.
  * Added coverage confirming that capacity limits prevent a new workload from being admitted when resources are reserved.
  * Added coverage confirming that scheduling decisions reflect effective resource requests and default values.
  * Added validation that existing assignments are preserved and workloads with different effective requests receive distinct scheduling identities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->