### PR TITLE
[site] Document RayService support for elastic workloads

### DIFF
--- a/site/content/en/docs/concepts/elastic_workload.md
+++ b/site/content/en/docs/concepts/elastic_workload.md
@@ -50,6 +50,14 @@ The parallelism can be adjusted (increased or decreased) as long as the job rema
 
 See [Run A RayJob](/docs/tasks/run/rayjobs)
 
+## RayCluster
+
+See [Run A RayCluster](/docs/tasks/run/rayclusters)
+
+## RayService
+
+See [Run A RayService](/docs/tasks/run/rayservices)
+
 ## Feature Gate
 
 Elastic Workloads via Workload Slices are gated by the following feature flag:
@@ -72,6 +80,7 @@ metadata:
    * `batch/v1.Job`
    * `ray.io/v1.RayJob`
    * `ray.io/v1.RayCluster`
+   * `ray.io/v1.RayService`
 * Elastic workloads are not supported for jobs with partial admission enabled.
 
     * Attempting to scale jobs with partial admission enabled will result in an admission validation error similar to the following:
@@ -81,5 +90,5 @@ metadata:
       error when patching "job.yaml": admission webhook "vjob.kb.io" denied the request: spec.parallelism: Forbidden: cannot change when partial admission is enabled and the job is not suspended
       ```
 * When scaling up a previously admitted job the new workload must reuse the originally assigned flavor, even if other eligible flavors have available capacity.
-* No Multikueue support.
+* MultiKueue support for elastic workloads is currently available only for `batch/v1.Job` and `ray.io/v1.RayCluster` (not supported for `ray.io/v1.RayJob` or `ray.io/v1.RayService`).
 * No Topology-Aware Scheduling (TAS) support. 

--- a/site/content/en/docs/tasks/run/rayservices.md
+++ b/site/content/en/docs/tasks/run/rayservices.md
@@ -15,7 +15,7 @@ This guide is for [serving users](/docs/tasks#serving-user) that have a basic un
 
 ## Before you begin
 
-1. Make sure you are using KubeRay v1.3.0 or newer.
+1. Make sure you are using Kueue v0.17.0 or newer and KubeRay v1.3.0 or newer.
 
 2. Check [Administer cluster quotas](/docs/tasks/manage/administer_cluster_quotas) for details on the initial Kueue setup.
 
@@ -92,6 +92,6 @@ The RayService looks like the following:
 {{< include "examples/jobs/ray-service-sample.yaml" "yaml" >}}
 
 {{% alert title="Note" color="primary" %}}
-The example above comes from [here](https://raw.githubusercontent.com/ray-project/kuberay/v1.7.0/ray-operator/config/samples/ray-service.sample.yaml)
+The example above comes from [the KubeRay RayService sample](https://raw.githubusercontent.com/ray-project/kuberay/v1.7.0/ray-operator/config/samples/ray-service.sample.yaml)
 and only has the `queue-name` label added.
 {{% /alert %}}

--- a/site/content/en/docs/tasks/run/rayservices.md
+++ b/site/content/en/docs/tasks/run/rayservices.md
@@ -9,22 +9,17 @@ description: >
 
 This page shows how to leverage Kueue's scheduling and resource management capabilities when running [RayService](https://docs.ray.io/en/latest/cluster/kubernetes/getting-started/rayservice-quick-start.html).
 
-Before v0.17.0, Kueue manages the RayService through the RayCluster created for it. Since v0.17.0, Kueue manages the RayService as top level job which is similar like how Kueue manages the RayJob.
+Kueue manages the RayService as a top-level job, similar to how Kueue manages the RayJob.
 
 This guide is for [serving users](/docs/tasks#serving-user) that have a basic understanding of Kueue. For more information, see [Kueue's overview](/docs/overview).
 
 ## Before you begin
 
-1. Make sure you are using Kueue v0.6.0 version or newer and KubeRay v1.3.0 or newer.
+1. Make sure you are using KubeRay v1.3.0 or newer.
 
 2. Check [Administer cluster quotas](/docs/tasks/manage/administer_cluster_quotas) for details on the initial Kueue setup.
 
 3. See [KubeRay Installation](https://docs.ray.io/en/latest/cluster/kubernetes/getting-started/kuberay-operator-installation.html) for installation and configuration details of KubeRay.
-
-{{% alert title="Note" color="primary" %}}
-RayService is managed by Kueue through RayCluster, and in order to use RayCluster, prior to v0.17.0, you need to restart Kueue after the installation.
-You can do it by running: `kubectl delete pods -l control-plane=controller-manager -n kueue-system`.
-{{% /alert %}}
 
 ## RayService definition
 
@@ -65,10 +60,30 @@ spec:
 
 ### c. Suspend control
 
-Kueue controls the `spec.suspend` field of the RayService. When a RayService is admitted by Kueue, Kueue will unsuspend it by setting `spec.suspend` to `false`, regardless of its previous value.
+Kueue controls the `spec.rayClusterConfig.suspend` field of the RayService. When a RayService is admitted by Kueue, Kueue will unsuspend it by setting `spec.rayClusterConfig.suspend` to `false`, regardless of its previous value.
 
 ### d. Limitations
-- Limited Worker Groups: Because a Kueue workload can have a maximum of 18 PodSets, the maximum number of `spec.rayClusterConfig.workerGroupSpecs` is 17
+
+- Limited Worker Groups: Because a Kueue workload can have a maximum of 18 PodSets, the maximum number of `spec.rayClusterConfig.workerGroupSpecs` is 17.
+- In-Tree Autoscaling Constraints: Autoscaling is only supported for [elastic](/docs/concepts/elastic_workload) RayService objects. To enable in-tree autoscaling:
+
+  1. Activate the `ElasticJobsViaWorkloadSlices` feature gate.
+  2. Annotate the RayService object with:
+
+     ```yaml
+     metadata:
+       annotations:
+         kueue.x-k8s.io/elastic-job: "true"
+     ```
+  3. Enable the Ray autoscaler of your RayService object by setting:
+
+     ```yaml
+     spec:
+       rayClusterConfig:
+         enableInTreeAutoscaling: true
+     ```
+
+- Rolling Upgrades: Kueue's Workload Slices feature currently manages quota for a single active cluster. Upgrade strategies that provision a secondary surge cluster (`spec.upgradeStrategy.type: NewCluster` or `NewClusterWithIncrementalUpgrade`) are not currently supported when workload slicing is enabled because pending cluster pods will remain gated. To use workload slicing with autoscaling, use `spec.upgradeStrategy.type: None` or apply updates in-place.
 
 ## Example RayService
 
@@ -77,6 +92,6 @@ The RayService looks like the following:
 {{< include "examples/jobs/ray-service-sample.yaml" "yaml" >}}
 
 {{% alert title="Note" color="primary" %}}
-The example above comes from [here](https://raw.githubusercontent.com/ray-project/kuberay/v1.4.2/ray-operator/config/samples/ray-service.sample.yaml)
-and only has the `queue-name` label added and requests updated.
+The example above comes from [here](https://raw.githubusercontent.com/ray-project/kuberay/v1.7.0/ray-operator/config/samples/ray-service.sample.yaml)
+and only has the `queue-name` label added.
 {{% /alert %}}

--- a/site/content/en/docs/tasks/run/rayservices.md
+++ b/site/content/en/docs/tasks/run/rayservices.md
@@ -64,7 +64,6 @@ Kueue controls the `spec.rayClusterConfig.suspend` field of the RayService. When
 
 ### d. Limitations
 
-- Limited Worker Groups: Because a Kueue workload can have a maximum of 18 PodSets, the maximum number of `spec.rayClusterConfig.workerGroupSpecs` is 17.
 - In-Tree Autoscaling Constraints: Autoscaling is only supported for [elastic](/docs/concepts/elastic_workload) RayService objects. To enable in-tree autoscaling:
 
   1. Activate the `ElasticJobsViaWorkloadSlices` feature gate.

--- a/site/content/zh-CN/docs/concepts/elastic_workload.md
+++ b/site/content/zh-CN/docs/concepts/elastic_workload.md
@@ -56,6 +56,14 @@ description: >
 
 参见[运行 RayJob](/docs/tasks/run/rayjobs)
 
+## RayCluster
+
+参见[运行 RayCluster](/zh-cn/docs/tasks/run/rayclusters)
+
+## RayService
+
+参见[运行 RayService](/zh-cn/docs/tasks/run/rayservices)
+
 ## 特性门控
 
 通过工作负载切片实现的弹性工作负载由以下特性门控控制：
@@ -78,6 +86,7 @@ metadata:
     * `batch/v1.Job`
     * `ray.io/v1.RayJob`
     * `ray.io/v1.RayCluster`
+    * `ray.io/v1.RayService`
 * 对于启用了部分准入的 Job，不支持弹性工作负载。
 
     * 尝试扩缩启用了部分准入的 Job 将导致准入验证错误，类似于以下内容：
@@ -87,5 +96,5 @@ metadata:
       error when patching "job.yaml": admission webhook "vjob.kb.io" denied the request: spec.parallelism: Forbidden: cannot change when partial admission is enabled and the job is not suspended
       ```
 * 扩大之前已接受的 Job 时，新工作负载必须重用最初分配的规格，即使有其他符合条件且有可用容量的规格。
