### PR TITLE
Parallelize per-platform builds in multiplatform-build.sh

### DIFF
--- a/hack/multiplatform-build.sh
+++ b/hack/multiplatform-build.sh
@@ -28,26 +28,44 @@ PLATFORMS=${PLATFORMS:-linux/amd64}
 CURRENT_DIR=$(dirname "${BASH_SOURCE[0]}")
 ROOT_PATH=$(realpath "${CURRENT_DIR}/..")
 BUILD_PATH=${BUILD_PATH:-${ROOT_PATH}/artifacts}
+MAIN_PACKAGE=$1
 
 mkdir -p "${BUILD_PATH}"
 
-IFS=","
-for PLATFORM in ${PLATFORMS} ; do
-  export GOOS="${PLATFORM%/*}"
-  export GOARCH="${PLATFORM#*/}"
-  EXTENSION=""
+# Builds a single platform in its own subshell so that build_platform
+# invocations can run concurrently in the background; each uses a
+# platform-scoped tmp dir so parallel runs don't race on the same files.
+build_platform() {
+  local PLATFORM=$1
+  local GOOS="${PLATFORM%/*}"
+  local GOARCH="${PLATFORM#*/}"
+  local EXTENSION=""
 
   if [ "${GOOS}" == "windows" ]; then
     EXTENSION=".exe"
   fi
 
-  echo "Building for $PLATFORM platform"
-  FULL_NAME=${BUILD_NAME}-${GOOS}-${GOARCH}
-  "${GO_CMD}" build -ldflags="${LD_FLAGS}" -o "${BUILD_PATH}/${FULL_NAME}${EXTENSION}" "$1"
+  echo "Building for ${PLATFORM} platform"
+  local FULL_NAME=${BUILD_NAME}-${GOOS}-${GOARCH}
+  local TMP_PATH="${BUILD_PATH}/tmp-${GOOS}-${GOARCH}"
+  GOOS="${GOOS}" GOARCH="${GOARCH}" "${GO_CMD}" build -ldflags="${LD_FLAGS}" -o "${BUILD_PATH}/${FULL_NAME}${EXTENSION}" "${MAIN_PACKAGE}"
 
-  mkdir -p "${BUILD_PATH}/tmp"
-  cp "${ROOT_PATH}/LICENSE" "${BUILD_PATH}/tmp"
-  cp "${BUILD_PATH}/${FULL_NAME}${EXTENSION}" "${BUILD_PATH}/tmp/${BUILD_NAME}${EXTENSION}"
-  (cd "${BUILD_PATH}/tmp" && tar -czf "${BUILD_PATH}/${FULL_NAME}.tar.gz" ./*)
-  rm -R "${BUILD_PATH}/tmp"
+  mkdir -p "${TMP_PATH}"
+  cp "${ROOT_PATH}/LICENSE" "${TMP_PATH}"
+  cp "${BUILD_PATH}/${FULL_NAME}${EXTENSION}" "${TMP_PATH}/${BUILD_NAME}${EXTENSION}"
+  (cd "${TMP_PATH}" && tar -czf "${BUILD_PATH}/${FULL_NAME}.tar.gz" ./*)
+  rm -R "${TMP_PATH}"
+}
+
+IFS=","
+PIDS=()
+for PLATFORM in ${PLATFORMS} ; do
+  build_platform "${PLATFORM}" &
+  PIDS+=("$!")
 done
+
+STATUS=0
+for PID in "${PIDS[@]}"; do
+  wait "${PID}" || STATUS=1
+done
+exit "${STATUS}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

`hack/multiplatform-build.sh` cross-compiles `kueuectl` for every platform in
`CLI_PLATFORMS` (currently `linux/amd64,linux/arm64,darwin/amd64,darwin/arm64`)
sequentially in a single `for` loop, called from the `artifacts` / `release-artifacts`
Make targets used by `/create-draft-release`. Building one platform at a time is the
long pole in that release job.

This PR parallelizes the loop: each platform's build+package steps are extracted into
a `build_platform` function that's launched as a background job per platform, with
`wait` used to collect exit statuses afterward.

Two things had to change to make backgrounding safe, not just add `&`:
- The original script staged files for every platform through the same
  `${BUILD_PATH}/tmp` directory before tarring it up. Running that unchanged in
  parallel would race — concurrent platforms would stomp on each other's staged
  files. Each platform now gets its own `${BUILD_PATH}/tmp-${GOOS}-${GOARCH}`
  staging directory.
- The original script used `export GOOS=`/`export GOARCH=` to set the build
  environment for the whole loop iteration. Now `GOOS`/`GOARCH` are scoped to just
  the `go build` invocation (`GOOS=... GOARCH=... go build ...`) inside the function.

One behavior change worth flagging for reviewers: previously, under `set -o errexit`,
a build failure on platform N meant platforms after it in the loop never started.
Now all platforms launch unconditionally and the script still exits non-zero if any
of them failed, but a failure on one platform no longer prevents the others from
completing and producing their artifacts. This seems like a strict improvement for a
release job (more informative output, no reason for an arm64 failure to block an
amd64 artifact from being produced), but it is a change from today's all-or-nothing
short-circuit behavior.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #15110

#### Special notes for your reviewer:

Validation performed (see commit message for full detail): `shellcheck` against the
repo's `.shellcheckrc` is clean. Since Docker isn't available in my environment, I
couldn't run `make shell-lint` itself (which runs shellcheck in a container), so I
ran the `shellcheck` CLI directly with the same config as a substitute — same tool,
same rcfile, just not containerized.

I could not run the real `make artifacts` / `kueuectl` cross-compile across all four
`CLI_PLATFORMS` end-to-end in my sandbox — it has very little free disk, and several
concurrent full builds of kueue's large dependency tree (k8s.io, kubeflow trainer,
ray, jobset, volcano, scheduler-plugins, etc.) exhausted it. That's a sandbox
resource constraint (`go build` failing with "no space left on device"), not a script
logic issue. To validate the actual change in isolation — the staging-directory race
fix, the `GOOS`/`GOARCH` scoping, and exit-code propagation from background jobs —
I ran the modified script directly against a trivial standalone `main.go` across five
platforms (including Windows, to exercise the `.exe` extension path), confirming
clean concurrent completion, correct non-overlapping tar contents per platform, and
correct non-zero exit when I intentionally broke the build. Details in the commit
message.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

---
AI assistance: this change was drafted with Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved multiplatform builds by running platform builds concurrently in isolated temporary directories.
  - Build commands now correctly report failure when any platform build does not succeed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->