### PR TITLE
Use wrapper functions instead of callbacks in RayService PodSets tests

### DIFF
--- a/pkg/controller/jobs/rayservice/rayservice_controller_test.go
+++ b/pkg/controller/jobs/rayservice/rayservice_controller_test.go
@@ -37,12 +37,12 @@ import (
 	"sigs.k8s.io/kueue/pkg/workloadslicing"
 )
 
-// headSpecWithAutoscaler returns the head PodSpec with the autoscaler sidecar
-// container appended, matching what BuildPodSets adds when in-tree autoscaling
-// is enabled (KubeRay's default 500m CPU / 512Mi memory).
-func headSpecWithAutoscaler(rayService *RayService) corev1.PodSpec {
-	spec := rayService.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.DeepCopy()
-	spec.Containers = append(spec.Containers, corev1.Container{
+func TestPodSets(t *testing.T) {
+	collectorImage := "quay.io/kuberay/collector:v1.7.0"
+
+	// autoscaler mirrors the sidecar KubeRay injects into the head Pod when
+	// in-tree autoscaling is enabled, with KubeRay's default resources.
+	autoscaler := corev1.Container{
 		Name: "autoscaler",
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
@@ -54,15 +54,28 @@ func headSpecWithAutoscaler(rayService *RayService) corev1.PodSpec {
 				corev1.ResourceMemory: resource.MustParse("512Mi"),
 			},
 		},
-	})
-	return *spec
-}
+	}
+	// collector mirrors the History Server collector KubeRay injects into every
+	// head and worker Pod, with KubeRay's default resources.
+	collector := corev1.Container{
+		Name:  rayutils.CollectorContainerName,
+		Image: collectorImage,
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("64Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("200m"),
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+		},
+	}
 
-func TestPodSets(t *testing.T) {
 	testCases := map[string]struct {
 		rayService   *RayService
 		rayCluster   *rayv1.RayCluster
-		wantPodSets  func(rayService *RayService) []kueue.PodSet
+		wantPodSets  []kueue.PodSet
 		featureGates map[featuregate.Feature]bool
 	}{
 		"no annotations": {
@@ -96,18 +109,16 @@ func TestPodSets(t *testing.T) {
 					},
 				},
 			}),
-			wantPodSets: func(rayService *RayService) []kueue.PodSet {
-				return []kueue.PodSet{
-					*utiltestingapi.MakePodSet(headGroupPodSetName, 1).
-						PodSpec(*rayService.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.DeepCopy()).
-						Obj(),
-					*utiltestingapi.MakePodSet("group1", 1).
-						PodSpec(*rayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.DeepCopy()).
-						Obj(),
-					*utiltestingapi.MakePodSet("group2", 3).
-						PodSpec(*rayService.Spec.RayClusterSpec.WorkerGroupSpecs[1].Template.Spec.DeepCopy()).
-						Obj(),
-				}
+			wantPodSets: []kueue.PodSet{
+				*utiltestingapi.MakePodSet(headGroupPodSetName, 1).
+					PodSpec(corev1.PodSpec{Containers: []corev1.Container{{Name: "head_c"}}}).
+					Obj(),
+				*utiltestingapi.MakePodSet("group1", 1).
+					PodSpec(corev1.PodSpec{Containers: []corev1.Container{{Name: "group1_c"}}}).
+					Obj(),
+				*utiltestingapi.MakePodSet("group2", 3).
+					PodSpec(corev1.PodSpec{Containers: []corev1.Container{{Name: "group2_c"}}}).
+					Obj(),
 			},
 			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
@@ -127,33 +138,17 @@ func TestPodSets(t *testing.T) {
 				}).
 				WithHistoryServerOptions(&rayv1.HistoryServerOptions{
 					CollectorOptions: &rayv1.CollectorOptions{
-						Image: new("quay.io/kuberay/collector:v1.7.0"),
+						Image: &collectorImage,
 					},
 				}).
 				Obj()),