-* 不支持多队列。
+* 弹性工作负载的 MultiKueue 支持目前仅适用于 `batch/v1.Job` 和 `ray.io/v1.RayCluster`（不支持 `ray.io/v1.RayJob` 或 `ray.io/v1.RayService`）。
 * 不支持拓扑感知调度（TAS）。

--- a/site/content/zh-CN/docs/tasks/run/rayservices.md
+++ b/site/content/zh-CN/docs/tasks/run/rayservices.md
@@ -17,7 +17,7 @@ Kueue 可以直接管理 RayService，类似其直接管理 RayJob。
 
 ## 开始之前 {#before-you-begin}
 
-1. 请确保你使用的是 KubeRay v1.3.0 或更高版本。
+1. 请确保你使用的是 Kueue v0.17.0 或更高版本，以及 KubeRay v1.3.0 或更高版本。
 
 2. 请参见 [管理集群配额](/zh-cn/docs/tasks/manage/administer_cluster_quotas)了解初始 Kueue 设置的详细信息。
 
@@ -95,6 +95,6 @@ RayService 如下所示：
 {{< include "examples/jobs/ray-service-sample.yaml" "yaml" >}}
 
 {{% alert title="注意" color="primary" %}}
-上述示例来自[这里](https://raw.githubusercontent.com/ray-project/kuberay/v1.7.0/ray-operator/config/samples/ray-service.sample.yaml)，
+上述示例来自[KubeRay RayService 示例](https://raw.githubusercontent.com/ray-project/kuberay/v1.7.0/ray-operator/config/samples/ray-service.sample.yaml)，
 仅添加了 `queue-name` 标签。
 {{% /alert %}}

--- a/site/content/zh-CN/docs/tasks/run/rayservices.md
+++ b/site/content/zh-CN/docs/tasks/run/rayservices.md
@@ -10,25 +10,18 @@ description: >
 本页演示如何利用 Kueue 的调度与资源管理能力运行
 [RayService](https://docs.ray.io/en/latest/cluster/kubernetes/getting-started/rayservice-quick-start.html) 。
 
-在v0.17.0之前，Kueue 通过为 RayService 创建的 RayCluster 来管理 RayService。从v0.17.0开始，Kueue 可以直接管理 RayService，类似其直接管理 RayJob，
-不再通过 RayCluster。
+Kueue 可以直接管理 RayService，类似其直接管理 RayJob。
 
 本指南面向对 Kueue 有基本了解的、[对外提供服务的用户](/zh-cn/docs/tasks#serving-user)。
 更多信息，请参见 [Kueue 概览](/zh-cn/docs/overview)。
 
 ## 开始之前 {#before-you-begin}
 
-1. 请确保你使用的是 Kueue v0.6.0 版本或更高版本，以及 KubeRay v1.3.0 或更高版本。
+1. 请确保你使用的是 KubeRay v1.3.0 或更高版本。
 
 2. 请参见 [管理集群配额](/zh-cn/docs/tasks/manage/administer_cluster_quotas)了解初始 Kueue 设置的详细信息。
 
 3. 请参见 [KubeRay 安装说明](https://docs.ray.io/en/latest/cluster/kubernetes/getting-started/raycluster-quick-start.html#step-2-deploy-a-kuberay-operator)了解 KubeRay 的安装和配置详情。
-
-{{% alert title="注意" color="primary" %}}
-RayService 通过 RayCluster 由 Kueue 管理；
-在 v0.17.0 之前，你需要在完成安装后重启 Kueue 才能使用 RayCluster。你可以通过运行
-`kubectl delete pods -l control-plane=controller-manager -n kueue-system` 来完成此操作。
-{{% /alert %}}
 
 ## RayService 定义 {#rayservice-definition}
 
@@ -71,11 +64,29 @@ spec:
 
 ### c. Suspend 控制 {#c-suspend-control}
 
-Kueue 控制 RayService 的 `spec.suspend` 字段。当 RayService 被 Kueue 接纳时，Kueue 会通过将 `spec.suspend` 设置为 `false` 来取消暂停，无论其之前的值是什么。
+Kueue 控制 RayService 的 `spec.rayClusterConfig.suspend` 字段。当 RayService 被 Kueue 接纳时，Kueue 会通过将 `spec.rayClusterConfig.suspend` 设置为 `false` 来取消暂停，无论其之前的值是什么。
 
 ### d. 限制事项 {#c-limitations}
-- 有限的 Worker Group：由于 Kueue 工作负载最多可以有 8 个 PodSet,
-  所以`spec.rayClusterConfig.workerGroupSpecs` 的最大数量为 7。
+- 有限的 Worker Group：由于 Kueue 工作负载最多可以有 18 个 PodSet，所以 `spec.rayClusterConfig.workerGroupSpecs` 的最大数量为 17。
+- 内建自动扩缩约束：自动扩缩仅支持[弹性](/zh-cn/docs/concepts/elastic_workload) RayService 对象。要启用内建自动扩缩：
+
+  1. 启用 `ElasticJobsViaWorkloadSlices` 特性门控。
+  2. 为 RayService 对象添加注解：
+
+     ```yaml
+     metadata:
+       annotations:
+         kueue.x-k8s.io/elastic-job: "true"
+     ```
+  3. 设置以下字段启用 RayService 的 Ray 自动扩缩器：
+
+     ```yaml
+     spec:
+       rayClusterConfig:
+         enableInTreeAutoscaling: true
+     ```
+
+- 滚动升级限制：Kueue 的工作负载切片特性目前仅管理单个活跃集群的配额。启用工作负载切片时，暂不支持创建二级临时集群的升级策略（`spec.upgradeStrategy.type: NewCluster` 或 `NewClusterWithIncrementalUpgrade`），因为待处理集群的 Pod 会保持被门控状态。要在使用工作负载切片的同时进行自动扩缩，请使用 `spec.upgradeStrategy.type: None` 或进行就地更新。
 
 ## RayService 示例{#example-rayservice}
 
@@ -84,6 +95,6 @@ RayService 如下所示：
 {{< include "examples/jobs/ray-service-sample.yaml" "yaml" >}}
 
 {{% alert title="注意" color="primary" %}}
-上述示例来自[这里](https://raw.githubusercontent.com/ray-project/kuberay/v1.4.2/ray-operator/config/samples/ray-service.sample.yaml)，
-仅添加了 `queue-name` 标签并更新了请求。
+上述示例来自[这里](https://raw.githubusercontent.com/ray-project/kuberay/v1.7.0/ray-operator/config/samples/ray-service.sample.yaml)，
+仅添加了 `queue-name` 标签。
 {{% /alert %}}

--- a/site/content/zh-CN/docs/tasks/run/rayservices.md
+++ b/site/content/zh-CN/docs/tasks/run/rayservices.md
@@ -67,7 +67,6 @@ spec:
 Kueue 控制 RayService 的 `spec.rayClusterConfig.suspend` 字段。当 RayService 被 Kueue 接纳时，Kueue 会通过将 `spec.rayClusterConfig.suspend` 设置为 `false` 来取消暂停，无论其之前的值是什么。
 
 ### d. 限制事项 {#c-limitations}
-- 有限的 Worker Group：由于 Kueue 工作负载最多可以有 18 个 PodSet，所以 `spec.rayClusterConfig.workerGroupSpecs` 的最大数量为 17。
 - 内建自动扩缩约束：自动扩缩仅支持[弹性](/zh-cn/docs/concepts/elastic_workload) RayService 对象。要启用内建自动扩缩：
 
   1. 启用 `ElasticJobsViaWorkloadSlices` 特性门控。

--- a/site/static/examples/jobs/ray-service-sample.yaml
+++ b/site/static/examples/jobs/ray-service-sample.yaml
@@ -1,8 +1,11 @@
+# Make sure to increase resource requests and limits before using this example in production.
+# For examples with more realistic resource configuration, see
+# ray-cluster.complete.large.yaml and
+# ray-cluster.autoscaler.large.yaml.
 apiVersion: ray.io/v1
 kind: RayService
 metadata:
-  name: test-rayservice
-  namespace: default
+  name: rayservice-sample
   labels:
     kueue.x-k8s.io/queue-name: user-queue
 spec:
@@ -59,7 +62,7 @@ spec:
           - name: Router
             num_replicas: 1
   rayClusterConfig:
-    rayVersion: '2.46.0' # should match the Ray version in the image of the containers
+    rayVersion: '2.52.0' # should match the Ray version in the image of the containers
     ######################headGroupSpecs#################################
     # Ray head pod template.
     headGroupSpec:
@@ -72,14 +75,14 @@ spec:
         spec:
           containers:
           - name: ray-head
-            image: rayproject/ray:2.46.0
+            image: rayproject/ray:2.52.0
             resources:
               limits:
-                cpu: 4
-                memory: 6Gi
+                cpu: "2"
+                memory: "5Gi"
               requests:
-                cpu: 2
-                memory: 4Gi
+                cpu: "2"
+                memory: "2Gi"
     workerGroupSpecs:
     # the pod replicas in this group typed worker
     - replicas: 1
@@ -96,11 +99,11 @@ spec:
         spec:
           containers:
           - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
-            image: rayproject/ray:2.46.0
+            image: rayproject/ray:2.52.0
             resources:
               limits:
-                cpu: "2"
-                memory: "4Gi"
-              requests:
                 cpu: "1"
+                memory: "2Gi"
+              requests:
+                cpu: "500m"
                 memory: "2Gi"


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
This PR updates the Kueue documentation and samples for `RayService` integration.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
AI assistance was used to help author, cross-verify, and format these documentation updates in accordance with the Kubernetes AI Tool Usage Policy.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added RayCluster and RayService workflow guidance to elastic workload documentation.
  - Clarified MultiKueue support and updated RayService prerequisites, suspend configuration, autoscaling, rolling-upgrade limitations, and example references.
  - Updated the equivalent Chinese-language documentation.

- **Examples**
  - Renamed and refreshed the RayService sample with configuration guidance and Ray 2.52.0.
  - Adjusted head and worker container resource requests and limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->