### PR TITLE
KEP-10076: Quota Release Strategy per integration

### DIFF
--- a/keps/10076-quota-release-strategy/README.md
+++ b/keps/10076-quota-release-strategy/README.md
@@ -32,7 +32,7 @@
 
 ## Summary
 
-This proposal introduces a top-level configuration setting `.quotaReleaseStrategy` in Kueue's Configuration API (`apis/config/v1beta2`). It allows cluster administrators to configure when Kueue releases workload quota reservation during eviction and preemption — either immediately upon deletion initiation (`OnTerminating`) or delayed until all underlying pods reach a terminal phase (`OnTerminal`).
+This proposal introduces a per-integration configuration setting `.integrations.quotaReleaseStrategy` in Kueue's Configuration API (`apis/config/v1beta2`), gated by the `QuotaReleaseStrategy` Feature Gate (Alpha, disabled by default in v0.20). It allows cluster administrators to configure when Kueue releases workload quota reservation during eviction and preemption on a per-framework basis — either immediately upon deletion initiation / status change (`OnQuotaReleased`) or delayed until all underlying pods reach a terminal phase (`OnTerminal`).
 
 ## Motivation
 
@@ -42,9 +42,9 @@ When a workload terminates, its pods may remain in the `Terminating` phase for m
 
 ### Goals
 
-- Provide a top-level Configuration API setting `.quotaReleaseStrategy` to control quota release timing across Kueue integrations during eviction and preemption.
-- Support `OnTerminating` (default) for fast quota release upon workload eviction.
-- Support `OnTerminal` to delay quota release until underlying pods physically transition to a terminal state (`Succeeded` or `Failed`) upon eviction.
+- Provide a per-integration Configuration API setting `.integrations.quotaReleaseStrategy` to control quota release timing across Kueue integrations during eviction and preemption, guarded by the `QuotaReleaseStrategy` feature gate.
+- Support `OnQuotaReleased` (implicit default for all frameworks) for fast quota release upon workload eviction.
+- Support `OnTerminal` in Alpha (v0.20) specifically for `batch/v1.Job` and `Pod` integrations to delay quota release until underlying pods physically transition to a terminal state (`Succeeded` or `Failed`) upon eviction.
 
 ### Non-Goals
 
@@ -57,17 +57,23 @@ When a workload terminates, its pods may remain in the `Terminating` phase for m
 
 ### Notes/Constraints/Caveats
 
-- **Deprecation of `FastQuotaReleaseInPodIntegration`**: The `FastQuotaReleaseInPodIntegration` feature gate (introduced in KEP-6143 for Pod integration) is deprecated in v0.20 and superseded by the top-level `.quotaReleaseStrategy` Configuration API setting. When `.quotaReleaseStrategy` is set, it takes precedence over the legacy feature gate.
+- **`QuotaReleaseStrategy` Feature Gate**: The feature is guarded by the `QuotaReleaseStrategy` feature gate (Alpha, disabled by default in v0.20). When disabled, Kueue defaults to `OnQuotaReleased`.
+- **Deprecation of `FastQuotaReleaseInPodIntegration`**: The `FastQuotaReleaseInPodIntegration` feature gate (introduced in KEP-6143 for Pod integration) is deprecated in v0.20 and superseded by `.quotaReleaseStrategy`. When `.quotaReleaseStrategy` is configured and enabled, it takes precedence over the legacy feature gate.
 
 ### Configuration Example
 
-Administrators configure the strategy in the Kueue `Configuration` ConfigMap:
+Administrators configure the strategy under `integrations` in the Kueue `Configuration` ConfigMap:
 
 ```yaml
 apiVersion: config.kueue.x-k8s.io/v1beta2
 kind: Configuration
 namespace: kueue-system
-quotaReleaseStrategy: OnTerminal
+integrations:
+  frameworks:
+  - "batch/job"
+  - "pod"
+  quotaReleaseStrategy:
+    "batch/job": OnTerminal
 waitForPodsReady:
   timeout: 30m
 ```
@@ -81,35 +87,48 @@ As a cluster admin running 8x A100 GPU nodes with Topology-Aware Scheduling, I w
 apiVersion: config.kueue.x-k8s.io/v1beta2
 kind: Configuration
 namespace: kueue-system
-quotaReleaseStrategy: OnTerminal
+integrations:
+  frameworks:
+  - "batch/job"
+  quotaReleaseStrategy:
+    "batch/job": OnTerminal
 ```
 
 #### Story 2: Standard Batch Workload Administrator
-As a cluster admin running standard batch workloads, I want quota released immediately when deletion is initiated (`OnTerminating`) so subsequent workloads can be admitted without waiting for pod teardown.
+As a cluster admin running standard batch workloads, I want quota released immediately when deletion is initiated (`OnQuotaReleased`) so subsequent workloads can be admitted without waiting for pod teardown.
 
 ```yaml
 apiVersion: config.kueue.x-k8s.io/v1beta2
 kind: Configuration
 namespace: kueue-system
-quotaReleaseStrategy: OnTerminating
+integrations:
+  frameworks:
+  - "batch/job"
+  quotaReleaseStrategy:
+    "batch/job": OnQuotaReleased
 ```
 
 ### Risks and Mitigations
 
 - **Risk**: Under `OnTerminal`, if a pod gets stuck terminating indefinitely on a reachable node (e.g. due to hardware PCIe errors or kernel driver deadlocks where the node remains `Ready`) or too long gracefulTerminationPeriod, Kueue will hold the quota reservation indefinitely. Kueue's failure recovery does not apply to reachable nodes.
-- **Mitigation / Trade-off**: This is an accepted trade-off for clusters opting into `OnTerminal`, which prioritize avoiding `FailedScheduling` loops on occupied nodes over aggressive quota reclamation. Quota is held until external remediation (e.g., node problem detector, node auto-repair, or admin intervention) removes the stuck pod. Clusters prioritizing rapid quota turnover can remain on the default `OnTerminating` strategy.
+- **Mitigation / Trade-off**: This is an accepted trade-off for clusters opting into `OnTerminal`, which prioritize avoiding `FailedScheduling` loops on occupied nodes over aggressive quota reclamation. Quota is held until external remediation (e.g., node problem detector, node auto-repair, or admin intervention) removes the stuck pod. Clusters prioritizing rapid quota turnover can remain on the default `OnQuotaReleased` strategy.
 
 ## Design Details
 
 ### Configuration API & YAML Manifest
 
-The `.quotaReleaseStrategy` field is configured directly at the top level of the Kueue `Configuration` ConfigMap:
+The `quotaReleaseStrategy` map is configured under `integrations` in the Kueue `Configuration` ConfigMap:
 
 ```yaml
 apiVersion: config.kueue.x-k8s.io/v1beta2
 kind: Configuration
 namespace: kueue-system
