### PR TITLE
replace logr.Discard() with ContextWithLog in tests

### DIFF
--- a/pkg/cache/scheduler/tas_cache_update_test.go
+++ b/pkg/cache/scheduler/tas_cache_update_test.go
@@ -19,7 +19,6 @@ package scheduler
 import (
 	"testing"
 
-	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 
@@ -49,8 +48,9 @@ func TestTASCacheUpdateFlavorTolerationsPreservesUsage(t *testing.T) {
 			corev1.ResourceCPU: 1,
 		}),
 	}}
+	_, log := utiltesting.ContextWithLog(t)
 	originalFlavorCache := tasCache.Get("tas-flavor")
-	originalFlavorCache.addUsage(logr.Discard(), wlKey, topologyRequests)
+	originalFlavorCache.addUsage(log, wlKey, topologyRequests)
 
 	toleration := corev1.Toleration{
 		Key:      "example.com/dedicated",
@@ -115,9 +115,10 @@ func TestTASCacheUpdateFlavorNodeLabelsPreservesUsage(t *testing.T) {
 			corev1.ResourceCPU: 1,
 		}),
 	}}
+	_, log := utiltesting.ContextWithLog(t)
 	originalFlavorCache := tasCache.Get("tas-flavor")
 	originalTree, _ := originalFlavorCache.cachedOrBuiltTree()
-	originalFlavorCache.addUsage(logr.Discard(), wlKey, topologyRequests)
+	originalFlavorCache.addUsage(log, wlKey, topologyRequests)
 
 	updatedNodeLabels := map[string]string{"node-group": "other"}
 	flavor.Spec.NodeLabels = updatedNodeLabels
@@ -170,9 +171,10 @@ func TestTASCacheUpdateTopologyLevelsPreservesUsage(t *testing.T) {
 			corev1.ResourceCPU: 1,
 		}),
 	}}
+	_, log := utiltesting.ContextWithLog(t)
 	originalFlavorCache := tasCache.Get("tas-flavor")
 	originalTree, _ := originalFlavorCache.cachedOrBuiltTree()
-	originalFlavorCache.addUsage(logr.Discard(), wlKey, topologyRequests)
+	originalFlavorCache.addUsage(log, wlKey, topologyRequests)
 
 	updatedTopology := utiltestingapi.MakeTopology("default").
 		Levels(utiltesting.DefaultBlockTopologyLevel, corev1.LabelHostname).

--- a/pkg/cache/scheduler/tas_flavor_snapshot_bench_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_bench_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,6 +28,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/resources"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	testingnode "sigs.k8s.io/kueue/pkg/util/testingjobs/node"
 	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
 )
