### PR TITLE
Automated cherry pick of #14863: fix: clear sticky preemptorWorkload when preemption fails

### DIFF
--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -672,6 +672,9 @@ func (c *ClusterQueue) requeueIfNotPresent(log logr.Logger, wInfo *workload.Info
 			logV.Info("Setting preemptor workload", "clusterQueue", wInfo.ClusterQueue, "workload", key)
 		}
 		c.pw.set(key, c.queueingStrategy == kueue.BestEffortFIFO, wInfo.LastEvaluatedGeneration)
+	} else if c.pw.matches(key, false, 0) {
+		log.V(3).Info("Clearing preemptor workload", "clusterQueue", wInfo.ClusterQueue, "workload", key, "reason", reason)
+		c.pw.clear()
 	}
 	c.forgetInflightByKey(key)
 

--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -1396,6 +1396,61 @@ func TestBestEffortFIFORequeueIfNotPresent(t *testing.T) {
 	}
 }
 
+func TestBestEffortFIFOFailedPreemptionNotSticky(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	cq, err := newClusterQueue(ctx, nil,
+		&kueue.ClusterQueue{
+			Spec: kueue.ClusterQueueSpec{
+				QueueingStrategy: kueue.BestEffortFIFO,
+			},
+		},
+		workload.Ordering{PodsReadyRequeuingTimestamp: config.EvictionTimestamp},
+		nil, nil)
+	if err != nil {
+		t.Fatalf("Failed to create ClusterQueue: %v", err)
+	}
+
+	lowPriorityWl := utiltestingapi.MakeWorkload("low-wl", defaultNamespace).
+		Priority(0).
+		Obj()
+	highPriorityWl := utiltestingapi.MakeWorkload("high-wl", defaultNamespace).
+		Priority(10).
+		Obj()
+
+	// When lowPriorityWl is requeued with PendingPreemption, it becomes sticky at the head
+	// even if a higher priority workload is pushed.
+	cq.PushOrUpdate(workload.NewInfo(lowPriorityWl))
+	popped := cq.Pop()
+	if popped == nil || popped.Obj.Name != "low-wl" {
+		t.Fatalf("Expected low-wl to be popped first, got %v", popped)
+	}
+	cq.RequeueIfNotPresent(ctx, popped, RequeueReasonPendingPreemption, "")
+	cq.PushOrUpdate(workload.NewInfo(highPriorityWl))
+
+	// Because low-wl is sticky, it pops before high-wl despite lower priority.
+	poppedLow := cq.Pop()
+	if poppedLow == nil || poppedLow.Obj.Name != "low-wl" {
+		t.Errorf("Expected sticky low-wl to pop before high-wl, got %v", poppedLow)
+	}
+	poppedHigh := cq.Pop()
+	if poppedHigh == nil || poppedHigh.Obj.Name != "high-wl" {
+		t.Errorf("Expected high-wl to pop second, got %v", poppedHigh)
+	}
+
+	// When lowPriorityWl is requeued with PreemptionFailed, it does NOT become sticky,
+	// and any previous sticky state is cleared.
+	// Therefore, highPriorityWl pops before lowPriorityWl according to priority order.
+	cq.RequeueIfNotPresent(ctx, poppedLow, RequeueReasonPreemptionFailed, "")
+	cq.RequeueIfNotPresent(ctx, poppedHigh, RequeueReasonFailedAfterNomination, "")
+
+	if got := cq.Pop(); got == nil || got.Obj.Name != "high-wl" {
+		t.Errorf("Expected non-sticky high-wl to pop before low-wl with failed preemption, got %v", got)
+	}
+	if got := cq.Pop(); got == nil || got.Obj.Name != "low-wl" {
+		t.Errorf("Expected low-wl to pop second, got %v", got)
+	}
+}
+
 func TestFIFOClusterQueue(t *testing.T) {
 	ctx, log := utiltesting.ContextWithLog(t)
 	q, err := newClusterQueue(ctx, nil,


### PR DESCRIPTION
Cherry pick of #14863 on release-0.19.

#14863: fix: clear sticky preemptorWorkload when preemption fails

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
Scheduling: Fix a bug in BestEffortFIFO where a workload with failed preemption could remain sticky at the queue head.
```