### PR TITLE
Implement DynamicQuotaOrchestrator reconciler for capacity discovery - phase 1

### DIFF
--- a/charts/kueue/templates/rbac/role.yaml
+++ b/charts/kueue/templates/rbac/role.yaml
@@ -298,6 +298,7 @@ rules:
       - admissionchecks/status
       - clusterqueues/status
       - cohorts/status
+      - dynamicquotaorchestrators/status
       - localqueues/status
       - multikueueclusters/status
       - workloads/status
@@ -308,7 +309,9 @@ rules:
   - apiGroups:
       - kueue.x-k8s.io
     resources:
+      - capacityproviders
       - cohorts
+      - dynamicquotaorchestrators
       - localqueues
       - multikueueclusters
       - multikueueconfigs

--- a/config/components/rbac/role.yaml
+++ b/config/components/rbac/role.yaml
@@ -279,6 +279,7 @@ rules:
   - admissionchecks/status
   - clusterqueues/status
   - cohorts/status
+  - dynamicquotaorchestrators/status
   - localqueues/status
   - multikueueclusters/status
   - workloads/status
@@ -289,7 +290,9 @@ rules:
 - apiGroups:
   - kueue.x-k8s.io
   resources:
+  - capacityproviders
   - cohorts
+  - dynamicquotaorchestrators
   - localqueues
   - multikueueclusters
   - multikueueconfigs

--- a/pkg/controller/core/core.go
+++ b/pkg/controller/core/core.go
@@ -134,6 +134,13 @@ func SetupControllers(mgr ctrl.Manager, qManager *qcache.Manager, cc *schdcache.
 		}
 	}
 
+	if features.Enabled(features.DynamicQuotaOrchestration) {
+		dqoRec := NewDynamicQuotaOrchestratorReconciler(mgr.GetClient(), WithDynamicQuotaOrchestratorRoleTracker(opts.RoleTracker))
+		if err := dqoRec.SetupWithManager(mgr); err != nil {
+			return "DynamicQuotaOrchestrator", err
+		}
+	}
+
 	qManager.AddTopologyUpdateWatcher(cqRec)
 	qManager.AddWorkloadUpdateWatcher(qRec)
 	qManager.AddWorkloadUpdateWatcher(cqRec)

