### PR TITLE
api: Dynamic Quota Orchestration API follow-ups

### DIFF
--- a/apis/kueue/v1alpha1/capacityprovider_types.go
+++ b/apis/kueue/v1alpha1/capacityprovider_types.go
@@ -26,6 +26,7 @@ type CapacityProviderSpec struct {
 	// publish capacity. DQO ignores entries in status.capacity.flavors whose
 	// names are not listed here.
 	//
+	// +required
 	// +listType=map
 	// +listMapKey=name
 	// +kubebuilder:validation:MinItems=1
@@ -63,21 +64,21 @@ type CapacityProviderParametersReference struct {
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:Pattern="^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
-	APIGroup string `json:"apiGroup,omitempty"`
+	APIGroup string `json:"apiGroup"`
 
 	// kind is the type of the resource being referenced.
 	// +required
 	// +kubebuilder:validation:MaxLength=63
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:Pattern="^(?i)[a-z]([-a-z0-9]*[a-z0-9])?$"
-	Kind string `json:"kind,omitempty"`
+	Kind string `json:"kind"`
 
 	// name is the name of the resource being referenced.
 	// +required
 	// +kubebuilder:validation:MaxLength=63
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:Pattern="^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
-	Name string `json:"name,omitempty"`
+	Name string `json:"name"`
 }
 
 type CapacityProviderStatus struct {
@@ -100,6 +101,7 @@ type CapacityProviderStatus struct {
 type CapacityProviderNormalizedCapacity struct {
 	// flavors contains capacity per flavor and resource.
 	//
+	// +required
 	// +listType=map
 	// +listMapKey=name
 	// +kubebuilder:validation:MaxItems=64

--- a/apis/kueue/v1alpha1/dynamicquotaorchestrator_types.go
+++ b/apis/kueue/v1alpha1/dynamicquotaorchestrator_types.go
@@ -39,6 +39,7 @@ type DynamicQuotaOrchestratorSpec struct {
 type CapacityDiscovery struct {
 	// providers lists CapacityProvider objects consumed by this DQO.
 	//
+	// +required
 	// +listType=map
 	// +listMapKey=name
 	// +kubebuilder:validation:MinItems=1
@@ -48,6 +49,8 @@ type CapacityDiscovery struct {
 
 type CapacityDiscoveryProviderContribution struct {
 	// name identifies a CapacityProvider.
+	//
+	// +required
 	Name CapacityProviderName `json:"name"`
 
 	// effectiveCapacityMultiplier specifies the multiplier applied to the
@@ -81,6 +84,8 @@ type CapacityDistributionSubtreeRootRef struct {
 	Kind SubtreeRootRefKind `json:"kind"`
 
 	// name indicates the name of the quota node, i.e. ClusterQueue or Cohort.
+	//
+	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:Pattern="^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
@@ -92,6 +97,7 @@ type CapacityDistributionSubtreeRootRef struct {
 // +kubebuilder:validation:Pattern="^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
 type CapacityProviderName string
 
+// TODO: once we graduate this API to beta, we should leverage beta API's ResourceFlavorReference type instead of Alpha one.
 // ResourceFlavorReference is the name of the ResourceFlavor.
 // +kubebuilder:validation:MaxLength=253
 // +kubebuilder:validation:Pattern="^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
@@ -117,6 +123,7 @@ type DynamicQuotaOrchestratorStatus struct {
 type EffectiveCapacity struct {
 	// flavors contains capacity per flavor and resource.
 	//
+	// +required
 	// +listType=map
 	// +listMapKey=name
 	// +kubebuilder:validation:MaxItems=128

--- a/test/integration/singlecluster/webhook/core/capacityprovider_test.go
+++ b/test/integration/singlecluster/webhook/core/capacityprovider_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"fmt"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingalpha "sigs.k8s.io/kueue/pkg/util/testing/v1alpha1"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var _ = ginkgo.Describe("CapacityProvider Validation", func() {
+	ginkgo.BeforeEach(func() {
+		fwk.StartManager(ctx, cfg, managerSetup)
+	})
+	ginkgo.AfterEach(func() {
+		fwk.StopManager(ctx)
+	})
+
+	ginkgo.When("Creating CapacityProvider", func() {
+		ginkgo.It("Should allow valid parameters reference", func() {
+			cp := utiltestingalpha.MakeCapacityProvider("cp-valid-params").
+				ControllerName("test-controller").
+				OrchestratedFlavors("flavor-1").
+				Parameters("example.com", "Config", "my-config").
+				Obj()
+
+			util.MustCreate(ctx, k8sClient, cp)
+			defer func() {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, cp, true)
+			}()
+		})
+
+		ginkgo.DescribeTable("Validate parameters reference on creation",
+			func(apiGroup, kind, name string) {
+				cp := utiltestingalpha.MakeCapacityProvider("cp-invalid-params").
+					ControllerName("test-controller").
+					OrchestratedFlavors("flavor-1").
+					Parameters(apiGroup, kind, name).
+					Obj()
+
+				err := k8sClient.Create(ctx, cp)
+				gomega.Expect(err).To(gomega.HaveOccurred())
+				gomega.Expect(err).To(utiltesting.BeInvalidError())
+			},
+			ginkgo.Entry("Disallow empty apiGroup", "", "Config", "my-config"),
+			ginkgo.Entry("Disallow empty kind", "example.com", "", "my-config"),
+			ginkgo.Entry("Disallow empty name", "example.com", "Config", ""),
+		)
+
+		ginkgo.It("Should disallow empty orchestratedFlavors", func() {
+			cp := utiltestingalpha.MakeCapacityProvider("cp-empty-flavors").
+				ControllerName("test-controller").
+				Obj()
+
+			err := k8sClient.Create(ctx, cp)
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err).To(utiltesting.BeInvalidError())
+		})
+	})
+
+	ginkgo.When("Updating CapacityProvider spec", func() {
+		ginkgo.It("Should enforce controllerName immutability", func() {
+			cp := utiltestingalpha.MakeCapacityProvider("cp-immutability").
+				ControllerName("initial-controller").
+				OrchestratedFlavors("flavor-1").
+				Obj()
+
+			util.MustCreate(ctx, k8sClient, cp)
+			defer func() {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, cp, true)
+			}()
+
+			var fetched kueuealpha.CapacityProvider
+			gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cp), &fetched)).To(gomega.Succeed())
+
+			ginkgo.By("Rejecting an update that modifies controllerName")
+			fetched.Spec.ControllerName = "modified-controller"
+			err := k8sClient.Update(ctx, &fetched)
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err).To(utiltesting.BeInvalidError())
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("field is immutable"))
+
+			ginkgo.By("Allowing an update that keeps controllerName unchanged")
+			gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cp), &fetched)).To(gomega.Succeed())
+			fetched.Spec.OrchestratedFlavors = append(fetched.Spec.OrchestratedFlavors, kueuealpha.CapacityProviderOrchestratedFlavor{
+				Name: "flavor-2",
+			})
+			gomega.Expect(k8sClient.Update(ctx, &fetched)).To(gomega.Succeed())
+		})
+	})
+
+	ginkgo.When("Updating CapacityProvider status capacity flavors resources", func() {
+		ginkgo.DescribeTable("Validate resources count in status.capacity.flavors[*]",
+			func(resourceCount int, isValid bool) {
+				cp := utiltestingalpha.MakeCapacityProvider(fmt.Sprintf("cp-res-%d", resourceCount)).
+					ControllerName("controller-res").
+					OrchestratedFlavors("flavor-1").
+					Obj()
+
+				util.MustCreate(ctx, k8sClient, cp)
+				defer func() {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, cp, true)
+				}()
+
+				resources := corev1.ResourceList{}
+				for i := range resourceCount {
+					resources[corev1.ResourceName(fmt.Sprintf("example.com/res-%d", i))] = resource.MustParse("1")
+				}
+
+				var fetched kueuealpha.CapacityProvider
+				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cp), &fetched)).To(gomega.Succeed())
+				fetched.Status.Capacity = &kueuealpha.CapacityProviderNormalizedCapacity{
+					Flavors: []kueuealpha.CapacityProviderNormalizedCapacityFlavor{
+						{
+							Name:      "flavor-1",
+							Resources: resources,
+						},
+					},
+				}
+
+				err := k8sClient.Status().Update(ctx, &fetched)
+				if isValid {
+					gomega.Expect(err).To(gomega.Succeed())
+				} else {
+					gomega.Expect(err).To(gomega.HaveOccurred())
+					gomega.Expect(err).To(utiltesting.BeInvalidError())
+					gomega.Expect(err.Error()).To(gomega.ContainSubstring("resource capacity must have between 1 and 64 entries"))
+				}
+			},
+			ginkgo.Entry("Disallow empty resources (count 0)", 0, false),
+			ginkgo.Entry("Allow minimum valid resources (count 1)", 1, true),
+			ginkgo.Entry("Allow maximum valid resources (count 64)", 64, true),
+			ginkgo.Entry("Disallow too many resources (count 65)", 65, false),
+		)
+	})
+})

