### PR TITLE
Extract resource multiplication to a helper

### DIFF
--- a/pkg/util/resource/resource.go
+++ b/pkg/util/resource/resource.go
@@ -133,3 +133,12 @@ func isNativeResource(name corev1.ResourceName) bool {
 func isHugePageResourceName(name corev1.ResourceName) bool {
 	return strings.HasPrefix(string(name), corev1.ResourceHugePagesPrefix)
 }
+
+// MultiplyQuantity returns the product of two resource.Quantity values with arbitrary precision.
+func MultiplyQuantity(value, mul resource.Quantity) resource.Quantity {
+	value = value.DeepCopy()
+	mul = mul.DeepCopy()
+	product := inf.Dec{}
+	product.Mul(value.AsDec(), mul.AsDec())
+	return *resource.NewDecimalQuantity(product, value.Format)
+}

--- a/pkg/util/resource/resource_test.go
+++ b/pkg/util/resource/resource_test.go
@@ -442,3 +442,49 @@ func TestMergeKeepMaxOwnsItsResult(t *testing.T) {
 		})
 	}
 }
+
+func TestMultiplyQuantity(t *testing.T) {
+	cases := map[string]struct {
+		value resource.Quantity
+		mul   resource.Quantity
+		want  resource.Quantity
+	}{
+		"integer multiplication": {
+			value: resource.MustParse("2"),
+			mul:   resource.MustParse("3"),
+			want:  resource.MustParse("6"),
+		},
+		"multiplication by zero": {
+			value: resource.MustParse("10"),
+			mul:   resource.MustParse("0"),
+			want:  resource.MustParse("0"),
+		},
+		"milli quantity multiplication": {
+			value: resource.MustParse("500m"),
+			mul:   resource.MustParse("2"),
+			want:  resource.MustParse("1"),
+		},
+		"fractional multiplier": {
+			value: resource.MustParse("10"),
+			mul:   resource.MustParse("0.5"),
+			want:  resource.MustParse("5"),
+		},
+		"binary SI format preserved": {
+			value: resource.MustParse("1Gi"),
+			mul:   resource.MustParse("2"),
+			want:  resource.MustParse("2Gi"),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := MultiplyQuantity(tc.value, tc.mul)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("MultiplyQuantity() mismatch (-want +got):\n%s", diff)
+			}
+			if got.Format != tc.value.Format {
+				t.Errorf("MultiplyQuantity() format mismatch: got %v, want %v", got.Format, tc.value.Format)
+			}
+		})
+	}
+}

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"gopkg.in/inf.v0"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -660,13 +659,13 @@ func applyResourceTransformations(input corev1.ResourceList, transforms map[core
 		outputInputVal := inputQuantity
 		if mapping.MultiplyBy != "" {
 			if q, ok := input[mapping.MultiplyBy]; ok {
-				outputInputVal = multiplyResourceQuantities(inputQuantity, q)
+				outputInputVal = utilresource.MultiplyQuantity(inputQuantity, q)
 			}
 		}
 
 		outputs := make(corev1.ResourceList, len(mapping.Outputs))
 		for outputName, baseFactor := range mapping.Outputs {
-			outputs[outputName] = multiplyResourceQuantities(outputInputVal, baseFactor)
+			outputs[outputName] = utilresource.MultiplyQuantity(outputInputVal, baseFactor)
 		}
 		// Summed rather than assigned, so which order the input map is walked
 		// in does not decide which contribution to a name survives.
@@ -681,14 +680,6 @@ func applyResourceTransformations(input corev1.ResourceList, transforms map[core
 		}
 	}
 	return utilresource.MergeResourceListKeepSum(retained, generated)
-}
-
-func multiplyResourceQuantities(value, mul resource.Quantity) resource.Quantity {
-	value = value.DeepCopy()
-	mul = mul.DeepCopy()
-	product := inf.Dec{}
-	product.Mul(value.AsDec(), mul.AsDec())
-	return *resource.NewDecimalQuantity(product, value.Format)
 }
 
 func CanBePartiallyAdmitted(wl *kueue.Workload) bool {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

Extract resource multiplication to a helper method. The helper will by also used by DQO controller for `EffectiveCapacityMultiplier` in following PRs.

#### Which issue(s) this PR fixes:
Part of #12382 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiplying resource quantities while preserving their original format, including milli- and binary-SI quantities.

* **Bug Fixes**
  * Improved resource transformation calculations for zero, integer, and fractional multipliers.

* **Tests**
  * Added coverage for quantity multiplication across multiple formats and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->