-			wantPodSets: func(_ *RayService) []kueue.PodSet {
-				collector := corev1.Container{
-					Name:  rayutils.CollectorContainerName,
-					Image: "quay.io/kuberay/collector:v1.7.0",
-					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("50m"),
-							corev1.ResourceMemory: resource.MustParse("64Mi"),
-						},
-						Limits: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("200m"),
-							corev1.ResourceMemory: resource.MustParse("256Mi"),
-						},
-					},
-				}
-				return []kueue.PodSet{
-					*utiltestingapi.MakePodSet(headGroupPodSetName, 1).
-						PodSpec(corev1.PodSpec{Containers: []corev1.Container{{Name: "head_c"}, collector}}).
-						Obj(),
-					*utiltestingapi.MakePodSet("group1", 2).
-						PodSpec(corev1.PodSpec{Containers: []corev1.Container{{Name: "group1_c"}, collector}}).
-						Obj(),
-				}
+			wantPodSets: []kueue.PodSet{
+				*utiltestingapi.MakePodSet(headGroupPodSetName, 1).
+					PodSpec(corev1.PodSpec{Containers: []corev1.Container{{Name: "head_c"}, collector}}).
+					Obj(),
+				*utiltestingapi.MakePodSet("group1", 2).
+					PodSpec(corev1.PodSpec{Containers: []corev1.Container{{Name: "group1_c"}, collector}}).
+					Obj(),
 			},
 			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
@@ -191,19 +186,17 @@ func TestPodSets(t *testing.T) {
 					},
 				},
 			}),
-			wantPodSets: func(rayService *RayService) []kueue.PodSet {
-				return []kueue.PodSet{
-					*utiltestingapi.MakePodSet(headGroupPodSetName, 1).
-						PodSpec(*rayService.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.DeepCopy()).
-						Annotations(rayService.Spec.RayClusterSpec.HeadGroupSpec.Template.Annotations).
-						RequiredTopologyRequest("cloud.com/block").
-						Obj(),
-					*utiltestingapi.MakePodSet("group1", 1).
-						PodSpec(*rayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.DeepCopy()).
-						Annotations(rayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Annotations).
-						RequiredTopologyRequest("cloud.com/block").
-						Obj(),
-				}
+			wantPodSets: []kueue.PodSet{
+				*utiltestingapi.MakePodSet(headGroupPodSetName, 1).
+					PodSpec(corev1.PodSpec{Containers: []corev1.Container{{Name: "head_c"}}}).
+					Annotations(map[string]string{kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block"}).
+					RequiredTopologyRequest("cloud.com/block").
+					Obj(),
+				*utiltestingapi.MakePodSet("group1", 1).
+					PodSpec(corev1.PodSpec{Containers: []corev1.Container{{Name: "group1_c"}}}).
+					Annotations(map[string]string{kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block"}).
+					RequiredTopologyRequest("cloud.com/block").
+					Obj(),
 			},
 			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
@@ -233,15 +226,14 @@ func TestPodSets(t *testing.T) {
 					},
 				},
 			}),
-			wantPodSets: func(rayService *RayService) []kueue.PodSet {
-				return []kueue.PodSet{
-					*utiltestingapi.MakePodSet(headGroupPodSetName, 1).
-						PodSpec(*rayService.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.DeepCopy()).
-						Obj(),
-					*utiltestingapi.MakePodSet("group1", 6). // 2 replicas * 3 NumOfHosts
-											PodSpec(*rayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.DeepCopy()).
-											Obj(),
-				}
+			wantPodSets: []kueue.PodSet{
+				*utiltestingapi.MakePodSet(headGroupPodSetName, 1).
+					PodSpec(corev1.PodSpec{Containers: []corev1.Container{{Name: "head_c"}}}).
+					Obj(),
+				// 2 replicas * 3 NumOfHosts
+				*utiltestingapi.MakePodSet("group1", 6).
+					PodSpec(corev1.PodSpec{Containers: []corev1.Container{{Name: "group1_c"}}}).
+					Obj(),
 			},
 			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
@@ -279,27 +271,25 @@ func TestPodSets(t *testing.T) {
 					},
 				},
 			}),