--- a/test/integration/singlecluster/webhook/core/dynamicquotaorchestrator_test.go
+++ b/test/integration/singlecluster/webhook/core/dynamicquotaorchestrator_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"fmt"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingalpha "sigs.k8s.io/kueue/pkg/util/testing/v1alpha1"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var _ = ginkgo.Describe("DynamicQuotaOrchestrator Validation", func() {
+	ginkgo.BeforeEach(func() {
+		fwk.StartManager(ctx, cfg, managerSetup)
+	})
+	ginkgo.AfterEach(func() {
+		fwk.StopManager(ctx)
+	})
+
+	ginkgo.When("Creating DynamicQuotaOrchestrator", func() {
+		ginkgo.DescribeTable("Validate effectiveCapacityMultiplier in spec.capacityDiscovery.providers[*]",
+			func(multiplier *resource.Quantity, isValid bool) {
+				dqo := utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-mult").
+					DiscoveryProvider("cp-1", multiplier).
+					Obj()
+
+				err := k8sClient.Create(ctx, dqo)
+				if isValid {
+					gomega.Expect(err).To(gomega.Succeed())
+					defer func() {
+						util.ExpectObjectToBeDeleted(ctx, k8sClient, dqo, true)
+					}()
+				} else {
+					gomega.Expect(err).To(gomega.HaveOccurred())
+					gomega.Expect(err).To(utiltesting.BeInvalidError())
+					gomega.Expect(err.Error()).To(gomega.ContainSubstring("effectiveCapacityMultiplier must be non-negative"))
+				}
+			},
+			ginkgo.Entry("Allow nil multiplier (defaults to 1)", nil, true),
+			ginkgo.Entry("Allow zero integer multiplier", resource.NewQuantity(0, resource.DecimalSI), true),
+			ginkgo.Entry("Allow positive integer multiplier", resource.NewQuantity(1, resource.DecimalSI), true),
+			ginkgo.Entry("Allow positive fractional quantity multiplier", func() *resource.Quantity {
+				q := resource.MustParse("1.5")
+				return &q
+			}(), true),
+			ginkgo.Entry("Allow positive milli-quantity multiplier", func() *resource.Quantity {
+				q := resource.MustParse("500m")
+				return &q
+			}(), true),
+			ginkgo.Entry("Disallow negative integer multiplier", resource.NewQuantity(-1, resource.DecimalSI), false),
+			ginkgo.Entry("Disallow negative quantity multiplier", func() *resource.Quantity {
+				q := resource.MustParse("-500m")
+				return &q
+			}(), false),
+		)
+
+		ginkgo.It("Should disallow empty subtreeRootQuotaRef name", func() {
+			dqo := utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-empty-name").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.ClusterQueueSubtreeRootRefKind, "").
+				Obj()
+
+			err := k8sClient.Create(ctx, dqo)
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err).To(utiltesting.BeInvalidError())
+		})
+
+		ginkgo.It("Should disallow empty providers", func() {
+			dqo := utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-empty-providers").
+				Obj()
+
+			err := k8sClient.Create(ctx, dqo)
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err).To(utiltesting.BeInvalidError())
+		})
+
+		ginkgo.It("Should disallow provider with empty name", func() {
+			dqo := utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-empty-provider-name").
+				DiscoveryProvider("", nil).
+				Obj()
+
+			err := k8sClient.Create(ctx, dqo)
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err).To(utiltesting.BeInvalidError())
+		})
+
+		ginkgo.It("Should allow valid subtreeRootQuotaRef name", func() {
+			dqo := utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-valid-name").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.ClusterQueueSubtreeRootRefKind, "valid-clusterqueue").
+				Obj()
+
+			util.MustCreate(ctx, k8sClient, dqo)
+			defer func() {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, dqo, true)
+			}()
+		})
+	})
+
+	ginkgo.When("Updating DynamicQuotaOrchestrator status effective capacity flavors resources", func() {
+		ginkgo.DescribeTable("Validate resources count in status.effectiveCapacity.flavors[*]",
+			func(resourceCount int, isValid bool) {
+				dqo := utiltestingalpha.MakeDynamicQuotaOrchestrator(fmt.Sprintf("dqo-res-%d", resourceCount)).
+					DiscoveryProvider("cp-1", nil).
+					Obj()
+
+				util.MustCreate(ctx, k8sClient, dqo)
+				defer func() {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, dqo, true)
+				}()
+
+				resources := corev1.ResourceList{}
+				for i := range resourceCount {
+					resources[corev1.ResourceName(fmt.Sprintf("example.com/res-%d", i))] = resource.MustParse("1")
+				}
+
+				var fetched kueuealpha.DynamicQuotaOrchestrator
+				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(dqo), &fetched)).To(gomega.Succeed())
+				fetched.Status.EffectiveCapacity = &kueuealpha.EffectiveCapacity{
+					Flavors: []kueuealpha.EffectiveCapacityFlavor{
+						{
+							Name:      "flavor-1",
+							Resources: resources,
+						},
+					},
+				}
+
+				err := k8sClient.Status().Update(ctx, &fetched)
+				if isValid {
+					gomega.Expect(err).To(gomega.Succeed())
+				} else {
+					gomega.Expect(err).To(gomega.HaveOccurred())
+					gomega.Expect(err).To(utiltesting.BeInvalidError())
+					gomega.Expect(err.Error()).To(gomega.ContainSubstring("resource capacity must have between 1 and 64 entries"))
+				}
+			},
+			ginkgo.Entry("Disallow empty resources (count 0)", 0, false),
+			ginkgo.Entry("Allow minimum valid resources (count 1)", 1, true),
+			ginkgo.Entry("Allow maximum valid resources (count 64)", 64, true),
+			ginkgo.Entry("Disallow too many resources (count 65)", 65, false),
+		)
+	})
+})


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/kind api-change

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

