### PR TITLE
queue: resolve ClusterQueue for unassigned or pre-admitted workloads in QueueAssociatedInadmissibleWorkloadsAfter

### DIFF
--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -865,28 +865,40 @@ func (m *Manager) deleteWorkloadWithoutLock(log logr.Logger, wlKey workload.Refe
 	m.DeleteSecondPassWithoutLock(wlKey)
 }
 
+func (m *Manager) clusterQueueForWorkloadReferenceWithoutLock(wlKey workload.Reference, wl *kueue.Workload) kueue.ClusterQueueReference {
+	if qKey, ok := m.workloadAssignedQueues[wlKey]; ok {
+		if q := m.localQueues[qKey]; q != nil {
+			return q.ClusterQueue
+		}
+	}
+	if wl != nil && wl.Status.Admission != nil {
+		// Fallback: the workload was admitted but never tracked in the queue
+		// manager (e.g. pre-admitted workloads in unit tests), or the local
+		// queue was already deleted. Use the CQ name from admission status.
+		return wl.Status.Admission.ClusterQueue
+	}
+	return ""
+}
+
 // QueueAssociatedInadmissibleWorkloadsAfter requeues into the heaps all
 // previously inadmissible workloads in the same ClusterQueue and cohort (if
 // they exist) as the provided admitted workload to the heaps.
 // An optional action can be executed at the beginning of the function,
 // while holding the lock, to provide atomicity with the operations in the
 // queues.
-func (m *Manager) QueueAssociatedInadmissibleWorkloadsAfter(ctx context.Context, wlKey workload.Reference, action func()) {
+// The wl parameter is optional: when non-nil it is used as a fallback to
+// resolve the ClusterQueue when the workload was not tracked in
+// workloadAssignedQueues (e.g. admitted workloads loaded directly into the
+// cache without going through the queue manager).
+func (m *Manager) QueueAssociatedInadmissibleWorkloadsAfter(ctx context.Context, wlKey workload.Reference, action func(), wl *kueue.Workload) {
 	m.Lock()
 	defer m.Unlock()
 	if action != nil {
 		action()
 	}
 
-	qKey, ok := m.workloadAssignedQueues[wlKey]
-	if !ok {
-		return
-	}
-	q := m.localQueues[qKey]
-	if q == nil {
-		return
-	}
-	cq := m.hm.ClusterQueue(q.ClusterQueue)
+	cqName := m.clusterQueueForWorkloadReferenceWithoutLock(wlKey, wl)
+	cq := m.hm.ClusterQueue(cqName)
 	if cq == nil {
 		return
 	}

--- a/pkg/cache/queue/manager_test.go
+++ b/pkg/cache/queue/manager_test.go
@@ -3217,3 +3217,73 @@ func TestLQPendingWorkloads_InadmissibleAndDelete(t *testing.T) {
 		t.Errorf("after delete silver: gold/inadmissible = %v, want 1", got)
 	}
 }
+
+func TestQueueAssociatedInadmissibleWorkloadsAfter(t *testing.T) {
+	cq := utiltestingapi.MakeClusterQueue("cq").Obj()
+	lq := utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj()
+	ctx, _ := utiltesting.ContextWithLog(t)
+
+	cases := map[string]struct {
+		setup          func(mgr *Manager, w *kueue.Workload)
+		workload       *kueue.Workload
+		wantRequeuedCQ bool
+	}{
+		"workload assigned to local queue": {
+			setup: func(mgr *Manager, w *kueue.Workload) {
+				_ = mgr.AddClusterQueue(ctx, cq)
+				_ = mgr.AddLocalQueue(ctx, lq)
+				_ = mgr.AddOrUpdateWorkload(logr.Discard(), w)
+			},
+			workload:       utiltestingapi.MakeWorkload("wl", "ns").Queue("lq").Obj(),
+			wantRequeuedCQ: true,
+		},
+		"pre-admitted workload without queue assignment fallback to admission": {
+			setup: func(mgr *Manager, w *kueue.Workload) {
+				_ = mgr.AddClusterQueue(ctx, cq)
+			},
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").Obj(), time.Now()).
+				Obj(),
+			wantRequeuedCQ: true,
+		},
+		"workload with assigned queue whose localQueue was deleted fallback to admission": {
+			setup: func(mgr *Manager, w *kueue.Workload) {
+				_ = mgr.AddClusterQueue(ctx, cq)
+				_ = mgr.AddLocalQueue(ctx, lq)
+				_ = mgr.AddOrUpdateWorkload(logr.Discard(), w)
+				mgr.DeleteLocalQueue(logr.Discard(), lq)
+			},
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				Queue("lq").
+				ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").Obj(), time.Now()).
+				Obj(),
+			wantRequeuedCQ: true,
+		},
+		"untracked workload without admission returns without notification": {
+			setup: func(mgr *Manager, w *kueue.Workload) {
+				_ = mgr.AddClusterQueue(ctx, cq)
+			},
+			workload:       utiltestingapi.MakeWorkload("wl", "ns").Obj(),
+			wantRequeuedCQ: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			mgr, requeuer := NewManagerForUnitTestsWithRequeuer(
+				utiltesting.NewFakeClient(),
+				nil,
+				WithPreemptionExpectations(preemptexpectations.New()),
+			)
+			tc.setup(mgr, tc.workload)
+			requeuer.cqs.Clear()
+
+			mgr.QueueAssociatedInadmissibleWorkloadsAfter(ctx, workload.Key(tc.workload), nil, tc.workload)
+
+			hasCQ := requeuer.cqs.Has(kueue.ClusterQueueReference(cq.Name))
+			if hasCQ != tc.wantRequeuedCQ {
+				t.Errorf("got requeued CQ %t, want %t", hasCQ, tc.wantRequeuedCQ)
+			}
+		})
+	}
+}

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -1318,7 +1318,7 @@ func (r *WorkloadReconciler) Delete(e event.TypedDeleteEvent[*kueue.Workload]) b
 		if err := r.cache.DeleteWorkload(log, wlKey); err != nil {
 			log.Error(err, "Failed to delete workload from cache")
 		}