--- a/pkg/controller/core/dynamicquotaorchestrator_controller.go
+++ b/pkg/controller/core/dynamicquotaorchestrator_controller.go
@@ -1,0 +1,241 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"slices"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+
+	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
+	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
+	"sigs.k8s.io/kueue/pkg/features"
+	utilresource "sigs.k8s.io/kueue/pkg/util/resource"
+	"sigs.k8s.io/kueue/pkg/util/roletracker"
+)
+
+const (
+	dqoControllerName = "dynamicquotaorchestrator-reconciler"
+)
+
+type DynamicQuotaOrchestratorReconciler struct {
+	client      client.Client
+	roleTracker *roletracker.RoleTracker
+	logName     string
+}
+
+type DynamicQuotaOrchestratorReconcilerOption func(*DynamicQuotaOrchestratorReconciler)
+
+// WithDynamicQuotaOrchestratorRoleTracker configures the RoleTracker for the reconciler.
+func WithDynamicQuotaOrchestratorRoleTracker(rt *roletracker.RoleTracker) DynamicQuotaOrchestratorReconcilerOption {
+	return func(r *DynamicQuotaOrchestratorReconciler) {
+		r.roleTracker = rt
+	}
+}
+
+// NewDynamicQuotaOrchestratorReconciler instantiates a new DynamicQuotaOrchestrator reconciler.
+func NewDynamicQuotaOrchestratorReconciler(client client.Client, opts ...DynamicQuotaOrchestratorReconcilerOption) *DynamicQuotaOrchestratorReconciler {
+	r := &DynamicQuotaOrchestratorReconciler{
+		client:  client,
+		logName: dqoControllerName,
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
+}
+
+func (r *DynamicQuotaOrchestratorReconciler) logger() logr.Logger {
+	return roletracker.WithReplicaRole(ctrl.Log.WithName(r.logName), r.roleTracker)
+}
+
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=dynamicquotaorchestrators,verbs=get;list;watch
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=dynamicquotaorchestrators/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=capacityproviders,verbs=get;list;watch
+
+// SetupWithManager registers the DynamicQuotaOrchestrator controller and its watches with the manager.
+func (r *DynamicQuotaOrchestratorReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&kueuealpha.DynamicQuotaOrchestrator{}).
+		Watches(
+			&kueuealpha.CapacityProvider{},
+			handler.EnqueueRequestsFromMapFunc(r.mapCapacityProviderToDQOs),
+		).
+		Complete(r)
+}
+
+// mapCapacityProviderToDQOs maps a CapacityProvider event to reconcile requests for all DynamicQuotaOrchestrators referencing it.
+func (r *DynamicQuotaOrchestratorReconciler) mapCapacityProviderToDQOs(ctx context.Context, obj client.Object) []ctrl.Request {
+	capacityProvider, ok := obj.(*kueuealpha.CapacityProvider)
+	if !ok || capacityProvider == nil {
+		return nil
+	}
+	var orchestratorList kueuealpha.DynamicQuotaOrchestratorList
+	if err := r.client.List(ctx, &orchestratorList, client.MatchingFields{
+		indexer.DynamicQuotaOrchestratorCapacityProviderKey: capacityProvider.Name,
+	}); err != nil {
+		r.logger().Error(err, "Failed to list DynamicQuotaOrchestrators for CapacityProvider", "capacityProvider", capacityProvider.Name)
+		return nil
+	}
+	requests := make([]ctrl.Request, 0, len(orchestratorList.Items))
+	for _, orchestrator := range orchestratorList.Items {
+		requests = append(requests, ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: orchestrator.Name},
+		})
+	}
+	return requests
+}
+
+// Reconcile coordinates capacity discovery for a DynamicQuotaOrchestrator.
+func (r *DynamicQuotaOrchestratorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	if !features.Enabled(features.DynamicQuotaOrchestration) {
+		return ctrl.Result{}, nil
+	}
+
+	log := ctrl.LoggerFrom(ctx)
+	log.V(2).Info("Reconcile DynamicQuotaOrchestrator")
+
+	var orchestrator kueuealpha.DynamicQuotaOrchestrator
+	if err := r.client.Get(ctx, req.NamespacedName, &orchestrator); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if !orchestrator.DeletionTimestamp.IsZero() {
+		return ctrl.Result{}, nil
+	}
+
+	oldStatus := orchestrator.Status.DeepCopy()
+
+	// Phase 1: Capacity Discovery
+	discoveryErr := r.reconcileDiscovery(ctx, &orchestrator)
+	err := r.updateStatus(ctx, &orchestrator, oldStatus)
+	return ctrl.Result{}, errors.Join(discoveryErr, err)
+}
+
+// reconcileDiscovery performs Phase 1 reconciliation: aggregates normalized capacities across referenced CapacityProviders.
+func (r *DynamicQuotaOrchestratorReconciler) reconcileDiscovery(ctx context.Context, orchestrator *kueuealpha.DynamicQuotaOrchestrator) error {
+	aggregatedCapacity := make(map[kueuealpha.ResourceFlavorReference]corev1.ResourceList)
+
+	for _, providerContribution := range orchestrator.Spec.CapacityDiscovery.Providers {
+		var capacityProvider kueuealpha.CapacityProvider
+		if err := r.client.Get(ctx, types.NamespacedName{Name: string(providerContribution.Name)}, &capacityProvider); err != nil {
+			if apierrors.IsNotFound(err) {
+				r.setDiscoveryCondition(
+					orchestrator,
+					metav1.ConditionFalse,
+					kueuealpha.DynamicQuotaOrchestratorReasonMisconfigured,
+					fmt.Sprintf("CapacityProvider %q not found", providerContribution.Name),
+				)
+				orchestrator.Status.EffectiveCapacity = nil
+				return nil
+			}
+			return err
+		}
+
+		if !apimeta.IsStatusConditionTrue(capacityProvider.Status.Conditions, kueuealpha.CapacityProviderCapacitySynchronized) {
+			r.setDiscoveryCondition(
+				orchestrator,
+				metav1.ConditionFalse,
+				kueuealpha.DynamicQuotaOrchestratorReasonProviderNotReady,
+				fmt.Sprintf("CapacityProvider %q is not synchronized", providerContribution.Name),
+			)
+			orchestrator.Status.EffectiveCapacity = nil
+			return nil
+		}
+
+		aggregateProviderCapacity(capacityProvider.Status.Capacity, capacityProvider.Spec.OrchestratedFlavors, providerContribution.EffectiveCapacityMultiplier, aggregatedCapacity)
+	}
+
+	effectiveCapacityFlavors := make([]kueuealpha.EffectiveCapacityFlavor, 0, len(aggregatedCapacity))
+	for _, flavorName := range slices.Sorted(maps.Keys(aggregatedCapacity)) {
+		effectiveCapacityFlavors = append(effectiveCapacityFlavors, kueuealpha.EffectiveCapacityFlavor{
+			Name:      flavorName,
+			Resources: aggregatedCapacity[flavorName],
+		})
+	}
+
+	orchestrator.Status.EffectiveCapacity = &kueuealpha.EffectiveCapacity{
+		Flavors: effectiveCapacityFlavors,
+	}
+	r.setDiscoveryCondition(orchestrator, metav1.ConditionTrue, kueuealpha.DynamicQuotaOrchestratorReasonComputed, "Aggregated capacity successfully computed")
+	return nil
+}
+
+// aggregateProviderCapacity scales and adds flavor resource quantities from a single CapacityProvider into the running aggregated total,
+// filtering exclusively by the flavors declared in the CapacityProvider's spec.orchestratedFlavors.
+func aggregateProviderCapacity(
+	capacity *kueuealpha.CapacityProviderNormalizedCapacity,
+	orchestratedFlavors []kueuealpha.CapacityProviderOrchestratedFlavor,
+	multiplier *resource.Quantity,
+	aggregatedCapacity map[kueuealpha.ResourceFlavorReference]corev1.ResourceList,
+) {
+	if capacity == nil {
+		return
+	}
+	allowedFlavors := sets.New[kueuealpha.ResourceFlavorReference]()
+	for _, f := range orchestratedFlavors {
+		allowedFlavors.Insert(f.Name)
+	}
+	for _, flavor := range capacity.Flavors {
+		if !allowedFlavors.Has(flavor.Name) {
+			continue
+		}
+		res := flavor.Resources
+		if len(res) == 0 {
+			continue
+		}
+		if multiplier != nil {
+			res = make(corev1.ResourceList, len(flavor.Resources))
+			for k, v := range flavor.Resources {
+				res[k] = utilresource.MultiplyQuantity(v, *multiplier)
+			}
+		}
+		aggregatedCapacity[flavor.Name] = utilresource.MergeResourceListKeepSum(aggregatedCapacity[flavor.Name], res)
+	}
+}
+
+func (r *DynamicQuotaOrchestratorReconciler) setDiscoveryCondition(orchestrator *kueuealpha.DynamicQuotaOrchestrator, status metav1.ConditionStatus, reason, message string) {
+	apimeta.SetStatusCondition(&orchestrator.Status.Conditions, metav1.Condition{
+		Type:               kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+		Status:             status,
+		ObservedGeneration: orchestrator.Generation,
+		Reason:             reason,
+		Message:            message,
+	})
+}
+
+func (r *DynamicQuotaOrchestratorReconciler) updateStatus(ctx context.Context, orchestrator *kueuealpha.DynamicQuotaOrchestrator, oldStatus *kueuealpha.DynamicQuotaOrchestratorStatus) error {
+	if equality.Semantic.DeepEqual(oldStatus, &orchestrator.Status) {
+		return nil
+	}
+	return r.client.Status().Update(ctx, orchestrator)
+}

