### PR TITLE
Fix(flake): Job Webhook test fails when the default WPC does not exist

### DIFF
--- a/test/integration/singlecluster/webhook/jobs/job_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/job_webhook_test.go
@@ -21,9 +21,11 @@ import (
 	"github.com/onsi/gomega"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/discovery"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
@@ -316,15 +318,17 @@ var _ = ginkgo.Describe("Job Webhook with WorkloadPriorityClassDefaulting enable
 	ginkgo.It("Should not set the label when the default WPC does not exist", func() {
 		gomega.Expect(k8sClient.Delete(ctx, defaultWPC)).To(gomega.Succeed())
 
-		j := testingjob.MakeJob("job-no-default-wpc", ns.Name).Queue("test-queue").Obj()
-		util.MustCreate(ctx, k8sClient, j)
+		// Use Eventually with DryRun to wait for cache invalidation
+		gomega.Eventually(func(g gomega.Gomega) {
+			j := testingjob.MakeJob("job-no-default-wpc", ns.Name).Queue("test-queue").Obj()
 
-		lookupKey := types.NamespacedName{Name: j.Name, Namespace: j.Namespace}
-		createdJob := &batchv1.Job{}
-		gomega.Consistently(func(g gomega.Gomega) {
-			g.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
-			g.Expect(createdJob.Labels).ShouldNot(gomega.HaveKey(constants.WorkloadPriorityClassLabel))
-		}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+			// Use DryRun so we don't create actual jobs
+			opts := &client.CreateOptions{}
+			opts.DryRun = []string{metav1.DryRunAll}
+
+			g.Expect(k8sClient.Create(ctx, j, opts)).Should(gomega.Succeed())
+			g.Expect(j.Labels).ShouldNot(gomega.HaveKey(constants.WorkloadPriorityClassLabel))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 		defaultWPC = utiltestingapi.MakeWorkloadPriorityClass(constants.DefaultWorkloadPriorityClassName).PriorityValue(100).Obj()
 		util.MustCreate(ctx, k8sClient, defaultWPC)

--- a/test/integration/singlecluster/webhook/jobs/job_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/job_webhook_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/onsi/gomega"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/discovery"
@@ -318,15 +317,10 @@ var _ = ginkgo.Describe("Job Webhook with WorkloadPriorityClassDefaulting enable
 	ginkgo.It("Should not set the label when the default WPC does not exist", func() {
 		gomega.Expect(k8sClient.Delete(ctx, defaultWPC)).To(gomega.Succeed())
 
-		// Use Eventually with DryRun to wait for cache invalidation
 		gomega.Eventually(func(g gomega.Gomega) {
 			j := testingjob.MakeJob("job-no-default-wpc", ns.Name).Queue("test-queue").Obj()
 
-			// Use DryRun so we don't create actual jobs
-			opts := &client.CreateOptions{}
-			opts.DryRun = []string{metav1.DryRunAll}
-
-			g.Expect(k8sClient.Create(ctx, j, opts)).Should(gomega.Succeed())
+			g.Expect(k8sClient.Create(ctx, j, client.DryRunAll)).Should(gomega.Succeed())
 			g.Expect(j.Labels).ShouldNot(gomega.HaveKey(constants.WorkloadPriorityClassLabel))
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test
/kind flake
/area testing


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #15123

#### Special notes for your reviewer:

Delete util.MustCreate(ctx, k8sClient, j) - move job creation inside Eventually
Change Consistently → Eventually - retry instead of assert consistently
Add DryRun options - webhook runs but job isn't actually persisted
Move label check inside Eventually - check j.Labels directly (not from Get)

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Simplified dry-run Job creation in integration tests.
  * Removed an unused test dependency while preserving retry and label validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->