-	})
+	}, e.Object)
 
 	// Even if the state is unknown, the last cached state tells us whether the
 	// workload was in the queues and should be cleared from them.
@@ -1326,6 +1326,7 @@ func (r *WorkloadReconciler) Delete(e event.TypedDeleteEvent[*kueue.Workload]) b
 
 	if afs.Enabled(r.admissionFSConfig) {
 		// A Workload deleted before settling (e.g. a Job deleted while waiting
+
 		// for an AdmissionCheck) would leave its penalty pending forever,
 		// inflating the LocalQueue's fair-sharing usage until restart.
 		r.queues.AfsUsageLedger.SubPenalty(qutil.KeyFromWorkload(e.Object), queueafs.WorkloadReference(wlKey))
@@ -1392,7 +1393,8 @@ func (r *WorkloadReconciler) Update(e event.TypedUpdateEvent[*kueue.Workload]) b
 			if err := r.cache.DeleteWorkload(log, wlKey); err != nil && prevStatus == workload.StatusAdmitted {
 				log.Error(err, "Failed to delete workload from cache")
 			}
-		})
+		}, wlCopy)
+
 	case prevStatus == workload.StatusPending && status == workload.StatusPending:
 		switch {
 		case onHold:
@@ -1451,7 +1453,8 @@ func (r *WorkloadReconciler) Update(e event.TypedUpdateEvent[*kueue.Workload]) b
 			if !workload.NeedsSecondPass(wlCopy) {
 				r.queues.DeleteSecondPassWithoutLock(wlKey)
 			}
-		})
+		}, wlCopy)
+
 	case prevStatus == workload.StatusAdmitted && status == workload.StatusAdmitted && !equality.Semantic.DeepEqual(e.ObjectOld.Status.ReclaimablePods, e.ObjectNew.Status.ReclaimablePods),
 		features.Enabled(features.ElasticJobsViaWorkloadSlices) && workloadslicing.ScaledDown(workload.ExtractPodSetCountsFromWorkload(e.ObjectOld), workload.ExtractPodSetCountsFromWorkload(e.ObjectNew)),
 		workload.PriorityChanged(log, e.ObjectOld, e.ObjectNew):