--- a/pkg/controller/core/dynamicquotaorchestrator_controller_test.go
+++ b/pkg/controller/core/dynamicquotaorchestrator_controller_test.go
@@ -1,0 +1,367 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
+	"sigs.k8s.io/kueue/pkg/features"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingalpha "sigs.k8s.io/kueue/pkg/util/testing/v1alpha1"
+)
+
+func TestDynamicQuotaOrchestratorReconcile(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.DynamicQuotaOrchestration, true)
+	halfMultiplier := resource.MustParse("0.5")
+
+	cases := map[string]struct {
+		enableFeatureGate *bool
+		dqo               *kueuealpha.DynamicQuotaOrchestrator
+		capacityProviders []*kueuealpha.CapacityProvider
+		wantDQO           *kueuealpha.DynamicQuotaOrchestrator
+		wantErr           bool
+	}{
+		"discovery-only: provider not found": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-1").
+				DiscoveryProvider("non-existent-provider", nil).
+				Obj(),
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-1").
+				DiscoveryProvider("non-existent-provider", nil).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonMisconfigured,
+					Message: "CapacityProvider \"non-existent-provider\" not found",
+				}).
+				Obj(),
+			wantErr: false,
+		},
+		"discovery-only: provider not ready (no condition)": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-1").
+				DiscoveryProvider("cp-1", nil).
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-1").
+				DiscoveryProvider("cp-1", nil).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonProviderNotReady,
+					Message: "CapacityProvider \"cp-1\" is not synchronized",
+				}).
+				Obj(),
+			wantErr: false,
+		},
+		"discovery-only: single provider aggregated successfully": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-1").
+				DiscoveryProvider("cp-1", nil).
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
+								Resource(corev1.ResourceCPU, "100").
+								Resource(corev1.ResourceMemory, "50Gi").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-1").
+				DiscoveryProvider("cp-1", nil).
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("default-flavor").
+							Resource(corev1.ResourceCPU, "100").
+							Resource(corev1.ResourceMemory, "50Gi").
+							Obj(),
+					).
+					Obj(),
+				).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Obj(),
+		},
+		"discovery-only: multiple providers with multipliers": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-1").
+				DiscoveryProvider("cp-1", &halfMultiplier).
+				DiscoveryProvider("cp-2", &halfMultiplier).
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
+								Resource(corev1.ResourceCPU, "100").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+				utiltestingalpha.MakeCapacityProvider("cp-2").
+					OrchestratedFlavors("default-flavor", "gpu-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
+								Resource(corev1.ResourceCPU, "200").
+								Obj(),
+							utiltestingalpha.MakeNormalizedCapacityFlavor("gpu-flavor").
+								Resource("nvidia.com/gpu", "8").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-1").
+				DiscoveryProvider("cp-1", &halfMultiplier).
+				DiscoveryProvider("cp-2", &halfMultiplier).
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("default-flavor").
+							Resource(corev1.ResourceCPU, "150").
+							Obj(),
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("gpu-flavor").
+							Resource("nvidia.com/gpu", "4").
+							Obj(),
+					).
+					Obj(),
+				).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Obj(),
+		},
+		"discovery-only: filters flavors not declared in spec.orchestratedFlavors": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-filter").
+				DiscoveryProvider("cp-1", nil).
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("allowed-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("allowed-flavor").
+								Resource(corev1.ResourceCPU, "50").
+								Obj(),
+							utiltestingalpha.MakeNormalizedCapacityFlavor("unorchestrated-flavor").
+								Resource(corev1.ResourceCPU, "50").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-filter").
+				DiscoveryProvider("cp-1", nil).
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("allowed-flavor").
+							Resource(corev1.ResourceCPU, "50").
+							Obj(),
+					).
+					Obj(),
+				).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Obj(),
+		},
+		"discovery-only: no matching orchestrated flavors": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-no-match").
+				DiscoveryProvider("cp-1", nil).
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("other-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("provider-flavor").
+								Resource(corev1.ResourceCPU, "10").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-no-match").
+				DiscoveryProvider("cp-1", nil).
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors().
+					Obj(),
+				).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Obj(),
+		},
+		"discovery-only: provider reports empty capacity": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-empty").
+				DiscoveryProvider("cp-1", nil).
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().Obj()).
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-empty").
+				DiscoveryProvider("cp-1", nil).
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors().
+					Obj(),
+				).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Obj(),
+		},
+		"discovery-only: provider reports nil capacity with synchronized condition": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-nil-capacity").
+				DiscoveryProvider("cp-1", nil).
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-nil-capacity").
+				DiscoveryProvider("cp-1", nil).
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors().
+					Obj(),
+				).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Obj(),
+		},
+		"feature gate disabled": {
+			enableFeatureGate: new(bool),
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-disabled").
+				DiscoveryProvider("cp-1", nil).
+				Obj(),
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-disabled").
+				DiscoveryProvider("cp-1", nil).
+				Obj(),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if tc.enableFeatureGate != nil {
+				features.SetFeatureGateDuringTest(t, features.DynamicQuotaOrchestration, *tc.enableFeatureGate)
+			}
+			builder := utiltesting.NewClientBuilder()
+
+			objs := []client.Object{tc.dqo}
+			for _, cp := range tc.capacityProviders {
+				objs = append(objs, cp)
+			}
+
+			cl := builder.WithObjects(objs...).WithStatusSubresource(objs...).Build()
+			r := NewDynamicQuotaOrchestratorReconciler(cl)
+
+			ctx, _ := utiltesting.ContextWithLog(t)
+			_, err := r.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: tc.dqo.Name},
+			})
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("Reconcile error = %v, wantErr %v", err, tc.wantErr)
+			}
+
+			var gotDQO kueuealpha.DynamicQuotaOrchestrator
+			if err := cl.Get(ctx, types.NamespacedName{Name: tc.dqo.Name}, &gotDQO); err != nil {
+				t.Fatalf("Failed to get DQO: %v", err)
+			}
+
+			if diff := cmp.Diff(tc.wantDQO, &gotDQO,
+				cmpopts.IgnoreTypes(metav1.TypeMeta{}),
+				cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion", "CreationTimestamp", "Finalizers"),
+				cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime"),
+				cmpopts.EquateEmpty(),
+			); diff != "" {
+				t.Errorf("Unexpected DQO (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/controller/core/indexer/indexer.go
+++ b/pkg/controller/core/indexer/indexer.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
 	utilresource "sigs.k8s.io/kueue/pkg/util/resource"
@@ -35,17 +36,18 @@ import (
 )
 
 const (
-	WorkloadQueueKey                     = "spec.queueName"
-	WorkloadClusterQueueKey              = "status.admission.clusterQueue"
-	QueueClusterQueueKey                 = "spec.clusterQueue"
-	LimitRangeHasContainerOrPodType      = "spec.hasContainerOrPodType"
-	WorkloadQuotaReservedKey             = "status.quotaReserved"
-	WorkloadRuntimeClassKey              = "spec.runtimeClass"
-	OwnerReferenceUID                    = "metadata.ownerReferences.uid"
-	WorkloadAdmissionCheckKey            = "status.admissionChecks"
-	WorkloadPriorityClassKey             = "spec.priorityClassRef"
-	DeviceClassExtendedResourceNameIndex = "spec.extendedResourceName"
-	WorkloadExtendedResourceKey          = "spec.extendedResources"
+	WorkloadQueueKey                            = "spec.queueName"
+	WorkloadClusterQueueKey                     = "status.admission.clusterQueue"
+	QueueClusterQueueKey                        = "spec.clusterQueue"
+	LimitRangeHasContainerOrPodType             = "spec.hasContainerOrPodType"
+	WorkloadQuotaReservedKey                    = "status.quotaReserved"
+	WorkloadRuntimeClassKey                     = "spec.runtimeClass"
+	OwnerReferenceUID                           = "metadata.ownerReferences.uid"
+	WorkloadAdmissionCheckKey                   = "status.admissionChecks"
+	WorkloadPriorityClassKey                    = "spec.priorityClassRef"
+	DeviceClassExtendedResourceNameIndex        = "spec.extendedResourceName"
+	WorkloadExtendedResourceKey                 = "spec.extendedResources"
+	DynamicQuotaOrchestratorCapacityProviderKey = "spec.capacityDiscovery.providers.name"
 	// WorkloadSliceNameKey is an index for pods by their workload slice name annotation.
 	// Used to find pods belonging to an elastic workload slice chain.
 	WorkloadSliceNameKey = "metadata.workloadSliceName"
@@ -275,6 +277,19 @@ func IndexDeviceClassExtendedResourceName(obj client.Object) []string {
 	return []string{*dc.Spec.ExtendedResourceName}
 }
 
+// IndexDynamicQuotaOrchestratorCapacityProvider indexes DynamicQuotaOrchestrator by referenced CapacityProvider names.
+func IndexDynamicQuotaOrchestratorCapacityProvider(obj client.Object) []string {
+	dqo, ok := obj.(*kueuealpha.DynamicQuotaOrchestrator)
+	if !ok {
+		return nil
+	}
+	providers := make([]string, 0, len(dqo.Spec.CapacityDiscovery.Providers))
+	for _, p := range dqo.Spec.CapacityDiscovery.Providers {
+		providers = append(providers, string(p.Name))
+	}
+	return providers
+}
+
 // Setup sets the index with the given fields for core apis.
 func Setup(ctx context.Context, indexer client.FieldIndexer) error {
 	if err := indexer.IndexField(ctx, &kueue.Workload{}, WorkloadQueueKey, IndexWorkloadQueue); err != nil {
@@ -324,6 +339,11 @@ func Setup(ctx context.Context, indexer client.FieldIndexer) error {
 		}
 		if err := indexer.IndexField(ctx, &kueue.Workload{}, WorkloadExtendedResourceKey, IndexWorkloadExtendedResources); err != nil {
 			return fmt.Errorf("setting index on extended resources for Workload: %w", err)
+		}
+	}
+	if features.Enabled(features.DynamicQuotaOrchestration) {
+		if err := indexer.IndexField(ctx, &kueuealpha.DynamicQuotaOrchestrator{}, DynamicQuotaOrchestratorCapacityProviderKey, IndexDynamicQuotaOrchestratorCapacityProvider); err != nil {
+			return fmt.Errorf("setting index on capacity provider for DynamicQuotaOrchestrator: %w", err)
 		}
 	}
 	return nil

--- a/pkg/controller/core/indexer/indexer_test.go
+++ b/pkg/controller/core/indexer/indexer_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/features"
@@ -653,6 +654,44 @@ func TestIndexWorkloadExtendedResources(t *testing.T) {
 				cmpopts.SortSlices(func(a, b string) bool { return a < b }),
 				cmpopts.EquateEmpty(),
 			); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestIndexDynamicQuotaOrchestratorCapacityProvider(t *testing.T) {
+	cases := map[string]struct {
+		obj  client.Object
+		want []string
+	}{
+		"not DynamicQuotaOrchestrator": {
+			obj:  &kueue.Workload{},
+			want: nil,
+		},
+		"no providers": {
+			obj:  &kueuealpha.DynamicQuotaOrchestrator{},
+			want: []string{},
+		},
+		"multiple providers": {
+			obj: &kueuealpha.DynamicQuotaOrchestrator{
+				Spec: kueuealpha.DynamicQuotaOrchestratorSpec{
+					CapacityDiscovery: kueuealpha.CapacityDiscovery{
+						Providers: []kueuealpha.CapacityDiscoveryProviderContribution{
+							{Name: "cp1"},
+							{Name: "cp2"},
+						},
+					},
+				},
+			},
+			want: []string{"cp1", "cp2"},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := indexer.IndexDynamicQuotaOrchestratorCapacityProvider(tc.obj)
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/test/integration/singlecluster/controller/dynamicquotaorchestrator/dynamicquotaorchestrator_test.go
+++ b/test/integration/singlecluster/controller/dynamicquotaorchestrator/dynamicquotaorchestrator_test.go
@@ -1,0 +1,502 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamicquotaorchestrator
+
+import (
+	"context"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
+	"sigs.k8s.io/kueue/pkg/features"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingalpha "sigs.k8s.io/kueue/pkg/util/testing/v1alpha1"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var _ = ginkgo.Describe("DynamicQuotaOrchestrator controller", ginkgo.Label("controller:dynamicquotaorchestrator", "area:dynamicquotaorchestration"), func() {
+	var (
+		cps []*kueuealpha.CapacityProvider
+		dqo *kueuealpha.DynamicQuotaOrchestrator
+	)
+
+	ginkgo.BeforeEach(func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.DynamicQuotaOrchestration, true)
+	})
+
+	ginkgo.AfterEach(func() {
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, dqo, true)
+		for _, cp := range cps {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, cp, true)
+		}
+		dqo = nil
+		cps = nil
+	})
+
+	ginkgo.It("Should discover capacity from CapacityProvider and dynamically update", func() {
+		cp := utiltestingalpha.MakeCapacityProvider("discovery-cp").
+			ControllerName("example.com/test-provider").
+			OrchestratedFlavors("f1").
+			Capacity(
+				utiltestingalpha.MakeNormalizedCapacity().
+					Flavors(
+						utiltestingalpha.MakeNormalizedCapacityFlavor("f1").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj(),
+			).
+			Condition(metav1.Condition{
+				Type:               kueuealpha.CapacityProviderCapacitySynchronized,
+				Status:             metav1.ConditionTrue,
+				Reason:             kueuealpha.CapacityProviderReasonSynchronized,
+				Message:            "Capacity synchronized successfully",
+				LastTransitionTime: metav1.Now(),
+			}).
+			Obj()
+		cps = append(cps, cp)
+		createCapacityProvider(ctx, k8sClient, cp)
+
+		dqo = utiltestingalpha.MakeDynamicQuotaOrchestrator("discovery-dqo").
+			DiscoveryProvider(cp.Name, nil).
+			Obj()
+		util.MustCreate(ctx, k8sClient, dqo)
+
+		dqoKey := types.NamespacedName{Name: dqo.Name}
+		latestDQO := &kueuealpha.DynamicQuotaOrchestrator{}
+
+		ginkgo.By("Verifying initial discovery aggregation", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, dqoKey, latestDQO)).Should(gomega.Succeed())
+				g.Expect(latestDQO.Status.Conditions).Should(utiltesting.HaveConditionStatusTrueAndReason(
+					kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+				))
+
+				wantCapacity := utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("f1").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj()
+				g.Expect(cmp.Diff(wantCapacity, latestDQO.Status.EffectiveCapacity, cmpopts.EquateEmpty())).Should(gomega.BeEmpty())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("Updating capacity in CapacityProvider and verifying dynamic DQO update", func() {
+			updatedCapacity := utiltestingalpha.MakeNormalizedCapacity().
+				Flavors(
+					utiltestingalpha.MakeNormalizedCapacityFlavor("f1").
+						Resource(corev1.ResourceCPU, "250").
+						Obj()).
+				Obj()
+			setCapacityProviderCapacity(ctx, k8sClient, cp, updatedCapacity)
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, dqoKey, latestDQO)).Should(gomega.Succeed())
+				wantUpdatedCapacity := utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("f1").
+							Resource(corev1.ResourceCPU, "250").
+							Obj(),
+					).
+					Obj()
+				g.Expect(cmp.Diff(wantUpdatedCapacity, latestDQO.Status.EffectiveCapacity, cmpopts.EquateEmpty())).Should(gomega.BeEmpty())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+
+	ginkgo.It("Should transition condition between Computed and ProviderNotReady when CapacityProvider synchronization changes", func() {
+		cp := utiltestingalpha.MakeCapacityProvider("transition-cp").
+			ControllerName("example.com/test-provider").
+			OrchestratedFlavors("f1").
+			Capacity(
+				utiltestingalpha.MakeNormalizedCapacity().
+					Flavors(
+						utiltestingalpha.MakeNormalizedCapacityFlavor("f1").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj(),
+			).
+			Condition(metav1.Condition{
+				Type:               kueuealpha.CapacityProviderCapacitySynchronized,
+				Status:             metav1.ConditionTrue,
+				Reason:             kueuealpha.CapacityProviderReasonSynchronized,
+				Message:            "Capacity synchronized successfully",
+				LastTransitionTime: metav1.Now(),
+			}).
+			Obj()
+		cps = append(cps, cp)
+		createCapacityProvider(ctx, k8sClient, cp)
+
+		dqo = utiltestingalpha.MakeDynamicQuotaOrchestrator("transition-dqo").
+			DiscoveryProvider(cp.Name, nil).
+			Obj()
+		util.MustCreate(ctx, k8sClient, dqo)
+
+		dqoKey := types.NamespacedName{Name: dqo.Name}
+		latestDQO := &kueuealpha.DynamicQuotaOrchestrator{}
+
+		ginkgo.By("Verifying initial discovery aggregation", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, dqoKey, latestDQO)).Should(gomega.Succeed())
+				g.Expect(latestDQO.Status.Conditions).Should(utiltesting.HaveConditionStatusTrueAndReason(
+					kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+				))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("Marking CapacityProvider as unsynchronized and verifying DQO transitions to ProviderNotReady", func() {
+			setCapacityProviderSyncCondition(ctx, k8sClient, cp, metav1.ConditionFalse, kueuealpha.CapacityProviderReasonSourceUnavailable, "Backend source is unreachable")
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, dqoKey, latestDQO)).Should(gomega.Succeed())
+				g.Expect(latestDQO.Status.Conditions).Should(utiltesting.HaveConditionStatusFalseAndReason(
+					kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					kueuealpha.DynamicQuotaOrchestratorReasonProviderNotReady,
+				))
+				cond := apimeta.FindStatusCondition(latestDQO.Status.Conditions, kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed)
+				g.Expect(cond.Message).Should(gomega.ContainSubstring("\"transition-cp\" is not synchronized"))
+				g.Expect(latestDQO.Status.EffectiveCapacity).Should(gomega.BeNil())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("Re-synchronizing CapacityProvider and verifying DQO recovers to Computed", func() {
+			setCapacityProviderSyncCondition(ctx, k8sClient, cp, metav1.ConditionTrue, kueuealpha.CapacityProviderReasonSynchronized, "Capacity synchronized successfully")
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, dqoKey, latestDQO)).Should(gomega.Succeed())
+				g.Expect(latestDQO.Status.Conditions).Should(utiltesting.HaveConditionStatusTrueAndReason(
+					kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+				))
+
+				wantCapacity := utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("f1").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj()
+				g.Expect(cmp.Diff(wantCapacity, latestDQO.Status.EffectiveCapacity, cmpopts.EquateEmpty())).Should(gomega.BeEmpty())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+
+	ginkgo.It("Should aggregate capacity from multiple CapacityProviders and update when either provider changes", func() {
+		cp1 := utiltestingalpha.MakeCapacityProvider("multi-cp-1").
+			ControllerName("example.com/p1").
+			OrchestratedFlavors("f1").
+			Capacity(
+				utiltestingalpha.MakeNormalizedCapacity().
+					Flavors(
+						utiltestingalpha.MakeNormalizedCapacityFlavor("f1").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj(),
+			).
+			Condition(metav1.Condition{
+				Type:               kueuealpha.CapacityProviderCapacitySynchronized,
+				Status:             metav1.ConditionTrue,
+				Reason:             kueuealpha.CapacityProviderReasonSynchronized,
+				Message:            "Capacity synchronized successfully",
+				LastTransitionTime: metav1.Now(),
+			}).
+			Obj()
+		cps = append(cps, cp1)
+		createCapacityProvider(ctx, k8sClient, cp1)
+
+		cp2 := utiltestingalpha.MakeCapacityProvider("multi-cp-2").
+			ControllerName("example.com/p2").
+			OrchestratedFlavors("f1", "f2").
+			Capacity(
+				utiltestingalpha.MakeNormalizedCapacity().
+					Flavors(
+						utiltestingalpha.MakeNormalizedCapacityFlavor("f1").
+							Resource(corev1.ResourceCPU, "50").
+							Obj(),
+						utiltestingalpha.MakeNormalizedCapacityFlavor("f2").
+							Resource(corev1.ResourceMemory, "20Gi").
+							Obj(),
+					).
+					Obj(),
+			).
+			Condition(metav1.Condition{
+				Type:               kueuealpha.CapacityProviderCapacitySynchronized,
+				Status:             metav1.ConditionTrue,
+				Reason:             kueuealpha.CapacityProviderReasonSynchronized,
+				Message:            "Capacity synchronized successfully",
+				LastTransitionTime: metav1.Now(),
+			}).
+			Obj()
+		cps = append(cps, cp2)
+		createCapacityProvider(ctx, k8sClient, cp2)
+
+		dqo = utiltestingalpha.MakeDynamicQuotaOrchestrator("multi-dqo").
+			DiscoveryProvider("multi-cp-1", nil).
+			DiscoveryProvider("multi-cp-2", nil).
+			Obj()
+		util.MustCreate(ctx, k8sClient, dqo)
+
+		dqoKey := types.NamespacedName{Name: dqo.Name}
+		latestDQO := &kueuealpha.DynamicQuotaOrchestrator{}
+
+		ginkgo.By("Verifying combined effective capacity aggregation", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, dqoKey, latestDQO)).Should(gomega.Succeed())
+				g.Expect(latestDQO.Status.Conditions).Should(utiltesting.HaveConditionStatusTrueAndReason(
+					kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+				))
+
+				wantCapacity := utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("f1").
+							Resource(corev1.ResourceCPU, "150").
+							Obj(),
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("f2").
+							Resource(corev1.ResourceMemory, "20Gi").
+							Obj(),
+					).
+					Obj()
+				g.Expect(cmp.Diff(wantCapacity, latestDQO.Status.EffectiveCapacity, cmpopts.EquateEmpty())).Should(gomega.BeEmpty())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("Updating capacity in one provider and verifying dynamic re-aggregation", func() {
+			updatedFlavor := utiltestingalpha.MakeNormalizedCapacityFlavor("f1").
+				Resource(corev1.ResourceCPU, "200").
+				Obj()
+			updatedCapacity := utiltestingalpha.MakeNormalizedCapacity().
+				Flavors(updatedFlavor).
+				Obj()
+			setCapacityProviderCapacity(ctx, k8sClient, cp1, updatedCapacity)
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, dqoKey, latestDQO)).Should(gomega.Succeed())
+				wantUpdatedCapacity := utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("f1").
+							Resource(corev1.ResourceCPU, "250").
+							Obj(),
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("f2").
+							Resource(corev1.ResourceMemory, "20Gi").
+							Obj(),
+					).
+					Obj()
+				g.Expect(cmp.Diff(wantUpdatedCapacity, latestDQO.Status.EffectiveCapacity, cmpopts.EquateEmpty())).Should(gomega.BeEmpty())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+
+	ginkgo.It("Should report Misconfigured when referenced CapacityProvider is missing, and recover when it is created", func() {
+		dqo = utiltestingalpha.MakeDynamicQuotaOrchestrator("missing-provider-dqo").
+			DiscoveryProvider("late-cp", nil).
+			Obj()
+		util.MustCreate(ctx, k8sClient, dqo)
+
+		dqoKey := types.NamespacedName{Name: dqo.Name}
+		latestDQO := &kueuealpha.DynamicQuotaOrchestrator{}
+
+		ginkgo.By("Verifying DQO reports Misconfigured when provider does not exist", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, dqoKey, latestDQO)).Should(gomega.Succeed())
+				g.Expect(latestDQO.Status.Conditions).Should(utiltesting.HaveConditionStatusFalseAndReason(
+					kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					kueuealpha.DynamicQuotaOrchestratorReasonMisconfigured,
+				))
+				cond := apimeta.FindStatusCondition(latestDQO.Status.Conditions, kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed)
+				g.Expect(cond.Message).Should(gomega.ContainSubstring("CapacityProvider \"late-cp\" not found"))
+				g.Expect(latestDQO.Status.EffectiveCapacity).Should(gomega.BeNil())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("Creating late-arriving CapacityProvider and verifying recovery", func() {
+			cp := utiltestingalpha.MakeCapacityProvider("late-cp").
+				ControllerName("example.com/late-provider").
+				OrchestratedFlavors("f1").
+				Capacity(
+					utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("f1").
+								Resource(corev1.ResourceCPU, "75").
+								Obj(),
+						).
+						Obj(),
+				).
+				Condition(metav1.Condition{
+					Type:               kueuealpha.CapacityProviderCapacitySynchronized,
+					Status:             metav1.ConditionTrue,
+					Reason:             kueuealpha.CapacityProviderReasonSynchronized,
+					Message:            "Capacity synchronized successfully",
+					LastTransitionTime: metav1.Now(),
+				}).
+				Obj()
+			cps = append(cps, cp)
+			createCapacityProvider(ctx, k8sClient, cp)
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, dqoKey, latestDQO)).Should(gomega.Succeed())
+				g.Expect(latestDQO.Status.Conditions).Should(utiltesting.HaveConditionStatusTrueAndReason(
+					kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+				))
+
+				wantCapacity := utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("f1").
+							Resource(corev1.ResourceCPU, "75").
+							Obj(),
+					).
+					Obj()
+				g.Expect(cmp.Diff(wantCapacity, latestDQO.Status.EffectiveCapacity, cmpopts.EquateEmpty())).Should(gomega.BeEmpty())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+
+	ginkgo.It("Should filter unmanaged flavors and scale quantities using effectiveCapacityMultiplier", func() {
+		cp := utiltestingalpha.MakeCapacityProvider("filter-cp").
+			ControllerName("example.com/test-provider").
+			OrchestratedFlavors("allowed-flavor").
+			Capacity(
+				utiltestingalpha.MakeNormalizedCapacity().
+					Flavors(
+						utiltestingalpha.MakeNormalizedCapacityFlavor("allowed-flavor").
+							Resource(corev1.ResourceCPU, "100").
+							Resource(corev1.ResourceMemory, "50Gi").
+							Obj(),
+						utiltestingalpha.MakeNormalizedCapacityFlavor("unmanaged-flavor").
+							Resource(corev1.ResourceCPU, "500").
+							Obj(),
+					).
+					Obj(),
+			).
+			Condition(metav1.Condition{
+				Type:               kueuealpha.CapacityProviderCapacitySynchronized,
+				Status:             metav1.ConditionTrue,
+				Reason:             kueuealpha.CapacityProviderReasonSynchronized,
+				Message:            "Capacity synchronized successfully",
+				LastTransitionTime: metav1.Now(),
+			}).
+			Obj()
+		cps = append(cps, cp)
+		createCapacityProvider(ctx, k8sClient, cp)
+
+		halfMultiplier := resource.MustParse("0.5")
+		dqo = utiltestingalpha.MakeDynamicQuotaOrchestrator("filter-dqo").
+			DiscoveryProvider("filter-cp", &halfMultiplier).
+			Obj()
+		util.MustCreate(ctx, k8sClient, dqo)
+
+		dqoKey := types.NamespacedName{Name: dqo.Name}
+		latestDQO := &kueuealpha.DynamicQuotaOrchestrator{}
+
+		ginkgo.By("Verifying unmanaged flavor is ignored and multiplier scales resources", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, dqoKey, latestDQO)).Should(gomega.Succeed())
+				g.Expect(latestDQO.Status.Conditions).Should(utiltesting.HaveConditionStatusTrueAndReason(
+					kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+				))
+
+				wantCapacity := utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("allowed-flavor").
+							Resource(corev1.ResourceCPU, "50").
+							Resource(corev1.ResourceMemory, "25Gi").
+							Obj(),
+					).
+					Obj()
+				g.Expect(cmp.Diff(wantCapacity, latestDQO.Status.EffectiveCapacity, cmpopts.EquateEmpty())).Should(gomega.BeEmpty())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+})
+
+func createCapacityProvider(
+	ctx context.Context,
+	k8sClient client.Client,
+	cp *kueuealpha.CapacityProvider,
+) {
+	ginkgo.GinkgoHelper()
+	status := cp.Status.DeepCopy()
+	util.MustCreate(ctx, k8sClient, cp)
+	if status.Capacity != nil || len(status.Conditions) > 0 {
+		for i := range status.Conditions {
+			if status.Conditions[i].LastTransitionTime.IsZero() {
+				status.Conditions[i].LastTransitionTime = metav1.Now()
+			}
+		}
+		cp.Status = *status
+		gomega.Expect(k8sClient.Status().Update(ctx, cp)).Should(gomega.Succeed())
+	}
+}
+
+func setCapacityProviderCapacity(
+	ctx context.Context,
+	k8sClient client.Client,
+	cp *kueuealpha.CapacityProvider,
+	capacity *kueuealpha.CapacityProviderNormalizedCapacity,
+) {
+	var latestCp kueuealpha.CapacityProvider
+	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
+		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cp), &latestCp)).Should(gomega.Succeed())
+		latestCp.Status.Capacity = capacity
+		apimeta.SetStatusCondition(&latestCp.Status.Conditions, metav1.Condition{
+			Type:               kueuealpha.CapacityProviderCapacitySynchronized,
+			Status:             metav1.ConditionTrue,
+			Reason:             kueuealpha.CapacityProviderReasonSynchronized,
+			Message:            "Capacity synchronized successfully",
+			ObservedGeneration: latestCp.Generation,
+		})
+		g.Expect(k8sClient.Status().Update(ctx, &latestCp)).Should(gomega.Succeed())
+	}, util.Timeout, util.Interval).Should(gomega.Succeed(), util.AssertMsg("Failed to update CapacityProvider status", &latestCp))
+}
+
+func setCapacityProviderSyncCondition(
+	ctx context.Context,
+	k8sClient client.Client,
+	cp *kueuealpha.CapacityProvider,
+	status metav1.ConditionStatus,
+	reason, message string,
+) {
+	var latestCp kueuealpha.CapacityProvider
+	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
+		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cp), &latestCp)).Should(gomega.Succeed())
+		apimeta.SetStatusCondition(&latestCp.Status.Conditions, metav1.Condition{
+			Type:               kueuealpha.CapacityProviderCapacitySynchronized,
+			Status:             status,
+			Reason:             reason,
+			Message:            message,
+			ObservedGeneration: latestCp.Generation,
+		})
+		g.Expect(k8sClient.Status().Update(ctx, &latestCp)).Should(gomega.Succeed())
+	}, util.Timeout, util.Interval).Should(gomega.Succeed(), util.AssertMsg("Failed to update CapacityProvider condition", &latestCp))
+}

