### PR TITLE
[Trainer] Use SyncParallelCount to set parallelism/completions

### DIFF
--- a/pkg/controller/jobs/trainjob/trainjob_controller.go
+++ b/pkg/controller/jobs/trainjob/trainjob_controller.go
@@ -25,6 +25,7 @@ import (
 	kftrainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 	kftrainerruntime "github.com/kubeflow/trainer/v2/pkg/runtime"
 	kftrainerruntimecore "github.com/kubeflow/trainer/v2/pkg/runtime/core"
+	kftrainerframework "github.com/kubeflow/trainer/v2/pkg/runtime/framework"
 	kftrainerjobset "github.com/kubeflow/trainer/v2/pkg/runtime/framework/plugins/jobset"
 	trainjobutil "github.com/kubeflow/trainer/v2/pkg/util/trainjob"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -166,12 +167,16 @@ func getChildJobSet(ctx context.Context, c client.Client, t *TrainJob) (*jobseta
 		return nil, err
 	}
 
-	// Jobset replicaJob parallelism/completions are set outside of the jobset builder
-	for psIdx, ps := range info.TemplateSpec.PodSets {
-		if ps.Count != nil {
-			jobSetSpec.ReplicatedJobs[psIdx].Template.Spec.Parallelism = ps.Count
-			jobSetSpec.ReplicatedJobs[psIdx].Template.Spec.Completions = ps.Count
-		}
+	jobSetPlugin, err := kftrainerjobset.New(ctx, c, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	cbp, ok := jobSetPlugin.(kftrainerframework.ComponentBuilderPlugin)
+	if !ok {
+		return nil, errors.New("jobset plugin does not implement ComponentBuilderPlugin")
+	}
+	if err := cbp.SyncParallelCount(info); err != nil {
+		return nil, err
 	}
 
 	jobsetApply := kftrainerjobset.NewBuilder(jobsetapplyapi.JobSet(t.Name, t.Namespace).


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area integrations

#### What this PR does / why we need it:
In order to set the Jobset parallelism/completions fields, we currently loop over the `RuntimeInfo` podset list. This code was copied from the Trainer source code.

This PR replaces such loop  by a call to the Trainer `SyncParallelCount ` function

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8287

#### Special notes for your reviewer:

This code will **need** to be removed when we bump the Trainer to `v2.4.0` because this function will go private.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization of replica and completion counts for distributed training jobs.
  * Enhanced compatibility with the Kubeflow Trainer framework when creating child job sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->