### PR TITLE
test: fix highWlLookupKey using lowJob identity in "Should deduplicate env variables" e2e test release-0.18

### DIFF
--- a/test/e2e/singlecluster/baseline/job_test.go
+++ b/test/e2e/singlecluster/baseline/job_test.go
@@ -581,7 +581,7 @@ var _ = ginkgo.Describe("Kueue", ginkgo.Label("area:singlecluster", "feature:job
 			})
 
 			highCreatedWorkload := &kueue.Workload{}
-			highWlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(lowJob.Name, lowJob.UID), Namespace: ns.Name}
+			highWlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(highJob.Name, highJob.UID), Namespace: ns.Name}
 
 			ginkgo.By("Checking that the high-priority workload is created and admitted", func() {
 				gomega.Eventually(func(g gomega.Gomega) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/area test
Related to [#15033](https://github.com/kubernetes-sigs/kueue/pull/15033)
**What this PR does / why we need it:**
In the e2e test "Should deduplicate env variables" in
test/e2e/singlecluster/baseline/job_test.go, `highWlLookupKey` was constructed
using `lowJob.Name` and `lowJob.UID` instead of `highJob.Name` and `highJob.UID`.

This caused the assertion "high-priority workload is created and admitted" to look
up the low-priority workload object. Because the low-priority workload is admitted
first (before the high-priority job is even created), this assertion would trivially
pass and never actually verify that the preemption path correctly admitted the
high-priority workload.

The fix replaces `lowJob.Name, lowJob.UID` → `highJob.Name, highJob.UID` so the
lookup targets the correct object.

**Special notes for your reviewer:**
- One-line fix in a test file — no production code is touched.
- Without this fix the test is a false positive: it passes even when the
  high-priority workload is never admitted.
- `go build` and `go vet` pass cleanly on the affected package.

**Does this PR introduce a user-facing change?**
```release-note
NONE