### PR TITLE
Update main with the latest v0.18.7

### DIFF
--- a/CHANGELOG/CHANGELOG-0.18.md
+++ b/CHANGELOG/CHANGELOG-0.18.md
@@ -1,3 +1,61 @@
+## v0.18.7
+
+Changes since `v0.18.6`:
+
+## Actions Required Before Upgrading
+
+### (No, really, you MUST read this before you upgrade)
+
+- **Minor releases:** Review the `.0` release notes for each new minor version you cross; see: [`v0.17.0`](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.17.0), [`v0.18.0`](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.18.0).
+- **Patch releases:** Review the patch release notes leading up to this version, but *only* within this minor release line; see: [`v0.18.1`](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.18.1), [`v0.18.2`](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.18.2), [`v0.18.3`](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.18.3), [`v0.18.4`](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.18.4), [`v0.18.5`](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.18.5), [`v0.18.6`](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.18.6).
+
+- DRA & ResourceTransformation: Fixed a bug where DRA device-class mapping or a resource transformation under the reserved resource name `pods` was silently discarded or left the Workload permanently pending.
+  
+  Remove or rename those entries before upgrading, or the kueue-controller-manager will fail to start. Renaming a mapping name or an `outputs` key also requires updating the matching ClusterQueue `nominalQuota` entries in the same change. (#14758, @thc1006)
+ 
+## Changes by Kind
+
+### Bug or Regression
+
+- AdmissionChecks: Fix a bug where the Workload has an Admitted=True condition regardless of AdmissionCheck Rejection state. (#15006, @tenzen-y)
+- AdmissionFairSharing: Fixed preemption ordering for Workloads from same-named LocalQueues in different namespaces so that LocalQueue usage is considered. (#14875, @tomsen02)
+- FairSharing: Fix a bug where Kueue could miss valid preemption targets after selecting workloads from the preemptor's own ClusterQueue and lowering its DRS. The fix is guarded by the Alpha `FairSharingReevaluatePreemptionCandidates` feature gate, which is disabled by default. Enabling the gate may increase exposure to the known fair-sharing preemption-loop issue tracked in #14543. (#14768, @lightZebra)
+- Fixed a bug where a prebuilt or externally created Workload could be treated as equivalent to its Job even when the Job's pod template declared pod-level `resources` or `resourceClaims` that the Workload's PodSet omitted, letting the Workload reserve less quota than its Pods actually request. (#15015, @pujitha24)
+- Fixed a controller panic triggered by Namespace updates after a ClusterQueue failed to initialize because its Cohort had a cycle. (#14981, @YQ-Wang)
+- Helm: Fix a bug where user-defined metricsService labels are not propagated to the rendered manifests. (#15004, @HsiuChuanHsu)
+- KueueCtl: Fixed a bug where `kueuectl delete workload` deleted a recreated owner with a different UID. (#14883, @DevaanshPathak)
+- KueueCtl: Fixed the `kueuectl list clusterqueue` comand to respect KUEUECTL_LIST_REQUEST_LIMIT
+  and paginate API requests instead of issuing an unbounded LIST request. (#14881, @ErikJiang)
+- Kueueviz: fix namespace selector error on dashboard. (#14790, @mykysha)
+- MultiKueue: Fixed a bug where a Job is dispatched again due to propagated `spec.ttlSecondsAfterFinished` even after Job completion. Enable the Alpha `MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster` feature gate to enable fixing. (#14827, @kevin85421)
+- MultiKueue: Fixed a bug where a remote workload finishing with reason
+  OwnerNotFound was mirrored back verbatim, permanently finishing the manager
+  Workload and leaving the manager Pod's scheduling gates stuck. Such finishes
+  are now treated as a sync failure and reset for re-dispatch, matching
+  existing OutOfSync handling. (#15092, @mimowo)
+- MultiKueue: Fixed a bug where the WorkloadPriorityClass controller incorrectly updated the priority of MultiKueue remote workloads when a WorkloadPriorityClass value changed. Remote workloads are now skipped during priority synchronization. (#14996, @weizhoublue)
+- MultiKueue: Fixed stale observedGeneration on the AdmissionCheckActive condition after updating to a MultiKueueConfig that preserves the cluster health result. (#14914, @cryo-zd)
+- MultiKueue: Truncate quota automation condition messages so unsupported manager/worker resource configurations can be reported successfully. (#14988, @cryo-zd)
+- Observability: Scheduling hash re-computations are now logged at V5 via the contextual logger. (#15061, @apullo777)
+- Pending Workloads rejected by a LimitRange are requeued when the LimitRange's max, min, or maxLimitRequestRatio change, or the LimitRange is deleted. (#15030, @tomsen02)
+- Pod: Fixed a bug where a serving pod group's evicted pod could be left stuck in `Terminating` forever, since its `kueue.x-k8s.io/managed` finalizer was only removed for a Workload deletion, not for other evictions (e.g. a `recoveryTimeout` eviction). This could cause a legitimate replacement pod to be deleted as excess instead, or permanently block a same-name (StatefulSet-owned) replacement from ever being created. Kueue now removes the finalizer as soon as an evicted pod has actually terminated. (#14795, @mszadkow)
+- ProvisioningRequest: Fixed a bug where the `Active` condition's `observedGeneration` on a ProvisioningRequest AdmissionCheck was not updated when a configuration change kept the check healthy, leaving `observedGeneration` permanently behind `metadata.generation`. (#14933, @weizhoublue)
+- RayService: Fixed a bug where elastic (autoscaling) RayService pods could stay stuck in `SchedulingGated` on `kueue.x-k8s.io/elastic-job` after the origin workload slice was deleted, leaving the RayCluster below its desired replica count. (#15106, @mimowo)
+- Scheduling: Added the alpha `SchedulingEquivalenceHashingIgnorePodSetName` feature gate, disabled by default. When enabled, Workloads differing only in PodSet names share a scheduling equivalence class, so BestEffortFIFO queues stop re-evaluating each one individually. Requires `SchedulingEquivalenceHashing`. (#14805, @venuchitta)
+- Scheduling: Fix a bug in BestEffortFIFO where a workload with failed preemption could remain sticky at the queue head. (#15088, @tenzen-y)
+- Scheduling: Fix workloads becoming stranded after scheduling snapshot failures, and stale pending accounting when a LocalQueue moves to another ClusterQueue. (#13885, @apullo777)
+- Scheduling: Fixed a bug where a Workload deactivated with a derived `DeactivatedDueTo<Cause>` reason (such as `DeactivatedDueToRequeuingLimitExceeded`) could remain stuck after reactivation because its `WorkloadRequeued` condition was not transitioned. Such Workloads are now reactivated correctly. (#14878, @adibmbrk)
+- Scheduling: Fixed a bug where requeueing a Workload recomputed its scheduling equivalence hash even when neither the Workload nor its effective resource requests had changed, adding avoidable CPU and allocation overhead on the scheduler's requeue path. (#14958, @apullo777)
+- Scheduling: Fixed a bug which would charge the quota based on the LimitRange (if specified) for workloads
+  with only limits specified. That could create a mismatch between the charged quota and the resources actually
+  used by the running Pods. (#15038, @tomsen02)
+- SparkApplication: Fixed a bug where workloads using dynamic allocation could remain unready after executor scale-down. Workloads are now considered ready when the configured minimum number of executors is running. (#14982, @zhengchenyu)
+- TrainJob: Fix a bug where TrainJobs are stuck by using merge patches, instead of Updates, when admitting
+  or stopping TrainJobs, thus preserving the fields not represented in Kueue's vendored Trainer API. (#14841, @robert-bell)
+- WorkloadPriorityClass: Fixed a bug where a Workload that had reserved quota was repeatedly written with
+  a priorityClassRef the API server rejects, when its owner's WorkloadPriorityClass label was removed. (#15007, @tenzen-y)
+- WorkloadPriorityClass: Fixed the WorkloadPriorityClass controller to update workloads referencing a changed class through a bounded, cancellable worker pool instead of a serial, uninterruptible loop, and to report a single update error instead of one per failed workload. (#14944, @pujitha24)
+
 ## v0.18.6
 
 Changes since `v0.18.5`:

--- a/site/content/en/v0.18/docs/_index.md
+++ b/site/content/en/v0.18/docs/_index.md
@@ -2,14 +2,14 @@
 type: docs
 params:
   docs_minor: v0.18
-  version: v0.18.6
-  chart_version: 0.18.6
+  version: v0.18.7
+  chart_version: 0.18.7
 cascade:
   type: docs
   params:
     docs_minor: v0.18
-    version: v0.18.6
-    chart_version: 0.18.6
+    version: v0.18.7
+    chart_version: 0.18.7
 title: "Documentation"
 linkTitle: "Documentation"
 weight: 20

--- a/site/content/en/v0.18/docs/concepts/preemption.md
+++ b/site/content/en/v0.18/docs/concepts/preemption.md
@@ -156,6 +156,15 @@ The `preemptionStrategies` field in the Kueue Configuration indicates which cons
 preemption satisfy, with regards to the share values of the target and preempting ClusterQueues,
 before and after preempting a particular Workload.
 
+In a hierarchical cohort, the share values compared by the preemption strategies are the shares of
+the AlmostLeastCommonAncestors (AlmostLCA) of the preempting and target ClusterQueues, as defined
+in the [fair sharing KEP](https://github.com/kubernetes-sigs/kueue/blob/main/keps/1714-fair-sharing/README.md),
+rather than the shares of the ClusterQueues themselves. AlmostLCA(x, y) is the last but one
+node on the path from x to the lowest common ancestor of x and y; the strategies compare
+AlmostLCA(preemptor, target) with AlmostLCA(target, preemptor). In a flat cohort, where the
+preempting and target ClusterQueues share the same parent cohort, each AlmostLCA is the
+corresponding ClusterQueue itself.
+
 Different `preemptionStrategies` can lead to less or more preemptions under specific scenarios.
 These are the factors you should consider when configuring `preemptionStrategies`:
 - Tolerance to disruptions, in particular when single Workloads use a significant amount of the borrowable resources.
@@ -168,14 +177,15 @@ strategy in the list if there aren't any more Workloads that are candidates for 
 satisfy the current strategy and the preemptor still doesn't fit.
 
 The values you can put in the `preemptionStrategies` list are:
-- `LessThanOrEqualToFinalShare`: Only preempt a Workload if the share of the preempting ClusterQueue
-  with the preemptor Workload is less than or equal to the share of the target ClusterQueue
-  without the preempted Workload.
+- `LessThanOrEqualToFinalShare`: Only preempt a Workload if the share of
+  AlmostLCA(preemptor, target) with the preemptor Workload admitted is less than or equal to the
+  share of AlmostLCA(target, preemptor) without the workload to be preempted.
   This strategy might favor preemption of smaller workloads in the target ClusterQueue,
-  regardless of priority or start time, in an effort to keep the share of the ClusterQueue
+  regardless of priority or start time, in an effort to keep the share of AlmostLCA(target, preemptor)
   as high as possible.
-- `LessThanInitialShare`: Only preempt a Workload if the share of the preempting ClusterQueue
-  with the preemptor Workload is strictly less than the share of the target ClusterQueue.
+- `LessThanInitialShare`: Only preempt a Workload if the share of AlmostLCA(preemptor, target)
+  with the preemptor Workload admitted is strictly less than the share of
+  AlmostLCA(target, preemptor) with the workload to be preempted.
   Note that this strategy doesn't depend on the share usage of the Workload being preempted.
   As a result, the strategy chooses to first preempt workloads with the lowest priority and
   newest start time within the target ClusterQueue.

--- a/site/content/en/v0.18/docs/reference/kueue-config.v1beta1.md
+++ b/site/content/en/v0.18/docs/reference/kueue-config.v1beta1.md
@@ -601,7 +601,10 @@ followed by a slash and a DNS label, or just a DNS label.
 DNS labels consist of lower-case alphanumeric characters or hyphens,
 and must start and end with an alphanumeric character.
 DNS subdomain prefixes follow the same rules as DNS labels but can contain periods.
-The total length must not exceed 253 characters.</p>
+The total length must not exceed 253 characters.
+With KueueDRAIntegration enabled it must not be <code>pods</code>; that exact name is
+reserved for Kueue's internal Pod-count accounting. A qualified name such
+as <code>example.com/pods</code> is allowed.</p>
 </td>
 </tr>
 <tr><td><code>deviceClassNames</code> <B>[Required]</B><br/>
@@ -649,16 +652,24 @@ Defaults to false.</p>
    <p>preemptionStrategies indicates which constraints should a preemption satisfy.
 The preemption algorithm will only use the next strategy in the list if the
 incoming workload (preemptor) doesn't fit after using the previous strategies.
+AlmostLCA(x, y) is the last but one node on the path from x to the
+lowest common ancestor of x and y in the cohort hierarchy (see KEP-1714).
+The strategies compare the shares of AlmostLCA(preemptor, preemptee) and
+AlmostLCA(preemptee, preemptor). These are the shares of ClusterQueues themselves
+only when both ClusterQueues share the same parent Cohort.
 Possible values are:</p>
 <ul>
-<li>LessThanOrEqualToFinalShare: Only preempt a workload if the share of the preemptor CQ
-with the preemptor workload is less than or equal to the share of the preemptee CQ
+<li>LessThanOrEqualToFinalShare: Only preempt a workload if the share of
+AlmostLCA(preemptor, preemptee) with the preemptor workload admitted is
+less than or equal to the share of AlmostLCA(preemptee, preemptor)
 without the workload to be preempted.
 This strategy might favor preemption of smaller workloads in the preemptee CQ,
-regardless of priority or start time, in an effort to keep the share of the CQ
+regardless of priority or start time, in an effort to keep the share of AlmostLCA(preemptee, preemptor)
 as high as possible.</li>
-<li>LessThanInitialShare: Only preempt a workload if the share of the preemptor CQ
-with the incoming workload is strictly less than the share of the preemptee CQ.
+<li>LessThanInitialShare: Only preempt a workload if the share of
+AlmostLCA(preemptor, preemptee) with the preemptor workload admitted is
+strictly less than the share of AlmostLCA(preemptee, preemptor) with the
+workload to be preempted.
 This strategy doesn't depend on the share usage of the workload being preempted.
 As a result, the strategy chooses to preempt workloads with the lowest priority and
 newest start time first.
@@ -1124,7 +1135,9 @@ re-queuing an evicted workload.</p>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcename-v1-core"><code>k8s.io/api/core/v1.ResourceName</code></a>
 </td>
 <td>
-   <p>Input is the name of the input resource.</p>
+   <p>Input is the name of the input resource.
+It must not be <code>pods</code>; that exact name is reserved for Kueue's internal
+Pod-count accounting. A qualified name such as <code>example.com/pods</code> is allowed.</p>
 </td>
 </tr>
 <tr><td><code>strategy</code> <B>[Required]</B><br/>
@@ -1144,7 +1157,9 @@ specified.
 The requested amount of the resource is used to multiply the requested
 amount of the resource indicated by the &quot;input&quot; field when computing
 &quot;outputs&quot;. It does not change the quantity retained under &quot;input&quot; when
-&quot;strategy&quot; is Retain.</p>
+&quot;strategy&quot; is Retain.
+It must not be <code>pods</code>; that exact name is reserved for Kueue's internal
+Pod-count accounting. A qualified name such as <code>example.com/pods</code> is allowed.</p>
 </td>
 </tr>
 <tr><td><code>outputs</code> <B>[Required]</B><br/>
@@ -1152,6 +1167,9 @@ amount of the resource indicated by the &quot;input&quot; field when computing
 </td>
 <td>
    <p>Outputs specifies the output resources and quantities per unit of input resource.
+An output resource name must not be <code>pods</code>; that exact name is reserved for
+Kueue's internal Pod-count accounting. A qualified name such as
+<code>example.com/pods</code> is allowed.
 An empty Outputs combined with a <code>Replace</code> Strategy causes the Input resource to be ignored by Kueue.</p>
 </td>
 </tr>

--- a/site/content/en/v0.18/docs/reference/kueue-config.v1beta2.md
+++ b/site/content/en/v0.18/docs/reference/kueue-config.v1beta2.md
@@ -683,7 +683,10 @@ followed by a slash and a DNS label, or just a DNS label.
 DNS labels consist of lower-case alphanumeric characters or hyphens,
 and must start and end with an alphanumeric character.
 DNS subdomain prefixes follow the same rules as DNS labels but can contain periods.
-The total length must not exceed 253 characters.</p>
+The total length must not exceed 253 characters.
+With KueueDRAIntegration enabled it must not be <code>pods</code>; that exact name is
+reserved for Kueue's internal Pod-count accounting. A qualified name such
+as <code>example.com/pods</code> is allowed.</p>
 </td>
 </tr>
 <tr><td><code>deviceClassNames</code> <B>[Required]</B><br/>
@@ -763,16 +766,24 @@ Maps a DRA driver counter to the parent DeviceClassMapping's Kueue quota resourc
    <p>preemptionStrategies indicates which constraints should a preemption satisfy.
 The preemption algorithm will only use the next strategy in the list if the
 incoming workload (preemptor) doesn't fit after using the previous strategies.
+AlmostLCA(x, y) is the last but one node on the path from x to the
+lowest common ancestor of x and y in the cohort hierarchy (see KEP-1714).
+The strategies compare the shares of AlmostLCA(preemptor, preemptee) and
+AlmostLCA(preemptee, preemptor). These are the shares of ClusterQueues themselves
+only when both ClusterQueues share the same parent Cohort.
 Possible values are:</p>
 <ul>
-<li>LessThanOrEqualToFinalShare: Only preempt a workload if the share of the preemptor CQ
-with the preemptor workload is less than or equal to the share of the preemptee CQ
+<li>LessThanOrEqualToFinalShare: Only preempt a workload if the share of
+AlmostLCA(preemptor, preemptee) with the preemptor workload admitted is
+less than or equal to the share of AlmostLCA(preemptee, preemptor)
 without the workload to be preempted.
 This strategy might favor preemption of smaller workloads in the preemptee CQ,
-regardless of priority or start time, in an effort to keep the share of the CQ
+regardless of priority or start time, in an effort to keep the share of AlmostLCA(preemptee, preemptor)
 as high as possible.</li>
-<li>LessThanInitialShare: Only preempt a workload if the share of the preemptor CQ
-with the incoming workload is strictly less than the share of the preemptee CQ.
+<li>LessThanInitialShare: Only preempt a workload if the share of
+AlmostLCA(preemptor, preemptee) with the preemptor workload admitted is
+strictly less than the share of AlmostLCA(preemptee, preemptor) with the
+workload to be preempted.
 This strategy doesn't depend on the share usage of the workload being preempted.
 As a result, the strategy chooses to preempt workloads with the lowest priority and
 newest start time first.</li>
@@ -1183,7 +1194,9 @@ re-queuing an evicted workload.</p>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcename-v1-core"><code>k8s.io/api/core/v1.ResourceName</code></a>
 </td>
 <td>
-   <p>Input is the name of the input resource.</p>
+   <p>Input is the name of the input resource.
+It must not be <code>pods</code>; that exact name is reserved for Kueue's internal
+Pod-count accounting. A qualified name such as <code>example.com/pods</code> is allowed.</p>
 </td>
 </tr>
 <tr><td><code>strategy</code> <B>[Required]</B><br/>
@@ -1203,7 +1216,9 @@ specified.
 The requested amount of the resource is used to multiply the requested
 amount of the resource indicated by the &quot;input&quot; field when computing
 &quot;outputs&quot;. It does not change the quantity retained under &quot;input&quot; when
-&quot;strategy&quot; is Retain.</p>
+&quot;strategy&quot; is Retain.
+It must not be <code>pods</code>; that exact name is reserved for Kueue's internal
+Pod-count accounting. A qualified name such as <code>example.com/pods</code> is allowed.</p>
 </td>
 </tr>
 <tr><td><code>outputs</code> <B>[Required]</B><br/>
@@ -1211,6 +1226,9 @@ amount of the resource indicated by the &quot;input&quot; field when computing
 </td>
 <td>
    <p>Outputs specifies the output resources and quantities per unit of input resource.
+An output resource name must not be <code>pods</code>; that exact name is reserved for
+Kueue's internal Pod-count accounting. A qualified name such as
+<code>example.com/pods</code> is allowed.
 An empty Outputs combined with a <code>Replace</code> Strategy causes the Input resource to be ignored by Kueue.</p>
 </td>
 </tr>

--- a/site/content/zh-CN/v0.18/docs/_index.md
+++ b/site/content/zh-CN/v0.18/docs/_index.md
@@ -2,14 +2,14 @@
 type: docs
 params:
   docs_minor: v0.18
-  version: v0.18.6
-  chart_version: 0.18.6
+  version: v0.18.7
+  chart_version: 0.18.7
 cascade:
   type: docs
   params:
     docs_minor: v0.18
-    version: v0.18.6
-    chart_version: 0.18.6
+    version: v0.18.7
+    chart_version: 0.18.7
 title: "文档"
 linkTitle: "文档"
 weight: 20


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/area release

#### What this PR does / why we need it:
Update main with the latest v0.18.7.

#### Which issue(s) this PR fixes:
Part of #14694

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated v0.18 documentation and chart references to version 0.18.7 in English and Chinese.
  - Clarified Fair Sharing preemption comparisons for hierarchical cohorts.
  - Documented that the exact resource name `pods` is reserved for internal pod-count accounting; qualified names remain supported.
- **Changelog**
  - Added v0.18.7 release notes covering prerequisites, fixes, regressions, and new alpha scheduling and fair-sharing feature gates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->