### PR TITLE
Add support for handling EffectiveQuotas in Cohorts

### DIFF
--- a/pkg/cache/scheduler/cohort.go
+++ b/pkg/cache/scheduler/cohort.go
@@ -21,6 +21,7 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/cache/hierarchy"
+	"sigs.k8s.io/kueue/pkg/util/resourcegroups"
 )
 
 // cohort is a set of ClusterQueues that can borrow resources from each other.
@@ -46,7 +47,7 @@ func newCohort(name kueue.CohortReference) *cohort {
 func (c *cohort) updateCohort(apiCohort *kueue.Cohort, oldParent *cohort) error {
 	c.FairWeight = parseFairWeight(apiCohort.Spec.FairSharing)
 
-	c.resourceNode.Quotas = createResourceQuotas(apiCohort.Spec.ResourceGroups)
+	c.resourceNode.Quotas = createResourceQuotas(resourcegroups.EffectiveCohortResourceGroups(apiCohort))
 	if oldParent != nil && oldParent != c.Parent() {
 		updateCohortTreeResourcesIfNoCycle(oldParent)
 	}

--- a/pkg/cache/scheduler/resource_node_test.go
+++ b/pkg/cache/scheduler/resource_node_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/resources"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
@@ -63,5 +64,53 @@ func TestCohortLendable(t *testing.T) {
 	lendable := calculateLendable(cache.hm.Cohort("test-cohort"))
 	if diff := cmp.Diff(wantLendable, lendable); diff != "" {
 		t.Errorf("Unexpected cohort lendable (-want,+got):\n%s", diff)
+	}
+}
+
+func TestCohortEffectiveQuotasUpdateAndFallback(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.DynamicQuotaOrchestration, true)
+
+	cohortSpec := utiltestingapi.MakeCohort("test-cohort").
+		ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "10").Obj(),
+		).Obj()
+
+	c := newCohort("test-cohort")
+	if err := c.updateCohort(cohortSpec, nil); err != nil {
+		t.Fatalf("unexpected error updating cohort: %v", err)
+	}
+
+	fr := resources.FlavorResource{Flavor: "default", Resource: corev1.ResourceCPU}
+	if q := c.resourceNode.Quotas[fr]; q.Nominal != resources.NewAmount(10000) {
+		t.Errorf("expected nominal quota 10000 from spec, got %v", q.Nominal)
+	}
+
+	cohortEffective := utiltestingapi.MakeCohort("test-cohort").
+		ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "10").Obj(),
+		).
+		EffectiveQuotas(
+			*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "500").Obj(),
+		).Obj()
+
+	if err := c.updateCohort(cohortEffective, nil); err != nil {
+		t.Fatalf("unexpected error updating cohort: %v", err)
+	}
+
+	if q := c.resourceNode.Quotas[fr]; q.Nominal != resources.NewAmount(500000) {
+		t.Errorf("expected nominal quota 500000 from EffectiveQuotas, got %v", q.Nominal)
+	}
+
+	cohortCleared := utiltestingapi.MakeCohort("test-cohort").
+		ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "10").Obj(),
+		).Obj()
+
+	if err := c.updateCohort(cohortCleared, nil); err != nil {
+		t.Fatalf("unexpected error updating cohort: %v", err)
+	}
+
+	if q := c.resourceNode.Quotas[fr]; q.Nominal != resources.NewAmount(10000) {
+		t.Errorf("expected nominal quota 10000 after clearing EffectiveQuotas, got %v", q.Nominal)
 	}
 }

--- a/pkg/controller/core/cohort_controller.go
+++ b/pkg/controller/core/cohort_controller.go
@@ -39,6 +39,7 @@ import (
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/metrics"
+	"sigs.k8s.io/kueue/pkg/util/resourcegroups"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 )
 
@@ -147,7 +148,10 @@ func (r *CohortReconciler) Update(e event.TypedUpdateEvent[*kueue.Cohort]) bool 
 		e.ObjectNew.GetAnnotations(),
 	)
 
