### PR TITLE
Remove EquateEmpty from RayService TestPodSets comparison

### DIFF
--- a/pkg/controller/jobs/rayservice/rayservice_controller_test.go
+++ b/pkg/controller/jobs/rayservice/rayservice_controller_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	rayutils "github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	corev1 "k8s.io/api/core/v1"
@@ -546,7 +545,7 @@ func TestPodSets(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}
-			if diff := cmp.Diff(tc.wantPodSets, gotPodSets, cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(tc.wantPodSets, gotPodSets); diff != "" {
 				t.Errorf("PodSets() mismatch (-want +got):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area testing

#### What this PR does / why we need it:

Remove `cmpopts.EquateEmpty()` from the `TestPodSets` comparison in `rayservice_controller_test.go` so the test verifies explicit expected values.

#### Which issue(s) this PR fixes:

Fixes #15071

#### Special notes for your reviewer:

This PR was created with AI assistance.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated PodSet comparison tests to distinguish between empty and nil values.
  * Expanded coverage for History Server collector injection.
  * Replaced generated expectations with explicit fixtures for more precise validation of pod specifications, labels, topology settings, and containers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->