### PR TITLE
only apply runtimePatches if they don't exist in TrainJob mutating webook

### DIFF
--- a/pkg/controller/jobs/trainjob/trainjob_webhook.go
+++ b/pkg/controller/jobs/trainjob/trainjob_webhook.go
@@ -90,18 +90,19 @@ func (w *TrainJobWebhook) Default(ctx context.Context, obj *kftrainerapi.TrainJo
 	if err != nil {
 		return err
 	}
-	runtimePatch := kftrainerapi.RuntimePatch{
-		Manager: runtimePatchManagerName,
-		TrainingRuntimeSpec: &kftrainerapi.TrainingRuntimeSpecPatch{
-			Template: &kftrainerapi.JobSetTemplatePatch{
-				Spec: &kftrainerapi.JobSetSpecPatch{},
-			},
-		},
-	}
 	if suspend {
 		trainJob.Suspend()
 	}
-	trainJob.Spec.RuntimePatches = append(trainJob.Spec.RuntimePatches, runtimePatch)
+	if getKueueRuntimePatch(trainJob) == nil {
+		trainJob.Spec.RuntimePatches = append(trainJob.Spec.RuntimePatches, kftrainerapi.RuntimePatch{
+			Manager: runtimePatchManagerName,
+			TrainingRuntimeSpec: &kftrainerapi.TrainingRuntimeSpecPatch{
+				Template: &kftrainerapi.JobSetTemplatePatch{
+					Spec: &kftrainerapi.JobSetSpecPatch{},
+				},
+			},
+		})
+	}
 	return nil
 }
 

--- a/pkg/controller/jobs/trainjob/trainjob_webhook_test.go
+++ b/pkg/controller/jobs/trainjob/trainjob_webhook_test.go
@@ -196,6 +196,14 @@ func TestDefault(t *testing.T) {
 	testExpectedTrainJob := testTrainJob.Clone().RuntimePatches([]kftrainerapi.RuntimePatch{
 		testingtrainjob.MakeRuntimePatch(runtimePatchManagerName).Obj(),
 	})
+	userRuntimePatch := testingtrainjob.MakeRuntimePatch("example.com/user-manager").Obj()
+	testTrainJobWithUserRuntimePatch := testTrainJob.Clone().RuntimePatches([]kftrainerapi.RuntimePatch{userRuntimePatch})
+	testTrainJobWithRuntimePatch := testTrainJob.Clone().RuntimePatches([]kftrainerapi.RuntimePatch{
+		userRuntimePatch,
+		testingtrainjob.MakeRuntimePatch(runtimePatchManagerName).
+			Annotation("example.com/key", "value").
+			Obj(),
+	})
 	testCases := map[string]struct {
 		trainJob                     *kftrainerapi.TrainJob
 		defaultQueue                 *kueue.LocalQueue
@@ -215,6 +223,17 @@ func TestDefault(t *testing.T) {
 		"should not suspend a TrainJob without a queue label if manageJobsWithoutQueueName is not enabled": {
 			trainJob:     testTrainJob.DeepCopy(),
 			wantTrainJob: testExpectedTrainJob.DeepCopy(),
+		},
+		"should add a Kueue runtime patch when only a user runtime patch exists": {
+			trainJob: testTrainJobWithUserRuntimePatch.DeepCopy(),
+			wantTrainJob: testTrainJobWithUserRuntimePatch.Clone().RuntimePatches([]kftrainerapi.RuntimePatch{
+				userRuntimePatch,
+				testingtrainjob.MakeRuntimePatch(runtimePatchManagerName).Obj(),
+			}).Obj(),
+		},
+		"should preserve an existing Kueue runtime patch without adding a duplicate": {
+			trainJob:     testTrainJobWithRuntimePatch.DeepCopy(),
+			wantTrainJob: testTrainJobWithRuntimePatch.DeepCopy(),
 		},
 		"should suspend a TrainJob without a queue label if manageJobsWithoutQueueName is enabled": {
 			trainJob: testTrainJob.DeepCopy(),

--- a/test/integration/singlecluster/webhook/jobs/trainjob_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/trainjob_webhook_test.go
@@ -90,6 +90,40 @@ var _ = ginkgo.Describe("Trainjob Webhook", func() {
 			})
 		})
 
+		ginkgo.It("should preserve an existing Kueue runtime patch without adding a duplicate", func() {
+			testJobSet := testingjobset.MakeJobSet("", "").ReplicatedJobs(
+				testingjobset.ReplicatedJobRequirements{
+					Name:     "node",
+					Replicas: 1,
+				}).
+				Obj()
+			testTr := testingtrainjob.MakeTrainingRuntime("test", ns.Name, testJobSet.Spec)
+			userRuntimePatch := testingtrainjob.MakeRuntimePatch("example.com/user-manager").Obj()
+			kueueRuntimePatch := testingtrainjob.MakeRuntimePatch(testingtrainjob.KueueRuntimePatchManager).
+				Annotation("example.com/key", "value").
+				Obj()
+			trainJob := testingtrainjob.MakeTrainJob("trainjob-test", ns.Name).RuntimeRef(kftrainerapi.RuntimeRef{
+				APIGroup: new(kftrainerapi.GroupVersion.Group),
+				Name:     "test",
+				Kind:     new(kftrainerapi.TrainingRuntimeKind),
+			}).
+				RuntimePatches([]kftrainerapi.RuntimePatch{userRuntimePatch, kueueRuntimePatch}).
+				Obj()
+
+			ginkgo.By("creating the TrainJob with an existing Kueue runtime patch", func() {
+				util.MustCreate(ctx, k8sClient, testTr)
+				util.MustCreateWithRetry(ctx, k8sClient, trainJob)
+			})
+
+			ginkgo.By("preserving the runtime patches", func() {
+				createdTrainJob := kftrainerapi.TrainJob{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: trainJob.Name, Namespace: ns.Name}, &createdTrainJob)).Should(gomega.Succeed())
+					g.Expect(createdTrainJob.Spec.RuntimePatches).Should(gomega.Equal([]kftrainerapi.RuntimePatch{userRuntimePatch, kueueRuntimePatch}))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
 		ginkgo.It("should not suspend a TrainJob without queue", func() {
 			testJobSet := testingjobset.MakeJobSet("", "").ReplicatedJobs(
 				testingjobset.ReplicatedJobRequirements{


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
TrainJob mutating webhooks create sideeffects if applied multiple times.

It is common for platfroms to have their own webhooks and the hope is to make sure that webhooks can be reinvocated if any change happens. For TrainJob this becomes a problem since duplicate runtime patches can be applied.

Code only applies the runtimePatch if it doesn't exist.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #15210 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TrainJob: Fixed a bug where the TrainJob mutating webhook added a duplicate Kueue-owned runtimePatch entry on every update, causing spec.runtimePatches to accumulate stale entries.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate Kueue runtime patches when a TrainJob already includes one.
  - Preserved both user-defined and Kueue runtime patches during TrainJob creation and defaulting.

- **Tests**
  - Added coverage for existing user and Kueue runtime patches.
  - Added integration validation to ensure patches remain intact without duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->