### PR TITLE
Add support for handling EffectiveQuotas in ClusterQueues

### DIFF
--- a/pkg/cache/queue/pending_workloads.go
+++ b/pkg/cache/queue/pending_workloads.go
@@ -262,7 +262,7 @@ func (p *PendingWorkloads) subtractPendingResources(wInfo *workload.Info) {
 
 // UpdateConfiguredResources seeds pendingResourcesTotal with 0 for newly configured
 // resources so they appear in metrics even when no workloads are pending, and prunes
-// zero entries for resources removed from the spec.
+// zero entries for resources removed from the effective resource groups.
 func (p *PendingWorkloads) UpdateConfiguredResources(apiCQ *kueue.ClusterQueue) {
 	p.Lock()
 	defer p.Unlock()

--- a/pkg/cache/scheduler/clusterqueue_test.go
+++ b/pkg/cache/scheduler/clusterqueue_test.go
@@ -25,7 +25,9 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	tasindexer "sigs.k8s.io/kueue/pkg/controller/tas/indexer"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/metrics"
+	"sigs.k8s.io/kueue/pkg/resources"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 )
@@ -647,5 +649,61 @@ func TestClusterQueueReadinessWithTAS(t *testing.T) {
 				t.Errorf("Unexpected inactiveMessage (-want,+got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestClusterQueueEffectiveQuotasUpdateAndFallback(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.DynamicQuotaOrchestration, true)
+	ctx, log := utiltesting.ContextWithLog(t)
+	cache := New(utiltesting.NewFakeClient())
+
+	cqSpec := utiltestingapi.MakeClusterQueue("cq-eff").
+		ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "5").Obj(),
+		).Obj()
+
+	if err := cache.AddClusterQueue(ctx, cqSpec); err != nil {
+		t.Fatalf("failed to add CQ to cache: %v", err)
+	}
+
+	cqObj := cache.hm.ClusterQueue("cq-eff")
+	if cqObj == nil {
+		t.Fatalf("expected clusterqueue cq-eff in cache")
+	}
+
+	fr := resources.FlavorResource{Flavor: "default", Resource: corev1.ResourceCPU}
+	if q := cqObj.resourceNode.Quotas[fr]; q.Nominal != resources.NewAmount(5000) {
+		t.Errorf("expected nominal quota 5000 from spec, got %v", q.Nominal)
+	}
+
+	cqEffective := utiltestingapi.MakeClusterQueue("cq-eff").
+		ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "5").Obj(),
+		).
+		EffectiveQuotas(
+			*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "10").Obj(),
+		).Obj()
+
+	if err := cache.UpdateClusterQueue(log, cqEffective); err != nil {
+		t.Fatalf("failed to update CQ in cache: %v", err)
+	}
+
+	cqObj = cache.hm.ClusterQueue("cq-eff")
+	if q := cqObj.resourceNode.Quotas[fr]; q.Nominal != resources.NewAmount(10000) {
+		t.Errorf("expected nominal quota 10000 from EffectiveQuotas, got %v", q.Nominal)
+	}
+
+	cqCleared := utiltestingapi.MakeClusterQueue("cq-eff").
+		ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "5").Obj(),
+		).Obj()
+
+	if err := cache.UpdateClusterQueue(log, cqCleared); err != nil {
+		t.Fatalf("failed to update CQ in cache: %v", err)
+	}
+
+	cqObj = cache.hm.ClusterQueue("cq-eff")
+	if q := cqObj.resourceNode.Quotas[fr]; q.Nominal != resources.NewAmount(5000) {
+		t.Errorf("expected nominal quota 5000 after clearing EffectiveQuotas, got %v", q.Nominal)
 	}
 }