-	if equality.Semantic.DeepEqual(e.ObjectOld.Spec, e.ObjectNew.Spec) && !clUpdateRequired {
+	specOrQuotaUpdated := !equality.Semantic.DeepEqual(e.ObjectOld.Spec, e.ObjectNew.Spec) ||
+		!equality.Semantic.DeepEqual(resourcegroups.EffectiveCohortResourceGroups(e.ObjectOld), resourcegroups.EffectiveCohortResourceGroups(e.ObjectNew))
+
+	if !specOrQuotaUpdated && !clUpdateRequired {
 		log.V(2).Info("Skip Cohort update event as Cohort unchanged")
 		return false
 	}
@@ -196,7 +200,10 @@ func (r *CohortReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		)
 	}
 
-	log.V(2).Info("Cohort is being created or updated", "resources", cohort.Spec.ResourceGroups)
+	log.V(2).Info("Cohort is being created or updated",
+		"resources", resourcegroups.EffectiveCohortResourceGroups(&cohort),
+		"usesEffectiveQuotas", features.Enabled(features.DynamicQuotaOrchestration) && cohort.Status.EffectiveQuotas != nil,
+	)
 	if err := r.cache.AddOrUpdateCohort(&cohort); err != nil {
 		log.V(2).Error(err, "Error adding or updating cohort in the cache")
 		// Fail fast to avoid queue/status updates from a stale cache state.

--- a/pkg/controller/core/cohort_controller_test.go
+++ b/pkg/controller/core/cohort_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/component-base/featuregate"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -32,6 +33,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/resources"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -405,9 +407,10 @@ func TestCohortReconcilerFilters(t *testing.T) {
 	})
 
 	cases := map[string]struct {
-		old  *kueue.Cohort
-		new  *kueue.Cohort
-		want bool
+		featureGates map[featuregate.Feature]bool
+		old          *kueue.Cohort
+		new          *kueue.Cohort
+		want         bool
 	}{
 		"unchanged returns false": {
 			old: utiltestingapi.MakeCohort("cohort").ResourceGroup(
@@ -457,9 +460,48 @@ func TestCohortReconcilerFilters(t *testing.T) {
 			new:  utiltestingapi.MakeCohort("cohort").FairWeight(resource.MustParse("2")).Obj(),
 			want: true,
 		},
+		"updating status.effectiveQuotas with DynamicQuotaOrchestration enabled returns true": {
+			featureGates: map[featuregate.Feature]bool{features.DynamicQuotaOrchestration: true},
+			old: utiltestingapi.MakeCohort("cohort").ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas("red").Resource("cpu", "5").Obj(),
+			).Obj(),
+			new: utiltestingapi.MakeCohort("cohort").ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas("red").Resource("cpu", "5").Obj(),
+			).EffectiveQuotas(
+				*utiltestingapi.MakeFlavorQuotas("red").Resource("cpu", "10").Obj(),
+			).Obj(),
+			want: true,
+		},
+		"updating status.effectiveQuotas with DynamicQuotaOrchestration disabled returns false": {
+			featureGates: map[featuregate.Feature]bool{features.DynamicQuotaOrchestration: false},
+			old: utiltestingapi.MakeCohort("cohort").ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas("red").Resource("cpu", "5").Obj(),
+			).Obj(),
+			new: utiltestingapi.MakeCohort("cohort").ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas("red").Resource("cpu", "5").Obj(),
+			).EffectiveQuotas(
+				*utiltestingapi.MakeFlavorQuotas("red").Resource("cpu", "10").Obj(),
+			).Obj(),
+			want: false,
+		},
+		"updating unrelated status returns false": {
+			featureGates: map[featuregate.Feature]bool{features.DynamicQuotaOrchestration: true},
+			old: utiltestingapi.MakeCohort("cohort").ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas("red").Resource("cpu", "5").Obj(),
+			).Obj(),
+			new: func() *kueue.Cohort {
+				c := utiltestingapi.MakeCohort("cohort").ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("red").Resource("cpu", "5").Obj(),
+				).Obj()
+				c.Status.FairSharing = &kueue.FairSharingStatus{WeightedShare: 10}
+				return c
+			}(),
+			want: false,
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			e := event.TypedUpdateEvent[*kueue.Cohort]{
 				ObjectOld: tc.old,
 				ObjectNew: tc.new,

--- a/pkg/util/resourcegroups/effective.go
+++ b/pkg/util/resourcegroups/effective.go
@@ -33,10 +33,14 @@ func EffectiveResourceGroups(cq *kueue.ClusterQueue) []kueue.ResourceGroup {
 	return cq.Spec.ResourceGroups
 }
 
-// EffectiveCohortResourceGroups returns Spec.ResourceGroups.
+// EffectiveCohortResourceGroups returns Status.EffectiveQuotas.ResourceGroups when DynamicQuotaOrchestration
+// feature gate is enabled and effective quota is set; otherwise returns Spec.ResourceGroups.
 func EffectiveCohortResourceGroups(cohort *kueue.Cohort) []kueue.ResourceGroup {
 	if cohort == nil {
 		return nil
+	}
+	if features.Enabled(features.DynamicQuotaOrchestration) && cohort.Status.EffectiveQuotas != nil {
+		return cohort.Status.EffectiveQuotas.ResourceGroups
 	}
 	return cohort.Spec.ResourceGroups
 }

--- a/pkg/util/resourcegroups/effective_test.go
+++ b/pkg/util/resourcegroups/effective_test.go
@@ -91,3 +91,68 @@ func TestEffectiveResourceGroups(t *testing.T) {
 		})
 	}
 }
