### PR TITLE
Following on 14937

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -78,7 +78,7 @@ import (
 const (
 	FailedToStartFinishedReason = "FailedToStart"
 	managedOwnersChainLimit     = 10
-	fullScaleUpProbeExtra       = "full-scaleup-probe"
+	scaleUpProbeExtra           = "scale-up-probe"
 )
 
 var (
@@ -1671,7 +1671,7 @@ func ConstructWorkload(ctx context.Context, c client.Client, job GenericJob, lab
 		return nil, err
 	}
 	extra := ""
-	if WorkloadSliceEnabled(job) {
+	if shouldCreatePartialScaleUpProbe(job) {
 		extra, err = prepareWorkloadSliceForScaleUp(ctx, c, job, podSets)
 		if err != nil {
 			return nil, err
@@ -1700,19 +1700,23 @@ func ConstructWorkload(ctx context.Context, c client.Client, job GenericJob, lab
 	return wl, nil
 }
 
+// shouldCreatePartialScaleUpProbe reports whether the job takes the partial
+// replica scale-up path for its workload slices.
+func shouldCreatePartialScaleUpProbe(job GenericJob) bool {
+	return WorkloadSliceEnabled(job) &&
+		features.Enabled(features.ElasticJobsViaWorkloadSlicesWithPartialReplicaScaleUp) &&
+		job.Object().GetAnnotations()[constants.ElasticJobScaleUpStrategyAnnotationKey] == constants.ElasticJobScaleUpStrategyPartial
+}
+
 func prepareWorkloadSliceForScaleUp(ctx context.Context, c client.Client, job GenericJob, podSets []kueue.PodSet) (string, error) {
 	object := job.Object()
-	if !features.Enabled(features.ElasticJobsViaWorkloadSlicesWithPartialReplicaScaleUp) ||
-		object.GetAnnotations()[constants.ElasticJobScaleUpStrategyAnnotationKey] != constants.ElasticJobScaleUpStrategyPartial {
-		return "", nil
-	}
 	prevWl, err := workloadslicing.FindLatestActiveWorkload(ctx, c, object, job.GVK())
 	if err != nil {
 		return "", err
 	}
 	extra := ""
-	if prevWl != nil && workload.HasQuotaReservation(prevWl) {
-		extra = fullScaleUpProbeExtra
+	if prevWl != nil {
+		extra = scaleUpProbeExtra
 		if len(prevWl.Spec.PodSets) != len(podSets) {
 			extra = ""
 		} else {
@@ -1723,11 +1727,23 @@ func prepareWorkloadSliceForScaleUp(ctx context.Context, c client.Client, job Ge
 			}
 		}
 		grantedCounts := workload.ExtractGrantedPodSetCounts(prevWl)
+		admitted := int32(0)
 		for i := range podSets {
-			if prevAdmittedCount, ok := grantedCounts[podSets[i].Name]; ok && podSets[i].Count > prevAdmittedCount {
+			prevAdmittedCount, ok := grantedCounts[podSets[i].Name]
+			if !ok {
+				continue
+			}
+			admitted += prevAdmittedCount
+			if podSets[i].Count > prevAdmittedCount {
 				minCount := prevAdmittedCount + 1
 				podSets[i].MinCount = &minCount
 			}
+		}
+		if extra != "" {
+			// The admitted level the probe is issued against. It grows with every partial
+			// admission, so successive probes within one scale event get distinct names,
+			// while a retry against an unchanged level reuses the same one.
+			extra = fmt.Sprintf("%s-%d", extra, admitted)
 		}
 	}
 	return extra, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Cleanup initiative as followup to [PR](https://github.com/kubernetes-sigs/kueue/pull/14937)
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relates to #12100
Fixes #15101 

#### Special notes for your reviewer:
1. Rename `fullScaleUpProbeExtra` → `scaleUpProbeExtra` = "scale-up-probe". The workload's `MinCount` is prevAdmitted + 1, so it can be admitted partially too — it was never a full scale up.

2. Probe suffix = admitted level A (sum of prevWl's granted counts).
Within a scale event the Job spec is frozen, so generation can't tell two probes apart — the only thing that moves is how much has been admitted, which makes the granted-count sum the natural key. It also can't go backwards (a short pod set gets MinCount = prevAdmitted+1, a full one keeps its count), so successive probes always get distinct names. And being derived from admission status rather than random, a retry with nothing newly admitted recomputes the same name, keeping the Create idempotent.

3. Extract relevant conditions to `shouldCreatePartialScaleUpProbe`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved partial-replica scale-up probe handling for workloads using workload slicing and the partial scale-up strategy.
  * Scale-up probes now include the total admitted replica count, providing clearer tracking during scaling operations.
  * Workloads with pod sets exceeding their granted count continue to receive the appropriate minimum count during scale-up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->