### PR TITLE
Fix kueuectl pod output format detection

### DIFF
--- a/cmd/kueuectl/app/list/list_pods.go
+++ b/cmd/kueuectl/app/list/list_pods.go
@@ -138,7 +138,7 @@ func (o *PodOptions) Complete(clientGetter clientgetter.ClientGetter) error {
 	}
 
 	outputOption := ptr.Deref(o.PrintFlags.OutputFormat, "")
-	if outputOption == "" || strings.Contains(outputOption, "wide") {
+	if outputOption == "" || outputOption == "wide" {
 		o.ServerPrint = true
 	}
 

--- a/cmd/kueuectl/app/list/list_pods_test.go
+++ b/cmd/kueuectl/app/list/list_pods_test.go
@@ -106,6 +106,40 @@ valid-pod-1   1/1     Running   0          <unknown>   <none>   <none>   <none> 
 valid-pod-2   1/1     Running   0          <unknown>   <none>   <none>   <none>           <none>
 `,
 		}, {
+			name: "list pods with JSONPath containing wide",
+			job: &batchv1.Job{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "Job",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-job",
+					Namespace: metav1.NamespaceDefault,
+					Labels: map[string]string{
+						batchv1.JobNameLabel: "test-job",
+					},
+				},
+			},
+			pods: []corev1.Pod{
+				*basePod.Clone().
+					Name("valid-pod-1").
+					Label(batchv1.JobNameLabel, "test-job").
+					Label("wide", "selected-value").
+					Obj(),
+			},
+			mapperGVKs: []schema.GroupVersionKind{
+				{
+					Group:   "batch",
+					Version: "v1",
+					Kind:    "Job",
+				}, {
+					Group:   "",
+					Version: "v1",
+					Kind:    "Pod",
+				},
+			},
+			args:    []string{"--for", "job/test-job", "-o", "jsonpath={.metadata.labels.wide}"},
+			wantOut: "selected-value",
+		}, {
 			name: "list pods for valid batch/job type",
 			job: &batchv1.Job{
 				TypeMeta: metav1.TypeMeta{
@@ -651,14 +685,7 @@ func buildTestRuntimeScheme() (*runtime.Scheme, error) {
 }
 
 func mockRESTClient(codec runtime.Codec, tc podTestCase) (*restfake.RESTClient, error) {
-	var podRespBody io.ReadCloser
-
 	podList := &corev1.PodList{Items: tc.pods}
-	if len(podList.Items) == 0 {
-		podRespBody = emptyTableObjBody(codec)
-	} else {
-		podRespBody = podTableObjBody(codec, podList.Items...)
-	}
 
 	reqPathPrefix := fmt.Sprintf("/namespaces/%s", metav1.NamespaceDefault)
 	if slices.Contains(tc.args, "-A") || slices.Contains(tc.args, "all-namespaces") {
@@ -679,6 +706,16 @@ func mockRESTClient(codec runtime.Codec, tc podTestCase) (*restfake.RESTClient, 
 					Body:       io.NopCloser(strings.NewReader(runtime.EncodeOrDie(codec, tc.job))),
 				}, nil
 			case fmt.Sprintf("%s/pods", reqPathPrefix):
+				var podRespBody io.ReadCloser
+				if strings.Contains(request.Header.Get("Accept"), "as=Table") {
+					if len(podList.Items) == 0 {
+						podRespBody = emptyTableObjBody(codec)
+					} else {
+						podRespBody = podTableObjBody(codec, podList.Items...)
+					}
+				} else {
+					podRespBody = io.NopCloser(strings.NewReader(runtime.EncodeOrDie(codec, podList)))
+				}
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Header:     getDefaultHeader(),


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes `kueuectl list pods` output-format detection so server-side Pod table printing is selected only for default output and the exact `wide` format.

Previously, any supported output expression containing the substring `wide` was classified as wide output. For example, `-o jsonpath={.metadata.labels.wide}` printed the normal Pod table instead of the requested label value.

The command test harness now returns a Table only when the request advertises the Table media type and otherwise returns the raw PodList. This provides regression coverage through the command's real printer-selection and request path.

#### Which issue(s) this PR fixes:

Fixes #15155

#### Special notes for your reviewer:

Tests run:
- `go test ./cmd/kueuectl/app/list -run TestPodCmd -count=1`
- `go test ./cmd/kueuectl/app/list -count=1`
- `go test ./cmd/kueuectl/... -count=1`
- `go vet ./cmd/kueuectl/app/list`
- `git diff --check`

Some code was written by the human contributor; Codex helped with code drafting. The human contributor will review and finalize the changes.

#### Does this PR introduce a user-facing change?

```release-note
CLI: Fixed kueuectl list pods incorrectly treating any output format containing "wide" as -o wide, causing JSONPath and similar expressions to be silently ignored.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed pod listing with JSONPath output formats that contain the word “wide,” ensuring the requested output format is preserved.
  - Server-side table formatting is now used only for empty output formats or the exact `wide` format.
- **Tests**
  - Added coverage to verify correct behavior for JSONPath formats containing “wide” and for standard pod list responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->