### PR TITLE
Use NewInfoWithLogger at remaining production call sites

### DIFF
--- a/cmd/importer/pod/check.go
+++ b/cmd/importer/pod/check.go
@@ -134,7 +134,7 @@ func checkPodWorkload(ctx context.Context, c client.Client, importCache *cache.I
 	}
 	maps.Copy(wl.Labels, importCache.AddLabels)
 
-	info := workload.NewInfo(wl, importCache.WorkloadInfoOptions()...)
+	info := workload.NewInfoWithLogger(ctrl.LoggerFrom(ctx), wl, importCache.WorkloadInfoOptions()...)
 	flavors, err := flavorAssignmentsForRequests(importCache.FlavorsByResourceForClusterQueue(kueue.ClusterQueueReference(cq.Name)), cq.Name, info.TotalRequests[0].Requests)
 	if err != nil {
 		return nil, err

--- a/cmd/importer/pod/import.go
+++ b/cmd/importer/pod/import.go
@@ -201,7 +201,7 @@ func admitWorkload(
 ) error {
 	resourceFormatter := resources.NewResourceFormatter()
 	update := func(wl *kueue.Workload) (bool, error) {
-		info := workload.NewInfo(wl, workloadInfoOptions...)
+		info := workload.NewInfoWithLogger(ctrl.LoggerFrom(ctx), wl, workloadInfoOptions...)
 		admission := kueue.Admission{
 			ClusterQueue: kueue.ClusterQueueReference(cq.Name),
 			PodSetAssignments: []kueue.PodSetAssignment{

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -2081,7 +2081,7 @@ func (r *WorkloadReconciler) resolveGranularUnadmittedQuotaReservedCondition(
 			log.Error(err, "Invalid ClusterQueue NamespaceSelector", "clusterQueue", cq.Name)
 			return kueue.WorkloadQuotaReservedReasonMisconfigured, fmt.Sprintf("invalid namespace selector: %v", err), nil
 		}
-		wlInfo := workload.NewInfo(wl)
+		wlInfo := workload.NewInfoWithLogger(ctrl.LoggerFrom(ctx), wl)
 		admissibilityErr = workload.ValidateAdmissibility(ctx, r.client, wlInfo, selector)
 		if admissibilityErr != nil && errors.Is(admissibilityErr, workload.ErrInternal) {
 			return "", "", admissibilityErr


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Three remaining production call sites use `workload.NewInfo` even though they have a contextual logger available, so the V(5) scheduling hash log goes through `klog.Background()`. Switch them to `NewInfoWithLogger` so the log uses the caller's logger instead.

Kueue's binaries configure the controller-runtime logger but not klog, so these V(5) lines are currently not emitted. The hash values are unchanged.

After this change, there are no remaining production callers of `NewInfo`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #15053

#### Special notes for your reviewer:

#### Example log:

Captured from the `controller/core` integration suite at V(5), running the same Workload reconcile path before and after this change.

**Before:** the reconcile path emits no `Computed scheduling hash` line because it goes through `klog.Background()`.

**After:**

```
LEVEL(-5) workload-reconciler workload/workload.go:438 Computed scheduling hash
{"namespace":"core-workload-ns-selector-tjs49",
 "name":"wl-ns-mismatch",
 "reconcileID":"ddddc86f-702d-441a-a3d5-b264cf9b59b4",
 "hash":"a89f03b2466d027c", ...}
 ```
 
 The hash value is unchanged; the difference is that the hash can now be tied to a specific reconcile.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Observability: Scheduling hash re-computations are now logged at V5 via the contextual logger.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging context during workload import and admission checks.
  * Controller-related log messages now include the appropriate request context, making diagnostics more consistent without changing workload behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->