### PR TITLE
Make the hash-freshness spec converge regardless of refresh timing

### DIFF
--- a/test/integration/singlecluster/controller/core/workload_hash_freshness_test.go
+++ b/test/integration/singlecluster/controller/core/workload_hash_freshness_test.go
@@ -59,7 +59,11 @@ var _ = ginkgo.Describe("Scheduling hash freshness across LimitRange changes", f
 		clusterQueue = utiltestingapi.MakeClusterQueue("cq-hash-freshness").
 			ResourceGroup(
 				*utiltestingapi.MakeFlavorQuotas(smallFlavor.Name).Resource(corev1.ResourceCPU, "2").Obj(),
-				*utiltestingapi.MakeFlavorQuotas(largeFlavor.Name).Resource(corev1.ResourceCPU, "10").Obj(),
+				// Exactly one workload at the initial default: with large full,
+				// the stale (3 CPU) view of a second workload fits nowhere, so a
+				// racing admission before the LimitRange refresh is impossible —
+				// the spec converges regardless of event timing (kueue#15145).
+				*utiltestingapi.MakeFlavorQuotas(largeFlavor.Name).Resource(corev1.ResourceCPU, "3").Obj(),
 			).
 			Obj()
 		util.MustCreate(ctx, k8sClient, clusterQueue)
@@ -69,7 +73,7 @@ var _ = ginkgo.Describe("Scheduling hash freshness across LimitRange changes", f
 		util.ExpectLocalQueuesToBeActive(ctx, k8sClient, localQueue)
 
 		limitRange = utiltesting.MakeLimitRange("limits", ns.Name).
-			WithValue("DefaultRequest", corev1.ResourceCPU, "1").Obj()
+			WithValue("DefaultRequest", corev1.ResourceCPU, "3").Obj()
 		util.MustCreate(ctx, k8sClient, limitRange)
 	})
 
@@ -94,52 +98,38 @@ var _ = ginkgo.Describe("Scheduling hash freshness across LimitRange changes", f
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	}
 
-	setStopPolicy := func(p kueue.StopPolicy) {
-		gomega.Eventually(func(g gomega.Gomega) {
-			updatedCq := kueue.ClusterQueue{}
-			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &updatedCq)).To(gomega.Succeed())
-			updatedCq.Spec.StopPolicy = &p
-			g.Expect(k8sClient.Update(ctx, &updatedCq)).To(gomega.Succeed())
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-	}
-
 	ginkgo.It("places a raw-identical workload by its new effective resources after a defaultRequest change", func() {
 		wl1 := utiltestingapi.MakeWorkload("one", ns.Name).
 			Queue(kueue.LocalQueueName(localQueue.Name)).
 			Obj()
-		ginkgo.By("admitting the first raw workload on the small flavor (effective 1 CPU)", func() {
+		ginkgo.By("admitting the first raw workload on the large flavor (effective 3 CPU)", func() {
 			util.MustCreate(ctx, k8sClient, wl1)
-			expectAdmittedOnFlavor(wl1, smallFlavor.Name)
+			expectAdmittedOnFlavor(wl1, largeFlavor.Name)
 		})
 
-		wl2 := utiltestingapi.MakeWorkload("two", ns.Name).
-			Queue(kueue.LocalQueueName(localQueue.Name)).
-			Obj()
-		ginkgo.By("creating a raw-identical second workload while the ClusterQueue is held", func() {
-			// Holding the ClusterQueue makes the ordering between the
-			// LimitRange update and the second workload's admission
-			// deterministic: the workload is only evaluated after release.
-			setStopPolicy(kueue.Hold)
-			util.MustCreate(ctx, k8sClient, wl2)
-		})
-
-		ginkgo.By("raising the LimitRange defaultRequest to 3 CPU", func() {
+		ginkgo.By("lowering the LimitRange defaultRequest to 1 CPU", func() {
 			updatedLr := corev1.LimitRange{}
 			gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(limitRange), &updatedLr)).To(gomega.Succeed())
-			updatedLr.Spec.Limits[0].DefaultRequest[corev1.ResourceCPU] = resource.MustParse("3")
+			updatedLr.Spec.Limits[0].DefaultRequest[corev1.ResourceCPU] = resource.MustParse("1")
 			gomega.Expect(k8sClient.Update(ctx, &updatedLr)).To(gomega.Succeed())
 		})
 
-		ginkgo.By("releasing the ClusterQueue and admitting the second workload on the large flavor (effective 3 CPU)", func() {
-			// If the scheduling equivalence hash were not refreshed from the
-			// new effective resources, the second workload could reuse the
-			// first one's assignment and land on the small flavor.
-			setStopPolicy(kueue.None)
-			expectAdmittedOnFlavor(wl2, largeFlavor.Name)
+		ginkgo.By("admitting a raw-identical second workload on the small flavor (effective 1 CPU)", func() {
+			// The stale (3 CPU) view fits neither flavor — small is too small
+			// and large is full — so the only way to admission is through the
+			// refreshed effective resources. If the scheduling equivalence
+			// hash were not refreshed alongside them, the second workload
+			// would reuse the first one'"'"'s equivalence class against the full
+			// large flavor and stay pending.
+			wl2 := utiltestingapi.MakeWorkload("two", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl2)
+			expectAdmittedOnFlavor(wl2, smallFlavor.Name)
 		})
 
 		ginkgo.By("verifying the first workload keeps its original assignment", func() {
-			expectAdmittedOnFlavor(wl1, smallFlavor.Name)
+			expectAdmittedOnFlavor(wl1, largeFlavor.Name)
 		})
 	})
 })


### PR DESCRIPTION
#### What type of PR is this?

/kind flake
/kind cleanup

#### What this PR does / why we need it:

The hash-freshness spec raised the LimitRange `defaultRequest` and asserted
the second workload lands on the large flavor. Holding the ClusterQueue made
the admission ordering deterministic, but the pending workload's effective
resources are refreshed asynchronously and that refresh is not observable
from the test — releasing the queue could race it, admitting the workload
with the stale default onto the small flavor (#15145; the CI timeline in the
issue shows a 1ms race).

Instead of waiting for an unobservable refresh, invert the direction so the
race cannot produce a wrong admission: the default starts at 3 CPU, the large
flavor is sized to be exactly filled by the first workload, and the default
is then lowered to 1 CPU. The stale view of the second workload fits neither
flavor — the only path to admission is through the refreshed effective
resources, so the spec converges regardless of event timing (the same
convergence property as the long-stable "LimitRanges are defined and change"
spec). The stopPolicy hold machinery is removed.

The hash guard is preserved: with a stale equivalence hash the second
workload would reuse the first one's class against the full large flavor and
stay pending, failing the spec.

Ran 5x locally, all green.

#### Which issue(s) this PR fixes:

Fixes #15145

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

---

Written with AI assistance (Claude); I reviewed the race analysis and the
redesigned convergence argument.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated workload integration coverage to verify flavor assignment remains stable for an existing workload after LimitRange defaults change.
  * Added validation that an identical subsequent workload can be admitted using a smaller flavor when large-flavor capacity is reduced.
  * Removed the previous stop-policy-based scenario and its hold/release flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->