### PR TITLE
Raise a warning event when a PriorityClass is not found

### DIFF
--- a/pkg/controller/jobframework/events.go
+++ b/pkg/controller/jobframework/events.go
@@ -31,4 +31,5 @@ const (
 	ReasonJobNestingTooDeep     = "JobNestingTooDeep"
 
 	ReasonWorkloadPriorityClassNotFound = "WorkloadPriorityClassNotFound"
+	ReasonPriorityClassNotFound         = "PriorityClassNotFound"
 )

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1828,6 +1828,22 @@ func (r *JobReconciler) prepareWorkload(ctx context.Context, job GenericJob, wl 
 	return nil
 }
 
+// ExtractPriority resolves the priority the Workload should carry: from the
+// WorkloadPriorityClass the kueue.x-k8s.io/priority-class label names, and
+// otherwise from the scheduling.k8s.io PriorityClass the job names, either
+// through the integration's own accessor or through the first PodSet template
+// that sets one.
+//
+// A named class that does not exist is reported as a Warning event on the
+// object, here rather than from the error, which the callers aggregate and can
+// drop. Only a lookup a name sent us on reports, since that is the only case
+// where the missing class is known to be the one the object asked for rather
+// than a guess: an empty name resolves the cluster default, which names no
+// class, and a NotFound raised anywhere else keeps its existing handling.
+//
+// The event does not stand in for the error, which is returned unchanged, so
+// the reconcile still fails and no Workload is created or updated. A later
+// reconciliation succeeds once the class exists.
 func ExtractPriority(
 	ctx context.Context,
 	c client.Client,
@@ -1838,19 +1854,34 @@ func ExtractPriority(
 ) (*kueue.PriorityClassRef, int32, error) {
 	if workloadPriorityClass := WorkloadPriorityClassName(obj); len(workloadPriorityClass) > 0 {
 		ref, priority, err := utilpriority.GetPriorityFromWorkloadPriorityClass(ctx, c, workloadPriorityClass)
-		// Reported here rather than from the error, which the callers
-		// aggregate and can drop. Only reached when the label named a class,
-		// so a NotFound is that class and not one of the fallbacks below.
 		if apierrors.IsNotFound(err) {
 			r.Eventf(obj, nil, corev1.EventTypeWarning, ReasonWorkloadPriorityClassNotFound,
 				"WorkloadPriorityClassNotFound", "WorkloadPriorityClass %q not found", workloadPriorityClass)
 		}
 		return ref, priority, err
 	}
+
+	// The integration's own accessor wins over the PodSets, and can name a class
+	// that no Pod template carries: MPIJob and the Kubeflow jobs read
+	// .spec.runPolicy.schedulingPolicy.priorityClass ahead of their replica
+	// templates, so nothing else in the cluster ever resolves that name. Even a
+	// name that does come from a Pod template is only refused by the API server
+	// once a Pod is created, which a suspended job never does, so this lookup is
+	// where a missing class has to be noticed.
+	var priorityClassName string
 	if customPriorityClassFunc != nil {
-		return utilpriority.GetPriorityFromPriorityClass(ctx, c, customPriorityClassFunc())
+		priorityClassName = customPriorityClassFunc()
+	} else {
+		priorityClassName = extractPriorityFromPodSets(podSets)
 	}
-	return utilpriority.GetPriorityFromPriorityClass(ctx, c, extractPriorityFromPodSets(podSets))
+	ref, priority, err := utilpriority.GetPriorityFromPriorityClass(ctx, c, priorityClassName)
+	// An empty name resolved the cluster default instead, so there is no class
+	// the object asked for that a message could name.
+	if len(priorityClassName) > 0 && apierrors.IsNotFound(err) {
+		r.Eventf(obj, nil, corev1.EventTypeWarning, ReasonPriorityClassNotFound,
+			"PriorityClassNotFound", "PriorityClass %q not found", priorityClassName)
+	}
+	return ref, priority, err
 }
 
 func extractPriorityFromPodSets(podSets []kueue.PodSet) string {

--- a/pkg/controller/jobframework/workload_priority_test.go
+++ b/pkg/controller/jobframework/workload_priority_test.go
@@ -460,22 +460,26 @@ func raiseClassTo(value int32) func(t *testing.T, ctx context.Context, cl client
 	}
 }
 
-// TestExtractPriorityReportsMissingWorkloadPriorityClass pins which lookup
-// failure is reported. Only the class the label named can be reported by name;
-// a failure anywhere else leaves the answer unknown, so saying the class does
-// not exist would be a guess.
-func TestExtractPriorityReportsMissingWorkloadPriorityClass(t *testing.T) {
-	forbidden := apierrors.NewForbidden(
+// TestExtractPriorityReportsMissingClass pins which lookup failure is reported.
+// Only a class the object named can be reported by name, whether it is the
+// WorkloadPriorityClass the label named or the PriorityClass the integration or
+// a Pod template named. A failure anywhere else leaves the answer unknown, so
+// saying the class does not exist would be a guess.
+func TestExtractPriorityReportsMissingClass(t *testing.T) {
+	forbiddenWorkloadPriorityClass := apierrors.NewForbidden(
 		kueue.SchemeGroupVersion.WithResource("workloadpriorityclasses").GroupResource(),
 		"denied", errors.New("not allowed"))
+	forbiddenPriorityClass := apierrors.NewForbidden(
+		schedulingv1.Resource("priorityclasses"), "denied", errors.New("not allowed"))
 
 	cases := map[string]struct {
-		job          *batchv1.Job
-		podSets      []kueue.PodSet
-		objects      []client.Object
-		interceptors interceptor.Funcs
-		wantEvents   []utiltesting.EventRecord
-		wantErr      error
+		job                     *batchv1.Job
+		podSets                 []kueue.PodSet
+		customPriorityClassFunc func() string
+		objects                 []client.Object
+		interceptors            interceptor.Funcs
+		wantEvents              []utiltesting.EventRecord
+		wantErr                 error
 	}{
 		"an explicitly referenced class that does not exist": {
 			job: testingjob.MakeJob("job", "ns").WorkloadPriorityClass("missing").Obj(),
@@ -499,23 +503,105 @@ func TestExtractPriorityReportsMissingWorkloadPriorityClass(t *testing.T) {
 		"no class referenced at all": {
 			job: testingjob.MakeJob("job", "ns").Obj(),
 		},
-		// scheduling.k8s.io is a different resource and keeps its own handling.
 		"a pod template naming a PriorityClass that does not exist": {
 			job:     testingjob.MakeJob("job", "ns").Obj(),
 			podSets: []kueue.PodSet{*utiltestingapi.MakePodSet("main", 1).PriorityClass("missing-pc").Obj()},
+			wantEvents: []utiltesting.EventRecord{{
+				Key:       types.NamespacedName{Namespace: "ns", Name: "job"},
+				EventType: corev1.EventTypeWarning,
+				Reason:    ReasonPriorityClassNotFound,
+				Message:   `PriorityClass "missing-pc" not found`,
+			}},
 			wantErr: apierrors.NewNotFound(schedulingv1.Resource("priorityclasses"), "missing-pc"),
 		},
-		"a lookup that failed for another reason": {
-			job: testingjob.MakeJob("job", "ns").WorkloadPriorityClass("denied").Obj(),
+		"a pod template naming a PriorityClass that exists": {
+			job:     testingjob.MakeJob("job", "ns").Obj(),
+			podSets: []kueue.PodSet{*utiltestingapi.MakePodSet("main", 1).PriorityClass("present-pc").Obj()},
+			objects: []client.Object{
+				utiltesting.MakePriorityClass("present-pc").PriorityValue(10).Obj(),
+			},
+		},
+		// An integration that resolves the name itself is asked before the Pod
+		// templates, so the class it names is the one reported even when a
+		// template names a different, existing one.
+		"an integration resolving a PriorityClass that does not exist": {
+			job:                     testingjob.MakeJob("job", "ns").Obj(),
+			podSets:                 []kueue.PodSet{*utiltestingapi.MakePodSet("main", 1).PriorityClass("present-pc").Obj()},
+			customPriorityClassFunc: func() string { return "missing-pc" },
+			objects: []client.Object{
+				utiltesting.MakePriorityClass("present-pc").PriorityValue(10).Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{{
+				Key:       types.NamespacedName{Namespace: "ns", Name: "job"},
+				EventType: corev1.EventTypeWarning,
+				Reason:    ReasonPriorityClassNotFound,
+				Message:   `PriorityClass "missing-pc" not found`,
+			}},
+			wantErr: apierrors.NewNotFound(schedulingv1.Resource("priorityclasses"), "missing-pc"),
+		},
+		// The label wins over both, so a missing PriorityClass under it is never
+		// reached and only the class the label named is reported.
+		"a label naming a missing class over a pod template naming a missing PriorityClass": {
+			job:     testingjob.MakeJob("job", "ns").WorkloadPriorityClass("missing").Obj(),
+			podSets: []kueue.PodSet{*utiltestingapi.MakePodSet("main", 1).PriorityClass("missing-pc").Obj()},
+			wantEvents: []utiltesting.EventRecord{{
+				Key:       types.NamespacedName{Namespace: "ns", Name: "job"},
+				EventType: corev1.EventTypeWarning,
+				Reason:    ReasonWorkloadPriorityClassNotFound,
+				Message:   `WorkloadPriorityClass "missing" not found`,
+			}},
+			wantErr: apierrors.NewNotFound(
+				kueue.SchemeGroupVersion.WithResource("workloadpriorityclasses").GroupResource(),
+				"missing",
+			),
+		},
+		// An integration that names nothing resolves the cluster default, which
+		// names no class, so there is nothing that could be reported by name. The
+		// Pod template is not consulted as a fallback, which is why naming a class
+		// that does not exist there still reports nothing.
+		"an integration resolving no PriorityClass at all": {
+			job:                     testingjob.MakeJob("job", "ns").Obj(),
+			podSets:                 []kueue.PodSet{*utiltestingapi.MakePodSet("main", 1).PriorityClass("missing-pc").Obj()},
+			customPriorityClassFunc: func() string { return "" },
+		},
+		// The cluster default is read with a List, so a NotFound from it is about
+		// the resource and not about a class the object named.
+		"a cluster default lookup that returned NotFound": {
+			job: testingjob.MakeJob("job", "ns").Obj(),
+			interceptors: interceptor.Funcs{
+				List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+					if _, isClassList := list.(*schedulingv1.PriorityClassList); isClassList {
+						return apierrors.NewNotFound(schedulingv1.Resource("priorityclasses"), "")
+					}
+					return c.List(ctx, list, opts...)
+				},
+			},
+			wantErr: apierrors.NewNotFound(schedulingv1.Resource("priorityclasses"), ""),
+		},
+		"a PriorityClass lookup that failed for another reason": {
+			job:     testingjob.MakeJob("job", "ns").Obj(),
+			podSets: []kueue.PodSet{*utiltestingapi.MakePodSet("main", 1).PriorityClass("denied").Obj()},
 			interceptors: interceptor.Funcs{
 				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-					if _, isClass := obj.(*kueue.WorkloadPriorityClass); isClass {
-						return forbidden
+					if _, isClass := obj.(*schedulingv1.PriorityClass); isClass {
+						return forbiddenPriorityClass
 					}
 					return c.Get(ctx, key, obj, opts...)
 				},
 			},
-			wantErr: forbidden,
+			wantErr: forbiddenPriorityClass,
+		},
+		"a WorkloadPriorityClass lookup that failed for another reason": {
+			job: testingjob.MakeJob("job", "ns").WorkloadPriorityClass("denied").Obj(),
+			interceptors: interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if _, isClass := obj.(*kueue.WorkloadPriorityClass); isClass {
+						return forbiddenWorkloadPriorityClass
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+			},
+			wantErr: forbiddenWorkloadPriorityClass,
 		},
 	}
 	for name, tc := range cases {
@@ -531,7 +617,7 @@ func TestExtractPriorityReportsMissingWorkloadPriorityClass(t *testing.T) {
 			recorder := &utiltesting.EventRecorder{}
 
 			// The event does not stand in for the error: the reconcile still fails.
-			_, _, err := ExtractPriority(t.Context(), cl, recorder, tc.job, podSets, nil)
+			_, _, err := ExtractPriority(t.Context(), cl, recorder, tc.job, podSets, tc.customPriorityClassFunc)
 
 			if diff := cmp.Diff(tc.wantErr, err); diff != "" {
 				t.Fatalf("ExtractPriority() error (-want +got):\n%s", diff)

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -3089,6 +3089,36 @@ func TestReconciler(t *testing.T) {
 				},
 			},
 		},
+		// A suspended Job creates no Pod, so the API server never gets to refuse
+		// the name and Kueue is the only thing that resolves it.
+		"a warning names the PriorityClass that does not exist": {
+			job: baseJobWrapper.
+				Clone().
+				Suspend(true).
+				PriorityClass("missing-pc").
+				UID("test-uid").
+				Obj(),
+			wantJob: *baseJobWrapper.
+				Clone().
+				Suspend(true).
+				PriorityClass("missing-pc").
+				UID("test-uid").
+				Obj(),
+			// missing-pc is deliberately absent here.
+			priorityClasses: []client.Object{
+				basePCWrapper.Obj(),
+			},
+			// The error identity is pinned in jobframework, where it is classified.
+			wantErr: cmpopts.AnyError,
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: "job", Namespace: "ns"},
+					EventType: "Warning",
+					Reason:    jobframework.ReasonPriorityClassNotFound,
+					Message:   `PriorityClass "missing-pc" not found`,
+				},
+			},
+		},
 		// The boundary the concept page draws. A Workload whose priority came from
 		// a Pod PriorityClass is not re-resolved, so the label is taken and does
 		// nothing, and nothing is reported. Tracked separately; pinned here so the

--- a/pkg/controller/jobs/mpijob/mpijob_controller_test.go
+++ b/pkg/controller/jobs/mpijob/mpijob_controller_test.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/component-base/featuregate"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -506,12 +507,24 @@ func TestReconciler(t *testing.T) {
 	basePCWrapper := utiltesting.MakePriorityClass("test-pc").
 		PriorityValue(200)
 	testNamespace := utiltesting.MakeNamespaceWrapper("ns").Label(corev1.LabelMetadataName, "ns").Obj()
+	// Every case below reconciles the same MPIJob, so the cases that create a
+	// Workload report the same event. Its name is derived the way the reconciler
+	// derives it rather than spelled out with the generated suffix.
+	createdWorkloadEvents := []utiltesting.EventRecord{
+		{
+			Key:       types.NamespacedName{Name: "mpijob", Namespace: "ns"},
+			EventType: corev1.EventTypeNormal,
+			Reason:    jobframework.ReasonCreatedWorkload,
+			Message:   "Created Workload: ns/" + GetWorkloadNameForMPIJob("mpijob", ""),
+		},
+	}
 	cases := map[string]struct {
 		reconcilerOptions []jobframework.Option
 		job               *kfmpi.MPIJob
 		priorityClasses   []client.Object
 		wantJob           *kfmpi.MPIJob
 		wantWorkloads     []kueue.Workload
+		wantEvents        []utiltesting.EventRecord
 		wantErr           error
 	}{
 		"workload is created with podsets": {
@@ -533,6 +546,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Obj(),
 			},
+			wantEvents: createdWorkloadEvents,
 		},
 		"workload is created with podsets and workloadPriorityClass": {
 			reconcilerOptions: []jobframework.Option{
@@ -558,6 +572,7 @@ func TestReconciler(t *testing.T) {
 					Priority(100).
 					Obj(),
 			},
+			wantEvents: createdWorkloadEvents,
 		},
 		"workload is created with podsets and PriorityClass": {
 			reconcilerOptions: []jobframework.Option{
@@ -583,6 +598,7 @@ func TestReconciler(t *testing.T) {
 					Priority(200).
 					Obj(),
 			},
+			wantEvents: createdWorkloadEvents,
 		},
 		"workload is created with podsets, workloadPriorityClass and PriorityClass": {
 			reconcilerOptions: []jobframework.Option{
@@ -609,6 +625,35 @@ func TestReconciler(t *testing.T) {
 					WorkloadPriorityClassRef("test-wpc").
 					Priority(100).
 					Obj(),
+			},
+			wantEvents: createdWorkloadEvents,
+		},
+		// MPIJob resolves .spec.runPolicy.schedulingPolicy.priorityClass ahead of
+		// the launcher and worker templates, so the name Kueue looks up here never
+		// reaches a Pod spec. Nothing else in the cluster validates it, and the
+		// MPIJob is suspended, so without this warning the reference fails silently.
+		"a warning names the PriorityClass at runPolicy that does not exist": {
+			reconcilerOptions: []jobframework.Option{
+				jobframework.WithManageJobsWithoutQueueName(true),
+				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
+			},
+			job: testingmpijob.MakeMPIJob("mpijob", "ns").GenericLauncherAndWorker().Parallelism(2).
+				PriorityClass("missing-pc").Obj(),
+			// missing-pc is deliberately absent here.
+			priorityClasses: []client.Object{
+				basePCWrapper.Obj(),
+			},
+			wantJob: testingmpijob.MakeMPIJob("mpijob", "ns").GenericLauncherAndWorker().Parallelism(2).
+				PriorityClass("missing-pc").Obj(),
+			// The error identity is pinned in jobframework, where it is classified.
+			wantErr: cmpopts.AnyError,
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: "mpijob", Namespace: "ns"},
+					EventType: corev1.EventTypeWarning,
+					Reason:    jobframework.ReasonPriorityClassNotFound,
+					Message:   `PriorityClass "missing-pc" not found`,
+				},
 			},
 		},
 	}
@@ -650,6 +695,9 @@ func TestReconciler(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.wantWorkloads, gotWorkloads.Items, workloadCmpOpts...); diff != "" {
 				t.Errorf("Workloads after reconcile (-want,+got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantEvents, recorder.RecordedEvents, cmpopts.EquateEmpty(), cmpopts.SortSlices(utiltesting.SortEvents)); diff != "" {
+				t.Errorf("Events after reconcile (-want,+got):\n%s", diff)
 			}
 		})
 	}

--- a/site/content/en/docs/concepts/workload_priority_class.md
+++ b/site/content/en/docs/concepts/workload_priority_class.md
@@ -108,6 +108,23 @@ however the integration of the CRD with Kueue can implement
 to change this behavior. You can read the code for each job integration
 to learn how the priority class is obtained.
 
+## Referencing a PriorityClass
+
+Wherever the workload's priority comes from a `PriorityClass`, that `PriorityClass` must
+exist in the cluster. Kueue cannot resolve a priority from a name that does not exist, so
+it does not create the `Workload`, and the job it would have queued stays suspended.
+
+Kueue reports this as a `Warning` event with the reason `PriorityClassNotFound` on the
+object that named the class, so `kubectl describe` on that object names it. The `Workload`
+is created on a later reconciliation once the `PriorityClass` exists.
+
+Kubernetes refuses a Pod that names a nonexistent `PriorityClass` and reports that on the
+Pod's owner, but a job Kueue has suspended creates no Pod, so that error never appears. A
+CRD that defines the overall pod priority in a dedicated field does not reach a Pod spec
+at all: `MPIJob`, for example, resolves `.spec.runPolicy.schedulingPolicy.priorityClass`
+ahead of its launcher and worker templates, so the name Kueue looks up there need not
+appear on any Pod.
+
 ## Where workload's priority is used
 
 The priority of workloads is used for:

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -566,6 +566,81 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:batch", "area:jobs")
 		})
 	})
 