-quotaReleaseStrategy: OnTerminal
+integrations:
+  frameworks:
+  - "batch/job"
+  - "pod"
+  quotaReleaseStrategy:
+    "batch/job": OnTerminal
 waitForPodsReady:
   timeout: 30m
 ```
@@ -122,48 +141,53 @@ In `apis/config/v1beta2/configuration_types.go`:
 type QuotaReleaseStrategy string
 
 const (
-    // QuotaReleaseOnTerminating releases quota as soon as deletion is initiated
-    // or the workload is marked finished.
-    QuotaReleaseOnTerminating QuotaReleaseStrategy = "OnTerminating"
+    // QuotaReleaseOnQuotaReleased releases quota as soon as deletion is initiated
+    // or the workload status is updated.
+    QuotaReleaseOnQuotaReleased QuotaReleaseStrategy = "OnQuotaReleased"
 
     // QuotaReleaseOnTerminal holds quota until all underlying pods
     // have reached a terminal phase (Succeeded or Failed).
     QuotaReleaseOnTerminal QuotaReleaseStrategy = "OnTerminal"
 )
 
-type Configuration struct {
-    metav1.TypeMeta `json:",inline"`
+type Integrations struct {
+    Frameworks []string `json:"frameworks,omitempty"`
+    ExternalFrameworks []string `json:"externalFrameworks,omitempty"`
+    LabelKeysToCopy []string `json:"labelKeysToCopy,omitempty"`
 
-    // QuotaReleaseStrategy provides configuration options for controlling quota release timing.
+    // QuotaReleaseStrategy provides per-framework configuration options for controlling quota release timing.
+    // Keys correspond to framework names in Frameworks (e.g. "batch/job", "pod").
+    // In Alpha (v0.20), "OnTerminal" is supported only for "batch/job" and "pod".
+    // All other frameworks implicitly default to "OnQuotaReleased".
     // +optional
-    QuotaReleaseStrategy *QuotaReleaseStrategy `json:"quotaReleaseStrategy,omitempty"`
-
-    // ... existing fields ...
+    QuotaReleaseStrategy map[string]QuotaReleaseStrategy `json:"quotaReleaseStrategy,omitempty"`
 }
 ```
 
 ### Implementation overview
 
-The global configuration setting `.quotaReleaseStrategy` specifically governs the eviction and preemption lifecycle by configuring each integration's `job.IsActive(ctx)` behavior via the `JobReconciler` context (`jobframework.ContextWithQuotaReleaseStrategy`):
+The per-integration setting `.integrations.quotaReleaseStrategy[framework]` specifically governs the eviction and preemption lifecycle by configuring each integration's `job.IsActive(ctx, strategy)` behavior in the `JobReconciler`:
 
-- **Eviction / Preemption path (`job.IsActive`)**: When a workload is evicted (eg.  preempted), Kueue unsets the quota reservation once `!job.IsActive(ctx)`:
-  - **`OnTerminating`**: `IsActive(ctx)` returns `false` as soon as deletion is initiated or `job.Status.Active == 0`, allowing quota to be reclaimed promptly.
-  - **`OnTerminal`**: `IsActive(ctx)` returns `true` as long as underlying pods remain active or terminating (e.g., `ptr.Deref(job.Status.Terminating, 0) > 0` for `batch/v1.Job`, or pods are still running/terminating for `PodGroup`). Quota reservation and TAS capacity remain held until all pods finish terminating.
+- If `QuotaReleaseStrategy` feature gate is disabled, `r.quotaReleaseStrategy` defaults to `OnQuotaReleased`.
+- If enabled, each integration reconciler is initialized with its configured strategy (defaulting to `OnQuotaReleased` if omitted).
+- **Eviction / Preemption path (`job.IsActive`)**: When a workload is evicted (eg. preempted), Kueue unsets the quota reservation once `!job.IsActive(ctx, strategy)`:
+  - **`OnQuotaReleased`**: `IsActive(ctx, strategy)` returns `false` as soon as deletion is initiated or `job.Status.Active == 0`, allowing quota to be reclaimed promptly.
+  - **`OnTerminal`**: `IsActive(ctx, strategy)` returns `true` as long as underlying pods remain active or terminating (e.g., `ptr.Deref(job.Status.Terminating, 0) > 0` for `batch/v1.Job`, or pods are still running/terminating for `PodGroup`). Quota reservation and TAS capacity remain held until all pods finish terminating.
 - **Completion path (`job.Finished`)**: Normal job completion logic remains unchanged; `OnTerminal` does not alter `job.Finished(ctx)`.
 
 ### Integration Termination Criteria
 
-Under the **`OnTerminal`** strategy, Kueue determines whether a workload is fully terminated using specific criteria for each integration:
+In Alpha (v0.20), **`OnTerminal`** strategy support is specifically implemented for **`batch/v1.Job`** and **`Pod`** integrations. Other integrations default to **`OnQuotaReleased`**, with support for `OnTerminal` expanded to additional frameworks in Beta as child pod observation is supported.
 
