### PR TITLE
TAS: add feature gate for strict prebuilt workload equivalence (#15009)

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1498,7 +1498,7 @@ func EquivalentToWorkload(ctx context.Context, c client.Client, job GenericJob, 
 	if workload.IsAdmitted(wl) {
 		opts = append(opts, equality.WithIgnoreTolerations())
 	}
-	if !features.Enabled(features.TopologyAwareScheduling) {
+	if !features.Enabled(features.TASWithStrictPrebuiltWorkloadEquivalence) {
 		opts = append(opts, equality.WithIgnoreTopologyRequest())
 	}
 

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -180,6 +180,12 @@ const (
 	// Enable grouping v1beta2 TopologyAssignments by reusable hostname prefixes.
 	TASAssignmentsEncodingByHostnamePrefix featuregate.Feature = "TASAssignmentsEncodingByHostnamePrefix"
 
+	// owner: @sohankunkerkar
+	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/2724-topology-aware-scheduling
+	//
+	// Strict equivalence checks between a Job or single Pod and a prebuilt Workload when TAS is used.
+	TASWithStrictPrebuiltWorkloadEquivalence featuregate.Feature = "TASWithStrictPrebuiltWorkloadEquivalence"
+
 	// owner: @alaypatel07
 	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/2941-DRA
 	//
@@ -635,6 +641,7 @@ var defaultFeatureGateDependencies = map[featuregate.Feature][]featuregate.Featu
 	TASReplaceNodeOnNodeTaints:                   {TopologyAwareScheduling},
 	TASMultiLayerTopology:                        {TopologyAwareScheduling},
 	TASRespectNodeAffinityPreferred:              {TopologyAwareScheduling},
+	TASWithStrictPrebuiltWorkloadEquivalence:     {TopologyAwareScheduling},
 	UnadmittedWorkloadsExplicitStatus:            {UnadmittedWorkloadsObservability},
 	TASHandleOverlappingFlavors:                  {TopologyAwareScheduling},
 	TASProfileMixed:                              {TopologyAwareScheduling},
@@ -739,6 +746,9 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 	TASAssignmentsEncodingByHostnamePrefix: {
 		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Beta},
+	},
+	TASWithStrictPrebuiltWorkloadEquivalence: {
+		{Version: version.MustParse("0.20"), Default: false, PreRelease: featuregate.Alpha},
 	},
 	KueueDRAIntegration: {
 		{Version: version.MustParse("0.18"), Default: true, PreRelease: featuregate.Beta},

--- a/site/content/en/docs/concepts/topology_aware_scheduling.md
+++ b/site/content/en/docs/concepts/topology_aware_scheduling.md
@@ -445,6 +445,22 @@ outer slice size.
 This annotation is mutually exclusive with `kueue.x-k8s.io/podset-slice-required-topology`
 and `kueue.x-k8s.io/podset-slice-size`.
 
+### Strict prebuilt Workload equivalence
+{{< feature-state state="alpha" for_version="v0.20" >}}
+{{% alert title="Note" color="primary" %}}
+`TASWithStrictPrebuiltWorkloadEquivalence` is currently an alpha feature and is disabled by default.
+
+You can enable it by editing the `TASWithStrictPrebuiltWorkloadEquivalence` feature gate. Refer to the
+[Installation guide](/docs/installation/#change-the-feature-gates-configuration)
+for instructions on configuring feature gates.
+{{% /alert %}}
+
+When using prebuilt Workloads with Topology-Aware Scheduling, Jobs and Pods automatically derive indexing metadata (such as `batch.kubernetes.io/job-completion-index` for Jobs or `kueue.x-k8s.io/pod-group-pod-index` for Pods) into their `PodSet.TopologyRequest`.
+
+When `TASWithStrictPrebuiltWorkloadEquivalence` is disabled (default), Kueue maintains backward compatibility by ignoring `TopologyRequest` differences during prebuilt Workload equivalence checks, allowing hand-written prebuilt Workloads that omit the derived index label to match.
+
+When `TASWithStrictPrebuiltWorkloadEquivalence` is enabled, Kueue strictly verifies that the prebuilt Workload's complete `TopologyRequest` matches the Job or Pod's request. Any mismatched prebuilt Workload will be marked as `OutOfSync`. To migrate hand-written prebuilt Workloads when enabling this gate, ensure that the prebuilt Workload's `PodSet.TopologyRequest` specifies the exact topology level and indexing field (e.g. `podIndexLabel: "batch.kubernetes.io/job-completion-index"` for Jobs).
+
 ## Drawbacks
 
 When enabling the feature Kueue starts to keep track of all Pods and all nodes

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -523,6 +523,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.20"
+- name: TASWithStrictPrebuiltWorkloadEquivalence
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.20"
 - name: TLSOptions
   versionedSpecs:
   - default: true

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -523,6 +523,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.20"
+- name: TASWithStrictPrebuiltWorkloadEquivalence
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.20"
 - name: TLSOptions
   versionedSpecs:
   - default: true

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -3917,7 +3917,7 @@ var _ = ginkgo.Describe("Job controller with TopologyAwareScheduling", ginkgo.Or
 		})
 	})
 
-	ginkgo.It("should finish a prebuilt workload whose topology request differs from the job as OutOfSync", func() {
+	ginkgo.It("should adopt a prebuilt workload omitting podIndexLabel when TASWithStrictPrebuiltWorkloadEquivalence is disabled", func() {
 		container := corev1.Container{
 			Name:  "c",
 			Image: "pause",
@@ -3927,9 +3927,56 @@ var _ = ginkgo.Describe("Job controller with TopologyAwareScheduling", ginkgo.Or
 			Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
 		}
 
-		job := testingjob.MakeJob("job", ns.Name).
+		job := testingjob.MakeJob("job-compat", ns.Name).
 			Queue(kueue.LocalQueueName(localQueue.Name)).
-			PrebuiltWorkloadLabel("prebuilt-wl").
+			PrebuiltWorkloadLabel("prebuilt-wl-compat").
+			PodAnnotation(kueue.PodSetRequiredTopologyAnnotation, tasBlockLabel).
+			Containers(*container.DeepCopy()).
+			Obj()
+
+		wl := utiltestingapi.MakeWorkload("prebuilt-wl-compat", ns.Name).
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+				Containers(*container.DeepCopy()).
+				RequiredTopologyRequest(tasBlockLabel).
+				Obj()).
+			Obj()
+		ginkgo.By("creating a matching prebuilt workload which omits podIndexLabel", func() {
+			util.MustCreate(ctx, k8sClient, wl)
+		})
+
+		ginkgo.By("creating a job which requires block and references the prebuilt workload", func() {
+			util.MustCreate(ctx, k8sClient, job)
+		})
+
+		ginkgo.By("verify the prebuilt workload is admitted", func() {
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+		})
+
+		ginkgo.By("verify the job is unsuspended", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				createdJob := batchv1.Job{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), &createdJob)).To(gomega.Succeed())
+				g.Expect(ptr.Deref(createdJob.Spec.Suspend, true)).To(gomega.BeFalse())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+
+	ginkgo.It("should finish a prebuilt workload whose topology request differs from the job as OutOfSync when TASWithStrictPrebuiltWorkloadEquivalence is enabled", func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.TASWithStrictPrebuiltWorkloadEquivalence, true)
+
+		container := corev1.Container{
+			Name:  "c",
+			Image: "pause",
+		}
+		testingjob.SetContainerDefaults(&container)
+		container.Resources = corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+		}
+
+		job := testingjob.MakeJob("job-strict", ns.Name).
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			PrebuiltWorkloadLabel("prebuilt-wl-strict").
 			PodAnnotation(kueue.PodSetRequiredTopologyAnnotation, tasBlockLabel).
 			Containers(*container.DeepCopy()).
 			Obj()
@@ -3937,13 +3984,13 @@ var _ = ginkgo.Describe("Job controller with TopologyAwareScheduling", ginkgo.Or
 			util.MustCreate(ctx, k8sClient, job)
 		})
 
-		wl := utiltestingapi.MakeWorkload("prebuilt-wl", ns.Name).
+		wl := utiltestingapi.MakeWorkload("prebuilt-wl-strict", ns.Name).
 			PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 				Containers(*container.DeepCopy()).
 				PreferredTopologyRequest(tasBlockLabel).
 				Obj()).
 			Obj()
-		ginkgo.By("creating a matching prebuilt workload which only prefers block", func() {
+		ginkgo.By("creating a mismatched prebuilt workload which only prefers block", func() {
 			util.MustCreate(ctx, k8sClient, wl)
 		})
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area tas

#### What this PR does / why we need it:

Strict comparison of complete `PodSet.TopologyRequest` values is a behavior change. A Job derives `podIndexLabel` when a topology annotation is present. Previously, a hand-written prebuilt Workload that had the same required topology level but omitted `podIndexLabel` could match and start.

This PR introduces the `TASWithStrictPrebuiltWorkloadEquivalence` feature gate (Alpha, disabled by default) in v0.20:
- When disabled (default), backward compatibility is preserved: prebuilt Workloads that omit Job-derived `podIndexLabel` are matched and adopted.
- When enabled, strict equivalence is enforced: prebuilt Workloads with mismatched complete `TopologyRequest` are rejected and marked as `OutOfSync`.

#### Which issue(s) this PR fixes:

Fixes #15009

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Introduce the `TASWithStrictPrebuiltWorkloadEquivalence` alpha feature gate (disabled by default) to enable strict equivalence checking between Jobs/single Pods and prebuilt Workloads under TAS.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the alpha `TASWithStrictPrebuiltWorkloadEquivalence` feature gate, disabled by default.
  - When enabled, topology requests for prebuilt Workloads are checked strictly against Jobs and Pods; mismatches mark Workloads as `OutOfSync`.
  - When disabled, compatible prebuilt Workloads can continue to be adopted despite topology request differences.

- **Documentation**
  - Added guidance on strict prebuilt Workload equivalence, topology metadata, feature-gate behavior, and migration considerations.

- **Tests**
  - Added coverage for both strict and backward-compatible topology equivalence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->