+
+func TestEffectiveCohortResourceGroups(t *testing.T) {
+	specFlavor := utiltestingapi.MakeFlavorQuotas("spec-flavor").Resource(corev1.ResourceCPU, "10").FlavorQuotas
+	effectiveFlavor := utiltestingapi.MakeFlavorQuotas("effective-flavor").Resource(corev1.ResourceCPU, "20").FlavorQuotas
+
+	cases := map[string]struct {
+		dynamicQuota bool
+		cohort       *kueue.Cohort
+		wantRGs      []kueue.ResourceGroup
+	}{
+		"DynamicQuotaOrchestration disabled returns spec": {
+			dynamicQuota: false,
+			cohort: utiltestingapi.MakeCohort("test-cohort").
+				ResourceGroup(specFlavor).
+				EffectiveQuotas(effectiveFlavor).
+				Obj(),
+			wantRGs: []kueue.ResourceGroup{
+				utiltestingapi.ResourceGroup(specFlavor),
+			},
+		},
+		"DynamicQuotaOrchestration enabled returns status effectiveQuotas when set": {
+			dynamicQuota: true,
+			cohort: utiltestingapi.MakeCohort("test-cohort").
+				ResourceGroup(specFlavor).
+				EffectiveQuotas(effectiveFlavor).
+				Obj(),
+			wantRGs: []kueue.ResourceGroup{
+				utiltestingapi.ResourceGroup(effectiveFlavor),
+			},
+		},
+		"DynamicQuotaOrchestration enabled returns spec when effectiveQuotas is nil": {
+			dynamicQuota: true,
+			cohort: utiltestingapi.MakeCohort("test-cohort").
+				ResourceGroup(specFlavor).
+				Obj(),
+			wantRGs: []kueue.ResourceGroup{
+				utiltestingapi.ResourceGroup(specFlavor),
+			},
+		},
+		"DynamicQuotaOrchestration enabled returns empty status effectiveQuotas when set to empty": {
+			dynamicQuota: true,
+			cohort: func() *kueue.Cohort {
+				c := utiltestingapi.MakeCohort("test-cohort").ResourceGroup(specFlavor).Obj()
+				c.Status.EffectiveQuotas = &kueue.EffectiveQuotaStatus{ResourceGroups: []kueue.ResourceGroup{}}
+				return c
+			}(),
+			wantRGs: []kueue.ResourceGroup{},
+		},
+		"nil cohort returns nil": {
+			dynamicQuota: true,
+			cohort:       nil,
+			wantRGs:      nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.DynamicQuotaOrchestration, tc.dynamicQuota)
+
+			if diff := cmp.Diff(tc.wantRGs, EffectiveCohortResourceGroups(tc.cohort)); diff != "" {
+				t.Errorf("Unexpected EffectiveCohortResourceGroups (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/test/integration/singlecluster/scheduler/scheduler_dynamicquota_test.go
+++ b/test/integration/singlecluster/scheduler/scheduler_dynamicquota_test.go
@@ -32,10 +32,13 @@ import (
 
 var _ = ginkgo.Describe("Scheduler DynamicQuotaOrchestration", ginkgo.Ordered, func() {
 	var (
-		ns           *corev1.Namespace
-		flavor       *kueue.ResourceFlavor
-		clusterQueue *kueue.ClusterQueue
-		localQueue   *kueue.LocalQueue
+		ns                 *corev1.Namespace
+		flavor             *kueue.ResourceFlavor
+		clusterQueue       *kueue.ClusterQueue
+		localQueue         *kueue.LocalQueue
+		secondClusterQueue *kueue.ClusterQueue
+		secondLocalQueue   *kueue.LocalQueue
+		cohort             *kueue.Cohort
 	)
 
 	ginkgo.BeforeEach(func() {
@@ -57,12 +60,24 @@ var _ = ginkgo.Describe("Scheduler DynamicQuotaOrchestration", ginkgo.Ordered, f
 			ClusterQueue(clusterQueue.Name).
 			Obj()
 		util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueue)
+		secondClusterQueue = nil
+		secondLocalQueue = nil
+		cohort = nil
 	})
 
 	ginkgo.AfterEach(func() {
 		gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
 		gomega.Expect(util.DeleteObject(ctx, k8sClient, localQueue)).Should(gomega.Succeed())
+		if secondLocalQueue != nil {
+			gomega.Expect(util.DeleteObject(ctx, k8sClient, secondLocalQueue)).Should(gomega.Succeed())
+		}
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+		if secondClusterQueue != nil {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, secondClusterQueue, true)
+		}
+		if cohort != nil {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, cohort, true)
+		}
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, flavor, true)
 		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
 	})
@@ -182,7 +197,148 @@ var _ = ginkgo.Describe("Scheduler DynamicQuotaOrchestration", ginkgo.Ordered, f
 			util.ExpectWorkloadsToBePending(ctx, k8sClient, wl2)
 		})
 	})
+
+	ginkgo.Context("with Cohort", func() {
+		ginkgo.BeforeEach(func() {
+			cohort = utiltestingapi.MakeCohort("dynquota-cohort").
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas(flavor.Name).
+					Resource(corev1.ResourceCPU, "1").
+					Obj()).
+				Obj()
+			util.MustCreate(ctx, k8sClient, cohort)
+			gomega.Eventually(func(g gomega.Gomega) {
+				var currentCQ kueue.ClusterQueue
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &currentCQ)).To(gomega.Succeed())
+				currentCQ.Spec.CohortName = kueue.CohortReference(cohort.Name)
+				g.Expect(k8sClient.Update(ctx, &currentCQ)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("should admit workload borrowing from cohort when Cohort and CQ status are updated with EffectiveQuotas", func() {
+			wl := utiltestingapi.MakeWorkload("wl-cohort", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				Request(corev1.ResourceCPU, "4").
+				Obj()
+
+			ginkgo.By("creating a workload when CQ has 1 CPU and Cohort has 1 CPU (requesting 4 CPU)", func() {
+				util.MustCreate(ctx, k8sClient, wl)
+				util.ExpectWorkloadsToBePending(ctx, k8sClient, wl)
+			})
+
+			ginkgo.By("updating CQ and Cohort status with EffectiveQuotas (CQ 2 CPU, Cohort 3 CPU)", func() {
+				updateCQEffectiveQuotas(ctx, k8sClient, clusterQueue, flavor, "2", "dqo-test")
+				updateCohortEffectiveQuotas(ctx, k8sClient, cohort, flavor, "3", "dqo-test")
+			})
+
+			ginkgo.By("verifying the pending workload is scheduled and admitted borrowing from Cohort", func() {
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+			})
+		})
+
+		ginkgo.It("should fallback to spec when Cohort EffectiveQuotas status is cleared", func() {
+			ginkgo.By("updating CQ and Cohort status with EffectiveQuotas (CQ 2 CPU, Cohort 3 CPU)", func() {
+				updateCQEffectiveQuotas(ctx, k8sClient, clusterQueue, flavor, "2", "dqo-test")
+				updateCohortEffectiveQuotas(ctx, k8sClient, cohort, flavor, "3", "dqo-test")
+			})
+
+			wl1 := utiltestingapi.MakeWorkload("wl1-cohort-fallback", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				Request(corev1.ResourceCPU, "4").
+				Obj()
+
+			ginkgo.By("verifying initial workload uses CQ effective quota and borrows from Cohort", func() {
+				util.MustCreate(ctx, k8sClient, wl1)
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+			})
+
+			ginkgo.By("clearing EffectiveQuotas in Cohort status", func() {
+				updateCohortEffectiveQuotas(ctx, k8sClient, cohort, flavor, "", "")
+			})
+
+			ginkgo.By("verifying subsequent workload requiring Cohort borrowing stays pending", func() {
+				wl2 := utiltestingapi.MakeWorkload("wl2-cohort-fallback", ns.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).
+					Request(corev1.ResourceCPU, "1").
+					Obj()
+				util.MustCreate(ctx, k8sClient, wl2)
+				util.ExpectWorkloadsToBePending(ctx, k8sClient, wl2)
+			})
+		})
+
+		ginkgo.It("should share Cohort EffectiveQuotas across multiple ClusterQueues", func() {
+			secondClusterQueue = utiltestingapi.MakeClusterQueue("dynquota-cq2").
+				Cohort(kueue.CohortReference(cohort.Name)).
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas(flavor.Name).
+					Resource(corev1.ResourceCPU, "1").
+					Obj()).
+				Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, secondClusterQueue)
+
+			secondLocalQueue = utiltestingapi.MakeLocalQueue("dynquota-lq2", ns.Name).
+				ClusterQueue(secondClusterQueue.Name).
+				Obj()
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, secondLocalQueue)
+
+			ginkgo.By("updating CQ1, CQ2, and Cohort status with EffectiveQuotas (CQs 2 CPU each, Cohort 2 CPU)", func() {
+				updateCQEffectiveQuotas(ctx, k8sClient, clusterQueue, flavor, "2", "dqo-test")
+				updateCQEffectiveQuotas(ctx, k8sClient, secondClusterQueue, flavor, "2", "dqo-test")
+				updateCohortEffectiveQuotas(ctx, k8sClient, cohort, flavor, "2", "dqo-test")
+			})
+
+			wlCQ1 := utiltestingapi.MakeWorkload("wl-cq1", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				Request(corev1.ResourceCPU, "3").
+				Obj()
+
+			wlCQ2 := utiltestingapi.MakeWorkload("wl-cq2", ns.Name).
+				Queue(kueue.LocalQueueName(secondLocalQueue.Name)).
+				Request(corev1.ResourceCPU, "3").
+				Obj()
+
+			ginkgo.By("admitting wl-cq1 which uses 2 CPU from CQ1 and borrows 1 CPU from Cohort", func() {
+				util.MustCreate(ctx, k8sClient, wlCQ1)
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlCQ1)
+			})
+
+			ginkgo.By("admitting wl-cq2 which uses 2 CPU from CQ2 and borrows 1 CPU from Cohort", func() {
+				util.MustCreate(ctx, k8sClient, wlCQ2)
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlCQ2)
+			})
+
+			ginkgo.By("verifying a third workload stays pending when Cohort EffectiveQuotas is exhausted", func() {
+				wlCQ1Pending := utiltestingapi.MakeWorkload("wl-cq1-pending", ns.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).
+					Request(corev1.ResourceCPU, "1").
+					Obj()
+				util.MustCreate(ctx, k8sClient, wlCQ1Pending)
+				util.ExpectWorkloadsToBePending(ctx, k8sClient, wlCQ1Pending)
+			})
+		})
+
+		ginkgo.It("should ignore Cohort EffectiveQuotas status when DynamicQuotaOrchestration feature gate is disabled", func() {
+			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.DynamicQuotaOrchestration, false)
+
+			updateCQEffectiveQuotas(ctx, k8sClient, clusterQueue, flavor, "2", "dqo-test")
+			updateCohortEffectiveQuotas(ctx, k8sClient, cohort, flavor, "3", "dqo-test")
+
+			wl := utiltestingapi.MakeWorkload("wl-cohort-fg-disabled", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				Request(corev1.ResourceCPU, "3").
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, wl)
+		})
+	})
 })