-- First phase:
+- Supported in Alpha (v0.20):
   - **`batch/v1.Job`**: Evaluates `job.Status.Active` and `job.Status.Terminating`. Fully terminated when `ptr.Deref(job.Status.Active, 0) == 0` AND `ptr.Deref(job.Status.Terminating, 0) == 0`.
   - **Single `Pod`**: Evaluates `pod.Status.Phase`. Fully terminated when `pod.Status.Phase == corev1.PodSucceeded` OR `pod.Status.Phase == corev1.PodFailed`.
   - **`PodGroup` (StatefulSet, LeaderWorkerSet)**: Evaluates member Pod statuses. Fully terminated when all member Pods reach terminal phase (`Succeeded` or `Failed`).
-- The second phase or before Beta graduation:
+- Planned for Beta expansion:
   - **`JobSet`**: Evaluates `ReplicatedJobsStatus`. Fully terminated when for all replicated jobs, `Active == 0` AND `Terminating == 0`.
-  - **`Kubeflow` (PyTorchJob, MPIJob, TFJob, PaddleJob, JAXJob, XGBoostJob)**: Evaluates operator replica statuses. Fully terminated when all replica active and terminating counts are zero.
-  - **`Ray` (RayJob, RayCluster, RayService)**: Evaluates RayCluster pod phases. Fully terminated when all underlying RayCluster pods reach terminal state.
-  - **`AppWrapper` & `SparkApplication`**: Evaluates wrapped pod phases. Fully terminated when driver and executor pods reach terminal state.
+  - **`Kubeflow` (PyTorchJob, MPIJob, TFJob, PaddleJob, JAXJob, XGBoostJob)**: Evaluates operator replica statuses.
+  - **`Ray` (RayJob, RayCluster, RayService)**: Evaluates RayCluster pod phases.
+  - **`AppWrapper` & `SparkApplication`**: Evaluates wrapped pod phases.
 
 We didn't finalize approaches for the Integrations listed in the second phase to track the fully terminated state. We will revisit the evaluation way before Beta graduation.
 
@@ -173,31 +197,33 @@ The following table summarizes the effective default quota release behavior acro
 
 | Registered Integration / Execution Path | Effective Default Policy | Activity / Quota-Release Signal | Explicit Child-Pod Observation | Important Limitations |
 | :--- | :--- | :--- | :--- | :--- |
-| **pod (single Pod)** | `OnTerminating` | `Pod.IsActive()` returns false for a non-group Pod | No | Admission can be cleared in the same reconciliation that starts Pod deletion. Terminal phase is not awaited. |
+| **pod (single Pod)** | `OnQuotaReleased` | `Pod.IsActive()` returns false for a non-group Pod | No | Admission can be cleared in the same reconciliation that starts Pod deletion. Terminal phase is not awaited. |
 | **pod (PodGroup, default)** | `OnTerminal` | Active while at least one member Pod is Running and has not exceeded grace period | Yes (Pod API) | Only Running Pods count. Quota released after grace-period expiry even if Pod still reports Running. |
-| **pod (PodGroup, FastQuotaReleaseInPodIntegration=true)** | `OnTerminating` | Pod with deletionTimestamp ignored by `IsActive()` | Yes | Explicit non-default feature-gate configuration. |
-| **deployment** | `OnTerminating` | Each child Pod handled as single-Pod workload | No | No Deployment-level terminal check. Each Pod owns an independent Workload. |
+| **pod (PodGroup, FastQuotaReleaseInPodIntegration=true)** | `OnQuotaReleased` | Pod with deletionTimestamp ignored by `IsActive()` | Yes | Explicit non-default feature-gate configuration. |
+| **deployment** | `OnQuotaReleased` | Each child Pod handled as single-Pod workload | No | No Deployment-level terminal check. Each Pod owns an independent Workload. |
 | **statefulset (eviction path)** | `OnTerminal` | Inherits PodGroup `IsActive()` behavior | Yes | Applies only to eviction path and inherits grace-period cutoff. |
-| **statefulset (replicas=0)** | `OnTerminating` | Reconciler directly clears Workload quota reservation | No | Quota released before terminating StatefulSet Pods disappear. |
+| **statefulset (replicas=0)** | `OnQuotaReleased` | Reconciler directly clears Workload quota reservation | No | Quota released before terminating StatefulSet Pods disappear. |
 | **leaderworkerset (eviction path)** | `OnTerminal` | Each replica Workload inherits PodGroup `IsActive()` behavior | Yes | Applies per replica and inherits grace-period cutoff. |
