### PR TITLE
[release-0.18] Flip CompareBool to standard bool ordering

### DIFF
--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -946,8 +946,8 @@ func sortInactivePods(clock clock.Clock, inactivePods []corev1.Pod) {
 		return cmputil.LazyOr(
 			func() int {
 				return cmputil.CompareBool(
-					slices.Contains(pi.Finalizers, podconstants.PodFinalizer),
 					slices.Contains(pj.Finalizers, podconstants.PodFinalizer),
+					slices.Contains(pi.Finalizers, podconstants.PodFinalizer),
 				)
 			},
 			func() int {
@@ -971,15 +971,15 @@ func sortActivePods(activePods []corev1.Pod) {
 			func() int {
 				// Prefer to keep pods that have a finalizer.
 				return cmputil.CompareBool(
-					slices.Contains(pi.Finalizers, podconstants.PodFinalizer),
 					slices.Contains(pj.Finalizers, podconstants.PodFinalizer),
+					slices.Contains(pi.Finalizers, podconstants.PodFinalizer),
 				)
 			},
 			func() int {
 				// Prefer to keep pods that aren't gated.
 				return cmputil.CompareBool(
-					isGated(&pj),
 					isGated(&pi),
+					isGated(&pj),
 				)
 			},
 			func() int {

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -7011,6 +7011,111 @@ func TestIsPodRunnableOrSucceeded(t *testing.T) {
 	}
 }
 
+// TestSortActivePods pins down the ordering behavior of sortActivePods, in particular
+// the finalizer and gated-state tiebreakers that are implemented with cmputil.CompareBool.
+func TestSortActivePods(t *testing.T) {
+	now := time.Now()
+
+	tests := map[string]struct {
+		pods     []corev1.Pod
+		wantPods []string
+	}{
+		"finalizer state takes priority over creation timestamp": {
+			pods: []corev1.Pod{
+				*testingpod.MakePod("no-finalizer-newer", "ns").
+					CreationTimestamp(now).
+					Obj(),
+				*testingpod.MakePod("has-finalizer-older", "ns").
+					KueueFinalizer().
+					CreationTimestamp(now.Add(-time.Hour)).
+					Obj(),
+			},
+			wantPods: []string{"has-finalizer-older", "no-finalizer-newer"},
+		},
+		"non-gated pods sort before gated pods with the same finalizer state": {
+			pods: []corev1.Pod{
+				*testingpod.MakePod("gated", "ns").
+					KueueSchedulingGate().
+					Obj(),
+				*testingpod.MakePod("not-gated", "ns").
+					Obj(),
+			},
+			wantPods: []string{"not-gated", "gated"},
+		},
+		"older creation timestamp sorts first when finalizer and gate state match": {
+			pods: []corev1.Pod{
+				*testingpod.MakePod("newer", "ns").
+					CreationTimestamp(now).
+					Obj(),
+				*testingpod.MakePod("older", "ns").
+					CreationTimestamp(now.Add(-time.Hour)).
+					Obj(),
+			},
+			wantPods: []string{"older", "newer"},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			sortActivePods(tc.pods)
+			gotPods := make([]string, len(tc.pods))
+			for i, p := range tc.pods {
+				gotPods[i] = p.Name
+			}
+			if diff := cmp.Diff(tc.wantPods, gotPods); diff != "" {
+				t.Errorf("sortActivePods() ordering mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestSortInactivePods pins down the ordering behavior of sortInactivePods, in particular
+// the finalizer tiebreaker that is implemented with cmputil.CompareBool.
+func TestSortInactivePods(t *testing.T) {
+	now := time.Now()
+	fakeClock := testingclock.NewFakeClock(now)
+
+	tests := map[string]struct {
+		pods     []corev1.Pod
+		wantPods []string
+	}{
+		"finalizer state takes priority over last-active time": {
+			pods: []corev1.Pod{
+				*testingpod.MakePod("no-finalizer-active-later", "ns").
+					DeletionTimestamp(now.Add(-time.Minute)).
+					Obj(),
+				*testingpod.MakePod("has-finalizer-active-earlier", "ns").
+					KueueFinalizer().
+					DeletionTimestamp(now.Add(-time.Hour)).
+					Obj(),
+			},
+			wantPods: []string{"has-finalizer-active-earlier", "no-finalizer-active-later"},
+		},
+		"more recently active pods sort first when finalizer state matches": {
+			pods: []corev1.Pod{
+				*testingpod.MakePod("active-earlier", "ns").
+					DeletionTimestamp(now.Add(-time.Hour)).
+					Obj(),
+				*testingpod.MakePod("active-later", "ns").
+					DeletionTimestamp(now.Add(-time.Minute)).
+					Obj(),
+			},
+			wantPods: []string{"active-later", "active-earlier"},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			sortInactivePods(fakeClock, tc.pods)
+			gotPods := make([]string, len(tc.pods))
+			for i, p := range tc.pods {
+				gotPods[i] = p.Name
+			}
+			if diff := cmp.Diff(tc.wantPods, gotPods); diff != "" {
+				t.Errorf("sortInactivePods() ordering mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestStop(t *testing.T) {
 	now := time.Now()
 	fakeClock := testingclock.NewFakeClock(now)

--- a/pkg/scheduler/preemption/common/ordering.go
+++ b/pkg/scheduler/preemption/common/ordering.go
@@ -43,14 +43,14 @@ func CandidatesOrdering(log logr.Logger, afsEnabled bool, a, b *workload.Info, c
 	return cmputil.LazyOr(
 		func() int {
 			return cmputil.CompareBool(
-				workload.IsEvicted(a.Obj),
 				workload.IsEvicted(b.Obj),
+				workload.IsEvicted(a.Obj),
 			)
 		},
 		func() int {
 			return cmputil.CompareBool(
-				b.ClusterQueue == cq,
 				a.ClusterQueue == cq,
+				b.ClusterQueue == cq,
 			)
 		},
 		func() int {

--- a/pkg/util/cmp/cmp.go
+++ b/pkg/util/cmp/cmp.go
@@ -16,20 +16,21 @@ limitations under the License.
 
 package cmp
 
-// CompareBool compares two boolean values and returns:
+// CompareBool compares two boolean values following standard ordering
+// (false < true, matching cmp.Compare semantics) and returns:
 // - 0 if they are equal
-// - -1 if a is true and b is false
-// - 1 if a is false and b is true
+// - -1 if a is false and b is true
+// - 1 if a is true and b is false
 func CompareBool(a, b bool) int {
 	if a == b {
 		return 0
 	}
 
 	if a {
-		return -1
+		return 1
 	}
 
-	return 1
+	return -1
 }
 
 // LazyOr evaluates the provided functions in order and returns the first non-zero value.

--- a/pkg/util/cmp/cmp_test.go
+++ b/pkg/util/cmp/cmp_test.go
@@ -39,12 +39,12 @@ func TestCompareBool(t *testing.T) {
 		"a true, b false": {
 			a:   true,
 			b:   false,
-			exp: -1,
+			exp: 1,
 		},
 		"a false, b true": {
 			a:   false,
 			b:   true,
-			exp: 1,
+			exp: -1,
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
CompareBool put true before false, which is backwards from cmp.Compare and pretty much every other language's bool ordering. Callers had to swap args to get the sort order they actually wanted, which is confusing to read.

I then flipped the return values so false < true like normal, and update the 5 call sites in ordering.go and pod_controller.go so the actual sort order stays exactly the same as before. The argument order at each call site is changed to match the new semantics.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #15118 

#### Special notes for your reviewer:
Manual cherry-pick of #15128 to `release-0.18`. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