+
+func updateCohortEffectiveQuotas(ctx context.Context, k8sClient client.Client, cohort *kueue.Cohort, flavor *kueue.ResourceFlavor, cpuQty, orchestratorName string) {
+	gomega.Eventually(func(g gomega.Gomega) {
+		var currentCohort kueue.Cohort
+		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cohort), &currentCohort)).To(gomega.Succeed())
+		currentCohort.Status.EffectiveQuotas = makeEffectiveQuotaStatus(flavor, cpuQty, orchestratorName)
+		g.Expect(k8sClient.Status().Update(ctx, &currentCohort)).To(gomega.Succeed())
+	}, util.Timeout, util.Interval).Should(gomega.Succeed())
+}
 
 func updateCQEffectiveQuotas(ctx context.Context, k8sClient client.Client, cq *kueue.ClusterQueue, flavor *kueue.ResourceFlavor, cpuQty, orchestratorName string) {
 	gomega.Eventually(func(g gomega.Gomega) {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Part of [KEP-12382: Dynamic Quota Orchestration](https://github.com/kubernetes-sigs/kueue/pull/14104).
This PR adds scheduling, caching, and controller support for `status.effectiveQuotas` ONLY on `Cohort` under the new alpha feature gate `DynamicQuotaOrchestration`.

> [!NOTE]
> Changes for metrics will follow in a separate PR.

#### Which issue(s) this PR fixes:

Part of #12382

#### Special notes for your reviewer:

The remaining `ResourceGroups` references in the codebase (excluding test and cohort related files):

```bash
$ git grep -n "\.Spec\.ResourceGroups" -- 'pkg/**' 'cmd/**' ':(exclude)*_test.go'
cmd/importer/cache/cache.go:117:        rgs := make([]resourcegroups.ResourceGroup, 0, len(cq.Spec.ResourceGroups))
cmd/importer/cache/cache.go:118:        for _, rg := range cq.Spec.ResourceGroups {
cmd/importer/pod/check.go:106:  if len(cq.Spec.ResourceGroups) == 0 {
cmd/kueueviz/backend/handlers/cluster_queues.go:69:             for _, rg := range item.Spec.ResourceGroups {
cmd/kueueviz/backend/handlers/cluster_queues.go:79:                     "resourceGroups":     convertResourceGroups(item.Spec.ResourceGroups),
cmd/kueueviz/backend/handlers/cluster_queues.go:128:                    "resourceGroups":    convertResourceGroups(cq.Spec.ResourceGroups),
cmd/kueueviz/backend/handlers/cohorts.go:116:                                   "resourceGroups":    convertResourceGroups(item.Spec.ResourceGroups),
cmd/kueueviz/backend/handlers/resource_flavors.go:100:          resourceGroups := item.Spec.ResourceGroups
pkg/cache/scheduler/clusterqueue_metrics.go:54: for rgi := range oldCq.Spec.ResourceGroups {
pkg/cache/scheduler/clusterqueue_metrics.go:55:         oldRg := &oldCq.Spec.ResourceGroups[rgi]
pkg/controller/admissionchecks/multikueue/clusterqueue.go:105:  if len(cq.Spec.ResourceGroups) != 1 || len(cq.Spec.ResourceGroups[0].Flavors) != 1 {
pkg/controller/admissionchecks/multikueue/clusterqueue.go:115:  singleFlavor := &cq.Spec.ResourceGroups[0].Flavors[0]
pkg/controller/admissionchecks/multikueue/clusterqueue.go:122:  covered := sets.New(cq.Spec.ResourceGroups[0].CoveredResources...)
pkg/controller/admissionchecks/multikueue/clusterqueue.go:132:  for _, resName := range cq.Spec.ResourceGroups[0].CoveredResources {
pkg/controller/admissionchecks/multikueue/clusterqueue.go:220:                  for _, rg := range rcq.Spec.ResourceGroups {
pkg/controller/admissionchecks/multikueue/multikueuecluster.go:528:                     if ok1 && ok2 && !equality.Semantic.DeepEqual(oldCQ.Spec.ResourceGroups, newCQ.Spec.ResourceGroups) {
pkg/util/resourcegroups/effective.go:33:        return cq.Spec.ResourceGroups
pkg/util/resourcegroups/effective.go:45:        return cohort.Spec.ResourceGroups
pkg/util/testing/v1beta2/wrappers.go:934:       c.Spec.ResourceGroups = append(c.Spec.ResourceGroups, ResourceGroup(flavors...))
pkg/util/testing/v1beta2/wrappers.go:1095:      c.Spec.ResourceGroups = append(c.Spec.ResourceGroups, ResourceGroup(flavors...))
pkg/webhooks/clusterqueue_webhook.go:121:       allErrs = append(allErrs, validateResourceGroups(cq.Spec.ResourceGroups, config, path.Child("resourceGroups"), false)...)
pkg/webhooks/clusterqueue_webhook.go:131:       allErrs = append(allErrs, validateTotalFlavors(cq.Spec.ResourceGroups, path.Child("resourceGroups"))...)
pkg/webhooks/clusterqueue_webhook.go:132:       allErrs = append(allErrs, validateTotalCoveredResources(cq.Spec.ResourceGroups, path.Child("resourceGroups"))...)
pkg/webhooks/clusterqueue_webhook.go:133:       allErrs = append(allErrs, validateFlavorResourceCombinations(cq.Spec.ResourceGroups, path.Child("resourceGroups"))...)
pkg/webhooks/clusterqueue_webhook.go:146:               newFlavors := utilqueue.AllFlavors(newCQ.Spec.ResourceGroups)
pkg/webhooks/clusterqueue_webhook.go:148:                       utilqueue.AllFlavors(oldCQ.Spec.ResourceGroups).Equal(newFlavors) {
pkg/webhooks/clusterqueue_webhook.go:165:       validFlavors := utilqueue.AllFlavors(cq.Spec.ResourceGroups)
pkg/webhooks/clusterqueue_webhook.go:240:       if len(cq.Spec.ResourceGroups) != 1 {
pkg/webhooks/clusterqueue_webhook.go:241:               allErrs = append(allErrs, field.Invalid(path.Child("resourceGroups"), len(cq.Spec.ResourceGroups),
pkg/webhooks/clusterqueue_webhook.go:245:       if len(cq.Spec.ResourceGroups) == 1 && len(cq.Spec.ResourceGroups[0].Flavors) > 16 {
pkg/webhooks/clusterqueue_webhook.go:246:               allErrs = append(allErrs, field.Invalid(path.Child("resourceGroups").Index(0).Child("flavors"), len(cq.Spec.ResourceGroups[0].Flavors),
pkg/webhooks/clusterqueue_webhook.go:259:                       validFlavors := utilqueue.AllFlavors(cq.Spec.ResourceGroups)
pkg/webhooks/cohort_webhook.go:76:      allErrs = append(allErrs, validateResourceGroups(cohort.Spec.ResourceGroups, config, path.Child("resourceGroups"), true)...)
```

My reasoning for not replacing the remaining references:
- `pkg/controller/admissionchecks/multikueue/*` - it will be replaced by DQO so in my understanding we don't want to mix up two separate features
- `cmd/*` support for `EffectiveQuotas` in any of these should be developed separately in dedicated PRs. Like kueueviz, maybe we would add a separate field or something like this, tbd
- `pkg/webhooks/*` - these validate spec while `EffectiveQuotas` live in `status`

> AI assistance was used during the authoring and refinement of this PR.

#### Does this PR introduce a user-facing change?

```release-note
DynamicQuotaOrchestration: Supported `status.effectiveQuotas` in Cohort scheduling and controllers under the `DynamicQuotaOrchestration` feature gate, falling back to `spec.resourceGroups` when unset or disabled.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Cohort resource quotas can now be dynamically updated through effective quotas.
  - Updated effective quotas are applied to associated ClusterQueues and shared across multiple queues.
  - Clearing effective quotas restores the cohort’s configured quotas.
  - Dynamic quota behavior is controlled by the DynamicQuotaOrchestration feature gate.
  - Effective resource groups now reflect dynamic quota settings when enabled.

- **Bug Fixes**
  - Cohort updates now correctly trigger scheduling changes when effective quotas or resource groups change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->