-| **leaderworkerset (scale-down/rollout)** | `OnTerminating` | Reconciler directly deletes Workload | No | Workload deletion releases quota without waiting for replica Pods to reach terminal phase. |
-| **batch/job** | `OnTerminating` | `Job.status.active == 0` | No | K8s excludes terminating Pods from active count. Kueue does not independently inspect child Pods. |
-| **jobset** | `OnTerminating` | Every `ReplicatedJobsStatus[].Active == 0` | No | Relies on JobSet/Job status. Deleting child Jobs/Pods are not independently inspected. |
-| **kubeflow (jaxjob, paddlejob, tfjob, xgboostjob, mpijob)** | `OnTerminating` | Every replica `status.active == 0` | No | Relies entirely on operator status. |
-| **kubeflow (pytorchjob)** | `OnTerminating` | Every replica `status.active == 0` | No | Operator sets Active=0 after starting cleanup but before Pods physically disappear. |
-| **trainer.kubeflow (trainjob)** | `OnTerminating` | Every `JobsStatus[].Active == 0` | No | Relies on child Job status rather than observing child Pods. |
-| **appwrapper** | `OnTerminating` | `QuotaReserved` status condition no longer true | No | Timing delegated to AppWrapper controller. Kueue does not verify resource termination. |
-| **ray (raycluster)** | `OnTerminating` | `RayCluster.status.state != Ready` | No | Non-Ready state is not proof that every Ray Pod has terminated. |
-| **ray (rayjob)** | `OnTerminating` | `JobDeploymentStatus` becomes Suspended/New | No | Trusts RayJob status transition without inspecting underlying RayCluster Pods. |
-| **ray (rayservice)** | `OnTerminating` | `RayServiceReady` condition no longer true | No | False Ready condition is not proof that active/pending RayCluster has physically terminated. |
-| **sparkapplication** | `OnTerminating` | Application state no longer Running | No | Trusts SparkApplication status without inspecting driver or executor Pods. |
+| **leaderworkerset (scale-down/rollout)** | `OnQuotaReleased` | Reconciler directly deletes Workload | No | Workload deletion releases quota without waiting for replica Pods to reach terminal phase. |
+| **batch/job** | `OnQuotaReleased` | `Job.status.active == 0` | No | K8s excludes terminating Pods from active count. Kueue does not independently inspect child Pods. |
+| **jobset** | `OnQuotaReleased` | Every `ReplicatedJobsStatus[].Active == 0` | No | Relies on JobSet/Job status. Deleting child Jobs/Pods are not independently inspected. |
+| **kubeflow (jaxjob, paddlejob, tfjob, xgboostjob, mpijob)** | `OnQuotaReleased` | Every replica `status.active == 0` | No | Relies entirely on operator status. |
+| **kubeflow (pytorchjob)** | `OnQuotaReleased` | Every replica `status.active == 0` | No | Operator sets Active=0 after starting cleanup but before Pods physically disappear. |
+| **trainer.kubeflow (trainjob)** | `OnQuotaReleased` | Every `JobsStatus[].Active == 0` | No | Relies on child Job status rather than observing child Pods. |
+| **appwrapper** | `OnQuotaReleased` | `QuotaReserved` status condition no longer true | No | Timing delegated to AppWrapper controller. Kueue does not verify resource termination. |
+| **ray (raycluster)** | `OnQuotaReleased` | `RayCluster.status.state != Ready` | No | Non-Ready state is not proof that every Ray Pod has terminated. |
+| **ray (rayjob)** | `OnQuotaReleased` | `JobDeploymentStatus` becomes Suspended/New | No | Trusts RayJob status transition without inspecting underlying RayCluster Pods. |
+| **ray (rayservice)** | `OnQuotaReleased` | `RayServiceReady` condition no longer true | No | False Ready condition is not proof that active/pending RayCluster has physically terminated. |
+| **sparkapplication** | `OnQuotaReleased` | Application state no longer Running | No | Trusts SparkApplication status without inspecting driver or executor Pods. |
 
 ### Compatibility & Defaulting
 
-- **Default Strategy**: The default strategy is `OnTerminating` across all integrations.
+- **Default Strategy**: If not explicitly configured for a framework, the strategy implicitly defaults to `OnQuotaReleased`.
+- **Feature Gate**: Guarded by the `QuotaReleaseStrategy` feature gate (Alpha, disabled by default in v0.20).
+- **Validation**: In Alpha (v0.20), configuration validation ensures that only supported frameworks (`"batch/job"` and `"pod"`) can be configured with `OnTerminal`. Attempting to configure `OnTerminal` for unsupported frameworks (e.g. `AppWrapper`) returns a validation error. As additional integrations support child pod observation in Beta, validation will be relaxed per framework.
 - **Supported API Versions**: Supported in the `v1beta2` Configuration API. It is intentionally omitted from `v1beta1` to follow Kubernetes API evolution guidelines.
-- **Upgrade Impact on PodGroups/StatefulSets/LWS**: For `PodGroup` (and by extension `StatefulSet` and `LeaderWorkerSet` eviction paths), defaulting to `OnTerminating` is an accepted upgrade change that releases quota upon termination initiation (equivalent to enabling the legacy `FastQuotaReleaseInPodIntegration` feature gate). This eliminates head-of-line blocking during PodGroup preemption.
-- **Opting into `OnTerminal`**: Cluster administrators who require delayed quota release until underlying pods reach terminal phase (`Succeeded`/`Failed`) across workloads (e.g. in TAS bare-metal environments) can explicitly configure `quotaReleaseStrategy: OnTerminal`.
+- **Upgrade Impact on PodGroups/StatefulSets/LWS**: For `PodGroup` (and by extension `StatefulSet` and `LeaderWorkerSet` eviction paths), defaulting to `OnQuotaReleased` is an accepted upgrade change that releases quota upon termination initiation (equivalent to enabling the legacy `FastQuotaReleaseInPodIntegration` feature gate). This eliminates head-of-line blocking during PodGroup preemption.
+- **Opting into `OnTerminal`**: Cluster administrators who require delayed quota release until underlying pods reach terminal phase (`Succeeded`/`Failed`) can explicitly configure `integrations.quotaReleaseStrategy: { "batch/job": "OnTerminal" }`.
 
 ### Test Plan
 
@@ -218,11 +244,14 @@ The following table summarizes the effective default quota release behavior acro
 ## Graduation Criteria
 
 ### Alpha (v0.20)
-- Introduced `.quotaReleaseStrategy` in `v1beta2` Config API.
-- Implemented in core `batch/v1.Job` and Pod integrations.
+- Introduced `QuotaReleaseStrategy` Feature Gate (Alpha, disabled by default in v0.20).
+- Introduced `.integrations.quotaReleaseStrategy` in `v1beta2` Config API.
+- Implemented `OnTerminal` strategy support and validation for core `batch/v1.Job` and `Pod` integrations.
 
 ### Beta
-- Gather user feedback and support remaining integrations.
+- Expand `OnTerminal` strategy support scope to additional integrations as child pod observation is supported.
+- Relax configuration validation to allow `OnTerminal` on newly supported integrations.
+- Gather user feedback from production TAS and bare-metal GPU clusters.
 
 ## Implementation History
 
@@ -230,12 +259,12 @@ The following table summarizes the effective default quota release behavior acro
 
 ## Drawbacks
 
