### PR TITLE
Add Canva, Inc. to adopters list

### DIFF
--- a/site/data/adopters.yaml
+++ b/site/data/adopters.yaml
@@ -1,3 +1,12 @@
+- name: Canva, Inc.
+  url: https://canva.com
+  type: End User
+  description: Cloud AI Platform
+  integrations:
+  - JobSet
+  - ...
+  contact: '@groodt'
+  contact_url: https://github.com/groodt
 - name: CyberAgent, Inc.
   url: https://www.cyberagent.co.jp/en/
   type: End User


### PR DESCRIPTION
Added Canva, Inc. as a new adopter with details.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Canva, Inc. to the list of adopters of the Cloud AI Platform integrated with JobSet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

```release-note
NONE
```