@@ -1461,7 +1464,7 @@ func (r *WorkloadReconciler) Update(e event.TypedUpdateEvent[*kueue.Workload]) b
 			// to guarantee that requeued workloads are taken into account before
 			// the next scheduling cycle.
 			r.cache.AddOrUpdateWorkload(log, wlCopy)
-		})
+		}, wlCopy)
 
 	default:
 		// Workload update in the cache is handled here; however, some fields are immutable

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -8937,7 +8937,7 @@ func TestLastSchedulingContext(t *testing.T) {
 						if err != nil {
 							t.Errorf("Delete workload failed: %v", err)
 						}
-						qManager.QueueAssociatedInadmissibleWorkloadsAfter(ctx, workload.Key(&wl), nil)
+						qManager.QueueAssociatedInadmissibleWorkloadsAfter(ctx, workload.Key(&wl), nil, &wl)
 					}
 					watcher.ProcessRequeues(ctx)
 


### PR DESCRIPTION
#### What type of PR is this?

/kind flake
/kind bug

#### What this PR does / why we need it:

Fixes a flake/timeout in `TestLastSchedulingContext` (specifically `TryNextFlavor, but second flavor is full and can preempt on first`) where the test runner timed out after 10 minutes blocked in `pkg/cache/queue.(*Manager).Heads`.

When a workload was pre-admitted directly into the cache (common in unit tests) without passing through `AddOrUpdateWorkload`, or when its assigned `LocalQueue` was deleted, it was not registered in `m.workloadAssignedQueues`. When deleted/evicted, `QueueAssociatedInadmissibleWorkloadsAfter` returned early without notifying inadmissible workloads or broadcasting, leaving them stuck in the inadmissible set and stalling downstream scheduling cycles.

This PR:
1. Adds `clusterQueueForWorkloadReferenceWithoutLock(wlKey, wl)` helper to resolve the `ClusterQueue` from `m.workloadAssignedQueues`, with fallback to `wl.Status.Admission.ClusterQueue` if the queue assignment is missing or the local queue is deleted.
2. Updates `QueueAssociatedInadmissibleWorkloadsAfter` to accept an optional `*kueue.Workload` fallback parameter and use the helper.
3. Updates callers in `pkg/controller/core/workload_controller.go` and `pkg/scheduler/scheduler_test.go` to provide the workload reference where available.
4. Adds dedicated unit test coverage in `pkg/cache/queue/manager_test.go` (`TestQueueAssociatedInadmissibleWorkloadsAfter`) verifying normal assignment, admission fallback, and deleted local queue cases.

#### Which issue(s) this PR fixes:

Related issue: https://github.com/kubernetes-sigs/kueue/issues/15193

#### Special notes for your reviewer:

- AI assistance was used in creating this pull request.
- Verified locally with:
  `go test -race -count 3 -run 'TestLastSchedulingContext/TryNextFlavor' ./pkg/scheduler/...` (passed).
  `go test -v -run TestQueueAssociatedInadmissibleWorkloadsAfter ./pkg/cache/queue/...` (passed).

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed an issue where inadmissible workloads were not retried upon deletion of an admitted workload that lacked an active LocalQueue assignment (e.g., in unit tests or when the LocalQueue was removed). The bug didn't impact end users under normal cluster operations where workloads retain their LocalQueue mappings.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Workloads associated with a deleted or missing local queue are now correctly requeued using their recorded ClusterQueue admission.
  - Pre-admitted workloads continue to be requeued even when their local queue is no longer available.
  - Untracked workloads without admission remain excluded from requeueing.

- **Tests**
  - Added coverage for local queue deletion, pre-admitted workloads, and untracked workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->