### PR TITLE
Update main with the latest v0.19.3

### DIFF
--- a/CHANGELOG/CHANGELOG-0.19.md
+++ b/CHANGELOG/CHANGELOG-0.19.md
@@ -1,3 +1,67 @@
+## v0.19.3
+
+Changes since `v0.19.2`:
+
+## Actions Required Before Upgrading
+
+### (No, really, you MUST read this before you upgrade)
+
+- **Minor releases:** Review the `.0` release notes for each new minor version you cross; see: [`v0.18.0`](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.18.0), [`v0.19.0`](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.19.0).
+- **Patch releases:** Review the patch release notes leading up to this version, but *only* within this minor release line; see: [`v0.19.1`](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.19.1), [`v0.19.2`](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.19.2).
+
+- DRA & ResourceTransformation: Fixed a bug where DRA device-class mapping or a resource transformation under the reserved resource name `pods` was silently discarded or left the Workload permanently pending.
+  
+  Remove or rename those entries before upgrading, or the kueue-controller-manager will fail to start. Renaming a mapping name or an `outputs` key also requires updating the matching ClusterQueue `nominalQuota` entries in the same change. (#14756, @thc1006)
+ 
+## Changes by Kind
+
+### Feature
+
+- WorkloadAwareScheduler: Added the kueue.x-k8s.io/workload annotation to Pods created by Kueue-managed jobs when the SchedulerLibraryIntegration feature gate is enabled; previously only TopologyAwareScheduling added it. (#14796, @Singularity23x0)
+
+### Bug or Regression
+
+- AdmissionChecks: Fix a bug where the Workload has an Admitted=True condition regardless of AdmissionCheck Rejection state. (#14871, @TapanManu)
+- AdmissionFairSharing: Fixed preemption ordering for Workloads from same-named LocalQueues in different namespaces so that LocalQueue usage is considered. (#14876, @tomsen02)
+- DRA: Fixed config validation silently accepting capacity names with more than one slash, which produced a mapping that never matched any device. (#14953, @NasitSony)
+- FairSharing: Fix a bug where Kueue could miss valid preemption targets after selecting workloads from the preemptor's own ClusterQueue and lowering its DRS. The fix is guarded by the Alpha `FairSharingReevaluatePreemptionCandidates` feature gate, which is disabled by default. Enabling the gate may increase exposure to the known fair-sharing preemption-loop issue tracked in #14543. (#14767, @lightZebra)
+- Fixed a bug where a prebuilt or externally created Workload could be treated as equivalent to its Job even when the Job's pod template declared pod-level `resources` or `resourceClaims` that the Workload's PodSet omitted, letting the Workload reserve less quota than its Pods actually request. (#15016, @pujitha24)
+- Fixed a controller panic triggered by Namespace updates after a ClusterQueue failed to initialize because its Cohort had a cycle. (#14983, @YQ-Wang)
+- Helm: Fix a bug where user-defined metricsService labels are not propagated to the rendered manifests. (#15005, @HsiuChuanHsu)
+- KueueCtl: Fixed a bug where `kueuectl delete workload` deleted a recreated owner with a different UID. (#14882, @DevaanshPathak)
+- KueueCtl: Fixed the `kueuectl list clusterqueue` comand to respect KUEUECTL_LIST_REQUEST_LIMIT
+  and paginate API requests instead of issuing an unbounded LIST request. (#14880, @ErikJiang)
+- Kueueviz: Fixed the bug the WebSocket 1005 error would be shown on the dashboard after selecting a namespace. (#14789, @mykysha)
+- MultiKueue: Fixed a bug where a Job is dispatched again due to propagated `spec.ttlSecondsAfterFinished` even after Job completion. Enable the Alpha `MultiKueueBatchJobClearingTTLSecondsAfterFinishedOnWorkerCluster` feature gate to enable fixing. (#14828, @kevin85421)
+- MultiKueue: Fixed a bug where a remote workload finishing with reason
+  OwnerNotFound was mirrored back verbatim, permanently finishing the manager
+  Workload and leaving the manager Pod's scheduling gates stuck. Such finishes
+  are now treated as a sync failure and reset for re-dispatch, matching
+  existing OutOfSync handling. (#15082, @NasitSony)
+- MultiKueue: Fixed a bug where the WorkloadPriorityClass controller incorrectly updated the priority of MultiKueue remote workloads when a WorkloadPriorityClass value changed. Remote workloads are now skipped during priority synchronization. (#14995, @weizhoublue)
+- MultiKueue: Fixed stale observedGeneration on the AdmissionCheckActive condition after updating to a MultiKueueConfig that preserves the cluster health result. (#14915, @cryo-zd)
+- MultiKueue: Truncate quota automation condition messages so unsupported manager/worker resource configurations can be reported successfully. (#14989, @cryo-zd)
+- Observability: Fixed `kueue_pod_scheduling_gate_removal_seconds` observing negative durations when the controller clock trails the apiserver clock. The negative observations made the histogram's `_sum` decrease, which broke `rate()` over that series. (#14731, @Antrikshgwal)
+- Observability: Scheduling hash re-computations are now logged at V5 via the contextual logger. (#15060, @apullo777)
+- Pending Workloads rejected by a LimitRange are requeued when the LimitRange's max, min, or maxLimitRequestRatio change, or the LimitRange is deleted. (#15029, @tomsen02)
+- Pod: Fixed a bug where a serving pod group's evicted pod could be left stuck in `Terminating` forever, since its `kueue.x-k8s.io/managed` finalizer was only removed for a Workload deletion, not for other evictions (e.g. a `recoveryTimeout` eviction). This could cause a legitimate replacement pod to be deleted as excess instead, or permanently block a same-name (StatefulSet-owned) replacement from ever being created. Kueue now removes the finalizer as soon as an evicted pod has actually terminated. (#14793, @mszadkow)
+- ProvisioningRequest: Fixed a bug where the `Active` condition's `observedGeneration` on a ProvisioningRequest AdmissionCheck was not updated when a configuration change kept the check healthy, leaving `observedGeneration` permanently behind `metadata.generation`. (#14934, @weizhoublue)
+- RayService: Fixed a bug where elastic (autoscaling) RayService pods could stay stuck in `SchedulingGated` on `kueue.x-k8s.io/elastic-job` after the origin workload slice was deleted, leaving the RayCluster below its desired replica count. (#15103, @kevin85421)
+- Scheduling: Fix a bug in BestEffortFIFO where a workload with failed preemption could remain sticky at the queue head. (#15089, @tenzen-y)
+- Scheduling: Fix workloads becoming stranded after scheduling snapshot failures, and stale pending accounting when a LocalQueue moves to another ClusterQueue. (#13885, @apullo777)
+- Scheduling: Fixed a bug where Workloads differing only in PodSet names formed separate equivalence classes, so BestEffortFIFO queues re-evaluated each one individually and admission slowed on busy clusters. Controlled by the alpha `SchedulingEquivalenceHashingIgnorePodSetName` feature gate, disabled by default. When enabled, Workloads differing only in PodSet names share a scheduling equivalence class, so BestEffortFIFO queues stop re-evaluating each one individually. Requires `SchedulingEquivalenceHashing`. (#14804, @venuchitta)
+- Scheduling: Fixed a bug where a Workload deactivated with a derived `DeactivatedDueTo<Cause>` reason (such as `DeactivatedDueToRequeuingLimitExceeded`) could remain stuck after reactivation because its `WorkloadRequeued` condition was not transitioned. Such Workloads are now reactivated correctly. (#14879, @adibmbrk)
+- Scheduling: Fixed a bug where requeueing a Workload recomputed its scheduling equivalence hash even when neither the Workload nor its effective resource requests had changed, adding avoidable CPU and allocation overhead on the scheduler's requeue path. (#14958, @apullo777)
+- Scheduling: Fixed a bug which would charge the quota based on the LimitRange (if specified) for workloads
+  with only limits specified. That could create a mismatch between the charged quota and the resources actually
+  used by the running Pods. (#15039, @tomsen02)
+- SparkApplication: Fixed a bug where workloads using dynamic allocation could remain unready after executor scale-down. Workloads are now considered ready when the configured minimum number of executors is running. (#14984, @zhengchenyu)
+- TrainJob: Fix a bug where TrainJobs are stuck by using merge patches, instead of Updates, when admitting
+  or stopping TrainJobs, thus preserving the fields not represented in Kueue's vendored Trainer API. (#14842, @robert-bell)
+- WorkloadPriorityClass: Fixed a bug where a Workload that had reserved quota was repeatedly written with
+  a priorityClassRef the API server rejects, when its owner's WorkloadPriorityClass label was removed. (#15008, @tenzen-y)
+- WorkloadPriorityClass: Fixed the WorkloadPriorityClass controller to update workloads referencing a changed class through a bounded, cancellable worker pool instead of a serial, uninterruptible loop, and to report a single update error instead of one per failed workload. (#14945, @pujitha24)
+
 ## v0.19.2
 
 Changes since `v0.19.1`:

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ LD_FLAGS += -X '$(version_pkg).BuildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)'
 
 # Update these variables when preparing a new release or a release branch.
 # Then run `make prepare-release-branch`
-RELEASE_VERSION=v0.19.2
+RELEASE_VERSION=v0.19.3
 RELEASE_BRANCH=main
 # Application version for Helm and npm (strips leading 'v' from RELEASE_VERSION)
 APP_VERSION := $(shell echo $(RELEASE_VERSION) | cut -c2-)

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Read the [overview](https://kueue.sigs.k8s.io/docs/overview/) and watch the Kueu
 To install the latest release of Kueue in your cluster, run the following command:
 
 ```shell
-kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.19.2/manifests.yaml
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.19.3/manifests.yaml
 ```
 
 The controller runs in the `kueue-system` namespace.

--- a/SECURITY-INSIGHTS.yaml
+++ b/SECURITY-INSIGHTS.yaml
@@ -1,11 +1,11 @@
 header:
   schema-version: 1.0.0
   expiration-date: '2027-07-10T01:00:00.000Z'
-  last-updated: '2026-08-20'
-  last-reviewed: '2026-08-20'
-  commit-hash: "8eab68778fc1b52affe165fdf5af29d1e9b4f3cb"
+  last-updated: '2026-07-23'
+  last-reviewed: '2026-07-23'
+  commit-hash: "97e90b5276c8a87cc115783a3c25bcf515f1e922"
   project-url: 'https://github.com/kubernetes-sigs/kueue'
-  project-release: "0.19.2"
+  project-release: "0.19.3"
   changelog: 'https://github.com/kubernetes-sigs/kueue/tree/main/CHANGELOG'
   license: 'https://github.com/kubernetes-sigs/kueue/blob/main/LICENSE'
 project-lifecycle:
@@ -28,7 +28,7 @@ documentation:
   - 'https://kueue.sigs.k8s.io/docs/'
 distribution-points:
   - >-
-    https://github.com/kubernetes-sigs/kueue/releases/download/v0.19.2/manifests.yaml
+    https://github.com/kubernetes-sigs/kueue/releases/download/v0.19.3/manifests.yaml
 security-artifacts:
   threat-model:
     threat-model-created: false
@@ -73,7 +73,7 @@ dependencies:
   dependencies-lists:
     - 'https://github.com/kubernetes-sigs/kueue/blob/main/go.mod'
   sbom:
-    - sbom-file: https://github.com/kubernetes-sigs/kueue/releases/download/v0.19.2/kueue-v0.19.2.spdx.json
+    - sbom-file: https://github.com/kubernetes-sigs/kueue/releases/download/v0.19.3/kueue-v0.19.3.spdx.json
       sbom-format: SPDX
   dependencies-lifecycle:
     policy-url: 'https://github.com/kubernetes-sigs/kueue/blob/main/DEPENDENCY_LIFECYCLE.md'

--- a/charts/kueue/Chart.yaml
+++ b/charts/kueue/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # NOTE: Do not modify manually. In Kueue, the version and appVersion are
 # overridden to GIT_TAG when building the artifacts, including the helm charts,
 # via Makefile.
-version: 0.19.2
+version: 0.19.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.19.2"
+appVersion: "v0.19.3"

--- a/charts/kueue/README.md
+++ b/charts/kueue/README.md
@@ -1,6 +1,6 @@
 # kueue
 
-![Version: 0.19.2](https://img.shields.io/badge/Version-0.19.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.19.2](https://img.shields.io/badge/AppVersion-v0.19.2-informational?style=flat-square)
+![Version: 0.19.3](https://img.shields.io/badge/Version-0.19.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.19.3](https://img.shields.io/badge/AppVersion-v0.19.3-informational?style=flat-square)
 
 Kueue is a set of APIs and controllers for job queueing. It is a job-level manager that decides when a job should be admitted to start (as in pods can be created) and when it should stop (as in active pods should be deleted).
 
@@ -28,7 +28,7 @@ $ helm install kueue kueue/ --create-namespace --namespace kueue-system
 Or use the charts pushed to `oci://registry.k8s.io/kueue/charts/kueue`:
 
 ```bash
-helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.19.2" --create-namespace --namespace=kueue-system
+helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.19.3" --create-namespace --namespace=kueue-system
 ```
 
 For more advanced parametrization of Kueue, we recommend using a local overrides file, passed via the `--values` flag. For example:
@@ -50,7 +50,7 @@ controllerManager:
 ```
 
 ```bash
-helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.19.2" \
+helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.19.3" \
   --create-namespace --namespace=kueue-system \
   --values overrides.yaml
 ```
@@ -58,7 +58,7 @@ helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.19.2" \
 You can also use the `--set` flag. For example, to enable a feature gate (e.g., `TopologyAwareScheduling`):
 
 ```bash
-helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.19.2" \
+helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.19.3" \
   --create-namespace --namespace=kueue-system \
   --set "controllerManager.featureGates[0].name=TopologyAwareScheduling" \
   --set "controllerManager.featureGates[0].enabled=true"

--- a/charts/kueue/README.md.gotmpl
+++ b/charts/kueue/README.md.gotmpl
@@ -30,7 +30,7 @@ $ helm install kueue kueue/ --create-namespace --namespace kueue-system
 Or use the charts pushed to `oci://registry.k8s.io/kueue/charts/kueue`:
 
 ```bash
-helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.19.2" --create-namespace --namespace=kueue-system
+helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.19.3" --create-namespace --namespace=kueue-system
 ```
 
 For more advanced parametrization of Kueue, we recommend using a local overrides file, passed via the `--values` flag. For example:
@@ -52,7 +52,7 @@ controllerManager:
 ```
 
 ```bash
-helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.19.2" \
+helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.19.3" \
   --create-namespace --namespace=kueue-system \
   --values overrides.yaml
 ```
@@ -60,7 +60,7 @@ helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.19.2" \
 You can also use the `--set` flag. For example, to enable a feature gate (e.g., `TopologyAwareScheduling`):
 
 ```bash
-helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.19.2" \
+helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.19.3" \
   --create-namespace --namespace=kueue-system \
   --set "controllerManager.featureGates[0].name=TopologyAwareScheduling" \
   --set "controllerManager.featureGates[0].enabled=true"

--- a/cmd/experimental/kueue-populator/README.md
+++ b/cmd/experimental/kueue-populator/README.md
@@ -41,7 +41,7 @@ You can also install the `kueue-populator` using the provided Helm chart.
 
 ```bash
 helm install kueue-populator oci://registry.k8s.io/kueue/charts/kueue-populator \
-  --version 0.19.2 \
+  --version 0.19.3 \
   --namespace kueue-system \
   --create-namespace \
   --wait

--- a/cmd/experimental/kueue-populator/charts/kueue-populator/Chart.yaml
+++ b/cmd/experimental/kueue-populator/charts/kueue-populator/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: kueue-populator
 description: A Helm chart for Kueue Populator setup including Kueue, LocalQueue Creator, and default resources.
 type: application
-version: 0.19.2
-appVersion: "v0.19.2"
+version: 0.19.3
+appVersion: "v0.19.3"
 dependencies:
   - name: kueue
-    version: "~0.19.2"
+    version: "~0.19.3"
     repository: "file://../../../../../charts/kueue"
     condition: kueue.enabled

--- a/cmd/experimental/kueue-populator/charts/kueue-populator/README.md
+++ b/cmd/experimental/kueue-populator/charts/kueue-populator/README.md
@@ -34,7 +34,7 @@ You can install the chart directly from the OCI registry:
 
 ```bash
 helm install kueue-populator oci://registry.k8s.io/kueue/charts/kueue-populator \
-  --version 0.19.2 \
+  --version 0.19.3 \
   --namespace kueue-system \
   --create-namespace \
   --wait
@@ -112,7 +112,7 @@ kueuePopulator:
 
 ```bash
 helm install kueue-populator oci://registry.k8s.io/kueue/charts/kueue-populator \
-  --version 0.19.2 \
+  --version 0.19.3 \
   --namespace kueue-system \
   --create-namespace \
   --wait \
@@ -125,7 +125,7 @@ For simple configuration you may also use the minimalistic command:
 
 ```bash
 helm install kueue-populator oci://registry.k8s.io/kueue/charts/kueue-populator \
-  --version 0.19.2 \
+  --version 0.19.3 \
   --namespace kueue-system \
   --create-namespace \
   --wait \

--- a/cmd/experimental/kueue-priority-booster/charts/kueue-priority-booster/Chart.yaml
+++ b/cmd/experimental/kueue-priority-booster/charts/kueue-priority-booster/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: kueue-priority-booster
 description: A Helm chart for deploying the experimental Kueue priority-boost controller.
 type: application
-version: 0.19.2
-appVersion: "v0.19.2"
+version: 0.19.3
+appVersion: "v0.19.3"
 dependencies:
   - name: kueue
-    version: "~0.19.2"
+    version: "~0.19.3"
     repository: "file://../../../../../charts/kueue"
     condition: kueue.enabled

--- a/cmd/kueueviz/INSTALL.md
+++ b/cmd/kueueviz/INSTALL.md
@@ -3,7 +3,7 @@
 KueueViz can be installed using `kubectl` with the following command:
 
 ```
-kubectl create -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.19.2/kueueviz.yaml
+kubectl create -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.19.3/kueueviz.yaml
 ```
 If you are using `kind` and that you don't have an `ingress` controller, you can use `port-forward` to 
 configure and run `KueueViz`.
@@ -60,7 +60,7 @@ by ensuring that `enableKueueViz` is set to `true`:
 
 ```
 helm upgrade --install kueue oci://registry.k8s.io/kueue/charts/kueue \
-  --version="0.19.2" \
+  --version="0.19.3" \
   --namespace kueue-system \
   --set enableKueueViz=true \
   --create-namespace
@@ -81,7 +81,7 @@ kind create cluster
 kind get kubeconfig > kubeconfig
 export KUBECONFIG=$PWD/kubeconfig
 helm install kueue oci://us-central1-docker.pkg.dev/k8s-staging-images/charts/kueue \
-            --version="0.19.2" --create-namespace --namespace=kueue-system
+            --version="0.19.3" --create-namespace --namespace=kueue-system
 ```
 
 ## Build

--- a/cmd/kueueviz/frontend/package-lock.json
+++ b/cmd/kueueviz/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kueueviz-frontend",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kueueviz-frontend",
-      "version": "0.19.2",
+      "version": "0.19.3",
       "license": "Apache 2.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",

--- a/cmd/kueueviz/frontend/package.json
+++ b/cmd/kueueviz/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kueueviz-frontend",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "private": true,
   "description": "Frontend dashboard for visualizing Kueue status",
   "main": "src/index.jsx",

--- a/site/content/en/v0.19/docs/_index.md
+++ b/site/content/en/v0.19/docs/_index.md
@@ -2,14 +2,14 @@
 type: docs
 params:
   docs_minor: v0.19
-  version: v0.19.2
-  chart_version: 0.19.2
+  version: v0.19.3
+  chart_version: 0.19.3
 cascade:
   type: docs
   params:
     docs_minor: v0.19
-    version: v0.19.2
-    chart_version: 0.19.2
+    version: v0.19.3
+    chart_version: 0.19.3
 title: "Documentation"
 linkTitle: "Documentation"
 weight: 20

--- a/site/content/en/v0.19/docs/concepts/preemption.md
+++ b/site/content/en/v0.19/docs/concepts/preemption.md
@@ -156,6 +156,15 @@ The `preemptionStrategies` field in the Kueue Configuration indicates which cons
 preemption satisfy, with regards to the share values of the target and preempting ClusterQueues,
 before and after preempting a particular Workload.
 
+In a hierarchical cohort, the share values compared by the preemption strategies are the shares of
+the AlmostLeastCommonAncestors (AlmostLCA) of the preempting and target ClusterQueues, as defined
+in the [fair sharing KEP](https://github.com/kubernetes-sigs/kueue/blob/main/keps/1714-fair-sharing/README.md),
+rather than the shares of the ClusterQueues themselves. AlmostLCA(x, y) is the last but one
+node on the path from x to the lowest common ancestor of x and y; the strategies compare
+AlmostLCA(preemptor, target) with AlmostLCA(target, preemptor). In a flat cohort, where the
+preempting and target ClusterQueues share the same parent cohort, each AlmostLCA is the
+corresponding ClusterQueue itself.
+
 Different `preemptionStrategies` can lead to less or more preemptions under specific scenarios.
 These are the factors you should consider when configuring `preemptionStrategies`:
 - Tolerance to disruptions, in particular when single Workloads use a significant amount of the borrowable resources.
@@ -168,14 +177,15 @@ strategy in the list if there aren't any more Workloads that are candidates for 
 satisfy the current strategy and the preemptor still doesn't fit.
 
 The values you can put in the `preemptionStrategies` list are:
-- `LessThanOrEqualToFinalShare`: Only preempt a Workload if the share of the preempting ClusterQueue
-  with the preemptor Workload is less than or equal to the share of the target ClusterQueue
-  without the preempted Workload.
+- `LessThanOrEqualToFinalShare`: Only preempt a Workload if the share of
+  AlmostLCA(preemptor, target) with the preemptor Workload admitted is less than or equal to the
+  share of AlmostLCA(target, preemptor) without the workload to be preempted.
   This strategy might favor preemption of smaller workloads in the target ClusterQueue,
-  regardless of priority or start time, in an effort to keep the share of the ClusterQueue
+  regardless of priority or start time, in an effort to keep the share of AlmostLCA(target, preemptor)
   as high as possible.
-- `LessThanInitialShare`: Only preempt a Workload if the share of the preempting ClusterQueue
-  with the preemptor Workload is strictly less than the share of the target ClusterQueue.
+- `LessThanInitialShare`: Only preempt a Workload if the share of AlmostLCA(preemptor, target)
+  with the preemptor Workload admitted is strictly less than the share of
+  AlmostLCA(target, preemptor) with the workload to be preempted.
   Note that this strategy doesn't depend on the share usage of the Workload being preempted.
   As a result, the strategy chooses to first preempt workloads with the lowest priority and
   newest start time within the target ClusterQueue.

--- a/site/content/en/v0.19/docs/reference/kueue-config.v1beta1.md
+++ b/site/content/en/v0.19/docs/reference/kueue-config.v1beta1.md
@@ -601,7 +601,10 @@ followed by a slash and a DNS label, or just a DNS label.
 DNS labels consist of lower-case alphanumeric characters or hyphens,
 and must start and end with an alphanumeric character.
 DNS subdomain prefixes follow the same rules as DNS labels but can contain periods.
-The total length must not exceed 253 characters.</p>
+The total length must not exceed 253 characters.
+With KueueDRAIntegration enabled it must not be <code>pods</code>; that exact name is
+reserved for Kueue's internal Pod-count accounting. A qualified name such
+as <code>example.com/pods</code> is allowed.</p>
 </td>
 </tr>
 <tr><td><code>deviceClassNames</code> <B>[Required]</B><br/>
@@ -649,16 +652,24 @@ Defaults to false.</p>
    <p>preemptionStrategies indicates which constraints should a preemption satisfy.
 The preemption algorithm will only use the next strategy in the list if the
 incoming workload (preemptor) doesn't fit after using the previous strategies.
+AlmostLCA(x, y) is the last but one node on the path from x to the
+lowest common ancestor of x and y in the cohort hierarchy (see KEP-1714).
+The strategies compare the shares of AlmostLCA(preemptor, preemptee) and
+AlmostLCA(preemptee, preemptor). These are the shares of ClusterQueues themselves
+only when both ClusterQueues share the same parent Cohort.
 Possible values are:</p>
 <ul>
-<li>LessThanOrEqualToFinalShare: Only preempt a workload if the share of the preemptor CQ
-with the preemptor workload is less than or equal to the share of the preemptee CQ
+<li>LessThanOrEqualToFinalShare: Only preempt a workload if the share of
+AlmostLCA(preemptor, preemptee) with the preemptor workload admitted is
+less than or equal to the share of AlmostLCA(preemptee, preemptor)
 without the workload to be preempted.
 This strategy might favor preemption of smaller workloads in the preemptee CQ,
-regardless of priority or start time, in an effort to keep the share of the CQ
+regardless of priority or start time, in an effort to keep the share of AlmostLCA(preemptee, preemptor)
 as high as possible.</li>
-<li>LessThanInitialShare: Only preempt a workload if the share of the preemptor CQ
-with the incoming workload is strictly less than the share of the preemptee CQ.
+<li>LessThanInitialShare: Only preempt a workload if the share of
+AlmostLCA(preemptor, preemptee) with the preemptor workload admitted is
+strictly less than the share of AlmostLCA(preemptee, preemptor) with the
+workload to be preempted.
 This strategy doesn't depend on the share usage of the workload being preempted.
 As a result, the strategy chooses to preempt workloads with the lowest priority and
 newest start time first.
@@ -1124,7 +1135,9 @@ re-queuing an evicted workload.</p>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcename-v1-core"><code>k8s.io/api/core/v1.ResourceName</code></a>
 </td>
 <td>
-   <p>Input is the name of the input resource.</p>
+   <p>Input is the name of the input resource.
+It must not be <code>pods</code>; that exact name is reserved for Kueue's internal
+Pod-count accounting. A qualified name such as <code>example.com/pods</code> is allowed.</p>
 </td>
 </tr>
 <tr><td><code>strategy</code> <B>[Required]</B><br/>
@@ -1144,7 +1157,9 @@ specified.
 The requested amount of the resource is used to multiply the requested
 amount of the resource indicated by the &quot;input&quot; field when computing
 &quot;outputs&quot;. It does not change the quantity retained under &quot;input&quot; when
-&quot;strategy&quot; is Retain.</p>
+&quot;strategy&quot; is Retain.
+It must not be <code>pods</code>; that exact name is reserved for Kueue's internal
+Pod-count accounting. A qualified name such as <code>example.com/pods</code> is allowed.</p>
 </td>
 </tr>
 <tr><td><code>outputs</code> <B>[Required]</B><br/>
@@ -1152,6 +1167,9 @@ amount of the resource indicated by the &quot;input&quot; field when computing
 </td>
 <td>
    <p>Outputs specifies the output resources and quantities per unit of input resource.
+An output resource name must not be <code>pods</code>; that exact name is reserved for
+Kueue's internal Pod-count accounting. A qualified name such as
+<code>example.com/pods</code> is allowed.
 An empty Outputs combined with a <code>Replace</code> Strategy causes the Input resource to be ignored by Kueue.</p>
 </td>
 </tr>

--- a/site/content/en/v0.19/docs/reference/kueue-config.v1beta2.md
+++ b/site/content/en/v0.19/docs/reference/kueue-config.v1beta2.md
@@ -769,7 +769,10 @@ followed by a slash and a DNS label, or just a DNS label.
 DNS labels consist of lower-case alphanumeric characters or hyphens,
 and must start and end with an alphanumeric character.
 DNS subdomain prefixes follow the same rules as DNS labels but can contain periods.
-The total length must not exceed 253 characters.</p>
+The total length must not exceed 253 characters.
+With KueueDRAIntegration enabled it must not be <code>pods</code>; that exact name is
+reserved for Kueue's internal Pod-count accounting. A qualified name such
+as <code>example.com/pods</code> is allowed.</p>
 </td>
 </tr>
 <tr><td><code>deviceClassNames</code> <B>[Required]</B><br/>
@@ -859,16 +862,24 @@ Requires the KueueDRAIntegrationConsumableCapacity feature gate.</p>
    <p>preemptionStrategies indicates which constraints should a preemption satisfy.
 The preemption algorithm will only use the next strategy in the list if the
 incoming workload (preemptor) doesn't fit after using the previous strategies.
+AlmostLCA(x, y) is the last but one node on the path from x to the
+lowest common ancestor of x and y in the cohort hierarchy (see KEP-1714).
+The strategies compare the shares of AlmostLCA(preemptor, preemptee) and
+AlmostLCA(preemptee, preemptor). These are the shares of ClusterQueues themselves
+only when both ClusterQueues share the same parent Cohort.
 Possible values are:</p>
 <ul>
-<li>LessThanOrEqualToFinalShare: Only preempt a workload if the share of the preemptor CQ
-with the preemptor workload is less than or equal to the share of the preemptee CQ
+<li>LessThanOrEqualToFinalShare: Only preempt a workload if the share of
+AlmostLCA(preemptor, preemptee) with the preemptor workload admitted is
+less than or equal to the share of AlmostLCA(preemptee, preemptor)
 without the workload to be preempted.
 This strategy might favor preemption of smaller workloads in the preemptee CQ,
-regardless of priority or start time, in an effort to keep the share of the CQ
+regardless of priority or start time, in an effort to keep the share of AlmostLCA(preemptee, preemptor)
 as high as possible.</li>
-<li>LessThanInitialShare: Only preempt a workload if the share of the preemptor CQ
-with the incoming workload is strictly less than the share of the preemptee CQ.
+<li>LessThanInitialShare: Only preempt a workload if the share of
+AlmostLCA(preemptor, preemptee) with the preemptor workload admitted is
+strictly less than the share of AlmostLCA(preemptee, preemptor) with the
+workload to be preempted.
 This strategy doesn't depend on the share usage of the workload being preempted.
 As a result, the strategy chooses to preempt workloads with the lowest priority and
 newest start time first.</li>
@@ -1316,7 +1327,9 @@ re-queuing an evicted workload.</p>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcename-v1-core"><code>k8s.io/api/core/v1.ResourceName</code></a>
 </td>
 <td>
-   <p>Input is the name of the input resource.</p>
+   <p>Input is the name of the input resource.
+It must not be <code>pods</code>; that exact name is reserved for Kueue's internal
+Pod-count accounting. A qualified name such as <code>example.com/pods</code> is allowed.</p>
 </td>
 </tr>
 <tr><td><code>strategy</code> <B>[Required]</B><br/>
@@ -1336,7 +1349,9 @@ specified.
 The requested amount of the resource is used to multiply the requested
 amount of the resource indicated by the &quot;input&quot; field when computing
 &quot;outputs&quot;. It does not change the quantity retained under &quot;input&quot; when
-&quot;strategy&quot; is Retain.</p>
+&quot;strategy&quot; is Retain.
+It must not be <code>pods</code>; that exact name is reserved for Kueue's internal
+Pod-count accounting. A qualified name such as <code>example.com/pods</code> is allowed.</p>
 </td>
 </tr>
 <tr><td><code>outputs</code> <B>[Required]</B><br/>
@@ -1344,6 +1359,9 @@ amount of the resource indicated by the &quot;input&quot; field when computing
 </td>
 <td>
    <p>Outputs specifies the output resources and quantities per unit of input resource.
+An output resource name must not be <code>pods</code>; that exact name is reserved for
+Kueue's internal Pod-count accounting. A qualified name such as
+<code>example.com/pods</code> is allowed.
 An empty Outputs combined with a <code>Replace</code> Strategy causes the Input resource to be ignored by Kueue.</p>
 </td>
 </tr>

--- a/site/content/zh-CN/v0.19/docs/_index.md
+++ b/site/content/zh-CN/v0.19/docs/_index.md
@@ -2,14 +2,14 @@
 type: docs
 params:
   docs_minor: v0.19
-  version: v0.19.2
-  chart_version: 0.19.2
+  version: v0.19.3
+  chart_version: 0.19.3
 cascade:
   type: docs
   params:
     docs_minor: v0.19
-    version: v0.19.2
-    chart_version: 0.19.2
+    version: v0.19.3
+    chart_version: 0.19.3
 title: "文档"
 linkTitle: "文档"
 weight: 20

--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -106,10 +106,10 @@ ignoreFiles = []
   # The major.minor version tag for the version of the docs represented in this
   # branch of the repository. Used in the "version-banner" partial to display a
   # version number for this doc set.
-  version = "v0.19.2"
+  version = "v0.19.3"
 
   # Version of Kueue without the leading "v", as used for Helm charts.
-  chart_version = "0.19.2"
+  chart_version = "0.19.3"
   # Flag used in the "version-banner" partial to decide whether to display a
   # banner on every page indicating that this is an archived version of the docs.
   archived_version = false

--- a/test/e2e/kueueviz/package-lock.json
+++ b/test/e2e/kueueviz/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kueueviz-frontend-tests",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kueueviz-frontend-tests",
-      "version": "0.19.2",
+      "version": "0.19.3",
       "devDependencies": {
         "@testing-library/cypress": "^10.1.3",
         "cypress": "^15.21.0",

--- a/test/e2e/kueueviz/package.json
+++ b/test/e2e/kueueviz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kueueviz-frontend-tests",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "scripts": {
     "cypress:run": "cypress run --headless",
     "check-unused": "depcheck"


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/area release

#### What this PR does / why we need it:
Update main with the latest v0.19.3.

#### Which issue(s) this PR fixes:
Part of #14693

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workload-aware scheduling can annotate Pods with their associated Workload when the relevant feature gate is enabled.
* **Bug Fixes**
  * Includes fixes across scheduling, admission checks, fair sharing, DRA, Helm, KueueViz, MultiKueue, observability, workloads, and supported integrations.
* **Actions Required Before Upgrading**
  * Remove or rename DRA device-class mappings and resource transformations using the reserved resource name `pods`; otherwise mappings may be discarded or Workloads may remain pending.
* **Documentation**
  * Clarified hierarchical fair-sharing preemption behavior and the reserved `pods` resource name.
* **Release**
  * Updated installation references and charts to v0.19.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->