@@ -107,7 +107,7 @@ func BenchmarkTASFlavorSnapshot(b *testing.B) {
 func runBenchmarkTASFlavorSnapshot(b *testing.B, topo benchTopology, flavors int, name string, mode benchSnapshotMode) {
 	b.Run(name, func(b *testing.B) {
 		b.ReportAllocs()
-		log := logr.Discard()
+		_, log := utiltesting.ContextWithLog(b)
 
 		nodes := buildBenchNodes(topo)
 		levels := []string{benchBlockLabel, benchRackLabel, benchHostLabel}
@@ -199,7 +199,7 @@ func BenchmarkTASFlavorAssignment(b *testing.B) {
 func runBenchmarkTASFlavorAssignment(b *testing.B, topo benchTopology, name string, withLeader bool) {
 	b.Run(name, func(b *testing.B) {
 		b.ReportAllocs()
-		log := logr.Discard()
+		_, log := utiltesting.ContextWithLog(b)
 		nodes := buildBenchNodes(topo)
 		levels := []string{benchBlockLabel, benchRackLabel, benchHostLabel}
 

--- a/pkg/cache/scheduler/tas_overlapping_flavor_bench_test.go
+++ b/pkg/cache/scheduler/tas_overlapping_flavor_bench_test.go
@@ -25,6 +25,7 @@ import (
 
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/resources"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 )
 
@@ -74,7 +75,8 @@ func BenchmarkTASFlavorSnapshotOverlappingUsage(b *testing.B) {
 				)
 
 				// Held domains come from the flavor's own leaves; the rest are foreign.
-				held, err := flavorCache.snapshot(b.Context(), logr.Discard(), nil, nil)
+				_, setupLog := utiltesting.ContextWithLog(b)
+				held, err := flavorCache.snapshot(b.Context(), setupLog, nil, nil)
 				if err != nil {
 					b.Fatalf("initial TASFlavorSnapshot creation failed: %v", err)
 				}

--- a/pkg/cache/scheduler/tas_overlapping_flavor_bench_test.go
+++ b/pkg/cache/scheduler/tas_overlapping_flavor_bench_test.go
@@ -25,8 +25,8 @@ import (
 
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/resources"
-	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 )
 
 // countingSink is a logr.LogSink that counts only the "skip accounting for TAS

--- a/pkg/cache/scheduler/tas_overlapping_flavor_bench_test.go
+++ b/pkg/cache/scheduler/tas_overlapping_flavor_bench_test.go
@@ -75,8 +75,8 @@ func BenchmarkTASFlavorSnapshotOverlappingUsage(b *testing.B) {
 				)
 
 				// Held domains come from the flavor's own leaves; the rest are foreign.
-				_, setupLog := utiltesting.ContextWithLog(b)
-				held, err := flavorCache.snapshot(b.Context(), setupLog, nil, nil)
+				_, log := utiltesting.ContextWithLog(b)
+				held, err := flavorCache.snapshot(b.Context(), log, nil, nil)
 				if err != nil {
 					b.Fatalf("initial TASFlavorSnapshot creation failed: %v", err)
 				}
@@ -89,7 +89,7 @@ func BenchmarkTASFlavorSnapshotOverlappingUsage(b *testing.B) {
 				}
 
 				sink := &countingSink{enabledV: v}
-				log := logr.New(sink)
+				log = logr.New(sink)
 				b.ReportAllocs()
 				iters := 0
 				for b.Loop() {

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	batchv1 "k8s.io/api/batch/v1"
@@ -5278,7 +5277,8 @@ func TestTerminalIndexesCount(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			if got := terminalIndexesCount(logr.Discard(), tc.completedIndexes, tc.failedIndexes, tc.completions); got != tc.want {
+			_, log := utiltesting.ContextWithLog(t)
+			if got := terminalIndexesCount(log, tc.completedIndexes, tc.failedIndexes, tc.completions); got != tc.want {
 				t.Errorf("terminalIndexesCount(%q, %q, %d) = %d, want %d", tc.completedIndexes, tc.failedIndexes, tc.completions, got, tc.want)
 			}
 		})

--- a/pkg/dra/counters_test.go
+++ b/pkg/dra/counters_test.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/funcr"
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
@@ -285,7 +284,8 @@ func TestComputeCounterCharges(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := computeCounterCharges(logr.Discard(), tc.cc, tc.quotaResource, tc.matched, tc.count)
+			_, log := utiltesting.ContextWithLog(t)
+			got := computeCounterCharges(log, tc.cc, tc.quotaResource, tc.matched, tc.count)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("computeCounterCharges() mismatch (-want +got):\n%s", diff)
 			}

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -4845,11 +4845,12 @@ func TestAssignment_TotalRequestsFor(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			_, log := utiltesting.ContextWithLog(t)
 			a := &Assignment{
 				PodSets:              tt.fields.PodSets,
 				replaceWorkloadSlice: tt.fields.replaceWorkloadSlice,
 			}
-			got := a.TotalRequestsFor(logr.Discard(), tt.args.wl)
+			got := a.TotalRequestsFor(log, tt.args.wl)
 			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("TotalRequestsFor() (-want +got):\n%s", diff)
 			}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
@@ -9778,7 +9777,7 @@ func TestResourcesToReserve(t *testing.T) {
 			}
 			cqSnapshot := snapshot.ClusterQueue("cq")
 
-			got := resourcesToReserve(logr.Discard(), e, cqSnapshot)
+			got := resourcesToReserve(log, e, cqSnapshot)
 			if !reflect.DeepEqual(tc.wantReserved, got.Quota.Assigned) {
 				t.Errorf("%s failed\n: Want reservedMem: %v, got: %v", tc.name, tc.wantReserved, got)
 			}

--- a/pkg/util/roletracker/tracker_test.go
+++ b/pkg/util/roletracker/tracker_test.go
@@ -64,10 +64,10 @@ func TestRoleTracker_StartLeaderElection(t *testing.T) {
 				t.Errorf("Initial role = %q, want %q", got, RoleFollower)
 			}
 
-			ctx, cancel := context.WithCancel(t.Context())
+			ctx, log := utiltesting.ContextWithLog(t)
+			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 
-			_, log := utiltesting.ContextWithLog(t)
 			done := make(chan struct{})
 			go func() {
 				rt.Start(ctx, log)
@@ -133,7 +133,8 @@ func TestOnElected(t *testing.T) {
 				})
 			}
 
-			ctx, cancel := context.WithCancel(t.Context())
+			ctx, log := utiltesting.ContextWithLog(t)
+			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 
 			if tc.closeChannel {
@@ -143,7 +144,6 @@ func TestOnElected(t *testing.T) {
 				cancel()
 			}
 
-			_, log := utiltesting.ContextWithLog(t)
 			rt.Start(ctx, log)
 
 			if called != tc.expectCalled {

--- a/pkg/util/roletracker/tracker_test.go
+++ b/pkg/util/roletracker/tracker_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/go-logr/logr"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 )
 
 func TestNewRoleTracker(t *testing.T) {
@@ -67,9 +67,10 @@ func TestRoleTracker_StartLeaderElection(t *testing.T) {
 			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 
+			_, log := utiltesting.ContextWithLog(t)
 			done := make(chan struct{})
 			go func() {
-				rt.Start(ctx, logr.Discard())
+				rt.Start(ctx, log)
 				close(done)
 			}()
 
@@ -142,7 +143,8 @@ func TestOnElected(t *testing.T) {
 				cancel()
 			}
 
-			rt.Start(ctx, logr.Discard())
+			_, log := utiltesting.ContextWithLog(t)
+			rt.Start(ctx, log)
 
 			if called != tc.expectCalled {
 				t.Errorf("callback called = %v, want %v", called, tc.expectCalled)

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
@@ -1135,6 +1134,7 @@ func TestUpdateWithRebuild(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			_, log := utiltesting.ContextWithLog(t)
 			info := NewInfo(tc.initial, tc.initialOptions...)
 			if len(tc.updateOptions) == 0 {
 				if diff := cmp.Diff(tc.wantRequests, info.TotalRequests,
@@ -1143,7 +1143,7 @@ func TestUpdateWithRebuild(t *testing.T) {
 					t.Fatal("precondition failed: initial TotalRequests should differ from expected post-rebuild state")
 				}
 			}
-			info.Update(logr.Discard(), tc.updated, tc.updateOptions...)
+			info.Update(log, tc.updated, tc.updateOptions...)
 			if diff := cmp.Diff(tc.wantRequests, info.TotalRequests,
 				cmpopts.IgnoreFields(PodSetResources{}, "Flavors"),
 				cmp.Comparer(resources.Equal)); diff != "" {
@@ -3186,11 +3186,12 @@ func TestSchedulingHash(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			_, log := utiltesting.ContextWithLog(t)
 			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			info1 := NewInfo(tc.wl1)
-			info1.updateSchedulingHash(logr.Discard())
+			info1.updateSchedulingHash(log)
 			info2 := NewInfo(tc.wl2)
-			info2.updateSchedulingHash(logr.Discard())
+			info2.updateSchedulingHash(log)
 			if info1.SchedulingHash == "" {
 				t.Error("SchedulingHash should not be empty")
 			}
@@ -3204,13 +3205,14 @@ func TestSchedulingHash(t *testing.T) {
 	}
 
 	t.Run("DRA translation producing different TotalRequests produces different hash", func(t *testing.T) {
+		_, log := utiltesting.ContextWithLog(t)
 		features.SetFeatureGatesDuringTest(t, map[featuregate.Feature]bool{
 			features.SchedulingEquivalenceHashing: true,
 		})
 		wl := utiltestingapi.MakeWorkload("wl", "ns").
 			Request("example.com/gpu", "1").Obj()
 		before := NewInfo(wl)
-		before.updateSchedulingHash(logr.Discard())
+		before.updateSchedulingHash(log)
 
 		after := NewInfo(wl, WithPreprocessedDRAResources(
 			map[kueue.PodSetReference]corev1.ResourceList{
@@ -3222,7 +3224,7 @@ func TestSchedulingHash(t *testing.T) {
 				kueue.DefaultPodSetName: sets.New[corev1.ResourceName]("example.com/gpu"),
 			},
 		))
-		after.updateSchedulingHash(logr.Discard())
+		after.updateSchedulingHash(log)
 
 		if diff := cmp.Diff(before.TotalRequests, after.TotalRequests, cmp.Comparer(resources.Equal)); diff == "" {
 			t.Fatal("precondition failed: TotalRequests should differ after DRA translation")
@@ -3313,19 +3315,20 @@ func TestUpdateSchedulingHashReuse(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			_, log := utiltesting.ContextWithLog(t)
 			before := tc.info.SchedulingHash
 			if before == SchedulingHashUnknown {
 				t.Fatalf("precondition failed: hash is %q", before)
 			}
 
-			tc.info.Update(logr.Discard(), tc.reread, tc.opts...)
+			tc.info.Update(log, tc.reread, tc.opts...)
 
 			if got := tc.info.SchedulingHash == before; got != tc.wantReuse {
 				t.Errorf("hash reused = %v, want %v (hash %q -> %q)", got, tc.wantReuse, before, tc.info.SchedulingHash)
 			}
 			// A recomputed hash must describe the inputs the Info now holds.
 			if !tc.wantReuse {
-				want := computeSchedulingHash(logr.Discard(), tc.info.Obj, tc.info.TotalRequests)
+				want := computeSchedulingHash(log, tc.info.Obj, tc.info.TotalRequests)
 				if tc.info.SchedulingHash != want {
 					t.Errorf("SchedulingHash = %q, does not describe the Info's own inputs (%q)", tc.info.SchedulingHash, want)
 				}
@@ -3334,11 +3337,12 @@ func TestUpdateSchedulingHashReuse(t *testing.T) {
 	}
 
 	t.Run("the hash stays unknown while the feature gate is off", func(t *testing.T) {
+		_, log := utiltesting.ContextWithLog(t)
 		features.SetFeatureGatesDuringTest(t, map[featuregate.Feature]bool{
 			features.SchedulingEquivalenceHashing: false,
 		})
 		info := NewInfo(workload("uid", "1", 1))
-		info.Update(logr.Discard(), workload("uid", "1", 2))
+		info.Update(log, workload("uid", "1", 2))
 		if info.SchedulingHash != SchedulingHashUnknown {
 			t.Errorf("SchedulingHash = %q, want %q", info.SchedulingHash, SchedulingHashUnknown)
 		}

--- a/test/integration/multikueue/resource_formatter_test.go
+++ b/test/integration/multikueue/resource_formatter_test.go
@@ -56,7 +56,7 @@ func workerResourceUsageStrings(c cluster, resources ...corev1.ResourceName) map
 		flavorName       = "formatter-isolation"
 	)
 
-	log := logr.Discard()
+	log := logr.FromContextOrDiscard(c.ctx)
 	resourceFlavor := utiltestingapi.MakeResourceFlavor(flavorName).Obj()
 	c.schedulerCache.AddOrUpdateResourceFlavor(log, resourceFlavor)
 	ginkgo.DeferCleanup(func() {

--- a/test/integration/multikueue/resource_formatter_test.go
+++ b/test/integration/multikueue/resource_formatter_test.go
@@ -19,10 +19,10 @@ package multikueue
 import (
 	"time"
 
-	"github.com/go-logr/logr"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
@@ -56,7 +56,7 @@ func workerResourceUsageStrings(c cluster, resources ...corev1.ResourceName) map
 		flavorName       = "formatter-isolation"
 	)
 
-	log := logr.FromContextOrDiscard(c.ctx)
+	log := ctrl.LoggerFrom(c.ctx)
 	resourceFlavor := utiltestingapi.MakeResourceFlavor(flavorName).Obj()
 	c.schedulerCache.AddOrUpdateResourceFlavor(log, resourceFlavor)
 	ginkgo.DeferCleanup(func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

Use utiltesting.ContextWithLog consistently across test files instead of logr.Discard(), so tests emit logs through the standard test logger

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #15127 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Updated unit, integration, and benchmark tests to use context-aware test loggers instead of discarding log output.
  - Preserved logging context across scheduling, caching, workload, resource, role-tracking, and device resource allocation test scenarios.
  - Improved diagnostic information available when tests or benchmarks encounter logging-related failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->