### PR TITLE
[release-0.18] Avoid redundant scheduling equivalence hash computations

### DIFF
--- a/pkg/cache/queue/manager_test.go
+++ b/pkg/cache/queue/manager_test.go
@@ -34,12 +34,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/metrics"
 	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
@@ -1201,6 +1204,99 @@ func hasInflight(c *ClusterQueue, key workload.Reference) bool {
 	c.rwm.RLock()
 	defer c.rwm.RUnlock()
 	return c.inflight != nil && workload.Key(c.inflight.Obj) == key
+}
+
+// TestRequeueWorkloadSchedulingHash covers the hash over the real requeue path.
+// The Info's hash is replaced with a probe value first, so that carrying it over
+// is distinguishable from recomputing the same value.
+func TestRequeueWorkloadSchedulingHash(t *testing.T) {
+	const probe = "probe-hash"
+
+	cases := map[string]struct {
+		// mutate stands in for an update the scheduler did not see.
+		mutate func(*kueue.Workload)
+		// seed isolates the requests half of the guard: it moves the effective
+		// requests while the Workload comes back at the same version.
+		seed      client.Object
+		wantReuse bool
+	}{
+		"an unchanged re-read keeps the hash": {
+			wantReuse: true,
+		},
+		"a re-read at a new version recomputes the hash": {
+			mutate: func(wl *kueue.Workload) { wl.Spec.Priority = ptr.To[int32](1) },
+		},
+		"a LimitRange default that moves the effective requests recomputes the hash": {
+			seed: utiltesting.MakeLimitRange("lr", "ns").WithType(corev1.LimitTypeContainer).
+				WithValue("DefaultRequest", corev1.ResourceMemory, "1Gi").Obj(),
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, map[featuregate.Feature]bool{
+				features.SchedulingEquivalenceHashing: true,
+			})
+			wl := utiltestingapi.MakeWorkload("wl", "ns").Queue("foo").
+				Request(corev1.ResourceCPU, "1").Obj()
+			cl := utiltesting.NewClientBuilder().
+				WithIndex(&corev1.LimitRange{}, indexer.LimitRangeHasContainerOrPodType, indexer.IndexLimitRangeHasContainerOrPodType).
+				Build()
+			ctx, log := utiltesting.ContextWithLog(t)
+			ctx, cancel := context.WithTimeout(ctx, headsTimeout)
+			defer cancel()
+
+			manager := NewManagerForUnitTests(cl, nil, WithPreemptionExpectations(preemptexpectations.New()))
+			if err := manager.AddClusterQueue(ctx, utiltestingapi.MakeClusterQueue("cq").Obj()); err != nil {
+				t.Fatalf("Failed adding cluster queue: %v", err)
+			}
+			if err := manager.AddLocalQueue(ctx, utiltestingapi.MakeLocalQueue("foo", "ns").ClusterQueue("cq").Obj()); err != nil {
+				t.Fatalf("Failed adding queue: %v", err)
+			}
+			if err := cl.Create(ctx, wl); err != nil {
+				t.Fatalf("Failed adding workload to client: %v", err)
+			}
+			if err := manager.AddOrUpdateWorkload(log, wl); err != nil {
+				t.Fatalf("Failed adding workload to queue: %v", err)
+			}
+
+			go manager.CleanUpOnContext(ctx)
+			heads := manager.Heads(ctx)
+			if len(heads) != 1 {
+				t.Fatalf("Heads returned %d workloads, want 1", len(heads))
+			}
+			info := &heads[0].Info
+
+			if tc.mutate != nil {
+				updated := wl.DeepCopy()
+				tc.mutate(updated)
+				if err := cl.Update(ctx, updated); err != nil {
+					t.Fatalf("Failed updating workload: %v", err)
+				}
+			}
+
+			if tc.seed != nil {
+				if err := cl.Create(ctx, tc.seed); err != nil {
+					t.Fatalf("Failed adding %T to client: %v", tc.seed, err)
+				}
+			}
+
+			info.SchedulingHash = probe
+			if !manager.RequeueWorkload(ctx, info, RequeueReasonGeneric, "") {
+				t.Fatal("RequeueWorkload did not requeue the workload")
+			}
+
+			if gotReuse := info.SchedulingHash == probe; gotReuse != tc.wantReuse {
+				t.Errorf("hash reused = %v, want %v (hash %q)", gotReuse, tc.wantReuse, info.SchedulingHash)
+			}
+			// A recomputed hash must describe the Info the queue now holds. The
+			// reuse cases cannot be checked this way: what they keep is the probe.
+			if !tc.wantReuse {
+				if want := workload.NewInfo(info.Obj).SchedulingHash; info.SchedulingHash != want {
+					t.Errorf("SchedulingHash = %q, want %q", info.SchedulingHash, want)
+				}
+			}
+		})
+	}
 }
 
 func TestRequeueWorkload(t *testing.T) {

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -370,9 +370,57 @@ func (i *Info) updateSchedulingHash(log logr.Logger) {
 // recomputes the scheduling hash. Pass WithPreserveTotalRequests to skip
 // the TotalRequests rebuild (e.g., to retain DRA preprocessing on requeue).
 func (i *Info) Update(log logr.Logger, wl *kueue.Workload, opts ...InfoOption) {
+	prev := i.snapshotHashInputs()
 	i.Obj = wl
 	i.rebuildTotalRequests(opts...)
-	i.updateSchedulingHash(log)
+	if i.shouldUpdateSchedulingHash(prev) {
+		i.updateSchedulingHash(log)
+	}
+}
+
+// schedulingHashInputs is what an Info's SchedulingHash was computed from,
+// snapshotted before the Info is updated in place.
+type schedulingHashInputs struct {
+	hash     string
+	obj      *kueue.Workload
+	requests []PodSetResources
+}
+
+func (i *Info) snapshotHashInputs() schedulingHashInputs {
+	return schedulingHashInputs{hash: i.SchedulingHash, obj: i.Obj, requests: i.TotalRequests}
+}
+
+// shouldUpdateSchedulingHash reports whether prev's hash is missing or no longer
+// describes the Info. The effective requests are re-derived from cluster state,
+// so the Workload's version cannot vouch for them and both inputs are checked.
+func (i *Info) shouldUpdateSchedulingHash(prev schedulingHashInputs) bool {
+	return prev.hash == "" ||
+		!prev.sameWorkloadVersion(i.Obj) ||
+		!sameHashedRequests(prev.requests, i.TotalRequests)
+}
+
+// sameWorkloadVersion reports whether wl is the version the hash was computed
+// from. ResourceVersion covers the whole object, which is what the hash reads:
+// status and annotations included, not just the spec.
+func (p schedulingHashInputs) sameWorkloadVersion(wl *kueue.Workload) bool {
+	return p.obj != nil &&
+		p.obj.UID == wl.UID &&
+		p.obj.ResourceVersion != "" &&
+		p.obj.ResourceVersion == wl.ResourceVersion
+}
+
+// sameHashedRequests compares only what the scheduling shape is built from:
+// PodSetResources carries more fields than the hash reads.
+func sameHashedRequests(prev, current []PodSetResources) bool {
+	if len(prev) != len(current) {
+		return false
+	}
+	for i := range prev {
+		if prev[i].Count != current[i].Count || !resources.Equal(prev[i].Requests, current[i].Requests) {
+			return false
+		}
+	}
+	return true
 }
 
 // rebuildTotalRequests refreshes ClusterQueue and recomputes TotalRequests

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
@@ -3836,6 +3837,148 @@ func TestSchedulingHash(t *testing.T) {
 			t.Errorf("expected different hashes after DRA translation, got same %q", before.SchedulingHash)
 		}
 	})