--- a/pkg/controller/core/clusterqueue_controller.go
+++ b/pkg/controller/core/clusterqueue_controller.go
@@ -50,6 +50,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/metrics"
+	"sigs.k8s.io/kueue/pkg/util/resourcegroups"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
@@ -381,7 +382,8 @@ func (r *ClusterQueueReconciler) Update(e event.TypedUpdateEvent[*kueue.ClusterQ
 		return true
 	}
 	defer r.notifyWatchers(e.ObjectOld, e.ObjectNew)
-	specUpdated := !equality.Semantic.DeepEqual(e.ObjectOld.Spec, e.ObjectNew.Spec)
+	specOrQuotaUpdated := !equality.Semantic.DeepEqual(e.ObjectOld.Spec, e.ObjectNew.Spec) ||
+		!equality.Semantic.DeepEqual(resourcegroups.EffectiveResourceGroups(e.ObjectOld), resourcegroups.EffectiveResourceGroups(e.ObjectNew))
 
 	var labelsUpdated bool
 	if features.Enabled(features.CustomMetricLabels) {
@@ -394,7 +396,7 @@ func (r *ClusterQueueReconciler) Update(e event.TypedUpdateEvent[*kueue.ClusterQ
 	if err := r.cache.UpdateClusterQueue(log, e.ObjectNew); err != nil {
 		log.Error(err, "Failed to update clusterQueue in cache")
 	}
-	if err := r.qManager.UpdateClusterQueue(e.ObjectNew, specUpdated); err != nil {
+	if err := r.qManager.UpdateClusterQueue(e.ObjectNew, specOrQuotaUpdated); err != nil {
 		log.Error(err, "Failed to update clusterQueue in queue manager")
 	}
 

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -619,6 +619,11 @@ const (
 	// Note: This feature can be promoted to "beta" once https://github.com/kubernetes-sigs/kueue/issues/14543
 	// is fixed because it might boost chances for issue #14543 to appear.
 	FairSharingReevaluatePreemptionCandidates featuregate.Feature = "FairSharingReevaluatePreemptionCandidates"
+
+	// owner: @j-skiba
+	//
+	// Enables Dynamic Quota Orchestration and respecting Effective Quota in ClusterQueue/Cohort status.
+	DynamicQuotaOrchestration featuregate.Feature = "DynamicQuotaOrchestration"
 )
 
 func init() {
@@ -956,6 +961,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 
 	FairSharingReevaluatePreemptionCandidates: {
+		{Version: version.MustParse("0.20"), Default: false, PreRelease: featuregate.Alpha},
+	},
+
+	DynamicQuotaOrchestration: {
 		{Version: version.MustParse("0.20"), Default: false, PreRelease: featuregate.Alpha},
 	},
 }

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -7188,6 +7188,111 @@ func TestSchedule(t *testing.T) {
 				"hash-cq": {"default/wl-head"},
 			},
 		},
+		"admit workload using EffectiveQuotas when DynamicQuotaOrchestration is enabled": {
+			featureGates: map[featuregate.Feature]bool{features.DynamicQuotaOrchestration: true},
+			additionalClusterQueues: []kueue.ClusterQueue{
+				*utiltestingapi.MakeClusterQueue("eff-cq").
+					NamespaceSelector(&metav1.LabelSelector{}).
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "1").Obj()).
+					EffectiveQuotas(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "10").Obj()).
+					Obj(),
+			},
+			additionalLocalQueues: []kueue.LocalQueue{
+				*utiltestingapi.MakeLocalQueue("eff-queue", "default").ClusterQueue("eff-cq").Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("eff-wl", "default").
+					Queue("eff-queue").
+					PodSets(*utiltestingapi.MakePodSet("ps", 1).Request(corev1.ResourceCPU, "5").Obj()).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("eff-wl", "default").
+					Queue("eff-queue").
+					PodSets(*utiltestingapi.MakePodSet("ps", 1).Request(corev1.ResourceCPU, "5").Obj()).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionTrue,
+						Reason:             "QuotaReserved",
+						Message:            "Quota reserved in ClusterQueue eff-cq",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Admitted",
+						Message:            "The workload is admitted",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Admission(utiltestingapi.MakeAdmission("eff-cq").
+						PodSets(utiltestingapi.MakePodSetAssignment("ps").
+							Assignment(corev1.ResourceCPU, "default", "5").
+							Count(1).
+							Obj()).
+						Obj()).
+					Obj(),
+			},
+			wantAssignments: map[workload.Reference]kueue.Admission{
+				workload.Key(utiltestingapi.MakeWorkload("eff-wl", "default").Obj()): *utiltestingapi.MakeAdmission("eff-cq").
+					PodSets(utiltestingapi.MakePodSetAssignment("ps").
+						Assignment(corev1.ResourceCPU, "default", "5").
+						Count(1).
+						Obj()).
+					Obj(),
+			},
+		},
+		"ignore EffectiveQuotas when DynamicQuotaOrchestration is disabled": {
+			featureGates: map[featuregate.Feature]bool{features.DynamicQuotaOrchestration: false},
+			additionalClusterQueues: []kueue.ClusterQueue{
+				*utiltestingapi.MakeClusterQueue("eff-cq-disabled").
+					NamespaceSelector(&metav1.LabelSelector{}).
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "1").Obj()).
+					EffectiveQuotas(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "10").Obj()).
+					Obj(),
+			},
+			additionalLocalQueues: []kueue.LocalQueue{
+				*utiltestingapi.MakeLocalQueue("eff-queue-disabled", "default").ClusterQueue("eff-cq-disabled").Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("eff-wl-disabled", "default").
+					Queue("eff-queue-disabled").
+					PodSets(*utiltestingapi.MakePodSet("ps", 1).Request(corev1.ResourceCPU, "5").Obj()).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("eff-wl-disabled", "default").
+					Queue("eff-queue-disabled").
+					PodSets(*utiltestingapi.MakePodSet("ps", 1).Request(corev1.ResourceCPU, "5").Obj()).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadQuotaReservedReasonExceedsMaxQuota,
+						Message:            "couldn't assign flavors to pod set ps: insufficient quota for cpu in flavor default, previously considered podsets requests (0) + current podset request (5) > maximum capacity (1)",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadAdmittedReasonNoReservation,
+						Message:            "The workload has no reservation",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "ps",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("5"),
+						},
+					}).
+					Obj(),
+			},
+			wantInadmissibleLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+				"eff-cq-disabled": {"default/eff-wl-disabled"},
+			},
+		},
 	}
 	runScheduleTestCases(t, scheduleTestConfig{
 		queues:          queues,

--- a/pkg/util/resourcegroups/effective.go
+++ b/pkg/util/resourcegroups/effective.go
@@ -18,12 +18,17 @@ package resourcegroups
 
 import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
 )
 
-// EffectiveResourceGroups returns Spec.ResourceGroups.
+// EffectiveResourceGroups returns Status.EffectiveQuotas.ResourceGroups when DynamicQuotaOrchestration
+// feature gate is enabled and effective quota is set; otherwise returns Spec.ResourceGroups.
 func EffectiveResourceGroups(cq *kueue.ClusterQueue) []kueue.ResourceGroup {
 	if cq == nil {
 		return nil
+	}
+	if features.Enabled(features.DynamicQuotaOrchestration) && cq.Status.EffectiveQuotas != nil {
+		return cq.Status.EffectiveQuotas.ResourceGroups
 	}
 	return cq.Spec.ResourceGroups
 }

--- a/pkg/util/resourcegroups/effective_test.go
+++ b/pkg/util/resourcegroups/effective_test.go
@@ -23,17 +23,41 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 )
 
 func TestEffectiveResourceGroups(t *testing.T) {
 	specFlavor := utiltestingapi.MakeFlavorQuotas("spec-flavor").Resource(corev1.ResourceCPU, "10").FlavorQuotas
+	effectiveFlavor := utiltestingapi.MakeFlavorQuotas("effective-flavor").Resource(corev1.ResourceCPU, "20").FlavorQuotas
 
 	cases := map[string]struct {
-		cq      *kueue.ClusterQueue
-		wantRGs []kueue.ResourceGroup
+		dynamicQuota bool
+		cq           *kueue.ClusterQueue
+		wantRGs      []kueue.ResourceGroup
 	}{
-		"cluster queue returns spec resource groups": {
+		"DynamicQuotaOrchestration disabled returns spec": {
+			dynamicQuota: false,
+			cq: utiltestingapi.MakeClusterQueue("test-cq").
+				ResourceGroup(specFlavor).
+				EffectiveQuotas(effectiveFlavor).
+				Obj(),
+			wantRGs: []kueue.ResourceGroup{
+				utiltestingapi.ResourceGroup(specFlavor),
+			},
+		},
+		"DynamicQuotaOrchestration enabled returns status effectiveQuotas when set": {
+			dynamicQuota: true,
+			cq: utiltestingapi.MakeClusterQueue("test-cq").
+				ResourceGroup(specFlavor).
+				EffectiveQuotas(effectiveFlavor).
+				Obj(),
+			wantRGs: []kueue.ResourceGroup{
+				utiltestingapi.ResourceGroup(effectiveFlavor),
+			},
+		},
+		"DynamicQuotaOrchestration enabled returns spec when effectiveQuotas is nil": {
+			dynamicQuota: true,
 			cq: utiltestingapi.MakeClusterQueue("test-cq").
 				ResourceGroup(specFlavor).
 				Obj(),
@@ -41,46 +65,28 @@ func TestEffectiveResourceGroups(t *testing.T) {
 				utiltestingapi.ResourceGroup(specFlavor),
 			},
 		},
+		"DynamicQuotaOrchestration enabled returns empty status effectiveQuotas when set to empty": {
+			dynamicQuota: true,
+			cq: func() *kueue.ClusterQueue {
+				cq := utiltestingapi.MakeClusterQueue("test-cq").ResourceGroup(specFlavor).Obj()
+				cq.Status.EffectiveQuotas = &kueue.EffectiveQuotaStatus{ResourceGroups: []kueue.ResourceGroup{}}
+				return cq
+			}(),
+			wantRGs: []kueue.ResourceGroup{},
+		},
 		"nil cluster queue returns nil": {
-			cq:      nil,
-			wantRGs: nil,
+			dynamicQuota: true,
+			cq:           nil,
+			wantRGs:      nil,
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.DynamicQuotaOrchestration, tc.dynamicQuota)
+
 			if diff := cmp.Diff(tc.wantRGs, EffectiveResourceGroups(tc.cq)); diff != "" {
 				t.Errorf("Unexpected EffectiveResourceGroups (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestEffectiveCohortResourceGroups(t *testing.T) {
-	specFlavor := utiltestingapi.MakeFlavorQuotas("spec-flavor").Resource(corev1.ResourceCPU, "10").FlavorQuotas
-
-	cases := map[string]struct {
-		cohort  *kueue.Cohort
-		wantRGs []kueue.ResourceGroup
-	}{
-		"cohort returns spec resource groups": {
-			cohort: utiltestingapi.MakeCohort("test-cohort").
-				ResourceGroup(specFlavor).
-				Obj(),
-			wantRGs: []kueue.ResourceGroup{
-				utiltestingapi.ResourceGroup(specFlavor),
-			},
-		},
-		"nil cohort returns nil": {
-			cohort:  nil,
-			wantRGs: nil,
-		},
-	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			if diff := cmp.Diff(tc.wantRGs, EffectiveCohortResourceGroups(tc.cohort)); diff != "" {
-				t.Errorf("Unexpected EffectiveCohortResourceGroups (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -57,6 +57,12 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.19"
+- name: DynamicQuotaOrchestration
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.20"
 - name: ElasticJobsViaWorkloadSlices
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -57,6 +57,12 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.19"
+- name: DynamicQuotaOrchestration
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.20"
 - name: ElasticJobsViaWorkloadSlices
   versionedSpecs:
   - default: false

--- a/test/integration/singlecluster/scheduler/scheduler_dynamicquota_test.go
+++ b/test/integration/singlecluster/scheduler/scheduler_dynamicquota_test.go
@@ -1,0 +1,214 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"context"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var _ = ginkgo.Describe("Scheduler DynamicQuotaOrchestration", ginkgo.Ordered, func() {
+	var (
+		ns           *corev1.Namespace
+		flavor       *kueue.ResourceFlavor
+		clusterQueue *kueue.ClusterQueue
+		localQueue   *kueue.LocalQueue
+	)
+
+	ginkgo.BeforeEach(func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.DynamicQuotaOrchestration, true)
+
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "dynquota-")
+
+		flavor = utiltestingapi.MakeResourceFlavor("dynquota-flavor").Obj()
+		util.MustCreate(ctx, k8sClient, flavor)
+
+		clusterQueue = utiltestingapi.MakeClusterQueue("dynquota-cq").
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas(flavor.Name).
+				Resource(corev1.ResourceCPU, "1").
+				Obj()).
+			Obj()
+		util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, clusterQueue)
+
+		localQueue = utiltestingapi.MakeLocalQueue("dynquota-lq", ns.Name).
+			ClusterQueue(clusterQueue.Name).
+			Obj()
+		util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueue)
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+		gomega.Expect(util.DeleteObject(ctx, k8sClient, localQueue)).Should(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, flavor, true)
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+	})
+
+	ginkgo.It("should admit pending workloads when EffectiveQuotas status is updated with quota", func() {
+		wl := utiltestingapi.MakeWorkload("wl1", ns.Name).
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			Request(corev1.ResourceCPU, "2").
+			Obj()
+
+		ginkgo.By("creating a workload when spec quota is 1 CPU (requesting 2 CPU)", func() {
+			util.MustCreate(ctx, k8sClient, wl)
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, wl)
+		})
+
+		ginkgo.By("updating ClusterQueue status with EffectiveQuotas providing 5 CPU", func() {
+			updateCQEffectiveQuotas(ctx, k8sClient, clusterQueue, flavor, "5", "dqo-test")
+		})
+
+		ginkgo.By("verifying the pending workload is scheduled and admitted", func() {
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+		})
+
+		ginkgo.By("creating a second workload that fits within remaining EffectiveQuotas", func() {
+			wl2 := utiltestingapi.MakeWorkload("wl2", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				Request(corev1.ResourceCPU, "2").
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl2)
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl2)
+		})
+
+		ginkgo.By("creating a third workload that exceeds remaining EffectiveQuotas", func() {
+			wl3 := utiltestingapi.MakeWorkload("wl3", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				Request(corev1.ResourceCPU, "2").
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl3)
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, wl3)
+		})
+	})
+
+	ginkgo.It("should fallback to spec when EffectiveQuotas status is cleared", func() {
+		ginkgo.By("populating EffectiveQuotas to allow initial admission", func() {
+			updateCQEffectiveQuotas(ctx, k8sClient, clusterQueue, flavor, "5", "dqo-test")
+
+			wl1 := utiltestingapi.MakeWorkload("wl1", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				Request(corev1.ResourceCPU, "2").
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl1)
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+		})
+
+		ginkgo.By("clearing EffectiveQuotas in status", func() {
+			updateCQEffectiveQuotas(ctx, k8sClient, clusterQueue, flavor, "", "")
+		})
+
+		ginkgo.By("verifying subsequent workload falls back to spec and stays pending", func() {
+			wl2 := utiltestingapi.MakeWorkload("wl2", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				Request(corev1.ResourceCPU, "2").
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl2)
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, wl2)
+		})
+	})
+
+	ginkgo.It("should ignore EffectiveQuotas status when DynamicQuotaOrchestration feature gate is disabled", func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.DynamicQuotaOrchestration, false)
+
+		updateCQEffectiveQuotas(ctx, k8sClient, clusterQueue, flavor, "5", "dqo-test")
+
+		wl := utiltestingapi.MakeWorkload("wl-fg-disabled", ns.Name).
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			Request(corev1.ResourceCPU, "2").
+			Obj()
+		util.MustCreate(ctx, k8sClient, wl)
+		util.ExpectWorkloadsToBePending(ctx, k8sClient, wl)
+	})
+
+	ginkgo.It("should adjust scheduling capacity dynamically when EffectiveQuotas is reduced", func() {
+		ginkgo.By("setting initial EffectiveQuotas of 10 CPU", func() {
+			updateCQEffectiveQuotas(ctx, k8sClient, clusterQueue, flavor, "10", "dqo-test")
+		})
+
+		wl1 := utiltestingapi.MakeWorkload("wl1-reduction", ns.Name).
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			Request(corev1.ResourceCPU, "4").
+			Obj()
+		util.MustCreate(ctx, k8sClient, wl1)
+		util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+
+		ginkgo.By("reducing EffectiveQuotas to 5 CPU while wl1 is running", func() {
+			updateCQEffectiveQuotas(ctx, k8sClient, clusterQueue, flavor, "5", "dqo-test")
+		})
+
+		ginkgo.By("verifying running workload wl1 remains admitted", func() {
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+		})
+
+		ginkgo.By("verifying a new workload fitting within remaining reduced capacity is admitted", func() {
+			wlFitting := utiltestingapi.MakeWorkload("wl-fitting", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				Request(corev1.ResourceCPU, "1").
+				Obj()
+			util.MustCreate(ctx, k8sClient, wlFitting)
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlFitting)
+		})
+
+		ginkgo.By("verifying a new workload exceeding reduced EffectiveQuotas stays pending", func() {
+			wl2 := utiltestingapi.MakeWorkload("wl2-reduction", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				Request(corev1.ResourceCPU, "2").
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl2)
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, wl2)
+		})
+	})
+})
+
+func updateCQEffectiveQuotas(ctx context.Context, k8sClient client.Client, cq *kueue.ClusterQueue, flavor *kueue.ResourceFlavor, cpuQty, orchestratorName string) {
+	gomega.Eventually(func(g gomega.Gomega) {
+		var currentCQ kueue.ClusterQueue
+		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), &currentCQ)).To(gomega.Succeed())
+		currentCQ.Status.EffectiveQuotas = makeEffectiveQuotaStatus(flavor, cpuQty, orchestratorName)
+		g.Expect(k8sClient.Status().Update(ctx, &currentCQ)).To(gomega.Succeed())
+	}, util.Timeout, util.Interval).Should(gomega.Succeed())
+}
+
+func makeEffectiveQuotaStatus(flavor *kueue.ResourceFlavor, cpuQty, orchestratorName string) *kueue.EffectiveQuotaStatus {
+	if cpuQty == "" {
+		return nil
+	}
+	return &kueue.EffectiveQuotaStatus{
+		OrchestratorRef: kueue.EffectiveQuotaStatusOrchestratorRef{
+			APIGroup: "kueue.x-k8s.io",
+			Kind:     "DynamicQuotaOrchestrator",
+			Name:     orchestratorName,
+		},
+		ResourceGroups: []kueue.ResourceGroup{
+			utiltestingapi.ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas(flavor.Name).
+					Resource(corev1.ResourceCPU, cpuQty).
+					Obj(),
+			),
+		},
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Part of [KEP-12382: Dynamic Quota Orchestration](https://github.com/kubernetes-sigs/kueue/pull/14104).
This PR adds scheduling, caching, and controller support for `status.effectiveQuotas` ONLY on `ClusterQueue` under the new alpha feature gate `DynamicQuotaOrchestration`.

> [!NOTE]
> Support for `Cohort` effective quotas will follow in a separate PR.
> Changes for metrics will follow in a separate PR.

#### Which issue(s) this PR fixes:

Part of #12382

#### Special notes for your reviewer:

The remaining `ResourceGroups` references in the codebase (excluding test and cohort related files):

```bash
$ git grep -n "\.Spec\.ResourceGroups" -- 'pkg/**' 'cmd/**' ':(exclude)*_test.go' ':(exclude)*cohort*'
cmd/importer/cache/cache.go:117:        rgs := make([]resourcegroups.ResourceGroup, 0, len(cq.Spec.ResourceGroups))
cmd/importer/cache/cache.go:118:        for _, rg := range cq.Spec.ResourceGroups {
cmd/importer/pod/check.go:106:  if len(cq.Spec.ResourceGroups) == 0 {
cmd/kueueviz/backend/handlers/cluster_queues.go:69:             for _, rg := range item.Spec.ResourceGroups {
cmd/kueueviz/backend/handlers/cluster_queues.go:79:                     "resourceGroups":     convertResourceGroups(item.Spec.ResourceGroups),
cmd/kueueviz/backend/handlers/cluster_queues.go:128:                    "resourceGroups":    convertResourceGroups(cq.Spec.ResourceGroups),
cmd/kueueviz/backend/handlers/resource_flavors.go:100:          resourceGroups := item.Spec.ResourceGroups
pkg/cache/scheduler/clusterqueue_metrics.go:54: for rgi := range oldCq.Spec.ResourceGroups {
pkg/cache/scheduler/clusterqueue_metrics.go:55:         oldRg := &oldCq.Spec.ResourceGroups[rgi]
pkg/controller/admissionchecks/multikueue/clusterqueue.go:105:  if len(cq.Spec.ResourceGroups) != 1 || len(cq.Spec.ResourceGroups[0].Flavors) != 1 {
pkg/controller/admissionchecks/multikueue/clusterqueue.go:115:  singleFlavor := &cq.Spec.ResourceGroups[0].Flavors[0]
pkg/controller/admissionchecks/multikueue/clusterqueue.go:122:  covered := sets.New(cq.Spec.ResourceGroups[0].CoveredResources...)
pkg/controller/admissionchecks/multikueue/clusterqueue.go:132:  for _, resName := range cq.Spec.ResourceGroups[0].CoveredResources {
pkg/controller/admissionchecks/multikueue/clusterqueue.go:220:                  for _, rg := range rcq.Spec.ResourceGroups {
pkg/controller/admissionchecks/multikueue/multikueuecluster.go:528:                     if ok1 && ok2 && !equality.Semantic.DeepEqual(oldCQ.Spec.ResourceGroups, newCQ.Spec.ResourceGroups) {
pkg/util/resourcegroups/effective.go:33:        return cq.Spec.ResourceGroups
pkg/util/testing/v1beta2/wrappers.go:934:       c.Spec.ResourceGroups = append(c.Spec.ResourceGroups, ResourceGroup(flavors...))
pkg/util/testing/v1beta2/wrappers.go:1086:      c.Spec.ResourceGroups = append(c.Spec.ResourceGroups, ResourceGroup(flavors...))
pkg/webhooks/clusterqueue_webhook.go:121:       allErrs = append(allErrs, validateResourceGroups(cq.Spec.ResourceGroups, config, path.Child("resourceGroups"), false)...)
pkg/webhooks/clusterqueue_webhook.go:131:       allErrs = append(allErrs, validateTotalFlavors(cq.Spec.ResourceGroups, path.Child("resourceGroups"))...)
pkg/webhooks/clusterqueue_webhook.go:132:       allErrs = append(allErrs, validateTotalCoveredResources(cq.Spec.ResourceGroups, path.Child("resourceGroups"))...)
pkg/webhooks/clusterqueue_webhook.go:133:       allErrs = append(allErrs, validateFlavorResourceCombinations(cq.Spec.ResourceGroups, path.Child("resourceGroups"))...)
pkg/webhooks/clusterqueue_webhook.go:146:               newFlavors := utilqueue.AllFlavors(newCQ.Spec.ResourceGroups)
pkg/webhooks/clusterqueue_webhook.go:148:                       utilqueue.AllFlavors(oldCQ.Spec.ResourceGroups).Equal(newFlavors) {
pkg/webhooks/clusterqueue_webhook.go:165:       validFlavors := utilqueue.AllFlavors(cq.Spec.ResourceGroups)
pkg/webhooks/clusterqueue_webhook.go:240:       if len(cq.Spec.ResourceGroups) != 1 {
pkg/webhooks/clusterqueue_webhook.go:241:               allErrs = append(allErrs, field.Invalid(path.Child("resourceGroups"), len(cq.Spec.ResourceGroups),
pkg/webhooks/clusterqueue_webhook.go:245:       if len(cq.Spec.ResourceGroups) == 1 && len(cq.Spec.ResourceGroups[0].Flavors) > 16 {
pkg/webhooks/clusterqueue_webhook.go:246:               allErrs = append(allErrs, field.Invalid(path.Child("resourceGroups").Index(0).Child("flavors"), len(cq.Spec.ResourceGroups[0].Flavors),
pkg/webhooks/clusterqueue_webhook.go:259:                       validFlavors := utilqueue.AllFlavors(cq.Spec.ResourceGroups)
```

My reasoning for not replacing the remaining references:
- `pkg/controller/admissionchecks/multikueue/*` - it will be replaced by DQO so in my understanding we don't want to mix up two separate features
- `cmd/*` support for `EffectiveQuotas` in any of these should be developed separately in dedicated PRs. Like kueueviz, maybe we would add a separate field or something like this, tbd
- `pkg/webhooks/*` - these validate spec while `EffectiveQuotas` live in `status`

> AI assistance was used during the authoring and refinement of this PR.

#### Does this PR introduce a user-facing change?

```release-note
DynamicQuotaOrchestration: Supported `status.effectiveQuotas` in ClusterQueue scheduling and controllers under the `DynamicQuotaOrchestration` feature gate, falling back to `spec.resourceGroups` when unset or disabled.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an alpha **Dynamic Quota Orchestration** feature gate, disabled by default.
  * When enabled, scheduling can use updated effective quotas to admit workloads and adjust available capacity without changing configured quotas.
  * Scheduling falls back to configured quotas when effective quota information is unavailable or cleared.

* **Bug Fixes**
  * Cluster queue updates now respond to effective quota changes, keeping scheduling decisions and resource metrics current.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->