### PR TITLE
Do not clear minCount for Elastic Partial Scale-Up

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1493,7 +1493,7 @@ func EquivalentToWorkload(ctx context.Context, c client.Client, job GenericJob, 
 	if err != nil {
 		return false, err
 	}
-	jobPodSets := clearMinCountsIfFeatureDisabled(getPodSets)
+	jobPodSets := clearUnusableMinCounts(getPodSets, wl)
 
 	opts := make([]equality.ComparePodSetsOption, 0, 2)
 	if workload.IsAdmitted(wl) {
@@ -1819,7 +1819,7 @@ func (r *JobReconciler) prepareWorkload(ctx context.Context, job GenericJob, wl 
 		return err
 	}
 
-	wl.Spec.PodSets = clearMinCountsIfFeatureDisabled(wl.Spec.PodSets)
+	wl.Spec.PodSets = clearUnusableMinCounts(wl.Spec.PodSets, wl)
 
 	if WorkloadSliceEnabled(job) {
 		return prepareWorkloadSlice(ctx, r.client, job, wl)
@@ -2082,9 +2082,12 @@ func (r *genericReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return b.Complete(r)
 }
 
-// clearMinCountsIfFeatureDisabled sets the minCount for all podSets to nil if the PartialAdmission feature is not enabled
-func clearMinCountsIfFeatureDisabled(in []kueue.PodSet) []kueue.PodSet {
-	if features.Enabled(features.PartialAdmission) || len(in) == 0 {
+// clearUnusableMinCounts sets the minCount for all podSets to nil when no feature honors MinCount
+// for wl, so that a disabled feature's leftover minCount cannot be acted upon. The podSets are
+// passed separately from wl because callers compare job-derived podSets against wl, which supplies
+// only the feature/annotation state for the decision.
+func clearUnusableMinCounts(in []kueue.PodSet, wl *kueue.Workload) []kueue.PodSet {
+	if len(in) == 0 || workload.MinCountsUsable(wl) {
 		return in
 	}
 	for i := range in {

--- a/pkg/controller/jobframework/reconciler_internal_test.go
+++ b/pkg/controller/jobframework/reconciler_internal_test.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/pkg/workloadslicing"
 )
 
 func TestExpectedRunningPodSetsKeepsImplicitTASRequestInSync(t *testing.T) {
@@ -70,5 +71,71 @@ func TestExpectedRunningPodSetsKeepsImplicitTASRequestInSync(t *testing.T) {
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("running PodSets (-want,+got):\n%s", diff)
+	}
+}
+
+func TestClearUnusableMinCounts(t *testing.T) {
+	podSetsWithMinCount := func() []kueue.PodSet {
+		return []kueue.PodSet{
+			*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 10).SetMinimumCount(5).Obj(),
+		}
+	}
+	elasticWorkload := func() *utiltestingapi.WorkloadWrapper {
+		return utiltestingapi.MakeWorkload("wl", "default").
+			Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue)
+	}
+
+	nonElastic := utiltestingapi.MakeWorkload("wl", "default").Obj()
+	// The scale-up strategy annotation is set on the Job and is not propagated to the Workload, so
+	// it cannot take part in this decision; opting in is enforced where MinCount is produced.
+	elastic := elasticWorkload().Obj()
+
+	cases := map[string]struct {
+		partialAdmission     bool
+		partialReplicaScale  bool
+		wl                   *kueue.Workload
+		wantMinCountsCleared bool
+	}{
+		"PartialAdmission enabled: minCount is kept regardless of elastic status": {
+			partialAdmission:     true,
+			wl:                   nonElastic,
+			wantMinCountsCleared: false,
+		},
+		"both features disabled: minCount is cleared": {
+			wl:                   nonElastic,
+			wantMinCountsCleared: true,
+		},
+		"partial scale-up enabled, non-elastic workload: minCount is cleared": {
+			partialReplicaScale:  true,
+			wl:                   nonElastic,
+			wantMinCountsCleared: true,
+		},
+		"partial scale-up enabled, elastic workload: minCount is kept": {
+			partialReplicaScale:  true,
+			wl:                   elastic,
+			wantMinCountsCleared: false,
+		},
+		"elastic workload but partial scale-up disabled: minCount is cleared": {
+			wl:                   elastic,
+			wantMinCountsCleared: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, map[featuregate.Feature]bool{
+				features.ElasticJobsViaWorkloadSlices:                          true,
+				features.PartialAdmission:                                      tc.partialAdmission,
+				features.ElasticJobsViaWorkloadSlicesWithPartialReplicaScaleUp: tc.partialReplicaScale,
+			})
+
+			got := clearUnusableMinCounts(podSetsWithMinCount(), tc.wl)
+
+			for _, ps := range got {
+				if cleared := ps.MinCount == nil; cleared != tc.wantMinCountsCleared {
+					t.Errorf("podSet %q: minCount cleared = %v, want %v", ps.Name, cleared, tc.wantMinCountsCleared)
+				}
+			}
+		})
 	}
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -938,8 +938,7 @@ func (s *Scheduler) getInitialAssignments(ctx context.Context, wl *workload.Info
 		}
 	}
 
-	if (features.Enabled(features.PartialAdmission) || (features.Enabled(features.ElasticJobsViaWorkloadSlicesWithPartialReplicaScaleUp) && workload.IsElasticWorkload(wl.Obj))) &&
-		wl.CanBePartiallyAdmitted() {
+	if workload.MinCountsUsable(wl.Obj) && wl.CanBePartiallyAdmitted() {
 		reducer := flavorassigner.NewOrderedPodSetReducer(wl.Obj.Spec.PodSets, func(nextCounts []int32) (*partialAssignment, bool) {
 			assignment := flvAssigner.Assign(ctx, nextCounts)
 			mode := assignment.RepresentativeMode()

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -1709,6 +1709,24 @@ func IsElasticWorkload(wl *kueue.Workload) bool {
 	return features.Enabled(features.ElasticJobsViaWorkloadSlices) && wl.GetAnnotations()[constants.ElasticJobAnnotation] == "true"
 }
 
+// MinCountsUsable reports whether PodSet.MinCount is honored for the given Workload, i.e. whether
+// the workload may be partially admitted. MinCount is populated by two independent mechanisms, each
+// with its own feature gate: PartialAdmission (classic, e.g. batch/Job's job-min-parallelism) and
+// ElasticJobsViaWorkloadSlicesWithPartialReplicaScaleUp (elastic partial scale-up).
+//
+// Both the scheduler and the job reconciler must agree on this predicate: the reconciler clears
+// MinCounts it reports as unusable, so a looser check in the scheduler would admit on values the
+// reconciler already erased.
+//
+// The elastic branch cannot narrow further to workloads that actually opted into the "partial"
+// scale-up strategy, because the elastic-job-scale-up-strategy annotation is set on the Job and is
+// not propagated to the Workload. Opting in is instead enforced where MinCount is produced, so an
+// "atomic" workload reaches the scheduler with no MinCount to act on.
+func MinCountsUsable(wl *kueue.Workload) bool {
+	return features.Enabled(features.PartialAdmission) ||
+		(features.Enabled(features.ElasticJobsViaWorkloadSlicesWithPartialReplicaScaleUp) && IsElasticWorkload(wl))
+}
+
 // UnadmittedWorkloadReasonWithFallback returns the granularReason if the UnadmittedWorkloadsObservability
 // feature gate is enabled, otherwise it returns the fallback.
 func UnadmittedWorkloadReasonWithFallback(granularReason, fallback string) string {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
`clearMinCountsIfFeatureDisabled` wiped `podSets[*].minCount` whenever PartialAdmission was disabled — but elastic partial scale-up (KEP-12100) uses that same field under its own gate. 
The scheduler already checked both gates; the reconciler didn't. 
So with `ElasticJobsViaWorkloadSlicesWithPartialReplicaScaleUp=true` and `PartialAdmission=false`, the reconciler erased `minCount` before the scheduler saw it and elastic scale-ups were never partially admitted.

Adds `workload.MinCountsUsable()` — one predicate for "is minCount honored for this Workload".
Reconciler now uses it (the fix); scheduler uses it in place of its equivalent inline check, so the two can't drift apart again.
Renames `clearMinCountsIfFeatureDisabled` → `clearUnusableMinCounts`.

#### Which issue(s) this PR fixes:
Relates to #12100 

#### Special notes for your reviewer:
Scheduler behavior is unchanged — it's the same condition, just shared.

The helper only checks the feature gate and whether the Workload is elastic — it deliberately doesn't check for strategy: partial, because that annotation is only on the Job and never copied to the Workload, so the check would always fail. 
It isn't needed anyway: minCount is only ever written for jobs that asked for partial, so an atomic job reaches the scheduler with no minCount to act on.

AI assistance disclosure: this PR — code, tests, and this description — was written with the assistance of Claude Code. All changes were reviewed and verified by me.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved handling of minimum pod counts during workload admission.
* Minimum pod counts are now preserved when supported by the workload configuration and cleared only when they cannot affect admission.
* Scheduling now applies partial-admission pod-count adjustments consistently across supported workload types, including eligible elastic workloads.
* Improved consistency between workload validation and scheduling decisions for minimum pod counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->