--- a/test/integration/singlecluster/controller/dynamicquotaorchestrator/suite_test.go
+++ b/test/integration/singlecluster/controller/dynamicquotaorchestrator/suite_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamicquotaorchestrator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"sigs.k8s.io/kueue/pkg/controller/core"
+	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
+	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/webhooks"
+	"sigs.k8s.io/kueue/test/integration/framework"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	ctx       context.Context
+	fwk       *framework.Framework
+)
+
+func TestAPIs(t *testing.T) {
+	util.RunSuite(t, "DynamicQuotaOrchestrator Controller Suite")
+}
+
+var _ = ginkgo.BeforeSuite(func() {
+	features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.DynamicQuotaOrchestration, true)
+	fwk = &framework.Framework{}
+	cfg = fwk.Init()
+	ctx, k8sClient = fwk.SetupClient(cfg)
+	fwk.StartManager(ctx, cfg, managerSetup)
+})
+
+var _ = ginkgo.AfterSuite(func() {
+	fwk.Teardown()
+})
+
+func managerSetup(ctx context.Context, mgr manager.Manager) {
+	err := indexer.Setup(ctx, mgr.GetFieldIndexer())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	failedWebhook, err := webhooks.Setup(mgr, nil)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
+
+	dqoRec := core.NewDynamicQuotaOrchestratorReconciler(mgr.GetClient())
+	err = dqoRec.SetupWithManager(mgr)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This PR implements Phase 1 (Capacity Discovery) of the `DynamicQuotaOrchestrator` controller under KEP-12382 Dynamic Quota Orchestration, gated by the `DynamicQuotaOrchestration` feature gate.

This PR is strictly scoped to **Phase 1: Capacity Discovery & Aggregation**. **Phase 2 (propagating effective capacity to ClusterQueues and Cohorts)** will follow in a subsequent PR.

#### Which issue(s) this PR fixes:
Part of #12382 

#### Special notes for your reviewer:

> AI Disclosure: Created with assistance from AI tools

#### Does this PR introduce a user-facing change?
```release-note
DynamicQuotaOrchestration: Added the DynamicQuotaOrchestrator controller behind the `DynamicQuotaOrchestration` feature gate to discover and aggregate capacity across referenced CapacityProviders into effective capacity status.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Dynamic Quota Orchestration support for discovering effective capacity from referenced Capacity Providers.
  * Capacity is aggregated across multiple providers, filtered to orchestrated flavors, and adjusted using configured multipliers.
  * DynamicQuotaOrchestrator status now reports effective capacity and discovery conditions, including provider readiness and configuration issues.
  * Support is enabled when the Dynamic Quota Orchestration feature gate is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->