### PR TITLE
fix: prevent PodSetReducer int32 overflow

### DIFF
--- a/pkg/scheduler/flavorassigner/podset_reducer.go
+++ b/pkg/scheduler/flavorassigner/podset_reducer.go
@@ -82,7 +82,6 @@ func distributeOrderBased(out, fullCounts, deltas []int32, amount, _ int64) {
 // binary Search so the last call to fits() might not be a successful one
 // Returns nil if no solution was found
 func (psr *PodSetReducer[R]) Search() (R, bool) {
-	var lastGoodIdx int64
 	var lastR R
 
 	if psr.totalDelta == 0 {
@@ -90,29 +89,30 @@ func (psr *PodSetReducer[R]) Search() (R, bool) {
 	}
 
 	current := make([]int32, len(psr.podSets))
-	idx := searchInt64(psr.totalDelta+1, func(i int64) bool {
+	_, found := searchInt64(psr.totalDelta, func(i int64) bool {
 		psr.distribute(current, psr.fullCounts, psr.deltas, i, psr.totalDelta)
 		r, f := psr.fits(current)
 		if f {
-			lastGoodIdx = i
 			lastR = r
 		}
 		return f
 	})
-	return lastR, idx == lastGoodIdx
+
+	return lastR, found
 }
 
-func searchInt64(n int64, f func(int64) bool) int64 {
+func searchInt64(max int64, f func(int64) bool) (int64, bool) {
 	var i int64
-	j := n
+	j := max
 
 	for i < j {
 		h := i + (j-i)/2
-		if !f(h) {
-			i = h + 1
-		} else {
+		if f(h) {
 			j = h
+		} else {
+			i = h + 1
 		}
 	}
-	return i
+
+	return i, f(i)
 }

--- a/pkg/scheduler/flavorassigner/podset_reducer.go
+++ b/pkg/scheduler/flavorassigner/podset_reducer.go
@@ -18,7 +18,6 @@ package flavorassigner
 
 import (
 	"slices"
-	"sort"
 
 	"k8s.io/utils/ptr"
 
@@ -30,7 +29,7 @@ import (
 // how much each PodSet can individually give up. Every out[i] must be
 // monotonically non-increasing as amount grows, or the binary search in
 // Search breaks.
-type distributeFunc func(out, fullCounts, deltas []int32, amount, totalDelta int32)
+type distributeFunc func(out, fullCounts, deltas []int32, amount, totalDelta int64)
 
 // PodSetReducer helper structure used to gradually walk down
 // from PodSets[*].Count to *PodSets[*].MinimumCount.
@@ -38,7 +37,7 @@ type PodSetReducer[R any] struct {
 	podSets    []kueue.PodSet
 	fullCounts []int32
 	deltas     []int32
-	totalDelta int32
+	totalDelta int64
 	fits       func([]int32) (R, bool)
 	distribute distributeFunc
 }
@@ -58,7 +57,7 @@ func newPodSetReducer[R any](podSets []kueue.PodSet, fits func([]int32) (R, bool
 
 		d := ps.Count - ptr.Deref(ps.MinCount, ps.Count)
 		psr.deltas[i] = d
-		psr.totalDelta += d
+		psr.totalDelta += int64(d)
 	}
 	return psr
 }
@@ -70,11 +69,11 @@ func NewOrderedPodSetReducer[R any](podSets []kueue.PodSet, fits func([]int32) (
 	return newPodSetReducer(podSets, fits, distributeOrderBased)
 }
 
-func distributeOrderBased(out, fullCounts, deltas []int32, amount int32, _ int32) {
+func distributeOrderBased(out, fullCounts, deltas []int32, amount, _ int64) {
 	remaining := amount
 	for i, d := range slices.Backward(deltas) {
-		cut := min(d, remaining)
-		out[i] = fullCounts[i] - cut
+		cut := min(int64(d), remaining)
+		out[i] = fullCounts[i] - int32(cut)
 		remaining -= cut
 	}
 }
@@ -83,7 +82,7 @@ func distributeOrderBased(out, fullCounts, deltas []int32, amount int32, _ int32
 // binary Search so the last call to fits() might not be a successful one
 // Returns nil if no solution was found
 func (psr *PodSetReducer[R]) Search() (R, bool) {
-	var lastGoodIdx int
+	var lastGoodIdx int64
 	var lastR R
 
 	if psr.totalDelta == 0 {
@@ -91,8 +90,8 @@ func (psr *PodSetReducer[R]) Search() (R, bool) {
 	}
 
 	current := make([]int32, len(psr.podSets))
-	idx := sort.Search(int(psr.totalDelta)+1, func(i int) bool {
-		psr.distribute(current, psr.fullCounts, psr.deltas, int32(i), psr.totalDelta)
+	idx := searchInt64(psr.totalDelta+1, func(i int64) bool {
+		psr.distribute(current, psr.fullCounts, psr.deltas, i, psr.totalDelta)
 		r, f := psr.fits(current)
 		if f {
 			lastGoodIdx = i
@@ -101,4 +100,19 @@ func (psr *PodSetReducer[R]) Search() (R, bool) {
 		return f
 	})
 	return lastR, idx == lastGoodIdx
+}
+
+func searchInt64(n int64, f func(int64) bool) int64 {
+	var i int64
+	j := n
+
+	for i < j {
+		h := i + (j-i)/2
+		if !f(h) {
+			i = h + 1
+		} else {
+			j = h
+		}
+	}
+	return i
 }

--- a/pkg/scheduler/flavorassigner/podset_reducer.go
+++ b/pkg/scheduler/flavorassigner/podset_reducer.go
@@ -18,6 +18,7 @@ package flavorassigner
 
 import (
 	"slices"
+	"sort"
 
 	"k8s.io/utils/ptr"
 
@@ -89,8 +90,8 @@ func (psr *PodSetReducer[R]) Search() (R, bool) {
 	}
 
 	current := make([]int32, len(psr.podSets))
-	_, found := searchInt64(psr.totalDelta, func(i int64) bool {
-		psr.distribute(current, psr.fullCounts, psr.deltas, i, psr.totalDelta)
+	idx := sort.Search(int(psr.totalDelta), func(i int) bool {
+		psr.distribute(current, psr.fullCounts, psr.deltas, int64(i), psr.totalDelta)
 		r, f := psr.fits(current)
 		if f {
 			lastR = r
@@ -98,21 +99,11 @@ func (psr *PodSetReducer[R]) Search() (R, bool) {
 		return f
 	})
 
-	return lastR, found
-}
-
-func searchInt64(max int64, f func(int64) bool) (int64, bool) {
-	var i int64
-	j := max
-
-	for i < j {
-		h := i + (j-i)/2
-		if f(h) {
-			j = h
-		} else {
-			i = h + 1
-		}
+	if idx < int(psr.totalDelta) {
+		return lastR, true
 	}
 
-	return i, f(i)
+	// sort.Search searches [0, totalDelta), so check totalDelta separately.
+	psr.distribute(current, psr.fullCounts, psr.deltas, psr.totalDelta, psr.totalDelta)
+	return psr.fits(current)
 }

--- a/pkg/scheduler/flavorassigner/podset_reducer_test.go
+++ b/pkg/scheduler/flavorassigner/podset_reducer_test.go
@@ -29,7 +29,7 @@ func TestDistributeOrderBased(t *testing.T) {
 	cases := map[string]struct {
 		fullCounts []int32
 		deltas     []int32
-		amount     int32
+		amount     int64
 		wantOut    []int32
 	}{
 		"zero amount leaves everything at full count": {
@@ -66,9 +66,9 @@ func TestDistributeOrderBased(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			out := make([]int32, len(tc.fullCounts))
-			totalDelta := int32(0)
+			totalDelta := int64(0)
 			for _, d := range tc.deltas {
-				totalDelta += d
+				totalDelta += int64(d)
 			}
 			distributeOrderBased(out, tc.fullCounts, tc.deltas, tc.amount, totalDelta)
 			if diff := cmp.Diff(tc.wantOut, out); diff != "" {
@@ -151,5 +151,39 @@ func TestOrderedSearch(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestSearchTotalDeltaOverflow(t *testing.T) {
+	podSets := []kueue.PodSet{
+		*utiltestingapi.MakePodSet("ps1", 1_500_000_000).SetMinimumCount(1).Obj(),
+		*utiltestingapi.MakePodSet("ps2", 1_500_000_000).SetMinimumCount(1).Obj(),
+	}
+
+	fits := func(counts []int32) ([]int32, bool) {
+		total := int64(counts[0]) + int64(counts[1])
+		if total > 1_000_000_000 {
+			return nil, false
+		}
+
+		out := make([]int32, len(counts))
+		copy(out, counts)
+		return out, true
+	}
+
+	red := NewOrderedPodSetReducer(podSets, fits)
+
+	if want, got := int64(2_999_999_998), red.totalDelta; got != want {
+		t.Errorf("Unexpected totalDelta: %d, want %d", got, want)
+	}
+
+	count, found := red.Search()
+	if !found {
+		t.Fatal("Expected a solution")
+	}
+
+	wantCount := []int32{999_999_999, 1}
+	if diff := cmp.Diff(wantCount, count); diff != "" {
+		t.Errorf("Unexpected counts (-want,+got):\n%s", diff)
 	}
 }

--- a/pkg/scheduler/flavorassigner/podset_reducer_test.go
+++ b/pkg/scheduler/flavorassigner/podset_reducer_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package flavorassigner
 
 import (
+	"math"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -185,5 +186,18 @@ func TestSearchTotalDeltaOverflow(t *testing.T) {
 	wantCount := []int32{999_999_999, 1}
 	if diff := cmp.Diff(wantCount, count); diff != "" {
 		t.Errorf("Unexpected counts (-want,+got):\n%s", diff)
+	}
+}
+
+func TestSearchInt64MaxInt64(t *testing.T) {
+	got, found := searchInt64(math.MaxInt64, func(i int64) bool {
+		return i == math.MaxInt64
+	})
+
+	if !found {
+		t.Fatal("Expected to find a solution")
+	}
+	if got != math.MaxInt64 {
+		t.Errorf("Unexpected index: %d, want %d", got, math.MaxInt64)
 	}
 }

--- a/pkg/scheduler/flavorassigner/podset_reducer_test.go
+++ b/pkg/scheduler/flavorassigner/podset_reducer_test.go
@@ -155,15 +155,16 @@ func TestOrderedSearch(t *testing.T) {
 	}
 }
 
-func TestSearchTotalDeltaOverflow(t *testing.T) {
+func TestSearchTotalDeltaLarge(t *testing.T) {
 	podSets := []kueue.PodSet{
-		*utiltestingapi.MakePodSet("ps1", 1_500_000_000).SetMinimumCount(1).Obj(),
-		*utiltestingapi.MakePodSet("ps2", 1_500_000_000).SetMinimumCount(1).Obj(),
+		*utiltestingapi.MakePodSet("ps1", math.MaxInt32).SetMinimumCount(0).Obj(),
+		*utiltestingapi.MakePodSet("ps2", math.MaxInt32).SetMinimumCount(0).Obj(),
+		*utiltestingapi.MakePodSet("ps3", 1).SetMinimumCount(0).Obj(),
 	}
 
 	fits := func(counts []int32) ([]int32, bool) {
-		total := int64(counts[0]) + int64(counts[1])
-		if total > 1_000_000_000 {
+		total := int64(counts[0]) + int64(counts[1]) + int64(counts[2])
+		if total > 1 {
 			return nil, false
 		}
 
@@ -174,8 +175,8 @@ func TestSearchTotalDeltaOverflow(t *testing.T) {
 
 	red := NewOrderedPodSetReducer(podSets, fits)
 
-	if want, got := int64(2_999_999_998), red.totalDelta; got != want {
-		t.Errorf("Unexpected totalDelta: %d, want %d", got, want)
+	if want, got := int64(4_294_967_295), red.totalDelta; got != want {
+		t.Fatalf("Unexpected totalDelta: %d, want %d", got, want)
 	}
 
 	count, found := red.Search()
@@ -183,21 +184,8 @@ func TestSearchTotalDeltaOverflow(t *testing.T) {
 		t.Fatal("Expected a solution")
 	}
 
-	wantCount := []int32{999_999_999, 1}
+	wantCount := []int32{1, 0, 0}
 	if diff := cmp.Diff(wantCount, count); diff != "" {
 		t.Errorf("Unexpected counts (-want,+got):\n%s", diff)
-	}
-}
-
-func TestSearchInt64MaxInt64(t *testing.T) {
-	got, found := searchInt64(math.MaxInt64, func(i int64) bool {
-		return i == math.MaxInt64
-	})
-
-	if !found {
-		t.Fatal("Expected to find a solution")
-	}
-	if got != math.MaxInt64 {
-		t.Errorf("Unexpected index: %d, want %d", got, math.MaxInt64)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Prevents an int32 overflow when PodSetReducer aggregates the amount that can be removed across multiple PodSets.

Adds a regression test covering an aggregate shrink budget greater than math.MaxInt32.

#### Which issue(s) this PR fixes:

Fixes #15194

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

No.

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduling calculations for workloads with very large pod counts.
  * Prevented numeric overflow during pod set reduction, ensuring valid resource allocation results.
  * Increased reliability when searching for feasible scheduling solutions at numeric boundaries.

* **Tests**
  * Expanded coverage for large pod counts and high-value scheduling calculations.
  * Added validation for accurate search results when total resource adjustments exceed typical numeric limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->