-- Under `OnTerminal`, keeping `IsActive()` true until all underlying pods reach a terminal phase (`Succeeded`/`Failed`) means that if pods get stuck terminating or an integration controller fails to report terminal status (e.g., #14811), Kueue's eviction reconciliation exits waiting for status updates without scheduling a retry. In these scenarios, quota reservations can be held indefinitely rather than merely delayed, completely stalling quota recovery until manual or external remediation occurs. This is mitigated by defaulting `.quotaReleaseStrategy` to `OnTerminating`.
+- Under `OnTerminal`, keeping `IsActive()` true until all underlying pods reach a terminal phase (`Succeeded`/`Failed`) means that if pods get stuck terminating or an integration controller fails to report terminal status (e.g., #14811), Kueue's eviction reconciliation exits waiting for status updates without scheduling a retry. In these scenarios, quota reservations can be held indefinitely rather than merely delayed, completely stalling quota recovery until manual or external remediation occurs. This is mitigated by defaulting `.quotaReleaseStrategy` to `OnQuotaReleased`.
 
 ## Alternatives
 
-- **Feature gates instead of Configuration API**: Rejected because a global Configuration API knob is required for administrators to explicitly select release behavior across cluster workloads.
-- **Context propagation vs. explicit parameter for `QuotaReleaseStrategy`**: Passing the strategy via `context.Context` (e.g. `jobframework.ContextWithQuotaReleaseStrategy`) preserves the existing `job.IsActive()` interface without modifying method signatures across all integrations. However, to avoid unintended side effects—such as `TrainJob.Stop(ctx)` accidentally reading `OnTerminal` during eviction and failing with `"jobs are still active"`—the strategy is scoped specifically to the `IsActive(ctx)` evaluation after `job.Stop(ctx)` has already completed.
+- **Feature gates instead of Configuration API**: Rejected because a Configuration API knob is required for administrators to explicitly select release behavior across cluster workloads.
+- **Explicit parameter for `QuotaReleaseStrategy`**: Passing `QuotaReleaseStrategy` as an explicit parameter to `IsActive(ctx context.Context, strategy configapi.QuotaReleaseStrategy) bool` instead of `context.WithValue` keeps the method signature explicit, avoids hidden context dependencies, and simplifies unit testing across adapters.
 - **`nonTasUsageCache` in scheduler**: Maintaining a separate scheduler-side cache for non-TAS / terminating pod usage was rejected because it introduces additional cache synchronization complexity in the scheduler rather than addressing the core activity lifecycle in job controllers.
 - **Lazy TAS-pod-awareness in scheduler**: Having the TAS scheduler dynamically inspect underlying Pod objects during scheduling cycles was rejected because the scheduler must rely on cached `Workload` objects for high throughput and should not perform ad-hoc API queries during scheduling cycles.
 - **Dedicated background controller (`PodUsageReconciler`)**: Introducing a separate controller to watch pods and adjust quota reservations was rejected because it introduces additional controller and informer overhead, potential race conditions with `Workload` status reconciliation, and unnecessary complexity when existing job framework reconcilers already manage job activity.

--- a/keps/10076-quota-release-strategy/README.md
+++ b/keps/10076-quota-release-strategy/README.md
@@ -32,7 +32,7 @@
 
 ## Summary
 
-This proposal introduces a per-integration configuration setting `.integrations.quotaReleaseStrategy` in Kueue's Configuration API (`apis/config/v1beta2`), gated by the `QuotaReleaseStrategy` Feature Gate (Alpha, disabled by default in v0.20). It allows cluster administrators to configure when Kueue releases workload quota reservation during eviction and preemption on a per-framework basis — either immediately upon deletion initiation / status change (`OnQuotaReleased`) or delayed until all underlying pods reach a terminal phase (`OnTerminal`).
+This proposal introduces a per-integration configuration setting `.integrations.frameworkConfigs[].quotaReleaseStrategy` in Kueue's Configuration API (`apis/config/v1beta2`), gated by the `QuotaReleaseStrategy` Feature Gate (Alpha, disabled by default in v0.20). It allows cluster administrators to configure when Kueue releases workload quota reservation during eviction and preemption on a per-framework basis — either immediately upon deletion initiation / status change (`OnQuotaReleased`) or delayed until all underlying pods reach a terminal phase (`OnTerminal`).
 
 ## Motivation
 
@@ -42,8 +42,8 @@ When a workload terminates, its pods may remain in the `Terminating` phase for m
 
 ### Goals
 
-- Provide a per-integration Configuration API setting `.integrations.quotaReleaseStrategy` to control quota release timing across Kueue integrations during eviction and preemption, guarded by the `QuotaReleaseStrategy` feature gate.
-- Support `OnQuotaReleased` (implicit default for all frameworks) for fast quota release upon workload eviction.
+- Provide a per-integration Configuration API setting `.integrations.frameworkConfigs[].quotaReleaseStrategy` to control quota release timing across Kueue integrations during eviction and preemption, guarded by the `QuotaReleaseStrategy` feature gate.
+- Support `OnQuotaReleased` (default for `batch/job` and non-pod frameworks) for fast quota release upon workload eviction.
 - Support `OnTerminal` in Alpha (v0.20) specifically for `batch/v1.Job` and `Pod` integrations to delay quota release until underlying pods physically transition to a terminal state (`Succeeded` or `Failed`) upon eviction.
 
 ### Non-Goals
@@ -57,12 +57,12 @@ When a workload terminates, its pods may remain in the `Terminating` phase for m
 
 ### Notes/Constraints/Caveats
 
-- **`QuotaReleaseStrategy` Feature Gate**: The feature is guarded by the `QuotaReleaseStrategy` feature gate (Alpha, disabled by default in v0.20). When disabled, Kueue defaults to `OnQuotaReleased`.
-- **Deprecation of `FastQuotaReleaseInPodIntegration`**: The `FastQuotaReleaseInPodIntegration` feature gate (introduced in KEP-6143 for Pod integration) is deprecated in v0.20 and superseded by `.quotaReleaseStrategy`. When `.quotaReleaseStrategy` is configured and enabled, it takes precedence over the legacy feature gate.
+- **`QuotaReleaseStrategy` Feature Gate**: The feature is guarded by the `QuotaReleaseStrategy` feature gate (Alpha, disabled by default in v0.20). When disabled, Kueue defaults to the current default strategy described in the [Integration Release Behavior Summary](#integration-release-behavior-summary) table.
+- **Deprecation of `FastQuotaReleaseInPodIntegration`**: The `FastQuotaReleaseInPodIntegration` feature gate (introduced in KEP-6143 for Pod integration) is deprecated in v0.20 and superseded by `.integrations.frameworkConfigs[].quotaReleaseStrategy`. When configured and enabled, it takes precedence over the legacy feature gate.
 
 ### Configuration Example
 
-Administrators configure the strategy under `integrations` in the Kueue `Configuration` ConfigMap:
+Administrators configure the strategy under `integrations.frameworkConfigs` in the Kueue `Configuration` ConfigMap:
 
 ```yaml
 apiVersion: config.kueue.x-k8s.io/v1beta2
@@ -72,8 +72,9 @@ integrations:
   frameworks:
   - "batch/job"
   - "pod"
-  quotaReleaseStrategy:
-    "batch/job": OnTerminal
+  frameworkConfigs:
+  - name: "batch/job"
+    quotaReleaseStrategy: OnTerminal
 waitForPodsReady:
   timeout: 30m
 ```
@@ -90,8 +91,9 @@ namespace: kueue-system
 integrations:
   frameworks:
   - "batch/job"
-  quotaReleaseStrategy:
-    "batch/job": OnTerminal
+  frameworkConfigs:
+  - name: "batch/job"
+    quotaReleaseStrategy: OnTerminal
 ```
 
 #### Story 2: Standard Batch Workload Administrator
@@ -104,8 +106,9 @@ namespace: kueue-system
 integrations:
   frameworks:
   - "batch/job"
-  quotaReleaseStrategy:
-    "batch/job": OnQuotaReleased
+  frameworkConfigs:
+  - name: "batch/job"
+    quotaReleaseStrategy: OnQuotaReleased
 ```
 
 ### Risks and Mitigations
@@ -117,7 +120,7 @@ integrations:
 
 ### Configuration API & YAML Manifest
 
-The `quotaReleaseStrategy` map is configured under `integrations` in the Kueue `Configuration` ConfigMap:
+Per-integration configuration is configured under `integrations.frameworkConfigs` in the Kueue `Configuration` ConfigMap:
 
 ```yaml
 apiVersion: config.kueue.x-k8s.io/v1beta2
@@ -127,15 +130,16 @@ integrations:
   frameworks:
   - "batch/job"
   - "pod"
-  quotaReleaseStrategy:
-    "batch/job": OnTerminal
+  frameworkConfigs:
+  - name: "batch/job"
+    quotaReleaseStrategy: OnTerminal
 waitForPodsReady:
   timeout: 30m
 ```
 
 ### Go API Surface
 
-In `apis/config/v1beta2/configuration_types.go`:
+Proposed API in `apis/config/v1beta2/configuration_types.go`:
 
 ```go
 type QuotaReleaseStrategy string
@@ -151,28 +155,35 @@ const (
 )
 
 type Integrations struct {
-    Frameworks []string `json:"frameworks,omitempty"`
-    ExternalFrameworks []string `json:"externalFrameworks,omitempty"`
-    LabelKeysToCopy []string `json:"labelKeysToCopy,omitempty"`
+    // ... existing fields ...
 
-    // QuotaReleaseStrategy provides per-framework configuration options for controlling quota release timing.
-    // Keys correspond to framework names in Frameworks (e.g. "batch/job", "pod").
-    // In Alpha (v0.20), "OnTerminal" is supported only for "batch/job" and "pod".
-    // All other frameworks implicitly default to "OnQuotaReleased".
+    // FrameworkConfigs provides per-framework configuration options for controlling framework-specific behaviors.
     // +optional
-    QuotaReleaseStrategy map[string]QuotaReleaseStrategy `json:"quotaReleaseStrategy,omitempty"`
+    FrameworkConfigs []FrameworkConfig `json:"frameworkConfigs,omitempty"`
+}
+
+type FrameworkConfig struct {
+    // Name of the framework (must match an enabled framework in Frameworks, e.g. "batch/job", "pod").
+    // +required
+    Name string `json:"name"`
+
+    // QuotaReleaseStrategy controls when quota is released for this framework during eviction or preemption.
+    // In Alpha (v0.20), "OnTerminal" is supported only for "batch/job" and "pod".
+    // If omitted, the framework follows its default release behavior (see Integration Release Behavior Summary).
+    // +optional
+    QuotaReleaseStrategy *QuotaReleaseStrategy `json:"quotaReleaseStrategy,omitempty"`
 }
 ```
 
 ### Implementation overview
 
-The per-integration setting `.integrations.quotaReleaseStrategy[framework]` specifically governs the eviction and preemption lifecycle by configuring each integration's `job.IsActive(ctx, strategy)` behavior in the `JobReconciler`:
+The per-integration setting `.integrations.frameworkConfigs[].quotaReleaseStrategy` specifically governs the eviction and preemption lifecycle by configuring each integration's `job.IsActive(ctx, strategy)` behavior in the `JobReconciler`:
 
-- If `QuotaReleaseStrategy` feature gate is disabled, `r.quotaReleaseStrategy` defaults to `OnQuotaReleased`.
-- If enabled, each integration reconciler is initialized with its configured strategy (defaulting to `OnQuotaReleased` if omitted).
+- If `QuotaReleaseStrategy` feature gate is disabled, `r.quotaReleaseStrategy` defaults to the current default strategy described in the [Integration Release Behavior Summary](#integration-release-behavior-summary) table.
+- If enabled, each integration reconciler is initialized with its configured strategy from `frameworkConfigs` (falling back to its default strategy described in the [Integration Release Behavior Summary](#integration-release-behavior-summary) table if omitted).
 - **Eviction / Preemption path (`job.IsActive`)**: When a workload is evicted (eg. preempted), Kueue unsets the quota reservation once `!job.IsActive(ctx, strategy)`:
   - **`OnQuotaReleased`**: `IsActive(ctx, strategy)` returns `false` as soon as deletion is initiated or `job.Status.Active == 0`, allowing quota to be reclaimed promptly.
-  - **`OnTerminal`**: `IsActive(ctx, strategy)` returns `true` as long as underlying pods remain active or terminating (e.g., `ptr.Deref(job.Status.Terminating, 0) > 0` for `batch/v1.Job`, or pods are still running/terminating for `PodGroup`). Quota reservation and TAS capacity remain held until all pods finish terminating.
+  - **`OnTerminal`**: `IsActive(ctx, strategy)` returns `true` as long as underlying pods remain active or terminating (e.g., `ptr.Deref(job.Status.Terminating, 0) > 0` for `batch/v1.Job`; for `PodGroup`, member pods are active until reaching a terminal phase (`Succeeded`/`Failed`) or grace period cutoff). Quota reservation and TAS capacity remain held until pods finish terminating or grace period expires.
 - **Completion path (`job.Finished`)**: Normal job completion logic remains unchanged; `OnTerminal` does not alter `job.Finished(ctx)`.
 
 ### Integration Termination Criteria
@@ -182,7 +193,7 @@ In Alpha (v0.20), **`OnTerminal`** strategy support is specifically implemented 
 - Supported in Alpha (v0.20):
   - **`batch/v1.Job`**: Evaluates `job.Status.Active` and `job.Status.Terminating`. Fully terminated when `ptr.Deref(job.Status.Active, 0) == 0` AND `ptr.Deref(job.Status.Terminating, 0) == 0`.
   - **Single `Pod`**: Evaluates `pod.Status.Phase`. Fully terminated when `pod.Status.Phase == corev1.PodSucceeded` OR `pod.Status.Phase == corev1.PodFailed`.
-  - **`PodGroup` (StatefulSet, LeaderWorkerSet)**: Evaluates member Pod statuses. Fully terminated when all member Pods reach terminal phase (`Succeeded` or `Failed`).
+  - **`PodGroup` (StatefulSet, LeaderWorkerSet)**: Evaluates member Pod statuses. Fully terminated when all member Pods reach terminal phase (`Succeeded` or `Failed`) or exceed their deletion grace period.
 - Planned for Beta expansion:
   - **`JobSet`**: Evaluates `ReplicatedJobsStatus`. Fully terminated when for all replicated jobs, `Active == 0` AND `Terminating == 0`.
   - **`Kubeflow` (PyTorchJob, MPIJob, TFJob, PaddleJob, JAXJob, XGBoostJob)**: Evaluates operator replica statuses.
@@ -218,25 +229,26 @@ The following table summarizes the effective default quota release behavior acro
 
 ### Compatibility & Defaulting
 
-- **Default Strategy**: If not explicitly configured for a framework, the strategy implicitly defaults to `OnQuotaReleased`.
+- **Default Strategy**: If a framework is not specified in `frameworkConfigs` or its `quotaReleaseStrategy` is omitted, the strategy defaults to the framework's existing behavior described in the [Integration Release Behavior Summary](#integration-release-behavior-summary) table (e.g., `OnTerminal` for PodGroup unless `FastQuotaReleaseInPodIntegration` is enabled, and `OnQuotaReleased` for `batch/job` and other integrations).
 - **Feature Gate**: Guarded by the `QuotaReleaseStrategy` feature gate (Alpha, disabled by default in v0.20).
-- **Validation**: In Alpha (v0.20), configuration validation ensures that only supported frameworks (`"batch/job"` and `"pod"`) can be configured with `OnTerminal`. Attempting to configure `OnTerminal` for unsupported frameworks (e.g. `AppWrapper`) returns a validation error. As additional integrations support child pod observation in Beta, validation will be relaxed per framework.
+- **Validation**: In Alpha (v0.20), configuration validation ensures that:
+  - Each entry in `frameworkConfigs` has a non-empty `name` that matches an enabled framework in `frameworks`.
+  - Duplicate framework names in `frameworkConfigs` are rejected with a validation error (`field.Duplicate`).
+  - Only supported frameworks (`"batch/job"` and `"pod"`) can be configured with `OnTerminal`. Attempting to configure `OnTerminal` for unsupported frameworks (e.g. `AppWrapper`) returns a validation error. As additional integrations support child pod observation in Beta, validation will be relaxed per framework.
 - **Supported API Versions**: Supported in the `v1beta2` Configuration API. It is intentionally omitted from `v1beta1` to follow Kubernetes API evolution guidelines.
-- **Upgrade Impact on PodGroups/StatefulSets/LWS**: For `PodGroup` (and by extension `StatefulSet` and `LeaderWorkerSet` eviction paths), defaulting to `OnQuotaReleased` is an accepted upgrade change that releases quota upon termination initiation (equivalent to enabling the legacy `FastQuotaReleaseInPodIntegration` feature gate). This eliminates head-of-line blocking during PodGroup preemption.
-- **Opting into `OnTerminal`**: Cluster administrators who require delayed quota release until underlying pods reach terminal phase (`Succeeded`/`Failed`) can explicitly configure `integrations.quotaReleaseStrategy: { "batch/job": "OnTerminal" }`.
+- **Upgrade Impact on PodGroups/StatefulSets/LWS**: Existing defaults are preserved upon upgrade: if `frameworkConfigs` is omitted or unconfigured for `pod`, `PodGroup` (and by extension `StatefulSet` and `LeaderWorkerSet` eviction paths) retains its default `OnTerminal` behavior, while `batch/job` and other frameworks retain `OnQuotaReleased`. Cluster administrators seeking fast quota release for PodGroups can explicitly configure `name: "pod"` with `quotaReleaseStrategy: OnQuotaReleased`, which supersedes the deprecated `FastQuotaReleaseInPodIntegration` feature gate and eliminates head-of-line blocking during PodGroup preemption.
+- **Opting into `OnTerminal`**: Cluster administrators who require delayed quota release until underlying pods reach terminal phase (`Succeeded`/`Failed`) can explicitly configure `integrations.frameworkConfigs: [{ name: "batch/job", quotaReleaseStrategy: "OnTerminal" }]`.
 
 ### Test Plan
 
 #### Unit tests
-- `pkg/config`: Validate `QuotaReleaseStrategy` configuration parsing, defaulting, and field validation.
-- `pkg/controller/jobs/...`: Test `IsActive(ctx)` across **all** supported integrations under both `OnTerminating` and `OnTerminal` strategies:
-  - `pod`: Pod integration (`IsActive` returns true until pod is Succeeded/Failed under `OnTerminal`).
-  - `job`: `batch/v1.Job` integration (`IsActive` inspects `status.active` and `status.terminating`).
-  - `jobset`: JobSet integration.
-  - `kubeflow`: PyTorchJob, MPIJob, TFJob, PaddleJob, JAXJob, XGBoostJob integrations.
-  - `ray`: RayJob, RayCluster integrations.
-  - `appwrapper`: AppWrapper integration.
-  - `pod-based`: Deployment and StatefulSet integrations.
+- `pkg/config`: Validate `FrameworkConfigs` configuration parsing, defaulting, duplicate framework name validation, and field validation.
+- `pkg/controller/jobs/...`: Test `IsActive(ctx, strategy)` across integrations:
+  - Alpha scope (`OnTerminal` and `OnQuotaReleased`):
+    - `pod`: Pod integration (`IsActive` returns true until pod is Succeeded/Failed or grace period expires under `OnTerminal`).
+    - `job`: `batch/v1.Job` integration (`IsActive` inspects `status.active` and `status.terminating`).
+  - Default policy verification (`OnQuotaReleased`):
+    - `jobset`, `kubeflow`, `ray`, `appwrapper`, `deployment`, and `statefulset`.
 
 #### Integration tests
 - Verify quota release timing during eviction and preemption under both strategies.
@@ -245,7 +257,7 @@ The following table summarizes the effective default quota release behavior acro
 
 ### Alpha (v0.20)
 - Introduced `QuotaReleaseStrategy` Feature Gate (Alpha, disabled by default in v0.20).
-- Introduced `.integrations.quotaReleaseStrategy` in `v1beta2` Config API.
+- Introduced `.integrations.frameworkConfigs[].quotaReleaseStrategy` in `v1beta2` Config API.
 - Implemented `OnTerminal` strategy support and validation for core `batch/v1.Job` and `Pod` integrations.
 
 ### Beta
@@ -259,7 +271,7 @@ The following table summarizes the effective default quota release behavior acro
 
 ## Drawbacks
 
-- Under `OnTerminal`, keeping `IsActive()` true until all underlying pods reach a terminal phase (`Succeeded`/`Failed`) means that if pods get stuck terminating or an integration controller fails to report terminal status (e.g., #14811), Kueue's eviction reconciliation exits waiting for status updates without scheduling a retry. In these scenarios, quota reservations can be held indefinitely rather than merely delayed, completely stalling quota recovery until manual or external remediation occurs. This is mitigated by defaulting `.quotaReleaseStrategy` to `OnQuotaReleased`.
+- Under `OnTerminal`, keeping `IsActive()` true until all underlying pods reach a terminal phase (`Succeeded`/`Failed`) means that if pods get stuck terminating or an integration controller fails to report terminal status (e.g., #14811), Kueue's eviction reconciliation exits waiting for status updates without scheduling a retry. In these scenarios, quota reservations can be held indefinitely rather than merely delayed, completely stalling quota recovery until manual or external remediation occurs. This is mitigated by defaulting `.integrations.frameworkConfigs[].quotaReleaseStrategy` to the framework's default behavior (and leaving `OnTerminal` as an explicit opt-in for `batch/job`).
 
 ## Alternatives
 


### PR DESCRIPTION
#### What type of PR is this?

/kind kep
/area tas

#### What this PR does / why we need it:

This PR updates KEP-10076 to document the per-integration design for `.integrations.quotaReleaseStrategy` in Kueue's Configuration API (`apis/config/v1beta2`), addressing capacity accounting issues in Topology-Aware Scheduling (TAS) and bare-metal environments.

Following maintainer discussion with @mimowo and @tenzen-y on #13308, this KEP incorporates the following updates:
1. **Per-Integration Configuration**: Moves `quotaReleaseStrategy` under `integrations` (`integrations.quotaReleaseStrategy: map[string]QuotaReleaseStrategy`) so release behavior can be configured and supported independently per framework.
2. **Strategy Enums & Implicit Defaulting**: Introduces `OnQuotaReleased` (implicit default for all frameworks) and `OnTerminal`.
3. **Alpha (v0.20) Scope & Validation**: Restricts `OnTerminal` support to `batch/v1.Job` and `Pod` integrations in v0.20, with strict configuration validation rejecting `OnTerminal` on unsupported frameworks.
4. **Feature Gate**: Documents the `QuotaReleaseStrategy` feature gate (Alpha, disabled by default in v0.20).
5. **Reconciler Contract**: Updates design details to pass `QuotaReleaseStrategy` explicitly as a parameter (`job.IsActive(ctx, strategy)`).

#### Which issue(s) this PR fixes:

Related to #10076
Related to #13308

#### Special notes for your reviewer:

Incorporates the consensus reached between @mimowo and @tenzen-y on PR #13308.

> _Note: AI assistance was used for drafting and formatting this PR description in accordance with the Kubernetes AI tool usage guidelines._

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## AI summary

- Added per-integration `quotaReleaseStrategy` configuration under `integrations`.
- Added the Alpha `QuotaReleaseStrategy` feature gate.
- Renamed `OnTerminating` to `OnQuotaReleased`.
- Added `OnTerminal` support for Job and Pod integrations with validation.
- Updated defaulting, integration behavior, and reconciler documentation.

### Suggested release note

NONE
<!-- end of auto-generated comment: release notes by coderabbit.ai -->