### PR TITLE
fix(trainjob): preserve runtime tolerations in admission patch

### DIFF
--- a/pkg/controller/jobs/trainjob/trainjob_controller.go
+++ b/pkg/controller/jobs/trainjob/trainjob_controller.go
@@ -28,6 +28,7 @@ import (
 	kftrainerframework "github.com/kubeflow/trainer/v2/pkg/runtime/framework"
 	kftrainerjobset "github.com/kubeflow/trainer/v2/pkg/runtime/framework/plugins/jobset"
 	trainjobutil "github.com/kubeflow/trainer/v2/pkg/util/trainjob"
+	corev1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -47,6 +48,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/podset"
 	clientutil "sigs.k8s.io/kueue/pkg/util/client"
 	"sigs.k8s.io/kueue/pkg/util/slices"
+	utiltolerations "sigs.k8s.io/kueue/pkg/util/tolerations"
 )
 
 var (
@@ -244,8 +246,10 @@ func (t *TrainJob) PodSets(ctx context.Context, c client.Client) ([]kueue.PodSet
 	return wl.Spec.PodSets, nil
 }
 
+// RunWithPodSetsInfo applies admission assignments to the Kueue-owned Trainer
+// RuntimePatch while preserving tolerations resolved from the runtime.
 func (t *TrainJob) RunWithPodSetsInfo(ctx context.Context, c client.Client, podSetsInfo []podset.PodSetInfo) error {
-	jobset, err := getChildJobSet(ctx, c, t)
+	jobset, err := getChildJobSetWithoutKueuePatch(ctx, c, t)
 	if err != nil {
 		return err
 	}
@@ -254,8 +258,26 @@ func (t *TrainJob) RunWithPodSetsInfo(ctx context.Context, c client.Client, podS
 		return podset.BadPodSetsInfoLenError(len(jobset.Spec.ReplicatedJobs), len(podSetsInfo))
 	}
 
+	// Match admission assignments by name rather than relying on their order.
+	replicatedJobsByName := make(map[string]*jobsetapi.ReplicatedJob, len(jobset.Spec.ReplicatedJobs))
+	for i := range jobset.Spec.ReplicatedJobs {
+		replicatedJobsByName[jobset.Spec.ReplicatedJobs[i].Name] = &jobset.Spec.ReplicatedJobs[i]
+	}
+
 	var replicatedJobPatches []kftrainer.ReplicatedJobPatch
 	for _, info := range podSetsInfo {
+		replicatedJob, found := replicatedJobsByName[string(info.Name)]
+		if !found {
+			return fmt.Errorf("%w: podset %q does not match a replicated job", podset.ErrInvalidPodsetInfo, info.Name)
+		}
+
+		var tolerations []corev1.Toleration
+		if len(info.Tolerations) > 0 {
+			// Trainer treats PodSpecPatch.tolerations as an atomic list, so write
+			// the complete resolved list instead of replacing user tolerations
+			// with the admission additions.
+			tolerations = utiltolerations.Merge(replicatedJob.Template.Spec.Template.Spec.Tolerations, info.Tolerations)
+		}
 		replicatedJobPatches = append(replicatedJobPatches,
 			kftrainer.ReplicatedJobPatch{
 				Name: string(info.Name),
@@ -268,7 +290,7 @@ func (t *TrainJob) RunWithPodSetsInfo(ctx context.Context, c client.Client, podS
 							},
 							Spec: &kftrainer.PodSpecPatch{
 								NodeSelector:    info.NodeSelector,
-								Tolerations:     info.Tolerations,
+								Tolerations:     tolerations,
 								SchedulingGates: info.SchedulingGates,
 							},
 						},
@@ -294,6 +316,21 @@ func (t *TrainJob) RunWithPodSetsInfo(ctx context.Context, c client.Client, podS
 
 	t.Unsuspend()
 	return nil
+}
+
+// getChildJobSetWithoutKueuePatch resolves the JobSet from the runtime and
+// user-owned patches. Kueue's previous patch is excluded so stale admission
+// tolerations cannot be mistaken for user configuration on a re-admission.
+func getChildJobSetWithoutKueuePatch(ctx context.Context, c client.Client, t *TrainJob) (*jobsetapi.JobSet, error) {
+	trainJob := (*kftrainer.TrainJob)(t).DeepCopy()
+	userPatches := make([]kftrainer.RuntimePatch, 0, len(trainJob.Spec.RuntimePatches))
+	for _, patch := range trainJob.Spec.RuntimePatches {
+		if patch.Manager != runtimePatchManagerName {
+			userPatches = append(userPatches, patch)
+		}
+	}
+	trainJob.Spec.RuntimePatches = userPatches
+	return getChildJobSet(ctx, c, (*TrainJob)(trainJob))
 }
 
 func (t *TrainJob) Stop(ctx context.Context, c client.Client, podSetsInfo []podset.PodSetInfo, _ jobframework.StopReason, _ string) (bool, error) {

--- a/pkg/controller/jobs/trainjob/trainjob_controller.go
+++ b/pkg/controller/jobs/trainjob/trainjob_controller.go
@@ -264,9 +264,17 @@ func (t *TrainJob) RunWithPodSetsInfo(ctx context.Context, c client.Client, podS
 		replicatedJobsByName[jobset.Spec.ReplicatedJobs[i].Name] = &jobset.Spec.ReplicatedJobs[i]
 	}
 
+	// Keep the admission-to-replicated-job mapping one-to-one.
+	seenPodSets := make(map[string]struct{}, len(podSetsInfo))
 	var replicatedJobPatches []kftrainer.ReplicatedJobPatch
 	for _, info := range podSetsInfo {
-		replicatedJob, found := replicatedJobsByName[string(info.Name)]
+		name := string(info.Name)
+		if _, seen := seenPodSets[name]; seen {
+			return fmt.Errorf("%w: podset %q appears more than once", podset.ErrInvalidPodsetInfo, info.Name)
+		}
+		seenPodSets[name] = struct{}{}
+
+		replicatedJob, found := replicatedJobsByName[name]
 		if !found {
 			return fmt.Errorf("%w: podset %q does not match a replicated job", podset.ErrInvalidPodsetInfo, info.Name)
 		}

--- a/pkg/controller/jobs/trainjob/trainjob_controller_test.go
+++ b/pkg/controller/jobs/trainjob/trainjob_controller_test.go
@@ -84,10 +84,11 @@ func TestRunWithPodsetsInfo(t *testing.T) {
 	testCtr := testingtrainjob.MakeClusterTrainingRuntime("test", testJobset.Spec)
 
 	cases := map[string]struct {
-		trainJob     *kftrainerapi.TrainJob
-		podsetsInfo  []podset.PodSetInfo
-		wantTrainJob *kftrainerapi.TrainJob
-		wantErr      bool
+		trainJob        *kftrainerapi.TrainJob
+		podsetsInfo     []podset.PodSetInfo
+		wantTrainJob    *kftrainerapi.TrainJob
+		wantTolerations []corev1.Toleration
+		wantErr         bool
 	}{
 		"should add to the TrainJob the config specified in the PodSet info": {
 			trainJob: testTrainJob.Clone().
@@ -181,6 +182,7 @@ func TestRunWithPodsetsInfo(t *testing.T) {
 								PodLabel(constants.PodSetLabel, "node").
 								PodLabel("test-label", "label").
 								NodeSelector("gpu", "nvidia").
+								Toleration(*toleration1.DeepCopy()).
 								Toleration(*toleration2.DeepCopy()).
 								SchedulingGate("test-scheduling-gate-2").
 								Obj(),
@@ -189,7 +191,8 @@ func TestRunWithPodsetsInfo(t *testing.T) {
 				}).
 				Suspend(false).
 				Obj(),
-			wantErr: false,
+			wantTolerations: []corev1.Toleration{*toleration1.DeepCopy(), *toleration2.DeepCopy()},
+			wantErr:         false,
 		},
 		"should not modify the TrainJob if the wrong number of PodSet infos is provided": {
 			trainJob: testTrainJob.DeepCopy(),
@@ -206,6 +209,14 @@ func TestRunWithPodsetsInfo(t *testing.T) {
 					Tolerations:     []corev1.Toleration{*toleration2.DeepCopy()},
 					SchedulingGates: []corev1.PodSchedulingGate{{Name: "test-scheduling-gate-2"}},
 				},
+			},
+			wantTrainJob: testTrainJob.DeepCopy(),
+			wantErr:      true,
+		},
+		"should reject a PodSet info with an unknown name": {
+			trainJob: testTrainJob.DeepCopy(),
+			podsetsInfo: []podset.PodSetInfo{
+				{Name: "non-existent-job"},
 			},
 			wantTrainJob: testTrainJob.DeepCopy(),
 			wantErr:      true,
@@ -319,7 +330,209 @@ func TestRunWithPodsetsInfo(t *testing.T) {
 			if diff := cmp.Diff(tc.wantTrainJob, tc.trainJob, tjobCmpOpts); diff != "" {
 				t.Errorf("RunWithPodSetsInfo() mismatch (-want,+got):\n%s", diff)
 			}
+			if tc.wantTolerations != nil {
+				jobset, err := getChildJobSet(ctx, kClient, kTrainJob)
+				if err != nil {
+					t.Fatalf("getChildJobSet() error: %v", err)
+				}
+				gotTolerations := jobset.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.Tolerations
+				if diff := cmp.Diff(tc.wantTolerations, gotTolerations); diff != "" {
+					t.Errorf("rendered JobSet tolerations mismatch (-want,+got):\n%s", diff)
+				}
+			}
 		})
+	}
+}
+
+// TestRunWithPodSetsInfoMatchesReplicatedJobsByName verifies that admission
+// tolerations are merged into the matching replicated job regardless of input order.
+func TestRunWithPodSetsInfoMatchesReplicatedJobsByName(t *testing.T) {
+	chiefBase := corev1.Toleration{
+		Key:      "workload.example.com/chief",
+		Operator: corev1.TolerationOpEqual,
+		Value:    "true",
+		Effect:   corev1.TaintEffectNoSchedule,
+	}
+	workerBase := corev1.Toleration{
+		Key:      "workload.example.com/worker",
+		Operator: corev1.TolerationOpEqual,
+		Value:    "true",
+		Effect:   corev1.TaintEffectNoSchedule,
+	}
+	chiefInjected := corev1.Toleration{
+		Key:      "pool.example.com/chief",
+		Operator: corev1.TolerationOpEqual,
+		Value:    "reserved",
+		Effect:   corev1.TaintEffectNoExecute,
+	}
+	workerInjected := corev1.Toleration{
+		Key:      "pool.example.com/worker",
+		Operator: corev1.TolerationOpEqual,
+		Value:    "spot",
+		Effect:   corev1.TaintEffectNoExecute,
+	}
+
+	testJobSet := testingjobset.MakeJobSet("", "").ReplicatedJobs(
+		testingjobset.ReplicatedJobRequirements{Name: "chief"},
+		testingjobset.ReplicatedJobRequirements{Name: "worker"},
+	).Obj()
+	testJobSet.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.Tolerations = []corev1.Toleration{chiefBase}
+	testJobSet.Spec.ReplicatedJobs[1].Template.Spec.Template.Spec.Tolerations = []corev1.Toleration{workerBase}
+	testRuntime := testingtrainjob.MakeClusterTrainingRuntime("test", testJobSet.Spec)
+	testTrainJob := testingtrainjob.MakeTrainJob("trainjob", "ns").RuntimeRef(kftrainerapi.RuntimeRef{
+		APIGroup: new(kftrainerapi.GroupVersion.Group),
+		Name:     testRuntime.Name,
+		Kind:     new(kftrainerapi.ClusterTrainingRuntimeKind),
+	}).RuntimePatches([]kftrainerapi.RuntimePatch{
+		testingtrainjob.MakeRuntimePatch(runtimePatchManagerName).EmptyMetadata().Obj(),
+	}).Obj()
+
+	ctx, _ := utiltesting.ContextWithLog(t)
+	clientBuilder := utiltesting.NewClientBuilder(kftrainerapi.AddToScheme, jobsetapi.AddToScheme).WithObjects()
+	indexer := utiltesting.AsIndexer(clientBuilder)
+	kClient := clientBuilder.WithObjects(testTrainJob, testRuntime).Build()
+	recorder := &utiltesting.EventRecorder{}
+	if _, err := NewReconciler(ctx, kClient, indexer, recorder, jobframework.WithManageJobsWithoutQueueName(true)); err != nil {
+		t.Fatalf("Error creating the reconciler: %v", err)
+	}
+
+	trainJob := (*TrainJob)(testTrainJob)
+	// Reverse the admission order to ensure assignments are matched by name.
+	if err := trainJob.RunWithPodSetsInfo(ctx, kClient, []podset.PodSetInfo{
+		{Name: "worker", Tolerations: []corev1.Toleration{workerInjected}},
+		{Name: "chief", Tolerations: []corev1.Toleration{chiefInjected}},
+	}); err != nil {
+		t.Fatalf("RunWithPodSetsInfo() error = %v", err)
+	}
+
+	wantTolerations := map[string][]corev1.Toleration{
+		"chief":  {chiefBase, chiefInjected},
+		"worker": {workerBase, workerInjected},
+	}
+	kueuePatch := getKueueRuntimePatch(trainJob)
+	if kueuePatch == nil {
+		t.Fatal("expected Kueue RuntimePatch")
+	}
+	gotPatchTolerations := make(map[string][]corev1.Toleration, len(wantTolerations))
+	for _, replicatedJob := range kueuePatch.TrainingRuntimeSpec.Template.Spec.ReplicatedJobs {
+		gotPatchTolerations[replicatedJob.Name] = replicatedJob.Template.Spec.Template.Spec.Tolerations
+	}
+	if diff := cmp.Diff(wantTolerations, gotPatchTolerations); diff != "" {
+		t.Errorf("Kueue RuntimePatch tolerations mismatch (-want,+got):\n%s", diff)
+	}
+
+	jobSet, err := getChildJobSet(ctx, kClient, trainJob)
+	if err != nil {
+		t.Fatalf("getChildJobSet() error = %v", err)
+	}
+	gotJobSetTolerations := make(map[string][]corev1.Toleration, len(wantTolerations))
+	for _, replicatedJob := range jobSet.Spec.ReplicatedJobs {
+		gotJobSetTolerations[replicatedJob.Name] = replicatedJob.Template.Spec.Template.Spec.Tolerations
+	}
+	if diff := cmp.Diff(wantTolerations, gotJobSetTolerations); diff != "" {
+		t.Errorf("rendered JobSet tolerations mismatch (-want,+got):\n%s", diff)
+	}
+}
+
+// TestRunWithPodSetsInfoPreservesTrainingRuntimeTolerations verifies that the
+// Kueue patch retains tolerations defined by the resolved TrainingRuntime.
+func TestRunWithPodSetsInfoPreservesTrainingRuntimeTolerations(t *testing.T) {
+	baseToleration := corev1.Toleration{
+		Key:      "user.example.com/dedicated",
+		Operator: corev1.TolerationOpEqual,
+		Value:    "training",
+		Effect:   corev1.TaintEffectNoSchedule,
+	}
+	injectedToleration := corev1.Toleration{
+		Key:      "pool.example.com/gpu",
+		Operator: corev1.TolerationOpEqual,
+		Value:    "true",
+		Effect:   corev1.TaintEffectNoSchedule,
+	}
+	// Simulate an old Kueue-managed toleration left by a previous admission.
+	staleKueueToleration := corev1.Toleration{
+		Key:      "old.example.com/pool",
+		Operator: corev1.TolerationOpEqual,
+		Value:    "old",
+		Effect:   corev1.TaintEffectNoSchedule,
+	}
+
+	testJobSet := testingjobset.MakeJobSet("", "").ReplicatedJobs(
+		testingjobset.ReplicatedJobRequirements{Name: "node"},
+	).Obj()
+	testJobSet.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.Tolerations = []corev1.Toleration{baseToleration}
+	testRuntime := testingtrainjob.MakeClusterTrainingRuntime("test", testJobSet.Spec)
+	testTrainJob := testingtrainjob.MakeTrainJob("trainjob", "ns").RuntimeRef(kftrainerapi.RuntimeRef{
+		APIGroup: new(kftrainerapi.GroupVersion.Group),
+		Name:     testRuntime.Name,
+		Kind:     new(kftrainerapi.ClusterTrainingRuntimeKind),
+	}).RuntimePatches([]kftrainerapi.RuntimePatch{
+		testingtrainjob.MakeRuntimePatch(runtimePatchManagerName).
+			EmptyMetadata().
+			ReplicatedJobs(
+				testingtrainjob.MakeReplicatedJobPatch("node").
+					Toleration(staleKueueToleration).
+					Obj(),
+			).
+			Obj(),
+	}).Obj()
+
+	ctx, _ := utiltesting.ContextWithLog(t)
+	clientBuilder := utiltesting.NewClientBuilder(kftrainerapi.AddToScheme, jobsetapi.AddToScheme).WithObjects()
+	indexer := utiltesting.AsIndexer(clientBuilder)
+	kClient := clientBuilder.WithObjects(testTrainJob, testRuntime).Build()
+	recorder := &utiltesting.EventRecorder{}
+	if _, err := NewReconciler(ctx, kClient, indexer, recorder, jobframework.WithManageJobsWithoutQueueName(true)); err != nil {
+		t.Fatalf("Error creating the reconciler: %v", err)
+	}
+
+	trainJob := (*TrainJob)(testTrainJob)
+	if err := trainJob.RunWithPodSetsInfo(ctx, kClient, []podset.PodSetInfo{{
+		Name:        "node",
+		Tolerations: []corev1.Toleration{injectedToleration},
+	}}); err != nil {
+		t.Fatalf("RunWithPodSetsInfo() error = %v", err)
+	}
+	if err := trainJob.RunWithPodSetsInfo(ctx, kClient, []podset.PodSetInfo{{
+		Name:        "node",
+		Tolerations: []corev1.Toleration{injectedToleration},
+	}}); err != nil {
+		t.Fatalf("repeated RunWithPodSetsInfo() error = %v", err)
+	}
+
+	kueuePatch := getKueueRuntimePatch(trainJob)
+	if kueuePatch == nil {
+		t.Fatal("expected Kueue RuntimePatch")
+	}
+	gotTolerations := kueuePatch.TrainingRuntimeSpec.Template.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.Tolerations
+	wantTolerations := []corev1.Toleration{baseToleration, injectedToleration}
+	if diff := cmp.Diff(wantTolerations, gotTolerations); diff != "" {
+		t.Errorf("Kueue RuntimePatch tolerations mismatch (-want,+got):\n%s", diff)
+	}
+
+	jobset, err := getChildJobSet(ctx, kClient, trainJob)
+	if err != nil {
+		t.Fatalf("getChildJobSet() error = %v", err)
+	}
+	gotTolerations = jobset.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.Tolerations
+	if diff := cmp.Diff(wantTolerations, gotTolerations); diff != "" {
+		t.Errorf("rendered JobSet tolerations mismatch (-want,+got):\n%s", diff)
+	}
+
+	if err := trainJob.RunWithPodSetsInfo(ctx, kClient, []podset.PodSetInfo{{Name: "node"}}); err != nil {
+		t.Fatalf("RunWithPodSetsInfo() without injected tolerations error = %v", err)
+	}
+	kueuePatch = getKueueRuntimePatch(trainJob)
+	if got := kueuePatch.TrainingRuntimeSpec.Template.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.Tolerations; got != nil {
+		t.Errorf("Kueue RuntimePatch tolerations = %v, want nil when no tolerations are injected", got)
+	}
+	jobset, err = getChildJobSet(ctx, kClient, trainJob)
+	if err != nil {
+		t.Fatalf("getChildJobSet() after clearing injected tolerations error = %v", err)
+	}
+	gotTolerations = jobset.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.Tolerations
+	if diff := cmp.Diff([]corev1.Toleration{baseToleration}, gotTolerations); diff != "" {
+		t.Errorf("rendered JobSet tolerations after clearing injection mismatch (-want,+got):\n%s", diff)
 	}
 }
 

--- a/pkg/controller/jobs/trainjob/trainjob_controller_test.go
+++ b/pkg/controller/jobs/trainjob/trainjob_controller_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package trainjob
 
 import (
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -431,6 +433,47 @@ func TestRunWithPodSetsInfoMatchesReplicatedJobsByName(t *testing.T) {
 	}
 	if diff := cmp.Diff(wantTolerations, gotJobSetTolerations); diff != "" {
 		t.Errorf("rendered JobSet tolerations mismatch (-want,+got):\n%s", diff)
+	}
+}
+
+// TestRunWithPodSetsInfoRejectsDuplicatePodSetNames verifies that an admission
+// assignment cannot target the same replicated job more than once.
+func TestRunWithPodSetsInfoRejectsDuplicatePodSetNames(t *testing.T) {
+	testJobSet := testingjobset.MakeJobSet("", "").ReplicatedJobs(
+		testingjobset.ReplicatedJobRequirements{Name: "chief"},
+		testingjobset.ReplicatedJobRequirements{Name: "worker"},
+	).Obj()
+	testRuntime := testingtrainjob.MakeClusterTrainingRuntime("test", testJobSet.Spec)
+	testTrainJob := testingtrainjob.MakeTrainJob("trainjob", "ns").RuntimeRef(kftrainerapi.RuntimeRef{
+		APIGroup: new(kftrainerapi.GroupVersion.Group),
+		Name:     testRuntime.Name,
+		Kind:     new(kftrainerapi.ClusterTrainingRuntimeKind),
+	}).RuntimePatches([]kftrainerapi.RuntimePatch{
+		testingtrainjob.MakeRuntimePatch(runtimePatchManagerName).EmptyMetadata().Obj(),
+	}).Obj()
+
+	ctx, _ := utiltesting.ContextWithLog(t)
+	clientBuilder := utiltesting.NewClientBuilder(kftrainerapi.AddToScheme, jobsetapi.AddToScheme).WithObjects()
+	indexer := utiltesting.AsIndexer(clientBuilder)
+	kClient := clientBuilder.WithObjects(testTrainJob, testRuntime).Build()
+	recorder := &utiltesting.EventRecorder{}
+	if _, err := NewReconciler(ctx, kClient, indexer, recorder, jobframework.WithManageJobsWithoutQueueName(true)); err != nil {
+		t.Fatalf("Error creating the reconciler: %v", err)
+	}
+
+	trainJob := (*TrainJob)(testTrainJob)
+	err := trainJob.RunWithPodSetsInfo(ctx, kClient, []podset.PodSetInfo{
+		{Name: "chief"},
+		{Name: "chief"},
+	})
+	if !errors.Is(err, podset.ErrInvalidPodsetInfo) {
+		t.Fatalf("RunWithPodSetsInfo() error = %v, want an invalid podset info error", err)
+	}
+	if !strings.Contains(err.Error(), "appears more than once") {
+		t.Errorf("RunWithPodSetsInfo() error = %v, want a duplicate podset error", err)
+	}
+	if patch := getKueueRuntimePatch(trainJob); patch == nil || len(patch.TrainingRuntimeSpec.Template.Spec.ReplicatedJobs) != 0 {
+		t.Errorf("RunWithPodSetsInfo() modified the Kueue RuntimePatch: %#v", patch)
 	}
 }
 

--- a/pkg/controller/jobs/trainjob/trainjob_controller_test.go
+++ b/pkg/controller/jobs/trainjob/trainjob_controller_test.go
@@ -85,11 +85,100 @@ func TestRunWithPodsetsInfo(t *testing.T) {
 		}).Obj()
 	testCtr := testingtrainjob.MakeClusterTrainingRuntime("test", testJobset.Spec)
 
+	// Build a two-replicated-job runtime to exercise name-based matching and
+	// duplicate assignment validation.
+	multiJobset := testingjobset.MakeJobSet("", "").ReplicatedJobs(
+		testingjobset.ReplicatedJobRequirements{Name: "chief"},
+		testingjobset.ReplicatedJobRequirements{Name: "worker"},
+	).Obj()
+	multiJobset.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.Tolerations = []corev1.Toleration{*toleration1.DeepCopy()}
+	multiJobset.Spec.ReplicatedJobs[1].Template.Spec.Template.Spec.Tolerations = []corev1.Toleration{*toleration2.DeepCopy()}
+	multiCtr := testingtrainjob.MakeClusterTrainingRuntime("test", multiJobset.Spec)
+	chiefAdmissionToleration := corev1.Toleration{
+		Key:      "admission.example.com/chief",
+		Operator: corev1.TolerationOpEqual,
+		Value:    "reserved",
+		Effect:   corev1.TaintEffectNoSchedule,
+	}
+	workerAdmissionToleration := corev1.Toleration{
+		Key:      "admission.example.com/worker",
+		Operator: corev1.TolerationOpEqual,
+		Value:    "spot",
+		Effect:   corev1.TaintEffectNoExecute,
+	}
+	// withTolerations builds the complete replicated-job patch emitted by
+	// RunWithPodSetsInfo when only tolerations are configured.
+	withTolerations := func(name string, tolerations ...corev1.Toleration) kftrainerapi.ReplicatedJobPatch {
+		return kftrainerapi.ReplicatedJobPatch{
+			Name: name,
+			Template: &kftrainerapi.JobTemplatePatch{
+				Spec: &kftrainerapi.JobSpecPatch{
+					Template: &kftrainerapi.PodTemplatePatch{
+						Metadata: &metav1.ObjectMeta{},
+						Spec:     &kftrainerapi.PodSpecPatch{Tolerations: tolerations},
+					},
+				},
+			},
+		}
+	}
+	multiTrainJob := testTrainJob.Clone().RuntimePatches([]kftrainerapi.RuntimePatch{
+		testingtrainjob.MakeRuntimePatch(runtimePatchManagerName).EmptyMetadata().Obj(),
+	}).Obj()
+	multiWantTrainJob := testTrainJob.Clone().RuntimePatches([]kftrainerapi.RuntimePatch{
+		testingtrainjob.MakeRuntimePatch(runtimePatchManagerName).
+			EmptyMetadata().
+			ReplicatedJobs(
+				withTolerations("worker", *toleration2.DeepCopy(), workerAdmissionToleration),
+				withTolerations("chief", *toleration1.DeepCopy(), chiefAdmissionToleration),
+			).
+			Obj(),
+	}).Suspend(false).Obj()
+
+	staleBaseToleration := corev1.Toleration{
+		Key:      "user.example.com/dedicated",
+		Operator: corev1.TolerationOpEqual,
+		Value:    "training",
+		Effect:   corev1.TaintEffectNoSchedule,
+	}
+	staleJobset := testJobset.DeepCopy()
+	staleJobset.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.Tolerations = []corev1.Toleration{staleBaseToleration}
+	staleCtr := testingtrainjob.MakeClusterTrainingRuntime("test", staleJobset.Spec)
+	staleKueueToleration := corev1.Toleration{
+		Key:      "old.example.com/pool",
+		Operator: corev1.TolerationOpEqual,
+		Value:    "old",
+		Effect:   corev1.TaintEffectNoSchedule,
+	}
+	staleTrainJob := testTrainJob.Clone().RuntimePatches([]kftrainerapi.RuntimePatch{
+		testingtrainjob.MakeRuntimePatch(runtimePatchManagerName).
+			EmptyMetadata().
+			ReplicatedJobs(
+				withTolerations("node", staleKueueToleration),
+			).
+			Obj(),
+	}).Obj()
+	staleWantTrainJob := testTrainJob.Clone().RuntimePatches([]kftrainerapi.RuntimePatch{
+		testingtrainjob.MakeRuntimePatch(runtimePatchManagerName).
+			EmptyMetadata().
+			ReplicatedJobs(
+				withTolerations("node", staleBaseToleration, *toleration2.DeepCopy()),
+			).
+			Obj(),
+	}).Suspend(false).Obj()
+	staleClearedWantTrainJob := testTrainJob.Clone().RuntimePatches([]kftrainerapi.RuntimePatch{
+		testingtrainjob.MakeRuntimePatch(runtimePatchManagerName).
+			EmptyMetadata().
+			ReplicatedJobs(withTolerations("node")).
+			Obj(),
+	}).Suspend(false).Obj()
+
 	cases := map[string]struct {
 		trainJob        *kftrainerapi.TrainJob
+		runtime         *kftrainerapi.ClusterTrainingRuntime
 		podsetsInfo     []podset.PodSetInfo
 		wantTrainJob    *kftrainerapi.TrainJob
-		wantTolerations []corev1.Toleration
+		wantErrIs       error
+		wantErrContains string
 		wantErr         bool
 	}{
 		"should add to the TrainJob the config specified in the PodSet info": {
@@ -193,8 +282,47 @@ func TestRunWithPodsetsInfo(t *testing.T) {
 				}).
 				Suspend(false).
 				Obj(),
-			wantTolerations: []corev1.Toleration{*toleration1.DeepCopy(), *toleration2.DeepCopy()},
-			wantErr:         false,
+			wantErr: false,
+		},
+		"should match PodSet infos to replicated jobs by name": {
+			trainJob: multiTrainJob.DeepCopy(),
+			runtime:  multiCtr,
+			podsetsInfo: []podset.PodSetInfo{
+				{Name: "worker", Tolerations: []corev1.Toleration{workerAdmissionToleration}},
+				{Name: "chief", Tolerations: []corev1.Toleration{chiefAdmissionToleration}},
+			},
+			wantTrainJob: multiWantTrainJob,
+			wantErr:      false,
+		},
+		"should reject duplicate PodSet info names": {
+			trainJob:        multiTrainJob.DeepCopy(),
+			runtime:         multiCtr,
+			podsetsInfo:     []podset.PodSetInfo{{Name: "chief"}, {Name: "chief"}},
+			wantTrainJob:    multiTrainJob.DeepCopy(),
+			wantErrIs:       podset.ErrInvalidPodsetInfo,
+			wantErrContains: "appears more than once",
+			wantErr:         true,
+		},
+		"should preserve runtime tolerations and discard stale Kueue tolerations": {
+			trainJob:     staleTrainJob.DeepCopy(),
+			runtime:      staleCtr,
+			podsetsInfo:  []podset.PodSetInfo{{Name: "node", Tolerations: []corev1.Toleration{*toleration2.DeepCopy()}}},
+			wantTrainJob: staleWantTrainJob.DeepCopy(),
+			wantErr:      false,
+		},
+		"should not duplicate runtime tolerations on repeated admission": {
+			trainJob:     staleWantTrainJob.DeepCopy(),
+			runtime:      staleCtr,
+			podsetsInfo:  []podset.PodSetInfo{{Name: "node", Tolerations: []corev1.Toleration{*toleration2.DeepCopy()}}},
+			wantTrainJob: staleWantTrainJob.DeepCopy(),
+			wantErr:      false,
+		},
+		"should clear Kueue tolerations when admission has none": {
+			trainJob:     staleWantTrainJob.DeepCopy(),
+			runtime:      staleCtr,
+			podsetsInfo:  []podset.PodSetInfo{{Name: "node"}},
+			wantTrainJob: staleClearedWantTrainJob,
+			wantErr:      false,
 		},
 		"should not modify the TrainJob if the wrong number of PodSet infos is provided": {
 			trainJob: testTrainJob.DeepCopy(),
@@ -220,8 +348,10 @@ func TestRunWithPodsetsInfo(t *testing.T) {
 			podsetsInfo: []podset.PodSetInfo{
 				{Name: "non-existent-job"},
 			},
-			wantTrainJob: testTrainJob.DeepCopy(),
-			wantErr:      true,
+			wantTrainJob:    testTrainJob.DeepCopy(),
+			wantErrIs:       podset.ErrInvalidPodsetInfo,
+			wantErrContains: "does not match a replicated job",
+			wantErr:         true,
 		},
 		"should return an error if the trainjob references an unknown training runtime": {
 			trainJob: testTrainJob.DeepCopy(),
@@ -306,7 +436,11 @@ func TestRunWithPodsetsInfo(t *testing.T) {
 			ctx, _ := utiltesting.ContextWithLog(t)
 			clientBuilder := utiltesting.NewClientBuilder(kftrainerapi.AddToScheme, jobsetapi.AddToScheme).WithObjects()
 			indexer := utiltesting.AsIndexer(clientBuilder)
-			kClient := clientBuilder.WithObjects(tc.trainJob, testCtr).Build()
+			runtime := tc.runtime
+			if runtime == nil {
+				runtime = testCtr
+			}
+			kClient := clientBuilder.WithObjects(tc.trainJob, runtime).Build()
 			recorder := &utiltesting.EventRecorder{}
 			_, err := NewReconciler(ctx, kClient, indexer, recorder, jobframework.WithManageJobsWithoutQueueName(true))
 			if err != nil {
@@ -320,6 +454,12 @@ func TestRunWithPodsetsInfo(t *testing.T) {
 				if !tc.wantErr {
 					t.Errorf("unexpected RunWithPodSetsInfo() error: %v", err)
 				}
+				if tc.wantErrIs != nil && !errors.Is(err, tc.wantErrIs) {
+					t.Errorf("RunWithPodSetsInfo() error = %v, want error wrapping %v", err, tc.wantErrIs)
+				}
+				if tc.wantErrContains != "" && !strings.Contains(err.Error(), tc.wantErrContains) {
+					t.Errorf("RunWithPodSetsInfo() error = %v, want it to contain %q", err, tc.wantErrContains)
+				}
 				// Ensure that neither the podSpecOverrides nor the suspend fields were modified
 				if diff := cmp.Diff(tc.trainJob, originalTrainJob, tjobCmpOpts); diff != "" {
 					t.Errorf("the original trainJob was modified during a failed RunWithPodSetsInfo() (-want,+got):\n%s", diff)
@@ -332,250 +472,7 @@ func TestRunWithPodsetsInfo(t *testing.T) {
 			if diff := cmp.Diff(tc.wantTrainJob, tc.trainJob, tjobCmpOpts); diff != "" {
 				t.Errorf("RunWithPodSetsInfo() mismatch (-want,+got):\n%s", diff)
 			}
-			if tc.wantTolerations != nil {
-				jobset, err := getChildJobSet(ctx, kClient, kTrainJob)
-				if err != nil {
-					t.Fatalf("getChildJobSet() error: %v", err)
-				}
-				gotTolerations := jobset.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.Tolerations
-				if diff := cmp.Diff(tc.wantTolerations, gotTolerations); diff != "" {
-					t.Errorf("rendered JobSet tolerations mismatch (-want,+got):\n%s", diff)
-				}
-			}
 		})
-	}
-}
-
-// TestRunWithPodSetsInfoMatchesReplicatedJobsByName verifies that admission
-// tolerations are merged into the matching replicated job regardless of input order.
-func TestRunWithPodSetsInfoMatchesReplicatedJobsByName(t *testing.T) {
-	chiefBase := corev1.Toleration{
-		Key:      "workload.example.com/chief",
-		Operator: corev1.TolerationOpEqual,
-		Value:    "true",
-		Effect:   corev1.TaintEffectNoSchedule,
-	}
-	workerBase := corev1.Toleration{
-		Key:      "workload.example.com/worker",
-		Operator: corev1.TolerationOpEqual,
-		Value:    "true",
-		Effect:   corev1.TaintEffectNoSchedule,
-	}
-	chiefInjected := corev1.Toleration{
-		Key:      "pool.example.com/chief",
-		Operator: corev1.TolerationOpEqual,
-		Value:    "reserved",
-		Effect:   corev1.TaintEffectNoExecute,
-	}
-	workerInjected := corev1.Toleration{
-		Key:      "pool.example.com/worker",
-		Operator: corev1.TolerationOpEqual,
-		Value:    "spot",
-		Effect:   corev1.TaintEffectNoExecute,
-	}
-
-	testJobSet := testingjobset.MakeJobSet("", "").ReplicatedJobs(
-		testingjobset.ReplicatedJobRequirements{Name: "chief"},
-		testingjobset.ReplicatedJobRequirements{Name: "worker"},
-	).Obj()
-	testJobSet.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.Tolerations = []corev1.Toleration{chiefBase}
-	testJobSet.Spec.ReplicatedJobs[1].Template.Spec.Template.Spec.Tolerations = []corev1.Toleration{workerBase}
-	testRuntime := testingtrainjob.MakeClusterTrainingRuntime("test", testJobSet.Spec)
-	testTrainJob := testingtrainjob.MakeTrainJob("trainjob", "ns").RuntimeRef(kftrainerapi.RuntimeRef{
-		APIGroup: new(kftrainerapi.GroupVersion.Group),
-		Name:     testRuntime.Name,
-		Kind:     new(kftrainerapi.ClusterTrainingRuntimeKind),
-	}).RuntimePatches([]kftrainerapi.RuntimePatch{
-		testingtrainjob.MakeRuntimePatch(runtimePatchManagerName).EmptyMetadata().Obj(),
-	}).Obj()
-
-	ctx, _ := utiltesting.ContextWithLog(t)
-	clientBuilder := utiltesting.NewClientBuilder(kftrainerapi.AddToScheme, jobsetapi.AddToScheme).WithObjects()
-	indexer := utiltesting.AsIndexer(clientBuilder)
-	kClient := clientBuilder.WithObjects(testTrainJob, testRuntime).Build()
-	recorder := &utiltesting.EventRecorder{}
-	if _, err := NewReconciler(ctx, kClient, indexer, recorder, jobframework.WithManageJobsWithoutQueueName(true)); err != nil {
-		t.Fatalf("Error creating the reconciler: %v", err)
-	}
-
-	trainJob := (*TrainJob)(testTrainJob)
-	// Reverse the admission order to ensure assignments are matched by name.
-	if err := trainJob.RunWithPodSetsInfo(ctx, kClient, []podset.PodSetInfo{
-		{Name: "worker", Tolerations: []corev1.Toleration{workerInjected}},
-		{Name: "chief", Tolerations: []corev1.Toleration{chiefInjected}},
-	}); err != nil {
-		t.Fatalf("RunWithPodSetsInfo() error = %v", err)
-	}
-
-	wantTolerations := map[string][]corev1.Toleration{
-		"chief":  {chiefBase, chiefInjected},
-		"worker": {workerBase, workerInjected},
-	}
-	kueuePatch := getKueueRuntimePatch(trainJob)
-	if kueuePatch == nil {
-		t.Fatal("expected Kueue RuntimePatch")
-	}
-	gotPatchTolerations := make(map[string][]corev1.Toleration, len(wantTolerations))
-	for _, replicatedJob := range kueuePatch.TrainingRuntimeSpec.Template.Spec.ReplicatedJobs {
-		gotPatchTolerations[replicatedJob.Name] = replicatedJob.Template.Spec.Template.Spec.Tolerations
-	}
-	if diff := cmp.Diff(wantTolerations, gotPatchTolerations); diff != "" {
-		t.Errorf("Kueue RuntimePatch tolerations mismatch (-want,+got):\n%s", diff)
-	}
-
-	jobSet, err := getChildJobSet(ctx, kClient, trainJob)
-	if err != nil {
-		t.Fatalf("getChildJobSet() error = %v", err)
-	}
-	gotJobSetTolerations := make(map[string][]corev1.Toleration, len(wantTolerations))
-	for _, replicatedJob := range jobSet.Spec.ReplicatedJobs {
-		gotJobSetTolerations[replicatedJob.Name] = replicatedJob.Template.Spec.Template.Spec.Tolerations
-	}
-	if diff := cmp.Diff(wantTolerations, gotJobSetTolerations); diff != "" {
-		t.Errorf("rendered JobSet tolerations mismatch (-want,+got):\n%s", diff)
-	}
-}
-
-// TestRunWithPodSetsInfoRejectsDuplicatePodSetNames verifies that an admission
-// assignment cannot target the same replicated job more than once.
-func TestRunWithPodSetsInfoRejectsDuplicatePodSetNames(t *testing.T) {
-	testJobSet := testingjobset.MakeJobSet("", "").ReplicatedJobs(
-		testingjobset.ReplicatedJobRequirements{Name: "chief"},
-		testingjobset.ReplicatedJobRequirements{Name: "worker"},
-	).Obj()
-	testRuntime := testingtrainjob.MakeClusterTrainingRuntime("test", testJobSet.Spec)
-	testTrainJob := testingtrainjob.MakeTrainJob("trainjob", "ns").RuntimeRef(kftrainerapi.RuntimeRef{
-		APIGroup: new(kftrainerapi.GroupVersion.Group),
-		Name:     testRuntime.Name,
-		Kind:     new(kftrainerapi.ClusterTrainingRuntimeKind),
-	}).RuntimePatches([]kftrainerapi.RuntimePatch{
-		testingtrainjob.MakeRuntimePatch(runtimePatchManagerName).EmptyMetadata().Obj(),
-	}).Obj()
-
-	ctx, _ := utiltesting.ContextWithLog(t)
-	clientBuilder := utiltesting.NewClientBuilder(kftrainerapi.AddToScheme, jobsetapi.AddToScheme).WithObjects()
-	indexer := utiltesting.AsIndexer(clientBuilder)
-	kClient := clientBuilder.WithObjects(testTrainJob, testRuntime).Build()
-	recorder := &utiltesting.EventRecorder{}
-	if _, err := NewReconciler(ctx, kClient, indexer, recorder, jobframework.WithManageJobsWithoutQueueName(true)); err != nil {
-		t.Fatalf("Error creating the reconciler: %v", err)
-	}
-
-	trainJob := (*TrainJob)(testTrainJob)
-	err := trainJob.RunWithPodSetsInfo(ctx, kClient, []podset.PodSetInfo{
-		{Name: "chief"},
-		{Name: "chief"},
-	})
-	if !errors.Is(err, podset.ErrInvalidPodsetInfo) {
-		t.Fatalf("RunWithPodSetsInfo() error = %v, want an invalid podset info error", err)
-	}
-	if !strings.Contains(err.Error(), "appears more than once") {
-		t.Errorf("RunWithPodSetsInfo() error = %v, want a duplicate podset error", err)
-	}
-	if patch := getKueueRuntimePatch(trainJob); patch == nil || len(patch.TrainingRuntimeSpec.Template.Spec.ReplicatedJobs) != 0 {
-		t.Errorf("RunWithPodSetsInfo() modified the Kueue RuntimePatch: %#v", patch)
-	}
-}
-
-// TestRunWithPodSetsInfoPreservesTrainingRuntimeTolerations verifies that the
-// Kueue patch retains tolerations defined by the resolved TrainingRuntime.
-func TestRunWithPodSetsInfoPreservesTrainingRuntimeTolerations(t *testing.T) {
-	baseToleration := corev1.Toleration{
-		Key:      "user.example.com/dedicated",
-		Operator: corev1.TolerationOpEqual,
-		Value:    "training",
-		Effect:   corev1.TaintEffectNoSchedule,
-	}
-	injectedToleration := corev1.Toleration{
-		Key:      "pool.example.com/gpu",
-		Operator: corev1.TolerationOpEqual,
-		Value:    "true",
-		Effect:   corev1.TaintEffectNoSchedule,
-	}
-	// Simulate an old Kueue-managed toleration left by a previous admission.
-	staleKueueToleration := corev1.Toleration{
-		Key:      "old.example.com/pool",
-		Operator: corev1.TolerationOpEqual,
-		Value:    "old",
-		Effect:   corev1.TaintEffectNoSchedule,
-	}
-
-	testJobSet := testingjobset.MakeJobSet("", "").ReplicatedJobs(
-		testingjobset.ReplicatedJobRequirements{Name: "node"},
-	).Obj()
-	testJobSet.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.Tolerations = []corev1.Toleration{baseToleration}
-	testRuntime := testingtrainjob.MakeClusterTrainingRuntime("test", testJobSet.Spec)
-	testTrainJob := testingtrainjob.MakeTrainJob("trainjob", "ns").RuntimeRef(kftrainerapi.RuntimeRef{
-		APIGroup: new(kftrainerapi.GroupVersion.Group),
-		Name:     testRuntime.Name,
-		Kind:     new(kftrainerapi.ClusterTrainingRuntimeKind),
-	}).RuntimePatches([]kftrainerapi.RuntimePatch{
-		testingtrainjob.MakeRuntimePatch(runtimePatchManagerName).
-			EmptyMetadata().
-			ReplicatedJobs(
-				testingtrainjob.MakeReplicatedJobPatch("node").
-					Toleration(staleKueueToleration).
-					Obj(),
-			).
-			Obj(),
-	}).Obj()
-
-	ctx, _ := utiltesting.ContextWithLog(t)
-	clientBuilder := utiltesting.NewClientBuilder(kftrainerapi.AddToScheme, jobsetapi.AddToScheme).WithObjects()
-	indexer := utiltesting.AsIndexer(clientBuilder)
-	kClient := clientBuilder.WithObjects(testTrainJob, testRuntime).Build()
-	recorder := &utiltesting.EventRecorder{}
-	if _, err := NewReconciler(ctx, kClient, indexer, recorder, jobframework.WithManageJobsWithoutQueueName(true)); err != nil {
-		t.Fatalf("Error creating the reconciler: %v", err)
-	}
-
-	trainJob := (*TrainJob)(testTrainJob)
-	if err := trainJob.RunWithPodSetsInfo(ctx, kClient, []podset.PodSetInfo{{
-		Name:        "node",
-		Tolerations: []corev1.Toleration{injectedToleration},
-	}}); err != nil {
-		t.Fatalf("RunWithPodSetsInfo() error = %v", err)
-	}
-	if err := trainJob.RunWithPodSetsInfo(ctx, kClient, []podset.PodSetInfo{{
-		Name:        "node",
-		Tolerations: []corev1.Toleration{injectedToleration},
-	}}); err != nil {
-		t.Fatalf("repeated RunWithPodSetsInfo() error = %v", err)
-	}
-
-	kueuePatch := getKueueRuntimePatch(trainJob)
-	if kueuePatch == nil {
-		t.Fatal("expected Kueue RuntimePatch")
-	}
-	gotTolerations := kueuePatch.TrainingRuntimeSpec.Template.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.Tolerations
-	wantTolerations := []corev1.Toleration{baseToleration, injectedToleration}
-	if diff := cmp.Diff(wantTolerations, gotTolerations); diff != "" {
-		t.Errorf("Kueue RuntimePatch tolerations mismatch (-want,+got):\n%s", diff)
-	}
-
-	jobset, err := getChildJobSet(ctx, kClient, trainJob)
-	if err != nil {
-		t.Fatalf("getChildJobSet() error = %v", err)
-	}
-	gotTolerations = jobset.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.Tolerations
-	if diff := cmp.Diff(wantTolerations, gotTolerations); diff != "" {
-		t.Errorf("rendered JobSet tolerations mismatch (-want,+got):\n%s", diff)
-	}
-
-	if err := trainJob.RunWithPodSetsInfo(ctx, kClient, []podset.PodSetInfo{{Name: "node"}}); err != nil {
-		t.Fatalf("RunWithPodSetsInfo() without injected tolerations error = %v", err)
-	}
-	kueuePatch = getKueueRuntimePatch(trainJob)
-	if got := kueuePatch.TrainingRuntimeSpec.Template.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.Tolerations; got != nil {
-		t.Errorf("Kueue RuntimePatch tolerations = %v, want nil when no tolerations are injected", got)
-	}
-	jobset, err = getChildJobSet(ctx, kClient, trainJob)
-	if err != nil {
-		t.Fatalf("getChildJobSet() after clearing injected tolerations error = %v", err)
-	}
-	gotTolerations = jobset.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.Tolerations
-	if diff := cmp.Diff([]corev1.Toleration{baseToleration}, gotTolerations); diff != "" {
-		t.Errorf("rendered JobSet tolerations after clearing injection mismatch (-want,+got):\n%s", diff)
 	}
 }
 

--- a/pkg/podset/podset.go
+++ b/pkg/podset/podset.go
@@ -130,14 +130,7 @@ func (podSetInfo *PodSetInfo) Merge(o PodSetInfo) error {
 	utilmaps.Copy(&podSetInfo.Labels, o.Labels)
 	utilmaps.Copy(&podSetInfo.NodeSelector, o.NodeSelector)
 
-	// make sure we don't duplicate tolerations
-	for _, t := range o.Tolerations {
-		if !slices.ContainsFunc(podSetInfo.Tolerations, func(e corev1.Toleration) bool {
-			return utiltolerations.Equal(e, t)
-		}) {
-			podSetInfo.Tolerations = append(podSetInfo.Tolerations, t)
-		}
-	}
+	podSetInfo.Tolerations = utiltolerations.Merge(podSetInfo.Tolerations, o.Tolerations)
 	// make sure we don't duplicate schedulingGates
 	for _, t := range o.SchedulingGates {
 		if slices.Index(podSetInfo.SchedulingGates, t) == -1 {

--- a/pkg/util/tolerations/tolerations.go
+++ b/pkg/util/tolerations/tolerations.go
@@ -16,9 +16,15 @@ limitations under the License.
 
 package tolerations
 
-import corev1 "k8s.io/api/core/v1"
+import (
+	"slices"
 
-// Equal reports whether two tolerations describe the same toleration.
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Equal reports whether two tolerations have the same Kubernetes identity.
+// Identity consists of key, operator, value, and effect; TolerationSeconds is
+// intentionally ignored because it controls NoExecute duration, not matching.
 // The Kubernetes API defaults an empty Operator to "Equal", so Operator: ""
 // and Operator: "Equal" describe the same toleration and compare as equal.
 func Equal(a, b corev1.Toleration) bool {
@@ -29,4 +35,20 @@ func Equal(a, b corev1.Toleration) bool {
 		b.Operator = corev1.TolerationOpEqual
 	}
 	return a.MatchToleration(&b)
+}
+
+// Merge returns a copy of base followed by tolerations from extra that are not
+// already present. The first matching toleration wins, so base values and
+// ordering are preserved, including when TolerationSeconds differs. Neither
+// input slice is modified.
+func Merge(base, extras []corev1.Toleration) []corev1.Toleration {
+	merged := slices.Clone(base)
+	for _, t := range extras {
+		if !slices.ContainsFunc(merged, func(existing corev1.Toleration) bool {
+			return Equal(existing, t)
+		}) {
+			merged = append(merged, t)
+		}
+	}
+	return merged
 }

--- a/pkg/util/tolerations/tolerations_test.go
+++ b/pkg/util/tolerations/tolerations_test.go
@@ -19,6 +19,7 @@ package tolerations
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -75,6 +76,104 @@ func TestEqual(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			if got := Equal(tc.a, tc.b); got != tc.wantEq {
 				t.Errorf("Equal() = %v, want %v", got, tc.wantEq)
+			}
+		})
+	}
+}
+
+// TestMerge verifies order preservation, duplicate handling, and input ownership.
+func TestMerge(t *testing.T) {
+	base := []corev1.Toleration{
+		{
+			Key:      "base",
+			Operator: corev1.TolerationOpEqual,
+			Value:    "value",
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+	}
+	baseWithoutOperator := []corev1.Toleration{
+		{
+			Key:    "same",
+			Value:  "value",
+			Effect: corev1.TaintEffectNoSchedule,
+		},
+	}
+
+	cases := map[string]struct {
+		base, extra []corev1.Toleration
+		want        []corev1.Toleration
+	}{
+		"empty": {},
+		"append unique tolerations": {
+			base: base,
+			extra: []corev1.Toleration{
+				{Key: "second", Effect: corev1.TaintEffectNoExecute},
+				{Key: "third", Effect: corev1.TaintEffectNoSchedule},
+			},
+			want: append(append([]corev1.Toleration{}, base...),
+				corev1.Toleration{Key: "second", Effect: corev1.TaintEffectNoExecute},
+				corev1.Toleration{Key: "third", Effect: corev1.TaintEffectNoSchedule}),
+		},
+		"keep the base value for duplicates": {
+			base: []corev1.Toleration{{
+				Key:               "base",
+				Operator:          corev1.TolerationOpEqual,
+				Value:             "value",
+				Effect:            corev1.TaintEffectNoExecute,
+				TolerationSeconds: new(int64(10)),
+			}},
+			extra: []corev1.Toleration{
+				{Key: "base", Value: "value", Effect: corev1.TaintEffectNoExecute, TolerationSeconds: new(int64(20))},
+			},
+			want: []corev1.Toleration{{
+				Key:               "base",
+				Operator:          corev1.TolerationOpEqual,
+				Value:             "value",
+				Effect:            corev1.TaintEffectNoExecute,
+				TolerationSeconds: new(int64(10)),
+			}},
+		},
+		"treat empty and Equal operators as duplicates": {
+			base: baseWithoutOperator,
+			extra: []corev1.Toleration{
+				{Key: "same", Operator: corev1.TolerationOpEqual, Value: "value", Effect: corev1.TaintEffectNoSchedule},
+			},
+			want: baseWithoutOperator,
+		},
+		"ignore TolerationSeconds when checking identity": {
+			base: []corev1.Toleration{{
+				Key:               "seconds",
+				Operator:          corev1.TolerationOpEqual,
+				Value:             "value",
+				Effect:            corev1.TaintEffectNoExecute,
+				TolerationSeconds: new(int64(10)),
+			}},
+			extra: []corev1.Toleration{{
+				Key:               "seconds",
+				Operator:          corev1.TolerationOpEqual,
+				Value:             "value",
+				Effect:            corev1.TaintEffectNoExecute,
+				TolerationSeconds: new(int64(20)),
+			}},
+			want: []corev1.Toleration{{
+				Key:               "seconds",
+				Operator:          corev1.TolerationOpEqual,
+				Value:             "value",
+				Effect:            corev1.TaintEffectNoExecute,
+				TolerationSeconds: new(int64(10)),
+			}},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			baseCopy := append([]corev1.Toleration(nil), tc.base...)
+			got := Merge(tc.base, tc.extra)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Merge() mismatch (-want,+got):\n%s", diff)
+			}
+			if diff := cmp.Diff(baseCopy, tc.base); diff != "" {
+				t.Errorf("Merge() modified base (-want,+got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION

  #### What type of PR is this?
  /kind bug
  /area integrations

  #### What this PR does / why we need it:

  Kueue's Kubeflow Trainer TrainJob adapter now preserves tolerations resolved from the TrainingRuntime and
  user-owned runtime patches when applying admission assignments.

  The implementation:
  - removes the previous Kueue-managed RuntimePatch before resolving the JobSet;
  - matches PodSet admission assignments to ReplicatedJobs by name;
  - merges admission tolerations using Kubernetes toleration identity;
  - retains existing tolerations, including `TolerationSeconds`; and
  - reuses the merge logic in the generic PodSetInfo path.

  Trainer declares `PodSpecPatch.tolerations` as an atomic list. Without this change, ResourceFlavor
  tolerations replace existing runtime/user tolerations, which can change scheduling and eviction behavior
  or leave workloads Pending.

  #### Which issue(s) this PR fixes:

  Fixes #15161

  #### Special notes for your reviewer:

  - The complete resolved toleration list is written because Trainer's patch field is atomic.
  - Existing ordering and base values are preserved; only new admission tolerations are appended.
  - Tests cover duplicate identity, operator defaulting, `TolerationSeconds`, stale admission patches,
  rendered JobSets, and reversed multi-ReplicatedJob admission order.
  - This PR description and implementation were prepared with AI assistance, but I manually reviewed the
  complete diff and verified the behavior against the current Kueue, Trainer, JobSet, Kubernetes API source,
  and tests.

  #### Does this PR introduce a user-facing change?

  Yes. TrainJob admission no longer drops tolerations supplied by the TrainingRuntime or user-owned runtime
  patches when ResourceFlavor tolerations are added.

  ```release-note
TrainJob: Fixed admission dropping runtime-defined tolerations when ResourceFlavor tolerations were applied, which could leave pods Pending on tainted nodes.
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Preserved user-configured tolerations when applying admission settings.
* Merged admission tolerations without duplicating existing entries.
* Matched admission settings to replicated jobs by name, regardless of ordering.
* Prevented stale runtime settings from being mistaken for user configuration during re-admission.
* Kept repeated processing consistent and cleared injected tolerations when no longer provided.
* Rejected invalid pod set information containing unknown or duplicate names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->