### PR TITLE
[site] Isolate search indexes and preserve page context across doc versions

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
   base = "site"
   publish = "public"
-  command = "npm install && hugo --gc --minify && npx -y pagefind --site public"
+  command = "npm install && hugo --gc --minify && ./scripts/build-search.sh"
 
 [build.environment]
   HUGO_VERSION = "0.165.0"
@@ -12,12 +12,12 @@
   HUGO_BASEURL = "https://kueue.sigs.k8s.io/"
 
 [context.deploy-preview]
-  command = "hugo --enableGitInfo --buildFuture -b $DEPLOY_PRIME_URL && npx -y pagefind --site public && cp custom-headers/deploy-preview public/_headers"
+  command = "hugo --enableGitInfo --buildFuture -b $DEPLOY_PRIME_URL && ./scripts/build-search.sh && cp custom-headers/deploy-preview public/_headers"
   # Runs from "site"; "." includes docs, and "../netlify.toml" includes config changes.
   ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../netlify.toml"
 
 [context.branch-deploy]
-  command = "hugo --enableGitInfo --buildFuture -b $DEPLOY_PRIME_URL && npx -y pagefind --site public"
+  command = "hugo --enableGitInfo --buildFuture -b $DEPLOY_PRIME_URL && ./scripts/build-search.sh"
 
 [[redirects]]
   from = "/api/medium-feed"

--- a/site/layouts/_default/baseof.html
+++ b/site/layouts/_default/baseof.html
@@ -11,7 +11,7 @@
       {{ partial "navbar.html" . }}
     </header>
     <div class="container-fluid td-default td-outer">
-      <main role="main" class="td-main">
+      <main role="main" class="td-main" data-pagefind-body>
         {{ block "main" . }}{{ end }}
       </main>
       {{ partial "footer.html" . }}

--- a/site/layouts/docs/baseof.html
+++ b/site/layouts/docs/baseof.html
@@ -21,7 +21,7 @@
             {{ partial "toc.html" . }}
             {{ partial "taxonomy_terms_clouds.html" . }}
           </aside>
-          <main class="col-12 col-md-9 col-xl-8 ps-md-5" role="main">
+          <main class="col-12 col-md-9 col-xl-8 ps-md-5" role="main" data-pagefind-body>
             {{ partial "version-banner.html" . }}
             {{ if not .Site.Params.ui.breadcrumb_disable }}{{ partial "breadcrumb.html" . }}{{ end }}
             {{ block "main" . }}{{ end }}

--- a/site/layouts/partials/hooks/body-end.html
+++ b/site/layouts/partials/hooks/body-end.html
@@ -4,7 +4,11 @@
   </div>
 </div>
 
