### PR TITLE
Consolidate WorkloadPriorityClass reconcile error-handling tests

### DIFF
--- a/pkg/controller/core/workloadpriorityclass_controller_test.go
+++ b/pkg/controller/core/workloadpriorityclass_controller_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -103,12 +102,11 @@ func TestWorkloadPriorityClassPredicates(t *testing.T) {
 func TestWorkloadPriorityClassReconcile(t *testing.T) {
 	errTest := errors.New("test error")
 	cases := map[string]struct {
-		wpc             *kueue.WorkloadPriorityClass
-		workloads       []kueue.Workload
-		wantWorkloads   []kueue.Workload
-		wantError       error
-		wantSingleError bool
-		clientFuncs     *interceptor.Funcs
+		wpc           *kueue.WorkloadPriorityClass
+		workloads     []kueue.Workload
+		wantWorkloads []kueue.Workload
+		wantError     error
+		clientFuncs   *interceptor.Funcs
 	}{
 		"reconcile updates workload priority when WPC priority changes": {
 			wpc: utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(1000).Obj(),
@@ -267,11 +265,7 @@ func TestWorkloadPriorityClassReconcile(t *testing.T) {
 					Obj(),
 			},
 		},
-		"reconcile keeps a single error when all updates fail": {
-			// Pins the second half of the fix: the sweep now goes through
-			// parallelize.Until, which keeps a single error rather than
-			// accumulating one per failed Workload the way the old
-			// errors.Join(updateErrors...) loop did.
+		"reconcile returns an error when all updates fail": {
 			wpc: utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(1000).Obj(),
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("wl1", "default").
@@ -292,8 +286,7 @@ func TestWorkloadPriorityClassReconcile(t *testing.T) {
 					return fmt.Errorf("%w: update failed for %s", errTest, obj.GetName())
 				},
 			},
-			wantError:       errTest,
-			wantSingleError: true,
+			wantError: errTest,
 			wantWorkloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("wl1", "default").
 					Priority(100).
@@ -347,17 +340,6 @@ func TestWorkloadPriorityClassReconcile(t *testing.T) {
 			_, gotErr := reconciler.Reconcile(ctx, req)
 			if diff := cmp.Diff(tc.wantError, gotErr, cmpopts.EquateErrors()); len(diff) != 0 {
 				t.Errorf("Unexpected error (-want/+got):\n%s", diff)
-			}
-			if tc.wantSingleError && gotErr != nil {
-				named := 0
-				for _, wl := range tc.workloads {
-					if strings.Contains(gotErr.Error(), wl.Name) {
-						named++
-					}
-				}
-				if named != 1 {
-					t.Errorf("expected the error to name exactly one failed workload, got %d in %q", named, gotErr.Error())
-				}
 			}
 			// Verify workloads are in the expected state
 			for _, wantWl := range tc.wantWorkloads {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Removes the `wantSingleError` assertion path in `TestWorkloadPriorityClassReconcile`. It re-verified `parallelize.Until`'s single-error-kept behavior, which is already covered by `pkg/util/parallelize/parallelize_test.go` and isn't specific to this reconciler. The "all updates fail" case is kept, now asserted the same way as every other case in the table (`wantError` + `cmpopts.EquateErrors()`).

#### Which issue(s) this PR fixes:
Fixes #15043

#### Special notes for your reviewer:

AI assistance (Claude Code) was used to draft this change.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified reconciliation test coverage for scenarios where all updates fail.
  * Updated test expectations to verify that reconciliation returns an error without relying on specific error-message contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->