+	ginkgo.When("The referenced PriorityClass does not exist", func() {
+		ginkgo.It("Should report a warning and create no Workload when the pod template names a class that does not exist", func() {
+			// The API server accepts the Job itself: only Pod creation resolves
+			// priorityClassName, and a suspended Job creates no Pod. Kueue is the
+			// only thing that resolves the name here, so it has to be the one to
+			// report that it does not resolve.
+			job := testingjob.MakeJob(jobName, ns.Name).
+				Queue("main").
+				PriorityClass("missing-pc").
+				Obj()
+			util.MustCreate(ctx, k8sClient, job)
+
+			ginkgo.By("checking the warning is on this Job and names the missing class", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					ok, err := utiltesting.HasMatchingEventAppeared(ctx, k8sClient, func(e *eventsv1.Event) bool {
+						return e.Regarding.Namespace == ns.Name && e.Regarding.Name == job.Name &&
+							e.Regarding.Kind == "Job" && e.Regarding.UID == job.UID &&
+							e.Type == corev1.EventTypeWarning &&
+							e.Reason == jobframework.ReasonPriorityClassNotFound &&
+							e.Note == `PriorityClass "missing-pc" not found`
+					})
+					g.Expect(err).NotTo(gomega.HaveOccurred())
+					g.Expect(ok).To(gomega.BeTrue())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: ns.Name}
+
+			ginkgo.By("checking the workload is not created", func() {
+				gomega.Consistently(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlLookupKey, &kueue.Workload{})).Should(utiltesting.BeNotFoundError())
+				}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+			})
+
+			// The error stays retryable on purpose: the class may simply not have
+			// been created yet, and nothing here watches PriorityClass.
+			ginkgo.By("checking the workload appears once the class is created", func() {
+				pc := utiltesting.MakePriorityClass("missing-pc").PriorityValue(1000).Obj()
+				util.MustCreate(ctx, k8sClient, pc)
+				ginkgo.DeferCleanup(func() {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, pc, true)
+				})
+				util.ExpectWorkloadsWithPodPriority(ctx, k8sClient, pc.Name, pc.Value, wlLookupKey)
+			})
+		})
+
+		ginkgo.It("Should report nothing when the pod template names a class that exists", func() {
+			pc := utiltesting.MakePriorityClass("present-pc").PriorityValue(1000).Obj()
+			util.MustCreate(ctx, k8sClient, pc)
+			ginkgo.DeferCleanup(func() {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, pc, true)
+			})
+
+			job := testingjob.MakeJob(jobName, ns.Name).
+				Queue("main").
+				PriorityClass(pc.Name).
+				Obj()
+			util.MustCreate(ctx, k8sClient, job)
+
+			wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: ns.Name}
+
+			ginkgo.By("checking the workload carries that priority and nothing is reported", func() {
+				util.ExpectWorkloadsWithPodPriority(ctx, k8sClient, pc.Name, pc.Value, wlLookupKey)
+				// Polled as (found, err) rather than inverting an inner assertion, so a
+				// failed Event list is a test failure instead of looking like absence.
+				gomega.Consistently(func() (bool, error) {
+					return utiltesting.HasMatchingEventAppeared(ctx, k8sClient, func(e *eventsv1.Event) bool {
+						return e.Regarding.Namespace == ns.Name && e.Regarding.Name == job.Name &&
+							e.Reason == jobframework.ReasonPriorityClassNotFound
+					})
+				}, util.ConsistentDuration, util.ShortInterval).Should(gomega.BeFalse())
+			})
+		})
+	})
+
 	ginkgo.When("A prebuilt workload is used", func() {
 		ginkgo.It("Should get suspended if the workload is not found", func() {
 			job := testingjob.MakeJob("job", ns.Name).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/area integrations
/area website

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
A job that names a scheduling.k8s.io PriorityClass that does not exist stalls in reconciliation. Without a priority there is no Workload, so the job stays suspended and unqueued, and nothing reports why. ExtractPriority now reports that miss as a Warning event on the object, alongside the WorkloadPriorityClassNotFound event it already reports, so one call site covers every path that reaches the lookup.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #15171 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added a `Warning` event with reason `PriorityClassNotFound` when Kueue cannot resolve the `scheduling.k8s.io` `PriorityClass` a job names, making it visible why a suspended job stays unqueued with no `Workload` created.
```

____
Disclosure: AI assistance was used in the drafting of tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added warning events when referenced Kubernetes `PriorityClass` objects are missing.
  * Workload creation is delayed until a missing priority class becomes available.
  * Priority resolution now consistently reports missing classes across supported workload types.

* **Documentation**
  * Documented priority class references, missing-class behavior, warning events, and workload-specific effects.

* **Bug Fixes**
  * Improved priority propagation and error handling for Jobs, Pods, and MPIJobs using unavailable priority classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->