Follow-up to the alpha Dynamic Quota Orchestration API (#14557) addressing review feedback:
- Add explicit `+required` markers where required by API contract in `apis/kueue/v1alpha1/capacityprovider_types.go` and `apis/kueue/v1alpha1/dynamicquotaorchestrator_types.go`.
- Drop contradictory `omitempty` tags from required fields in `CapacityProviderParametersReference`.
- Document beta graduation type-reuse requirement for `ResourceFlavorReference`.
- Add integration tests covering CEL validations (immutability of `controllerName`, resource count bounds, non-negative multipliers) and schema validation for both `CapacityProvider` and `DynamicQuotaOrchestrator`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #15045

#### Special notes for your reviewer:

This pull request was developed with the assistance of AI (Google Antigravity) in compliance with the [Kubernetes AI Tool Usage Policy](https://www.kubernetes.dev/docs/guide/pull-requests/#ai-guidance).

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Validation**
  - Required fields in capacity provider and dynamic quota configurations are now enforced more consistently.
  - Required parameter reference fields are always serialized.
  - Validation covers provider names, flavor definitions, subtree references, and resource count limits.

- **Bug Fixes**
  - Invalid capacity provider and dynamic quota configurations are rejected during creation and status updates.

- **Tests**
  - Added integration coverage for webhook validation, including accepted and rejected configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->