-			wantPodSets: func(rayService *RayService) []kueue.PodSet {
-				return []kueue.PodSet{
-					*utiltestingapi.MakePodSet(headGroupPodSetName, 1).
-						PodSpec(corev1.PodSpec{
-							Containers: []corev1.Container{{
-								Name:  "head_c",
-								Image: "rayproject/ray:2.0.0",
-								Resources: corev1.ResourceRequirements{
-									Requests: corev1.ResourceList{
-										corev1.ResourceCPU:    resource.MustParse("200m"),
-										corev1.ResourceMemory: resource.MustParse("256Mi"),
-									},
+			wantPodSets: []kueue.PodSet{
+				*utiltestingapi.MakePodSet(headGroupPodSetName, 1).
+					PodSpec(corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name:  "head_c",
+							Image: "rayproject/ray:2.0.0",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("200m"),
+									corev1.ResourceMemory: resource.MustParse("256Mi"),
 								},
-							}},
-						}).
-						Labels(rayService.Spec.RayClusterSpec.HeadGroupSpec.Template.Labels).
-						Obj(),
-					*utiltestingapi.MakePodSet("group1", 1).
-						PodSpec(*rayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.DeepCopy()).
-						Obj(),
-				}
+							},
+						}},
+					}).
+					Labels(map[string]string{"ray.io/cluster": "rayservice"}).
+					Obj(),
+				*utiltestingapi.MakePodSet("group1", 1).
+					PodSpec(corev1.PodSpec{Containers: []corev1.Container{{Name: "group1_c"}}}).
+					Obj(),
 			},
 			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
@@ -359,15 +349,14 @@ func TestPodSets(t *testing.T) {
 					},
 				},
 			},
-			wantPodSets: func(rayService *RayService) []kueue.PodSet {
-				return []kueue.PodSet{
-					*utiltestingapi.MakePodSet(headGroupPodSetName, 1).
-						PodSpec(headSpecWithAutoscaler(rayService)).
-						Obj(),
-					*utiltestingapi.MakePodSet("group1", 5). // Updated from RayCluster
-											PodSpec(*rayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.DeepCopy()).
-											Obj(),
-				}
+			wantPodSets: []kueue.PodSet{
+				*utiltestingapi.MakePodSet(headGroupPodSetName, 1).
+					PodSpec(corev1.PodSpec{Containers: []corev1.Container{{Name: "head_c"}, autoscaler}}).
+					Obj(),
+				// Updated from RayCluster
+				*utiltestingapi.MakePodSet("group1", 5).
+					PodSpec(corev1.PodSpec{Containers: []corev1.Container{{Name: "group1_c"}}}).
+					Obj(),
 			},
 			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling:      false,
@@ -422,15 +411,14 @@ func TestPodSets(t *testing.T) {
 					},
 				},
 			},
-			wantPodSets: func(rayService *RayService) []kueue.PodSet {
-				return []kueue.PodSet{
-					*utiltestingapi.MakePodSet(headGroupPodSetName, 1).
-						PodSpec(*rayService.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.DeepCopy()).
-						Obj(),
-					*utiltestingapi.MakePodSet("group1", 2). // Uses spec count, not RayCluster
-											PodSpec(*rayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.DeepCopy()).
-											Obj(),
-				}
+			wantPodSets: []kueue.PodSet{
+				*utiltestingapi.MakePodSet(headGroupPodSetName, 1).
+					PodSpec(corev1.PodSpec{Containers: []corev1.Container{{Name: "head_c"}}}).
+					Obj(),
+				// Uses spec count, not RayCluster
+				*utiltestingapi.MakePodSet("group1", 2).
+					PodSpec(corev1.PodSpec{Containers: []corev1.Container{{Name: "group1_c"}}}).
+					Obj(),
 			},
 			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling:      false,
@@ -472,15 +460,14 @@ func TestPodSets(t *testing.T) {
 				},
 			}),
 			rayCluster: nil, // No RayCluster exists
