### PR TITLE
Use helper for getting ResourceGroups for ClusterQueues

### DIFF
--- a/pkg/cache/queue/pending_workloads.go
+++ b/pkg/cache/queue/pending_workloads.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/util/heap"
 	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
+	"sigs.k8s.io/kueue/pkg/util/resourcegroups"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 
@@ -276,7 +277,7 @@ func (p *PendingWorkloads) UpdateConfiguredResources(apiCQ *kueue.ClusterQueue) 
 	defer p.Unlock()
 
 	newConfigured := sets.New[corev1.ResourceName]()
-	for _, rg := range apiCQ.Spec.ResourceGroups {
+	for _, rg := range resourcegroups.EffectiveResourceGroups(apiCQ) {
 		for _, fq := range rg.Flavors {
 			for _, r := range fq.Resources {
 				newConfigured.Insert(r.Name)

--- a/pkg/cache/scheduler/clusterqueue.go
+++ b/pkg/cache/scheduler/clusterqueue.go
@@ -161,7 +161,7 @@ func (c *clusterQueue) updateClusterQueue(
 	}
 	c.NamespaceSelector = nsSelector
 
-	if c.updateQuotasAndResourceGroups(in.Spec.ResourceGroups) || oldParent != c.Parent() {
+	if c.updateQuotasAndResourceGroups(resourcegroups.EffectiveResourceGroups(in)) || oldParent != c.Parent() {
 		if oldParent != nil && oldParent != c.Parent() {
 			updateCohortTreeResourcesIfNoCycle(oldParent)
 		}

--- a/pkg/controller/concurrentadmission/controller.go
+++ b/pkg/controller/concurrentadmission/controller.go
@@ -48,6 +48,7 @@ import (
 	controllerconsts "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/util/resourcegroups"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	"sigs.k8s.io/kueue/pkg/workload"
 	"sigs.k8s.io/kueue/pkg/workload/concurrentadmission"
@@ -142,7 +143,7 @@ func clusterQueueFlavorsChanged() predicate.TypedPredicate[*kueue.ClusterQueue] 
 		DeleteFunc:  func(event.TypedDeleteEvent[*kueue.ClusterQueue]) bool { return false },
 		GenericFunc: func(event.TypedGenericEvent[*kueue.ClusterQueue]) bool { return false },
 		UpdateFunc: func(e event.TypedUpdateEvent[*kueue.ClusterQueue]) bool {
-			return !slices.EqualFunc(e.ObjectOld.Spec.ResourceGroups, e.ObjectNew.Spec.ResourceGroups,
+			return !slices.EqualFunc(resourcegroups.EffectiveResourceGroups(e.ObjectOld), resourcegroups.EffectiveResourceGroups(e.ObjectNew),
 				func(a, b kueue.ResourceGroup) bool {
 					return slices.EqualFunc(a.Flavors, b.Flavors,
 						func(x, y kueue.FlavorQuotas) bool {
@@ -197,8 +198,14 @@ func (r *variantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, nil
 	}
 
-	flavorOrder := make(map[kueue.ResourceFlavorReference]int, len(cq.Spec.ResourceGroups[0].Flavors))
-	for i, flavor := range cq.Spec.ResourceGroups[0].Flavors {
+	cqResourceGroups := resourcegroups.EffectiveResourceGroups(cq)
+	var cqFlavors []kueue.FlavorQuotas
+	if len(cqResourceGroups) > 0 {
+		cqFlavors = cqResourceGroups[0].Flavors
+	}
+
+	flavorOrder := make(map[kueue.ResourceFlavorReference]int, len(cqFlavors))
+	for i, flavor := range cqFlavors {
 		flavorOrder[flavor.Name] = i
 	}
 	variants = sortVariantsByFlavorOrder(variants, flavorOrder)
@@ -209,7 +216,7 @@ func (r *variantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// TODO: If ConcurrentAdmission is no longer enabled for this CQ, delete parent and variants.
 
 	log.V(3).Info("Reconciling variants against ClusterQueue flavors", "desired", len(flavorOrder), "actual", len(variants))
-	if err := r.createVariants(ctx, parent, variants, cq.Spec.ResourceGroups[0].Flavors); err != nil {
+	if err := r.createVariants(ctx, parent, variants, cqFlavors); err != nil {
 		return ctrl.Result{}, err
 	}
 	variants, err = r.deleteStaleVariants(ctx, parent, variants, flavorOrder)

--- a/pkg/controller/core/resourceflavor_controller.go
+++ b/pkg/controller/core/resourceflavor_controller.go
@@ -40,6 +40,7 @@ import (
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
+	"sigs.k8s.io/kueue/pkg/util/resourcegroups"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 )
 
@@ -224,8 +225,8 @@ func (r *ResourceFlavorReconciler) NotifyClusterQueueUpdate(oldCQ, newCQ *kueue.
 		return
 	}
 
-	oldFlavors := utilqueue.AllFlavors(oldCQ.Spec.ResourceGroups)
-	newFlavors := utilqueue.AllFlavors(newCQ.Spec.ResourceGroups)
+	oldFlavors := utilqueue.AllFlavors(resourcegroups.EffectiveResourceGroups(oldCQ))
+	newFlavors := utilqueue.AllFlavors(resourcegroups.EffectiveResourceGroups(newCQ))
 	if !oldFlavors.Equal(newFlavors) {
 		r.cqUpdateCh <- event.GenericEvent{Object: oldCQ}
 	}
@@ -258,7 +259,7 @@ func (h *cqHandler) Generic(_ context.Context, e event.GenericEvent, q workqueue
 		return
 	}
 
-	for _, rg := range cq.Spec.ResourceGroups {
+	for _, rg := range resourcegroups.EffectiveResourceGroups(cq) {
 		for _, flavor := range rg.Flavors {
 			if cqs := h.cache.ClusterQueuesUsingFlavor(flavor.Name); len(cqs) == 0 {
 				req := reconcile.Request{

--- a/pkg/util/admissioncheck/admissioncheck.go
+++ b/pkg/util/admissioncheck/admissioncheck.go
@@ -31,6 +31,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	controllerconsts "sigs.k8s.io/kueue/pkg/controller/constants"
 	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
+	"sigs.k8s.io/kueue/pkg/util/resourcegroups"
 )
 
 var (
@@ -174,7 +175,7 @@ func NewAdmissionChecks(cq *kueue.ClusterQueue) map[kueue.AdmissionCheckReferenc
 			if len(check.OnFlavors) > 0 {
 				checks[check.Name] = sets.New(check.OnFlavors...)
 			} else {
-				checks[check.Name] = utilqueue.AllFlavors(cq.Spec.ResourceGroups)
+				checks[check.Name] = utilqueue.AllFlavors(resourcegroups.EffectiveResourceGroups(cq))
 			}
 		}
 	} else {

--- a/pkg/util/resourcegroups/effective.go
+++ b/pkg/util/resourcegroups/effective.go
@@ -1,0 +1,37 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcegroups
+
+import (
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+)
+
+// EffectiveResourceGroups returns Spec.ResourceGroups.
+func EffectiveResourceGroups(cq *kueue.ClusterQueue) []kueue.ResourceGroup {
+	if cq == nil {
+		return nil
+	}
+	return cq.Spec.ResourceGroups
+}
+
+// EffectiveCohortResourceGroups returns Spec.ResourceGroups.
+func EffectiveCohortResourceGroups(cohort *kueue.Cohort) []kueue.ResourceGroup {
+	if cohort == nil {
+		return nil
+	}
+	return cohort.Spec.ResourceGroups
+}

--- a/pkg/util/resourcegroups/effective_test.go
+++ b/pkg/util/resourcegroups/effective_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcegroups
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+)
+
+func TestEffectiveResourceGroups(t *testing.T) {
+	specFlavor := utiltestingapi.MakeFlavorQuotas("spec-flavor").Resource(corev1.ResourceCPU, "10").FlavorQuotas
+
+	cases := map[string]struct {
+		cq      *kueue.ClusterQueue
+		wantRGs []kueue.ResourceGroup
+	}{
+		"cluster queue returns spec resource groups": {
+			cq: utiltestingapi.MakeClusterQueue("test-cq").
+				ResourceGroup(specFlavor).
+				Obj(),
+			wantRGs: []kueue.ResourceGroup{
+				utiltestingapi.ResourceGroup(specFlavor),
+			},
+		},
+		"nil cluster queue returns nil": {
+			cq:      nil,
+			wantRGs: nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if diff := cmp.Diff(tc.wantRGs, EffectiveResourceGroups(tc.cq)); diff != "" {
+				t.Errorf("Unexpected EffectiveResourceGroups (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestEffectiveCohortResourceGroups(t *testing.T) {
+	specFlavor := utiltestingapi.MakeFlavorQuotas("spec-flavor").Resource(corev1.ResourceCPU, "10").FlavorQuotas
+
+	cases := map[string]struct {
+		cohort  *kueue.Cohort
+		wantRGs []kueue.ResourceGroup
+	}{
+		"cohort returns spec resource groups": {
+			cohort: utiltestingapi.MakeCohort("test-cohort").
+				ResourceGroup(specFlavor).
+				Obj(),
+			wantRGs: []kueue.ResourceGroup{
+				utiltestingapi.ResourceGroup(specFlavor),
+			},
+		},
+		"nil cohort returns nil": {
+			cohort:  nil,
+			wantRGs: nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if diff := cmp.Diff(tc.wantRGs, EffectiveCohortResourceGroups(tc.cohort)); diff != "" {
+				t.Errorf("Unexpected EffectiveCohortResourceGroups (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/util/testing/v1beta2/wrappers.go
+++ b/pkg/util/testing/v1beta2/wrappers.go
@@ -935,6 +935,15 @@ func (c *CohortWrapper) ResourceGroup(flavors ...kueue.FlavorQuotas) *CohortWrap
 	return c
 }
 
+// EffectiveQuotas adds a ResourceGroup with flavors to status.effectiveQuotas.
+func (c *CohortWrapper) EffectiveQuotas(flavors ...kueue.FlavorQuotas) *CohortWrapper {
+	if c.Status.EffectiveQuotas == nil {
+		c.Status.EffectiveQuotas = &kueue.EffectiveQuotaStatus{}
+	}
+	c.Status.EffectiveQuotas.ResourceGroups = append(c.Status.EffectiveQuotas.ResourceGroups, ResourceGroup(flavors...))
+	return c
+}
+
 func (c *CohortWrapper) FairWeight(w resource.Quantity) *CohortWrapper {
 	if c.Spec.FairSharing == nil {
 		c.Spec.FairSharing = &kueue.FairSharing{}
@@ -1084,6 +1093,15 @@ func ResourceGroup(flavors ...kueue.FlavorQuotas) kueue.ResourceGroup {
 // ResourceGroup adds a ResourceGroup with flavors.
 func (c *ClusterQueueWrapper) ResourceGroup(flavors ...kueue.FlavorQuotas) *ClusterQueueWrapper {
 	c.Spec.ResourceGroups = append(c.Spec.ResourceGroups, ResourceGroup(flavors...))
+	return c
+}
+
+// EffectiveQuotas adds a ResourceGroup with flavors to status.effectiveQuotas.
+func (c *ClusterQueueWrapper) EffectiveQuotas(flavors ...kueue.FlavorQuotas) *ClusterQueueWrapper {
+	if c.Status.EffectiveQuotas == nil {
+		c.Status.EffectiveQuotas = &kueue.EffectiveQuotaStatus{}
+	}
+	c.Status.EffectiveQuotas.ResourceGroups = append(c.Status.EffectiveQuotas.ResourceGroups, ResourceGroup(flavors...))
 	return c
 }
 

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -61,6 +61,7 @@ import (
 	utilptr "sigs.k8s.io/kueue/pkg/util/ptr"
 	"sigs.k8s.io/kueue/pkg/util/queue"
 	utilresource "sigs.k8s.io/kueue/pkg/util/resource"
+	"sigs.k8s.io/kueue/pkg/util/resourcegroups"
 	utilslices "sigs.k8s.io/kueue/pkg/util/slices"
 	"sigs.k8s.io/kueue/pkg/util/tas"
 	"sigs.k8s.io/kueue/pkg/util/wait"
@@ -1532,7 +1533,7 @@ func AdmissionChecksForWorkload(log logr.Logger, wl *kueue.Workload, cq *kueue.C
 
 	// If no admission is present yet we can only list
 	// the checks which apply to all flavors supported by the ClusterQueue
-	allFlavors := queue.AllFlavors(cq.Spec.ResourceGroups)
+	allFlavors := queue.AllFlavors(resourcegroups.EffectiveResourceGroups(cq))
 	checksForAllFlavors := filterChecks(allChecks, func(acFlavors flavorSet) bool {
 		return acFlavors.IsSuperset(allFlavors)
 	})


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

This is a prep PR for https://github.com/kubernetes-sigs/kueue/pull/15040. Later this helper will decide whether it should return ResourceGroups from ClusterQueue's `spec` or `status.effectiveQuotas` based on FG and presence of effective quota.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resource group configuration is now interpreted consistently across scheduling, workload admission, quota tracking, and resource flavor handling.
  - Effective resource groups are correctly used when configurations are derived, including cases where groups are computed rather than explicitly listed.
  - Empty resource group configurations are handled safely without causing errors.

- **Testing**
  - Added coverage for effective resource group behavior for ClusterQueues and Cohorts.
  - Expanded testing utilities to support effective quota configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->