-<script src="/pagefind/pagefind-ui.js"></script>
+{{- $bundlePath := "/pagefind/" -}}
+{{- with .Page.Param "docs_minor" -}}
+  {{- $bundlePath = printf "/%s/pagefind/" . -}}
+{{- end -}}
+<script src="{{ $bundlePath }}pagefind-ui.js"></script>
 <script>
 window.addEventListener('DOMContentLoaded', function() {
   var overlay = document.getElementById('pagefind-search-overlay');
@@ -43,7 +47,7 @@ window.addEventListener('DOMContentLoaded', function() {
 
   if (document.getElementById("pagefind-sidebar-search")) {
     try {
-      new PagefindUI({ element: "#pagefind-sidebar-search", showImages: false, resetStyles: false });
+      new PagefindUI({ element: "#pagefind-sidebar-search", bundlePath: {{ $bundlePath }}, baseUrl: "/", showImages: false, resetStyles: false });
     } catch (e) {
       console.error("Failed to initialize sidebar search", e);
     }
@@ -51,7 +55,7 @@ window.addEventListener('DOMContentLoaded', function() {
 
   if (document.getElementById("pagefind-modal-search")) {
     try {
-      new PagefindUI({ element: "#pagefind-modal-search", showImages: false });
+      new PagefindUI({ element: "#pagefind-modal-search", bundlePath: {{ $bundlePath }}, baseUrl: "/", showImages: false });
     } catch (e) {
       console.error("Failed to initialize modal search", e);
     }

--- a/site/layouts/partials/hooks/head-end.html
+++ b/site/layouts/partials/hooks/head-end.html
@@ -1,4 +1,8 @@
-<link href="/pagefind/pagefind-ui.css" rel="stylesheet">
+{{- $bundlePath := "/pagefind/" -}}
+{{- with .Page.Param "docs_minor" -}}
+  {{- $bundlePath = printf "/%s/pagefind/" . -}}
+{{- end -}}
+<link href="{{ $bundlePath }}pagefind-ui.css" rel="stylesheet">
 {{ if .Site.Params.ui.showLightDarkModeMenu -}}
 {{/* Apply the color mode before first paint to avoid a light-theme flash.
      Mirrors Docsy's dark-mode.js (bundled in main.js, loaded at body end),

--- a/site/layouts/partials/navbar-version-selector.html
+++ b/site/layouts/partials/navbar-version-selector.html
@@ -9,11 +9,31 @@
 {{/* Preserve the current language when switching versions.
      .Site.LanguagePrefix is empty for the default language, "/zh-cn" etc. for others. */}}
 {{ $langPrefix := .Site.LanguagePrefix }}
+
+{{/* Extract the documentation subpath (starting from /docs/) to preserve page context */}}
+{{ $docSubpath := "" }}
+{{ $docMatches := findRE "/docs/.*" $.RelPermalink }}
+{{ if gt (len $docMatches) 0 }}
+	{{ $docSubpath = index $docMatches 0 }}
+{{ end }}
+
 <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 	{{ .Site.Params.version_menu }}: {{ $current }}
 </a>
 <div class="dropdown-menu dropdown-menu-md-right dropdown-menu-lg-left" aria-labelledby="navbarDropdownMenuLink">
 	{{ range .Site.Params.versions }}
-	<a class="dropdown-item{{ if eq .version $current }} active{{ end }}" href="{{ $langPrefix }}{{ .url }}">{{ .version }}</a>
+		{{ $targetUrl := printf "%s%s" $langPrefix .url }}
+		{{ if $docSubpath }}
+			{{ $targetPath := "" }}
+			{{ if eq .version "main" }}
+				{{ $targetPath = $docSubpath }}
+			{{ else }}
+				{{ $targetPath = printf "/%s%s" .version $docSubpath }}
+			{{ end }}
+			{{ with site.GetPage $targetPath }}
+				{{ $targetUrl = .RelPermalink }}
+			{{ end }}
+		{{ end }}
+		<a class="dropdown-item{{ if eq .version $current }} active{{ end }}" href="{{ $targetUrl }}">{{ .version }}</a>
 	{{ end }}
 </div>

--- a/site/scripts/build-search.sh
+++ b/site/scripts/build-search.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SITE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${SITE_DIR}"
+
+PUBLIC_DIR="public"
+
+if [ ! -d "${PUBLIC_DIR}" ]; then
+  echo "Error: ${PUBLIC_DIR} directory does not exist. Run hugo first." >&2
+  exit 1
+fi
+
+echo "Building search index for main docs and site..."
+rm -rf "${PUBLIC_DIR}/pagefind"
+npx -y pagefind --site "${PUBLIC_DIR}" \
+  --glob "{{docs,zh-cn/docs,community,zh-cn/community,adopters,zh-cn/adopters,examples,zh-cn/examples}/**/*.{html,htm},*.html,zh-cn/*.html}" \
+  --output-subdir pagefind
+
+echo "Building search indexes for versioned docs..."
+for dir in "${PUBLIC_DIR}"/v0.*; do
+  if [ -d "${dir}" ]; then
+    ver=$(basename "${dir}")
+    echo "Indexing version ${ver}..."
+    rm -rf "${PUBLIC_DIR}/${ver}/pagefind"
+    npx -y pagefind --site "${PUBLIC_DIR}" \
+      --glob "{$ver,zh-cn/$ver}/**/*.{html}" \
+      --output-subdir "${ver}/pagefind"
+  fi
+done
+
+echo "Search indexes built successfully."


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/area website

#### What this PR does / why we need it:

Previously, the documentation site had two major navigation and search UX issues:
- Duplicate search results as a consequence of having a single page index across all documentation versions.
- Loss of page context when switching documentation versions - version selector dropdown always redirected users to the documentation root.

This PR addresses these issues.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Tested locally across main, v0.19, and v0.18.

AI disclosure: This PR description, commit, and code changes were prepared with AI assistance following the Kubernetes AI Tool Usage Policy.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded documentation search across English and Chinese content, including version-specific documentation.
  - Search now works correctly when browsing different documentation versions.

- **Bug Fixes**
  - Documentation version switching now preserves the current page and subpath when an equivalent page is available.
  - Search resources load from the correct version-specific location, improving search reliability across versioned documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->