-			wantPodSets: func(rayService *RayService) []kueue.PodSet {
-				return []kueue.PodSet{
-					*utiltestingapi.MakePodSet(headGroupPodSetName, 1).
-						PodSpec(headSpecWithAutoscaler(rayService)).
-						Obj(),
-					*utiltestingapi.MakePodSet("group1", 3). // Fallback to spec count
-											PodSpec(*rayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.DeepCopy()).
-											Obj(),
-				}
+			wantPodSets: []kueue.PodSet{
+				*utiltestingapi.MakePodSet(headGroupPodSetName, 1).
+					PodSpec(corev1.PodSpec{Containers: []corev1.Container{{Name: "head_c"}, autoscaler}}).
+					Obj(),
+				// Fallback to spec count
+				*utiltestingapi.MakePodSet("group1", 3).
+					PodSpec(corev1.PodSpec{Containers: []corev1.Container{{Name: "group1_c"}}}).
+					Obj(),
 			},
 			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling:      false,
@@ -522,15 +509,14 @@ func TestPodSets(t *testing.T) {
 				},
 			}),
 			rayCluster: nil,
-			wantPodSets: func(rayService *RayService) []kueue.PodSet {
-				return []kueue.PodSet{
-					*utiltestingapi.MakePodSet(headGroupPodSetName, 1).
-						PodSpec(headSpecWithAutoscaler(rayService)).
-						Obj(),
-					*utiltestingapi.MakePodSet("group1", 2). // Uses spec count
-											PodSpec(*rayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.DeepCopy()).
-											Obj(),
-				}
+			wantPodSets: []kueue.PodSet{
+				*utiltestingapi.MakePodSet(headGroupPodSetName, 1).
+					PodSpec(corev1.PodSpec{Containers: []corev1.Container{{Name: "head_c"}, autoscaler}}).
+					Obj(),
+				// Uses spec count
+				*utiltestingapi.MakePodSet("group1", 2).
+					PodSpec(corev1.PodSpec{Containers: []corev1.Container{{Name: "group1_c"}}}).
+					Obj(),
 			},
 			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling:      false,
@@ -560,8 +546,7 @@ func TestPodSets(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}
-			wantPodSets := tc.wantPodSets(tc.rayService)
-			if diff := cmp.Diff(wantPodSets, gotPodSets, cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(tc.wantPodSets, gotPodSets, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("PodSets() mismatch (-want +got):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area testing
/area integrations
/area ray-integration

#### What this PR does / why we need it:

`TestPodSets` in the RayService controller used `wantPodSets func(*RayService) []kueue.PodSet`, so expected PodSets were built by copying fields from the input at runtime. That callback also blocked converting the History Server collector case to a plain `MakePodSet` wrapper, which was left as follow-up from #14670.

This PR replaces the callback with `wantPodSets []kueue.PodSet` built through `utiltestingapi.MakePodSet`. The History Server collector case is unchanged in coverage. The `headSpecWithAutoscaler` helper is removed in favor of the same wrapper style.

#### Which issue(s) this PR fixes:

Fixes #15069

#### Special notes for your reviewer:

Follow-up to https://github.com/kubernetes-sigs/kueue/pull/14670#discussion_r3920987186.

Validation:
- `go test ./pkg/controller/jobs/rayservice/...`
- `gofmt` and targeted `golangci-lint` (0 issues)

AI tools were used to assist with implementation and review. The final diff was manually reviewed and validated.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored PodSet test setup to use explicit expected values.
  * Centralized reusable autoscaler and history server container definitions in test scenarios.
  * Simplified validation by comparing expected and computed PodSets directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->