+}
+
+func TestUpdateSchedulingHashReuse(t *testing.T) {
+	features.SetFeatureGatesDuringTest(t, map[featuregate.Feature]bool{
+		features.SchedulingEquivalenceHashing: true,
+	})
+
+	// This helper hands back a different shape at an unchanged ResourceVersion,
+	// which production never does, so that reuse is observable. Only priority
+	// varies: the hash reads it, the effective requests do not.
+	workload := func(uid types.UID, rv string, priority int32) *kueue.Workload {
+		return utiltestingapi.MakeWorkload("wl", "ns").UID(uid).ResourceVersion(rv).
+			Priority(priority).Request(corev1.ResourceCPU, "1").Obj()
+	}
+	draWorkload := utiltestingapi.MakeWorkload("wl", "ns").UID("uid").ResourceVersion("1").
+		Request("example.com/gpu", "1").Obj()
+	draOptions := []InfoOption{WithPreprocessedDRAResources(
+		map[kueue.PodSetReference]corev1.ResourceList{
+			kueue.DefaultPodSetName: {"gpu": resource.MustParse("1")},
+		},
+		map[kueue.PodSetReference]sets.Set[corev1.ResourceName]{
+			kueue.DefaultPodSetName: sets.New[corev1.ResourceName]("example.com/gpu"),
+		},
+	)}
+
+	withoutHash := func(info *Info) *Info {
+		info.SchedulingHash = ""
+		return info
+	}
+
+	cases := map[string]struct {
+		info      *Info
+		reread    *kueue.Workload
+		opts      []InfoOption
+		wantReuse bool
+	}{
+		"same UID and ResourceVersion keeps the hash": {
+			info:      NewInfo(workload("uid", "1", 1)),
+			reread:    workload("uid", "1", 2),
+			wantReuse: true,
+		},
+		"changed ResourceVersion recomputes the hash": {
+			info:   NewInfo(workload("uid", "1", 1)),
+			reread: workload("uid", "2", 2),
+		},
+		"changed UID recomputes the hash": {
+			info:   NewInfo(workload("uid", "1", 1)),
+			reread: workload("other", "1", 2),
+		},
+		// Objects that never round-tripped through the API server share the
+		// empty ResourceVersion, which says nothing about their shape.
+		"absent ResourceVersion on both sides recomputes the hash": {
+			info:   NewInfo(workload("uid", "", 1)),
+			reread: workload("uid", "", 2),
+		},
+		"an Info holding no hash computes one": {
+			// Requests match, so only the missing hash can force the recompute.
+			info:   withoutHash(NewInfo(workload("uid", "1", 1))),
+			reread: workload("uid", "1", 2),
+		},
+		"an Info holding no object computes one": {
+			info:   &Info{SchedulingHash: "stale"},
+			reread: workload("uid", "1", 2),
+		},
+		// The requeue path carries DRA-preprocessed requests over deliberately,
+		// which leaves the version check to decide alone.
+		"preserved TotalRequests leave the decision to the version check": {
+			info: NewInfo(workload("uid", "1", 1)),
+			reread: utiltestingapi.MakeWorkload("wl", "ns").UID("uid").ResourceVersion("1").
+				Priority(2).Request(corev1.ResourceCPU, "2").Obj(),
+			opts:      []InfoOption{WithPreserveTotalRequests()},
+			wantReuse: true,
+		},
+		// The requeue path drops the DRA options when NeedsDRAReconcile turns
+		// false, which it can do at an unchanged ResourceVersion.
+		"dropped DRA preprocessing recomputes the hash": {
+			info:   NewInfo(draWorkload, draOptions...),
+			reread: draWorkload,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			before := tc.info.SchedulingHash
+			if before == SchedulingHashUnknown {
+				t.Fatalf("precondition failed: hash is %q", before)
+			}
+
+			tc.info.Update(logr.Discard(), tc.reread, tc.opts...)
+
+			if got := tc.info.SchedulingHash == before; got != tc.wantReuse {
+				t.Errorf("hash reused = %v, want %v (hash %q -> %q)", got, tc.wantReuse, before, tc.info.SchedulingHash)
+			}
+			// A recomputed hash must describe the inputs the Info now holds.
+			if !tc.wantReuse {
+				want := computeSchedulingHash(logr.Discard(), tc.info.Obj, tc.info.TotalRequests)
+				if tc.info.SchedulingHash != want {
+					t.Errorf("SchedulingHash = %q, does not describe the Info's own inputs (%q)", tc.info.SchedulingHash, want)
+				}
+			}
+		})
+	}
+
+	t.Run("the hash stays unknown while the feature gate is off", func(t *testing.T) {
+		features.SetFeatureGatesDuringTest(t, map[featuregate.Feature]bool{
+			features.SchedulingEquivalenceHashing: false,
+		})
+		info := NewInfo(workload("uid", "1", 1))
+		info.Update(logr.Discard(), workload("uid", "1", 2))
+		if info.SchedulingHash != SchedulingHashUnknown {
+			t.Errorf("SchedulingHash = %q, want %q", info.SchedulingHash, SchedulingHashUnknown)
+		}
+	})
+}
+
+func TestSameHashedRequests(t *testing.T) {
+	podSet := func(count int32, cpu int64) PodSetResources {
+		return PodSetResources{
+			Name:     kueue.DefaultPodSetName,
+			Count:    count,
+			Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: cpu}),
+		}
+	}
+
+	cases := map[string]struct {
+		prev, current []PodSetResources
+		want          bool
+	}{
+		"identical":            {prev: []PodSetResources{podSet(1, 1000)}, current: []PodSetResources{podSet(1, 1000)}, want: true},
+		"both empty":           {want: true},
+		"different count":      {prev: []PodSetResources{podSet(1, 1000)}, current: []PodSetResources{podSet(2, 1000)}},
+		"different requests":   {prev: []PodSetResources{podSet(1, 1000)}, current: []PodSetResources{podSet(1, 2000)}},
+		"a PodSet was added":   {prev: []PodSetResources{podSet(1, 1000)}, current: []PodSetResources{podSet(1, 1000), podSet(1, 1000)}},
+		"a PodSet was dropped": {prev: []PodSetResources{podSet(1, 1000), podSet(1, 1000)}, current: []PodSetResources{podSet(1, 1000)}},
+		"requests appeared":    {prev: []PodSetResources{{Name: kueue.DefaultPodSetName, Count: 1}}, current: []PodSetResources{podSet(1, 1000)}},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := sameHashedRequests(tc.prev, tc.current); got != tc.want {
+				t.Errorf("sameHashedRequests() = %v, want %v", got, tc.want)
+			}
+		})
+	}
 }
 
 func TestUsedNodes(t *testing.T) {


### PR DESCRIPTION
(cherry picked from commit 00bbe7fdae401084a764b01e17787731799d5686)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

cheery-pick of https://github.com/kubernetes-sigs/kueue/pull/14958

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Scheduling: Fixed a bug where requeueing a Workload recomputed its scheduling equivalence hash even when neither the Workload nor its effective resource requests had changed, adding avoidable CPU and allocation overhead on the scheduler's requeue path.
```
