### PR TITLE
Automated cherry pick of #14703: Fix elastic ungating when pods and the Workload have different owners

### DIFF
--- a/pkg/controller/core/indexer/indexer.go
+++ b/pkg/controller/core/indexer/indexer.go
@@ -177,9 +177,9 @@ func IndexOwnerUID(obj client.Object) []string {
 
 // IndexWorkloadSliceName indexes the workload slices of an elastic job. Scaling
 // such a job up does not resize its Workload: Kueue creates a new slice for the
-// larger size, so one job accumulates a chain of Workloads. Every
-// slice carries the name of the chain's first slice in the
-// WorkloadSliceNameAnnotation, which makes that name the chain's identity.
+// larger size, so one job accumulates a chain of Workloads. Every slice carries
+// the name of the chain's first slice in the WorkloadSliceNameAnnotation, which
+// makes that name the chain's identity.
 //
 // Indexing on it lets callers list all Workloads of a job by that first slice
 // name, including after the first slice itself has been deleted.

--- a/pkg/controller/core/indexer/indexer.go
+++ b/pkg/controller/core/indexer/indexer.go
@@ -175,9 +175,9 @@ func IndexOwnerUID(obj client.Object) []string {
 	return slices.Map(obj.GetOwnerReferences(), func(o *metav1.OwnerReference) string { return string(o.UID) })
 }
 
-// IndexWorkloadSliceName indexes the workload slices of an elastic job by their
-// chain. Scaling such a job up does not resize its Workload: Kueue creates a new
-// slice for the larger size, so one job accumulates a chain of Workloads. Every
+// IndexWorkloadSliceName indexes the workload slices of an elastic job. Scaling
+// such a job up does not resize its Workload: Kueue creates a new slice for the
+// larger size, so one job accumulates a chain of Workloads. Every
 // slice carries the name of the chain's first slice in the
 // WorkloadSliceNameAnnotation, which makes that name the chain's identity.
 //

--- a/pkg/controller/core/indexer/indexer.go
+++ b/pkg/controller/core/indexer/indexer.go
@@ -175,6 +175,23 @@ func IndexOwnerUID(obj client.Object) []string {
 	return slices.Map(obj.GetOwnerReferences(), func(o *metav1.OwnerReference) string { return string(o.UID) })
 }
 
+// IndexWorkloadSliceName indexes workloads by the slice chain they belong to.
+// Every slice created for an elastic job carries the chain's origin name, so the
+// chain stays addressable through its surviving slices once the origin itself is
+// gone. Matches IndexPodWorkloadSliceName so pods and slices share one key.
+func IndexWorkloadSliceName(obj client.Object) []string {
+	wl, ok := obj.(*kueue.Workload)
+	if !ok {
+		return nil
+	}
+	if value, found := wl.Annotations[kueue.WorkloadSliceNameAnnotation]; found {
+		return []string{value}
+	}
+	// The first slice of a chain is its own origin and is indexed under its name,
+	// which is what later slices inherit as the chain key.
+	return []string{wl.Name}
+}
+
 // IndexPodWorkloadSliceName indexes pods by their workload slice name annotation.
 // Uses WorkloadSliceNameAnnotation if present, otherwise falls back to WorkloadAnnotation
 // for non-elastic workloads.
@@ -292,6 +309,11 @@ func Setup(ctx context.Context, indexer client.FieldIndexer) error {
 	if features.Enabled(features.ElasticJobsViaWorkloadSlices) || features.Enabled(features.TopologyAwareScheduling) {
 		if err := indexer.IndexField(ctx, &corev1.Pod{}, WorkloadSliceNameKey, IndexPodWorkloadSliceName); err != nil {
 			return fmt.Errorf("setting index on workloadSliceName for Pod: %w", err)
+		}
+	}
+	if features.Enabled(features.ElasticJobsViaWorkloadSlices) {
+		if err := indexer.IndexField(ctx, &kueue.Workload{}, WorkloadSliceNameKey, IndexWorkloadSliceName); err != nil {
+			return fmt.Errorf("setting index on workloadSliceName for Workload: %w", err)
 		}
 	}
 	// Index DeviceClasses by extendedResourceName for fast lookup during extended resource translation.

--- a/pkg/controller/core/indexer/indexer.go
+++ b/pkg/controller/core/indexer/indexer.go
@@ -175,10 +175,14 @@ func IndexOwnerUID(obj client.Object) []string {
 	return slices.Map(obj.GetOwnerReferences(), func(o *metav1.OwnerReference) string { return string(o.UID) })
 }
 
-// IndexWorkloadSliceName indexes workloads by the slice chain they belong to.
-// Every slice created for an elastic job carries the chain's origin name, so the
-// chain stays addressable through its surviving slices once the origin itself is
-// gone. Matches IndexPodWorkloadSliceName so pods and slices share one key.
+// IndexWorkloadSliceName indexes the workload slices of an elastic job by their
+// chain. Scaling such a job up does not resize its Workload: Kueue creates a new
+// slice for the larger size, so one job accumulates a chain of Workloads. Every
+// slice carries the name of the chain's first slice in the
+// WorkloadSliceNameAnnotation, which makes that name the chain's identity.
+//
+// Indexing on it lets callers list all Workloads of a job by that first slice
+// name, including after the first slice itself has been deleted.
 func IndexWorkloadSliceName(obj client.Object) []string {
 	wl, ok := obj.(*kueue.Workload)
 	if !ok {
@@ -187,8 +191,8 @@ func IndexWorkloadSliceName(obj client.Object) []string {
 	if value, found := wl.Annotations[kueue.WorkloadSliceNameAnnotation]; found {
 		return []string{value}
 	}
-	// The first slice of a chain is its own origin and is indexed under its name,
-	// which is what later slices inherit as the chain key.
+	// The chain's first slice names itself, and is indexed before the annotation
+	// is applied.
 	return []string{wl.Name}
 }
 

--- a/pkg/controller/core/indexer/indexer.go
+++ b/pkg/controller/core/indexer/indexer.go
@@ -175,14 +175,10 @@ func IndexOwnerUID(obj client.Object) []string {
 	return slices.Map(obj.GetOwnerReferences(), func(o *metav1.OwnerReference) string { return string(o.UID) })
 }
 
-// IndexWorkloadSliceName indexes the workload slices of an elastic job. Scaling
-// such a job up does not resize its Workload: Kueue creates a new slice for the
-// larger size, so one job accumulates a chain of Workloads. Every slice carries
-// the name of the chain's first slice in the WorkloadSliceNameAnnotation, which
-// makes that name the chain's identity.
-//
-// Indexing on it lets callers list all Workloads of a job by that first slice
-// name, including after the first slice itself has been deleted.
+// IndexWorkloadSliceName indexes the workload slices of an elastic job. Every
+// slice in a chain carries the name of the chain's first slice in the
+// WorkloadSliceNameAnnotation, so indexing on it lists all Workloads of a job by
+// that name, including after the first slice itself has been deleted.
 func IndexWorkloadSliceName(obj client.Object) []string {
 	wl, ok := obj.(*kueue.Workload)
 	if !ok {

--- a/pkg/controller/elasticjobs/elastic_job_ungater.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater.go
@@ -359,7 +359,8 @@ func (r *elasticJobUngater) activeSlice(ctx context.Context, anyWl *kueue.Worklo
 }
 
 // latestActiveSliceForChain resolves the latest active workload slice of the chain
-// identified by sliceName in namespace, or nil if none qualifies for ungating.
+// identified by its first slice's name (sliceName), or nil if none qualifies for
+// ungating.
 func latestActiveSliceForChain(ctx context.Context, c client.Client, namespace, sliceName string) (*kueue.Workload, error) {
 	active, err := workloadslicing.FindLatestActiveWorkloadForSlice(ctx, c, namespace, sliceName)
 	if err != nil || active == nil || !workload.IsAdmitted(active) {

--- a/pkg/controller/elasticjobs/elastic_job_ungater.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater.go
@@ -352,20 +352,10 @@ func (r *elasticJobUngater) podsToUngate(ctx context.Context, wl *kueue.Workload
 	return gated, nil
 }
 
-// activeSlice resolves the chain's active slice for the workload anyWl belongs
-// to (see latestActiveSliceForChain), or nil if none qualifies for ungating.
+// activeSlice resolves the admitted slice of the chain the workload anyWl belongs
+// to, or nil if none is admitted.
 func (r *elasticJobUngater) activeSlice(ctx context.Context, anyWl *kueue.Workload) (*kueue.Workload, error) {
-	return latestActiveSliceForChain(ctx, r.client, anyWl.Namespace, workloadslicing.SliceName(anyWl))
-}
-
-// latestActiveSliceForChain resolves the latest active slice of the chain identified
-// by its first slice's name (sliceName), or nil if none qualifies for ungating.
-func latestActiveSliceForChain(ctx context.Context, c client.Client, namespace, sliceName string) (*kueue.Workload, error) {
-	active, err := workloadslicing.FindLatestActiveWorkloadForSlice(ctx, c, namespace, sliceName)
-	if err != nil || active == nil || !workload.IsAdmitted(active) {
-		return nil, err
-	}
-	return active, nil
+	return workloadslicing.FindLatestAdmittedWorkloadForSlice(ctx, r.client, anyWl.Namespace, workloadslicing.SliceName(anyWl))
 }
 
 // Workload predicates
@@ -433,7 +423,7 @@ func (h *elasticPodHandler) queueReconcileForPod(ctx context.Context, object cli
 		log := ctrl.LoggerFrom(ctx).WithValues("pod", klog.KObj(pod), "workloadSlice", sliceKey.String())
 		h.expectationsStore.ObservedUID(log, sliceKey, pod.UID)
 	}
-	active, err := latestActiveSliceForChain(ctx, h.client, pod.Namespace, sliceName)
+	active, err := workloadslicing.FindLatestAdmittedWorkloadForSlice(ctx, h.client, pod.Namespace, sliceName)
 	if err != nil || active == nil {
 		return
 	}

--- a/pkg/controller/elasticjobs/elastic_job_ungater.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater.go
@@ -24,9 +24,6 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	autoscaling "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
 	"k8s.io/client-go/util/workqueue"
@@ -356,29 +353,18 @@ func (r *elasticJobUngater) podsToUngate(ctx context.Context, wl *kueue.Workload
 }
 
 // activeSlice resolves the chain's active slice for the workload anyWl belongs
-// to (see latestActiveSliceForOwner), or nil if none qualifies for ungating.
+// to (see latestActiveSliceForChain), or nil if none qualifies for ungating.
 func (r *elasticJobUngater) activeSlice(ctx context.Context, anyWl *kueue.Workload) (*kueue.Workload, error) {
-	owner := metav1.GetControllerOf(anyWl)
-	if owner == nil {
-		return nil, nil
-	}
-	return latestActiveSliceForOwner(ctx, r.client, anyWl.Namespace, owner)
+	return latestActiveSliceForChain(ctx, r.client, anyWl.Namespace, workloadslicing.SliceName(anyWl))
 }
 
-func (h *elasticPodHandler) activeSliceForOwner(ctx context.Context, namespace string, owner *metav1.OwnerReference) (*kueue.Workload, error) {
-	return latestActiveSliceForOwner(ctx, h.client, namespace, owner)
-}
-
-// latestActiveSliceForOwner resolves the latest active workload slice owned by the
-// given job (owner) in namespace, or nil if none qualifies for ungating. Quota
+// latestActiveSliceForChain resolves the latest active workload slice of the chain
+// identified by sliceName in namespace, or nil if none qualifies for ungating. Quota
 // reservation alone is insufficient: AdmissionChecks may still be pending, and
 // releasing the elastic gate before then would let pods schedule ahead of
 // capacity, so full admission is required.
-func latestActiveSliceForOwner(ctx context.Context, c client.Client, namespace string, owner *metav1.OwnerReference) (*kueue.Workload, error) {
-	jobObject := &metav1.PartialObjectMetadata{
-		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: owner.Name},
-	}
-	active, err := workloadslicing.FindLatestActiveWorkload(ctx, c, jobObject, schema.FromAPIVersionAndKind(owner.APIVersion, owner.Kind))
+func latestActiveSliceForChain(ctx context.Context, c client.Client, namespace, sliceName string) (*kueue.Workload, error) {
+	active, err := workloadslicing.FindLatestActiveWorkloadForSlice(ctx, c, namespace, sliceName)
 	if err != nil || active == nil || !workload.IsAdmitted(active) {
 		return nil, err
 	}
@@ -450,16 +436,11 @@ func (h *elasticPodHandler) queueReconcileForPod(ctx context.Context, object cli
 		log := ctrl.LoggerFrom(ctx).WithValues("pod", klog.KObj(pod), "workloadSlice", sliceKey.String())
 		h.expectationsStore.ObservedUID(log, sliceKey, pod.UID)
 	}
-	// Enqueue the chain's active slice so Reconcile loads a live workload directly
-	// (a deleted origin slice no longer strands the pod). Resolve the owning job
-	// from the named slice if it still exists, otherwise from the pod's own
-	// controller owner-ref — the latter is what keeps ungating working after the
-	// origin slice the pod points at has been garbage-collected.
-	owner := h.ownerForPod(ctx, pod, sliceKey)
-	if owner == nil {
-		return
-	}
-	active, err := h.activeSliceForOwner(ctx, pod.Namespace, owner)
+	// Enqueue the chain's active slice so Reconcile loads a live workload directly.
+	// The chain key indexes the slices themselves, so this resolves without the
+	// origin slice the pod names, and without assuming the job that owns the pods
+	// is the one the Workload was created for.
+	active, err := latestActiveSliceForChain(ctx, h.client, pod.Namespace, sliceName)
 	if err != nil || active == nil {
 		return
 	}
@@ -467,23 +448,6 @@ func (h *elasticPodHandler) queueReconcileForPod(ctx context.Context, object cli
 		Namespace: active.Namespace,
 		Name:      active.Name,
 	}}, constants.UpdatesBatchPeriod)
-}
-
-// ownerForPod finds the job owning the pod's slice chain: prefer the controller
-// owner of the named slice when it still exists (pods are not always owned by the
-// job directly), and fall back to the pod's own controller owner-ref when that
-// slice has been deleted.
-func (h *elasticPodHandler) ownerForPod(ctx context.Context, pod *corev1.Pod, sliceKey types.NamespacedName) *metav1.OwnerReference {
-	slice := &kueue.Workload{}
-	switch err := h.client.Get(ctx, sliceKey, slice); {
-	case err == nil:
-		if owner := metav1.GetControllerOf(slice); owner != nil {
-			return owner
-		}
-	case !apierrors.IsNotFound(err):
-		return nil
-	}
-	return metav1.GetControllerOf(pod)
 }
 
 // podSliceName returns the slice-chain key for a pod: the WorkloadSliceName

--- a/pkg/controller/elasticjobs/elastic_job_ungater.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater.go
@@ -436,10 +436,6 @@ func (h *elasticPodHandler) queueReconcileForPod(ctx context.Context, object cli
 		log := ctrl.LoggerFrom(ctx).WithValues("pod", klog.KObj(pod), "workloadSlice", sliceKey.String())
 		h.expectationsStore.ObservedUID(log, sliceKey, pod.UID)
 	}
-	// Enqueue the chain's active slice so Reconcile loads a live workload directly.
-	// The chain key indexes the slices themselves, so this resolves without the
-	// origin slice the pod names, and without assuming the job that owns the pods
-	// is the one the Workload was created for.
 	active, err := latestActiveSliceForChain(ctx, h.client, pod.Namespace, sliceName)
 	if err != nil || active == nil {
 		return

--- a/pkg/controller/elasticjobs/elastic_job_ungater.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater.go
@@ -359,10 +359,7 @@ func (r *elasticJobUngater) activeSlice(ctx context.Context, anyWl *kueue.Worklo
 }
 
 // latestActiveSliceForChain resolves the latest active workload slice of the chain
-// identified by sliceName in namespace, or nil if none qualifies for ungating. Quota
-// reservation alone is insufficient: AdmissionChecks may still be pending, and
-// releasing the elastic gate before then would let pods schedule ahead of
-// capacity, so full admission is required.
+// identified by sliceName in namespace, or nil if none qualifies for ungating.
 func latestActiveSliceForChain(ctx context.Context, c client.Client, namespace, sliceName string) (*kueue.Workload, error) {
 	active, err := workloadslicing.FindLatestActiveWorkloadForSlice(ctx, c, namespace, sliceName)
 	if err != nil || active == nil || !workload.IsAdmitted(active) {

--- a/pkg/controller/elasticjobs/elastic_job_ungater.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater.go
@@ -358,9 +358,8 @@ func (r *elasticJobUngater) activeSlice(ctx context.Context, anyWl *kueue.Worklo
 	return latestActiveSliceForChain(ctx, r.client, anyWl.Namespace, workloadslicing.SliceName(anyWl))
 }
 
-// latestActiveSliceForChain resolves the latest active workload slice of the chain
-// identified by its first slice's name (sliceName), or nil if none qualifies for
-// ungating.
+// latestActiveSliceForChain resolves the latest active slice of the chain identified
+// by its first slice's name (sliceName), or nil if none qualifies for ungating.
 func latestActiveSliceForChain(ctx context.Context, c client.Client, namespace, sliceName string) (*kueue.Workload, error) {
 	active, err := workloadslicing.FindLatestActiveWorkloadForSlice(ctx, c, namespace, sliceName)
 	if err != nil || active == nil || !workload.IsAdmitted(active) {

--- a/pkg/controller/elasticjobs/elastic_job_ungater_test.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater_test.go
@@ -1076,6 +1076,7 @@ func TestReconcile(t *testing.T) {
 			clientBuilder := utiltesting.NewClientBuilder().
 				WithIndex(&corev1.Pod{}, coreindexer.WorkloadSliceNameKey, coreindexer.IndexPodWorkloadSliceName).
 				WithIndex(&kueue.Workload{}, coreindexer.OwnerReferenceIndexKey(rayClusterGVK), coreindexer.WorkloadOwnerIndexFunc(rayClusterGVK)).
+				WithIndex(&kueue.Workload{}, coreindexer.WorkloadSliceNameKey, coreindexer.IndexWorkloadSliceName).
 				WithInterceptorFuncs(interceptor.Funcs{
 					Patch: func(ctx context.Context, clnt client.WithWatch, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
 						// The fake client doesn't handle MergePatch for slice fields correctly.

--- a/pkg/workloadslicing/workloadslicing.go
+++ b/pkg/workloadslicing/workloadslicing.go
@@ -121,6 +121,41 @@ func FindNotFinishedWorkloads(ctx context.Context, clnt client.Client, jobObject
 	}), nil
 }
 
+// FindLatestActiveWorkloadForSlice returns the chain's active slice given the
+// chain key that every slice and pod of an elastic job carries, applying the same
+// selection rule as FindLatestActiveWorkload.
+//
+// Resolving by chain key rather than by owner keeps the lookup working when the
+// origin slice named by the key has been deleted, and when the object owning the
+// pods is not the object the Workload was created for — a RayService owns the
+// Workload while its child RayCluster owns the pods.
+func FindLatestActiveWorkloadForSlice(ctx context.Context, clnt client.Client, namespace, sliceName string) (*kueue.Workload, error) {
+	list := &kueue.WorkloadList{}
+	if err := clnt.List(ctx, list, client.InNamespace(namespace),
+		client.MatchingFields{indexer.WorkloadSliceNameKey: sliceName}); err != nil {
+		return nil, err
+	}
+
+	// Sort oldest-first; break same-second ties by UID for stable ordering.
+	slices.SortFunc(list.Items, func(a, b kueue.Workload) int {
+		if c := a.CreationTimestamp.Compare(b.CreationTimestamp.Time); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.UID, b.UID)
+	})
+
+	for i := range slices.Backward(list.Items) {
+		wl := &list.Items[i]
+		if workloadfinish.IsFinished(wl) {
+			continue
+		}
+		if workload.HasQuotaReservation(wl) && !workloadevict.IsEvicted(wl) {
+			return wl, nil
+		}
+	}
+	return nil, nil
+}
+
 // FindLatestActiveWorkload returns the newest non-finished, non-evicted workload
 // slice owned by the provided job object/gvk that holds a quota reservation, or
 // nil if none qualifies. This is the chain's "active" slice: its granted PodSet

--- a/pkg/workloadslicing/workloadslicing.go
+++ b/pkg/workloadslicing/workloadslicing.go
@@ -141,13 +141,13 @@ func FindLatestAdmittedWorkloadForSlice(ctx context.Context, clnt client.Client,
 
 	for i := range slices.Backward(list.Items) {
 		wl := &list.Items[i]
-		if workloadfinish.IsFinished(wl) {
+		if workload.IsFinished(wl) {
 			continue
 		}
 		// Eviction is two writes: the condition is set before the reservation is
 		// released, so an evicted slice can still report itself admitted while its
 		// capacity is on the way out.
-		if workload.IsAdmitted(wl) && !workloadevict.IsEvicted(wl) {
+		if workload.IsAdmitted(wl) && !workload.IsEvicted(wl) {
 			return wl, nil
 		}
 	}

--- a/pkg/workloadslicing/workloadslicing.go
+++ b/pkg/workloadslicing/workloadslicing.go
@@ -121,10 +121,10 @@ func FindNotFinishedWorkloads(ctx context.Context, clnt client.Client, jobObject
 	}), nil
 }
 
-// FindLatestActiveWorkloadForSlice returns the active slice of the chain identified
-// by its first slice's name (sliceName), which every slice and pod of an elastic job
-// carries, applying the same selection rule as FindLatestActiveWorkload.
-func FindLatestActiveWorkloadForSlice(ctx context.Context, clnt client.Client, namespace, sliceName string) (*kueue.Workload, error) {
+// FindLatestAdmittedWorkloadForSlice returns the admitted slice of the chain
+// identified by its first slice's name (sliceName), which every slice and pod of an
+// elastic job carries, or nil if none is admitted.
+func FindLatestAdmittedWorkloadForSlice(ctx context.Context, clnt client.Client, namespace, sliceName string) (*kueue.Workload, error) {
 	list := &kueue.WorkloadList{}
 	if err := clnt.List(ctx, list, client.InNamespace(namespace),
 		client.MatchingFields{indexer.WorkloadSliceNameKey: sliceName}); err != nil {
@@ -144,7 +144,10 @@ func FindLatestActiveWorkloadForSlice(ctx context.Context, clnt client.Client, n
 		if workloadfinish.IsFinished(wl) {
 			continue
 		}
-		if workload.HasQuotaReservation(wl) && !workloadevict.IsEvicted(wl) {
+		// Eviction is two writes: the condition is set before the reservation is
+		// released, so an evicted slice can still report itself admitted while its
+		// capacity is on the way out.
+		if workload.IsAdmitted(wl) && !workloadevict.IsEvicted(wl) {
 			return wl, nil
 		}
 	}

--- a/pkg/workloadslicing/workloadslicing.go
+++ b/pkg/workloadslicing/workloadslicing.go
@@ -124,11 +124,6 @@ func FindNotFinishedWorkloads(ctx context.Context, clnt client.Client, jobObject
 // FindLatestActiveWorkloadForSlice returns the active slice of the chain identified
 // by its first slice's name (sliceName), which every slice and pod of an elastic job
 // carries, applying the same selection rule as FindLatestActiveWorkload.
-//
-// Resolving by that name rather than by owner keeps the lookup working when the
-// first slice itself has been deleted, and when the object owning the pods is not
-// the object the Workload was created for — a RayService owns the Workload while
-// its child RayCluster owns the pods.
 func FindLatestActiveWorkloadForSlice(ctx context.Context, clnt client.Client, namespace, sliceName string) (*kueue.Workload, error) {
 	list := &kueue.WorkloadList{}
 	if err := clnt.List(ctx, list, client.InNamespace(namespace),

--- a/pkg/workloadslicing/workloadslicing.go
+++ b/pkg/workloadslicing/workloadslicing.go
@@ -121,14 +121,14 @@ func FindNotFinishedWorkloads(ctx context.Context, clnt client.Client, jobObject
 	}), nil
 }
 
-// FindLatestActiveWorkloadForSlice returns the chain's active slice given the
-// chain key that every slice and pod of an elastic job carries, applying the same
-// selection rule as FindLatestActiveWorkload.
+// FindLatestActiveWorkloadForSlice returns the active slice of the chain identified
+// by its first slice's name (sliceName), which every slice and pod of an elastic job
+// carries, applying the same selection rule as FindLatestActiveWorkload.
 //
-// Resolving by chain key rather than by owner keeps the lookup working when the
-// origin slice named by the key has been deleted, and when the object owning the
-// pods is not the object the Workload was created for — a RayService owns the
-// Workload while its child RayCluster owns the pods.
+// Resolving by that name rather than by owner keeps the lookup working when the
+// first slice itself has been deleted, and when the object owning the pods is not
+// the object the Workload was created for — a RayService owns the Workload while
+// its child RayCluster owns the pods.
 func FindLatestActiveWorkloadForSlice(ctx context.Context, clnt client.Client, namespace, sliceName string) (*kueue.Workload, error) {
 	list := &kueue.WorkloadList{}
 	if err := clnt.List(ctx, list, client.InNamespace(namespace),

--- a/test/integration/singlecluster/controller/jobs/rayservice/rayservice_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayservice/rayservice_controller_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rayservice
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/constants"
+	"sigs.k8s.io/kueue/pkg/features"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
+	testingrayservice "sigs.k8s.io/kueue/pkg/util/testingjobs/rayservice"
+	"sigs.k8s.io/kueue/pkg/workload"
+	workloadfinish "sigs.k8s.io/kueue/pkg/workload/finish"
+	"sigs.k8s.io/kueue/pkg/workloadslicing"
+	"sigs.k8s.io/kueue/test/integration/framework"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var _ = ginkgo.Describe("RayService with elastic jobs via workload-slices support", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+	var (
+		ns           *corev1.Namespace
+		clusterQueue *kueue.ClusterQueue
+		localQueue   *kueue.LocalQueue
+		resourceFlavor *kueue.ResourceFlavor
+	)
+
+	ginkgo.BeforeAll(func() {
+		gomega.Expect(utilfeature.DefaultMutableFeatureGate.SetFromMap(map[string]bool{string(features.ElasticJobsViaWorkloadSlices): true})).Should(gomega.Succeed())
+		fwk.StartManager(ctx, cfg, managerAndSchedulerSetup())
+	})
+
+	ginkgo.AfterAll(func() {
+		fwk.StopManager(ctx)
+	})
+
+	ginkgo.BeforeEach(func() {
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "rayservice-elastic-")
+
+		resourceFlavor = utiltestingapi.MakeResourceFlavor("flavor").Obj()
+		util.MustCreate(ctx, k8sClient, resourceFlavor)
+
+		clusterQueue = utiltestingapi.MakeClusterQueue("cq").
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas("flavor").
+				Resource(corev1.ResourceCPU, "10").
+				Resource(corev1.ResourceMemory, "5Gi").Obj()).
+			Obj()
+		util.MustCreate(ctx, k8sClient, clusterQueue)
+
+		localQueue = utiltestingapi.MakeLocalQueue("lq", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+		util.MustCreate(ctx, k8sClient, localQueue)
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, resourceFlavor, true)
+	})
+
+	ginkgo.It("Should ungate chain pods after the origin workload slice is deleted", framework.SlowSpec, func() {
+		// Same stranded-pod scenario as the RayCluster spec, but for a RayService:
+		// Kueue owns the Workload through the RayService while KubeRay owns the pods
+		// through the child RayCluster. Once the origin slice is gone, recovering the
+		// owning job from the pod's controller reference yields the RayCluster, whose
+		// kind does not match the RayService the Workload is indexed under.
+		service := testingrayservice.MakeService("foo", ns.Name).
+			Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			Queue(localQueue.Name).
+			Request(rayv1.HeadNode, corev1.ResourceCPU, "1").
+			Request(rayv1.WorkerNode, corev1.ResourceCPU, "1").
+			EnableInTreeAutoscaling().
+			Obj()
+
+		ginkgo.By("creating and admitting the rayservice's origin workload slice")
+		util.MustCreate(ctx, k8sClient, service)
+		var originSlice *kueue.Workload
+		gomega.Eventually(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+			g.Expect(workloads.Items).Should(gomega.HaveLen(1))
+			originSlice = &workloads.Items[0]
+			g.Expect(workload.IsAdmitted(originSlice)).Should(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		originSliceName := originSlice.Name
+
+		ginkgo.By("scaling up the worker replicas to create a second (active) slice")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(service), service)).Should(gomega.Succeed())
+			service.Spec.RayClusterSpec.WorkerGroupSpecs[0].Replicas = new(int32(2))
+			g.Expect(k8sClient.Update(ctx, service)).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		var activeSlice *kueue.Workload
+		gomega.Eventually(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+			g.Expect(workloads.Items).Should(gomega.HaveLen(2))
+			activeSlice = nil
+			for i := range workloads.Items {
+				if !workloadfinish.IsFinished(&workloads.Items[i]) {
+					activeSlice = &workloads.Items[i]
+				}
+			}
+			g.Expect(activeSlice).ShouldNot(gomega.BeNil())
+			g.Expect(activeSlice.Name).ShouldNot(gomega.Equal(originSliceName))
+			g.Expect(workload.IsAdmitted(activeSlice)).Should(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("deleting the origin slice to emulate a rollout GC of the old cluster's workloads")
+		util.DeleteWorkloadSliceAndAwaitDeletion(ctx, k8sClient, types.NamespacedName{Namespace: ns.Name, Name: originSliceName})
+
+		ginkgo.By("creating a still-gated pod that points at the now-deleted origin slice, owned by the child RayCluster")
+		childCluster := &rayv1.RayCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: service.Name + "-raycluster", Namespace: ns.Name},
+			Spec:       *service.Spec.RayClusterSpec.DeepCopy(),
+		}
+		util.MustCreate(ctx, k8sClient, childCluster)
+
+		gatedPod := testingpod.MakePod("worker-0", ns.Name).
+			Annotation(kueue.WorkloadAnnotation, originSliceName).
+			Annotation(kueue.WorkloadSliceNameAnnotation, originSliceName).
+			Label(constants.PodSetLabel, string(activeSlice.Spec.PodSets[1].Name)).
+			Gate(kueue.ElasticJobSchedulingGate).
+			Obj()
+		gatedPod.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion:         rayv1.SchemeGroupVersion.String(),
+			Kind:               "RayCluster",
+			Name:               childCluster.Name,
+			UID:                childCluster.UID,
+			Controller:         new(true),
+			BlockOwnerDeletion: new(true),
+		}}
+		util.MustCreate(ctx, k8sClient, gatedPod)
+
+		ginkgo.By("the ungater removes the elastic scheduling gate despite the origin slice being gone")
+		gomega.Eventually(func(g gomega.Gomega) {
+			var got corev1.Pod
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(gatedPod), &got)).To(gomega.Succeed())
+			g.Expect(got.Spec.SchedulingGates).ShouldNot(gomega.ContainElement(
+				corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+	})
+})

--- a/test/integration/singlecluster/controller/jobs/rayservice/rayservice_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayservice/rayservice_controller_test.go
@@ -36,7 +36,6 @@ import (
 	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
 	testingrayservice "sigs.k8s.io/kueue/pkg/util/testingjobs/rayservice"
 	"sigs.k8s.io/kueue/pkg/workload"
-	workloadfinish "sigs.k8s.io/kueue/pkg/workload/finish"
 	"sigs.k8s.io/kueue/pkg/workloadslicing"
 	"sigs.k8s.io/kueue/test/integration/framework"
 	"sigs.k8s.io/kueue/test/util"
@@ -140,13 +139,9 @@ var _ = ginkgo.Describe("RayService with elastic jobs via workload-slices suppor
 			workloads := &kueue.WorkloadList{}
 			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(ns.Name))).Should(gomega.Succeed())
 			g.Expect(workloads.Items).Should(gomega.HaveLen(2))
-			activeSlice = nil
-			for i := range workloads.Items {
-				if !workloadfinish.IsFinished(&workloads.Items[i]) {
-					activeSlice = &workloads.Items[i]
-				}
-			}
-			g.Expect(activeSlice).ShouldNot(gomega.BeNil())
+			activeWorkloads := util.FindNonFinishedWorkloads(workloads.Items)
+			g.Expect(activeWorkloads).Should(gomega.HaveLen(1))
+			activeSlice = &activeWorkloads[0]
 			g.Expect(activeSlice.Name).ShouldNot(gomega.Equal(originSliceName))
 			g.Expect(workload.IsAdmitted(activeSlice)).Should(gomega.BeTrue())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())

--- a/test/integration/singlecluster/controller/jobs/rayservice/rayservice_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayservice/rayservice_controller_test.go
@@ -17,6 +17,9 @@ limitations under the License.
 package rayservice
 
 import (
+	"fmt"
+	"slices"
+
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
@@ -41,9 +44,9 @@ import (
 
 var _ = ginkgo.Describe("RayService with elastic jobs via workload-slices support", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	var (
-		ns           *corev1.Namespace
-		clusterQueue *kueue.ClusterQueue
-		localQueue   *kueue.LocalQueue
+		ns             *corev1.Namespace
+		clusterQueue   *kueue.ClusterQueue
+		localQueue     *kueue.LocalQueue
 		resourceFlavor *kueue.ResourceFlavor
 	)
 
@@ -100,11 +103,36 @@ var _ = ginkgo.Describe("RayService with elastic jobs via workload-slices suppor
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		originSliceName := originSlice.Name
 
-		ginkgo.By("scaling up the worker replicas to create a second (active) slice")
+		ginkgo.By("creating the child RayCluster owned by the RayService, as KubeRay would")
+		// The child RayCluster is owned by the RayService, mirroring the real
+		// topology: the pods' controller owner (RayCluster) differs from the
+		// slices' owner (RayService).
+		childCluster := &rayv1.RayCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: service.Name + "-raycluster", Namespace: ns.Name},
+			Spec:       *service.Spec.RayClusterSpec.DeepCopy(),
+		}
+		childCluster.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion:         rayv1.SchemeGroupVersion.String(),
+			Kind:               "RayService",
+			Name:               service.Name,
+			UID:                service.UID,
+			Controller:         new(true),
+			BlockOwnerDeletion: new(true),
+		}}
+		util.MustCreate(ctx, k8sClient, childCluster)
+
+		ginkgo.By("promoting the child cluster to active in the RayService status, as KubeRay would")
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(service), service)).Should(gomega.Succeed())
-			service.Spec.RayClusterSpec.WorkerGroupSpecs[0].Replicas = new(int32(2))
-			g.Expect(k8sClient.Update(ctx, service)).Should(gomega.Succeed())
+			service.Status.ActiveServiceStatus.RayClusterName = childCluster.Name
+			g.Expect(k8sClient.Status().Update(ctx, service)).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("scaling up the child RayCluster's worker replicas, as the Ray autoscaler would")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(childCluster), childCluster)).Should(gomega.Succeed())
+			childCluster.Spec.WorkerGroupSpecs[0].Replicas = new(int32(2))
+			g.Expect(k8sClient.Update(ctx, childCluster)).Should(gomega.Succeed())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 		var activeSlice *kueue.Workload
@@ -126,35 +154,51 @@ var _ = ginkgo.Describe("RayService with elastic jobs via workload-slices suppor
 		ginkgo.By("deleting the origin slice to emulate a rollout GC of the old cluster's workloads")
 		util.DeleteWorkloadSliceAndAwaitDeletion(ctx, k8sClient, types.NamespacedName{Namespace: ns.Name, Name: originSliceName})
 
-		ginkgo.By("creating a still-gated pod that points at the now-deleted origin slice, owned by the child RayCluster")
-		childCluster := &rayv1.RayCluster{
-			ObjectMeta: metav1.ObjectMeta{Name: service.Name + "-raycluster", Namespace: ns.Name},
-			Spec:       *service.Spec.RayClusterSpec.DeepCopy(),
+		ginkgo.By("creating still-gated pods that point at the now-deleted origin slice, owned by the child RayCluster")
+		var workerPodSet kueue.PodSetReference
+		for _, ps := range activeSlice.Spec.PodSets {
+			if ps.Name != "head" {
+				workerPodSet = ps.Name
+			}
 		}
-		util.MustCreate(ctx, k8sClient, childCluster)
+		gomega.Expect(workerPodSet).ShouldNot(gomega.BeEmpty())
 
-		gatedPod := testingpod.MakePod("worker-0", ns.Name).
-			Annotation(kueue.WorkloadAnnotation, originSliceName).
-			Annotation(kueue.WorkloadSliceNameAnnotation, originSliceName).
-			Label(constants.PodSetLabel, string(activeSlice.Spec.PodSets[1].Name)).
-			Gate(kueue.ElasticJobSchedulingGate).
-			Obj()
-		gatedPod.OwnerReferences = []metav1.OwnerReference{{
-			APIVersion:         rayv1.SchemeGroupVersion.String(),
-			Kind:               "RayCluster",
-			Name:               childCluster.Name,
-			UID:                childCluster.UID,
-			Controller:         new(true),
-			BlockOwnerDeletion: new(true),
-		}}
-		util.MustCreate(ctx, k8sClient, gatedPod)
+		// One more gated pod than the active slice's granted worker count (2), so
+		// the test also pins that ungating stays capped by the admitted quota.
+		gatedPods := make([]*corev1.Pod, 3)
+		for i := range gatedPods {
+			gatedPods[i] = testingpod.MakePod(fmt.Sprintf("worker-%d", i), ns.Name).
+				Annotation(kueue.WorkloadAnnotation, originSliceName).
+				Annotation(kueue.WorkloadSliceNameAnnotation, originSliceName).
+				Label(constants.PodSetLabel, string(workerPodSet)).
+				Gate(kueue.ElasticJobSchedulingGate).
+				Obj()
+			gatedPods[i].OwnerReferences = []metav1.OwnerReference{{
+				APIVersion:         rayv1.SchemeGroupVersion.String(),
+				Kind:               "RayCluster",
+				Name:               childCluster.Name,
+				UID:                childCluster.UID,
+				Controller:         new(true),
+				BlockOwnerDeletion: new(true),
+			}}
+			util.MustCreate(ctx, k8sClient, gatedPods[i])
+		}
 
-		ginkgo.By("the ungater removes the elastic scheduling gate despite the origin slice being gone")
-		gomega.Eventually(func(g gomega.Gomega) {
+		hasElasticGate := func(g gomega.Gomega, pod *corev1.Pod) bool {
 			var got corev1.Pod
-			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(gatedPod), &got)).To(gomega.Succeed())
-			g.Expect(got.Spec.SchedulingGates).ShouldNot(gomega.ContainElement(
-				corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}))
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), &got)).To(gomega.Succeed())
+			return slices.Contains(got.Spec.SchedulingGates, corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate})
+		}
+
+		ginkgo.By("the ungater removes the elastic scheduling gate from the two lowest-named pods despite the origin slice being gone")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(hasElasticGate(g, gatedPods[0])).Should(gomega.BeFalse())
+			g.Expect(hasElasticGate(g, gatedPods[1])).Should(gomega.BeFalse())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("the pod beyond the active slice's granted worker count stays gated")
+		gomega.Consistently(func(g gomega.Gomega) {
+			g.Expect(hasElasticGate(g, gatedPods[2])).Should(gomega.BeTrue())
+		}, util.LongConsistentDuration, util.Interval).Should(gomega.Succeed())
 	})
 })

--- a/test/integration/singlecluster/controller/jobs/rayservice/rayservice_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayservice/rayservice_controller_test.go
@@ -80,11 +80,6 @@ var _ = ginkgo.Describe("RayService with elastic jobs via workload-slices suppor
 	})
 
 	ginkgo.It("Should ungate chain pods after the origin workload slice is deleted", framework.SlowSpec, func() {
-		// Same stranded-pod scenario as the RayCluster spec, but for a RayService:
-		// Kueue owns the Workload through the RayService while KubeRay owns the pods
-		// through the child RayCluster. Once the origin slice is gone, recovering the
-		// owning job from the pod's controller reference yields the RayCluster, whose
-		// kind does not match the RayService the Workload is indexed under.
 		service := testingrayservice.MakeService("foo", ns.Name).
 			Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
 			Queue(localQueue.Name).

--- a/test/integration/singlecluster/controller/jobs/rayservice/suite_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayservice/suite_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rayservice
+
+import (
+	"context"
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	config "sigs.k8s.io/kueue/apis/config/v1beta2"
+	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
+	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	"sigs.k8s.io/kueue/pkg/constants"
+	"sigs.k8s.io/kueue/pkg/controller/core"
+	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
+	"sigs.k8s.io/kueue/pkg/controller/elasticjobs"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/rayservice"
+	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/scheduler"
+	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
+	"sigs.k8s.io/kueue/pkg/webhooks"
+	"sigs.k8s.io/kueue/test/integration/framework"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	ctx       context.Context
+	fwk       *framework.Framework
+)
+
+func TestAPIs(t *testing.T) {
+	util.RunSuite(t, "RayService Controller Suite")
+}
+
+var _ = ginkgo.BeforeSuite(func() {
+	fwk = &framework.Framework{
+		DepCRDPaths: []string{util.RayOperatorCrds},
+	}
+
+	cfg = fwk.Init()
+	ctx, k8sClient = fwk.SetupClient(cfg)
+})
+
+var _ = ginkgo.AfterSuite(func() {
+	fwk.Teardown()
+})
+
+func managerAndSchedulerSetup(opts ...jobframework.Option) framework.ManagerSetup {
+	return func(ctx context.Context, mgr manager.Manager) {
+		err := indexer.Setup(ctx, mgr.GetFieldIndexer())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		cCache := schdcache.New(mgr.GetClient())
+		preemptionExpectations := preemptexpectations.New()
+		queueOptions := []qcache.Option{qcache.WithPreemptionExpectations(preemptionExpectations)}
+		queues := util.NewManagerForIntegrationTests(ctx, mgr.GetClient(), cCache, queueOptions...)
+		opts = append(opts, jobframework.WithQueues(queues))
+
+		failedCtrl, err := core.SetupControllers(
+			mgr,
+			queues,
+			cCache,
+			&config.Configuration{},
+			core.SetupControllersOpts{PreemptionExpectations: preemptionExpectations},
+		)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
+
+		failedWebhook, err := webhooks.Setup(mgr, nil)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
+
+		err = rayservice.SetupIndexes(ctx, mgr.GetFieldIndexer())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		reconciler, err := rayservice.NewReconciler(ctx, mgr.GetClient(), mgr.GetFieldIndexer(),
+			mgr.GetEventRecorder(constants.JobControllerName), opts...)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = reconciler.SetupWithManager(mgr)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = rayservice.SetupRayServiceWebhook(mgr, opts...)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		if features.Enabled(features.ElasticJobsViaWorkloadSlices) {
+			failedCtrl, err := elasticjobs.SetupWithManager(mgr, &config.Configuration{}, nil)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
+		}
+
+		sched := scheduler.New(
+			queues,
+			cCache,
+			mgr.GetClient(),
+			mgr.GetEventRecorder(constants.AdmissionName),
+			scheduler.WithPreemptionExpectations(preemptionExpectations),
+		)
+		err = sched.Start(ctx)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}
+}


### PR DESCRIPTION
Cherry pick of #14703 on release-0.18.

#14703: Fix elastic ungating when pods and the Workload have different owners

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
RayService: Fixed a bug where elastic (autoscaling) RayService pods could stay stuck in `SchedulingGated` on `kueue.x-k8s.io/elastic-job` after the origin workload slice was deleted, leaving the RayCluster below its desired replica count.
```