### PR TITLE
fix(flake): add timeouts to the e2e metrics fetch

### DIFF
--- a/pkg/util/testing/metrics_matchers_test.go
+++ b/pkg/util/testing/metrics_matchers_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/onsi/gomega/types"
+)
+
+func TestMetricsMatcher(t *testing.T) {
+	const (
+		metricsPage = `# HELP kueue_evicted_workloads_total The number of evicted workloads
+# TYPE kueue_evicted_workloads_total counter
+kueue_evicted_workloads_total{cluster_queue="cq",reason="Preempted"} 1
+kueue_preempted_workloads_total{preempting_cluster_queue="cq",reason="InClusterQueue"} 1
+kueue_local_queue_resource_usage{local_queue="lq",namespace="ns",resource="cpu"} 1
+`
+
+		// unauthorizedBody is what the metrics endpoint returns while the metrics-reader
+		// binding is not yet effective. Callers of ExcludeMetrics must not be handed such a
+		// body: it satisfies the matcher without proving anything about the metrics.
+		unauthorizedBody = `{"kind":"Status","message":"Unauthorized","code":401}`
+	)
+
+	testCases := map[string]struct {
+		newMatcher     func([][]string) types.GomegaMatcher
+		metrics        [][]string
+		actual         any
+		want           bool
+		wantErr        string
+		wantFailureMsg string
+	}{
+		"contains all expected metrics": {
+			newMatcher: ContainMetrics,
+			metrics:    [][]string{{"kueue_evicted_workloads_total"}, {"kueue_preempted_workloads_total"}},
+			actual:     metricsPage,
+			want:       true,
+		},
+		"contains a metric narrowed by its label values": {
+			newMatcher: ContainMetrics,
+			metrics:    [][]string{{"kueue_local_queue_resource_usage", "ns", "lq"}},
+			actual:     metricsPage,
+			want:       true,
+		},
+		"contains fails when a label value does not match": {
+			newMatcher: ContainMetrics,
+			metrics:    [][]string{{"kueue_local_queue_resource_usage", "other-ns"}},
+			actual:     metricsPage,
+			want:       false,
+			wantFailureMsg: `Expected to contain metric:
+    <[]string | len:2, cap:2>: [
+        "kueue_local_queue_resource_usage",
+        "other-ns",
+    ]
+
+Actual:
+    <string>: kueue_evicted_workloads_total{cluster_queue="cq",reason="Preempted"} 1
+    kueue_preempted_workloads_total{preempting_cluster_queue="cq",reason="InClusterQueue"} 1
+    kueue_local_queue_resource_usage{local_queue="lq",namespace="ns",resource="cpu"} 1`,
+		},
+		"excludes succeeds once the metrics are gone": {
+			newMatcher: ExcludeMetrics,
+			metrics:    [][]string{{"kueue_evicted_workloads_total"}},
+			actual:     "kueue_pending_workloads{cluster_queue=\"cq\"} 0\n",
+			want:       true,
+		},
+		"excludes fails while the metric is still reported": {
+			newMatcher: ExcludeMetrics,
+			metrics:    [][]string{{"kueue_evicted_workloads_total"}},
+			actual:     metricsPage,
+			want:       false,
+			wantFailureMsg: `Expected not to contain metric:
+    <[]string | len:1, cap:1>: [
+        "kueue_evicted_workloads_total",
+    ]
+
+Actual:
+    <string>: kueue_evicted_workloads_total{cluster_queue="cq",reason="Preempted"} 1
+    kueue_preempted_workloads_total{preempting_cluster_queue="cq",reason="InClusterQueue"} 1
+    kueue_local_queue_resource_usage{local_queue="lq",namespace="ns",resource="cpu"} 1`,
+		},
+		// Guards the reason util.GetKueueMetrics passes --fail to curl: without it an
+		// HTTP error is reported as a successful fetch, and this body then satisfies
+		// ExcludeMetrics, so ExpectMetricsNotToBeAvailable would pass for the wrong reason.
+		"excludes matches vacuously against an error body": {
+			newMatcher: ExcludeMetrics,
+			metrics:    [][]string{{"kueue_evicted_workloads_total"}},
+			actual:     unauthorizedBody,
+			want:       true,
+		},
+		"non-string input": {
+			newMatcher: ContainMetrics,
+			metrics:    [][]string{{"kueue_evicted_workloads_total"}},
+			actual:     42,
+			want:       false,
+			wantErr:    "Metrics matcher expects a string. Got:\n    <int>: 42",
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			matcher := tc.newMatcher(tc.metrics)
+			got, gotErr := matcher.Match(tc.actual)
+
+			var gotErrStr string
+			if gotErr != nil {
+				gotErrStr = gotErr.Error()
+			}
+
+			if diff := cmp.Diff(tc.wantErr, gotErrStr); diff != "" {
+				t.Errorf("Unexpected error (-want,+got):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Unexpected result (-want,+got):\n%s", diff)
+			}
+
+			if !got && gotErr == nil {
+				if diff := cmp.Diff(tc.wantFailureMsg, matcher.FailureMessage(tc.actual)); diff != "" {
+					t.Errorf("Unexpected failure message (-want,+got):\n%s", diff)
+				}
+			}
+		})
+	}
+}

--- a/test/e2e/certmanager/metrics_test.go
+++ b/test/e2e/certmanager/metrics_test.go
@@ -259,7 +259,7 @@ func getKueueMetricsSecure(curlPodName, curlContainerName string) ([]byte, error
 			"/bin/sh",
 			"-c",
 			fmt.Sprintf(
-				"curl -s --connect-timeout 5 --max-time 15 --cacert %s/ca.crt -H \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" https://%s.%s.svc.cluster.local:8443/metrics",
+				"curl -s --fail --connect-timeout 5 --max-time 15 --cacert %s/ca.crt -H \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" https://%s.%s.svc.cluster.local:8443/metrics",
 				certMountPath,
 				metricsServiceName,
 				kueueNS,

--- a/test/util/e2e.go
+++ b/test/util/e2e.go
@@ -723,23 +723,35 @@ func CreateNamespaceFromObjectWithLog(ctx context.Context, k8sClient client.Clie
 	return ns
 }
 
-func GetKueueMetrics(ctx context.Context, cfg *rest.Config, restClient *rest.RESTClient, curlPodName, curlContainerName string) (string, error) {
+// GetKueueMetrics scrapes the Kueue metrics endpoint from the given curl pod, returning the
+// response body and curl's stderr.
+//
+// The fetch is bounded because callers poll this helper from an Eventually block, which
+// cannot interrupt a call that is already in flight. Left unbounded, curl falls back to its
+// built-in 300s connection timeout - far longer than the LongTimeout budget the callers poll
+// with - so a single stalled fetch consumes the whole budget and is never retried.
+// --fail keeps a failed response on that same retry path: ExcludeMetrics matches vacuously
+// against an error body, so an unauthorized response would otherwise be accepted as proof
+// that the metrics are gone.
+func GetKueueMetrics(ctx context.Context, cfg *rest.Config, restClient *rest.RESTClient, curlPodName, curlContainerName string) (string, string, error) {
 	kueueNS := GetKueueNamespace()
-	metricsOutput, _, err := KExecute(ctx, cfg, restClient, kueueNS, curlPodName, curlContainerName, []string{
+	ctx, cancel := context.WithTimeout(ctx, MediumTimeout)
+	defer cancel()
+	metricsOutput, stderr, err := KExecute(ctx, cfg, restClient, kueueNS, curlPodName, curlContainerName, []string{
 		"/bin/sh", "-c",
 		fmt.Sprintf(
-			"curl -s -k -H \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" https://%s.%s.svc.cluster.local:8443/metrics",
+			"curl -sS --fail --connect-timeout 5 --max-time 15 -k -H \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" https://%s.%s.svc.cluster.local:8443/metrics",
 			DefaultMetricsServiceName, kueueNS,
 		),
 	})
-	return string(metricsOutput), err
+	return string(metricsOutput), string(stderr), err
 }
 
 func ExpectMetricsToBeAvailable(ctx context.Context, cfg *rest.Config, restClient *rest.RESTClient, curlPodName, curlContainerName string, metrics [][]string) {
 	ginkgo.GinkgoHelper()
 	gomega.Eventually(func(g gomega.Gomega) {
-		metricsOutput, err := GetKueueMetrics(ctx, cfg, restClient, curlPodName, curlContainerName)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
+		metricsOutput, stderr, err := GetKueueMetrics(ctx, cfg, restClient, curlPodName, curlContainerName)
+		g.Expect(err).NotTo(gomega.HaveOccurred(), "stderr: %s", stderr)
 		g.Expect(metricsOutput).Should(utiltesting.ContainMetrics(metrics))
 	}, LongTimeout, Interval).Should(gomega.Succeed())
 }
@@ -747,8 +759,8 @@ func ExpectMetricsToBeAvailable(ctx context.Context, cfg *rest.Config, restClien
 func ExpectMetricsNotToBeAvailable(ctx context.Context, cfg *rest.Config, restClient *rest.RESTClient, curlPodName, curlContainerName string, metrics [][]string) {
 	ginkgo.GinkgoHelper()
 	gomega.Eventually(func(g gomega.Gomega) {
-		metricsOutput, err := GetKueueMetrics(ctx, cfg, restClient, curlPodName, curlContainerName)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
+		metricsOutput, stderr, err := GetKueueMetrics(ctx, cfg, restClient, curlPodName, curlContainerName)
+		g.Expect(err).NotTo(gomega.HaveOccurred(), "stderr: %s", stderr)
 		g.Expect(metricsOutput).Should(utiltesting.ExcludeMetrics(metrics))
 	}, LongTimeout, Interval).Should(gomega.Succeed())
 }

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -1241,11 +1241,12 @@ func KExecute(ctx context.Context, cfg *rest.Config, client *rest.RESTClient, ns
 		return nil, nil, err
 	}
 
-	if err = executor.StreamWithContext(ctx, remotecommand.StreamOptions{Stdout: &out, Stderr: &outErr}); err != nil {
-		return nil, nil, err
-	}
+	// Return whatever was captured even on error: when the remote command exits
+	// non-zero the streams still hold its output, and stderr is usually the only
+	// explanation of the failure. Callers assert on err and report stderr with it.
+	err = executor.StreamWithContext(ctx, remotecommand.StreamOptions{Stdout: &out, Stderr: &outErr})
 
-	return out.Bytes(), outErr.Bytes(), nil
+	return out.Bytes(), outErr.Bytes(), err
 }
 
 // getProjectBaseDir retrieves the project base directory either from an environment variable or by searching for a Makefile.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind flake
/area testing
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
The metrics e2e tests read /metrics by running curl in a pod, wrapped in an Eventually that polls for 90s. The curl command set no timeout, so it fell back to curl's 300s default for the connect phase. Eventually can't interrupt a call that's already running, so one stalled connection ate the full budget. The spec failed after a single attempt with "Timed out after 300.975s" and "command terminated with exit code 28", with nothing to say why exactly.

I have added --connect-timeout 5 and --max-time 15 which are the same values the certmanager suite already uses, plus a context deadline so a hung exec stream can't outlast the budget either.

Also pass --fail. Without it curl exits 0 on an HTTP error and hands the error body back as if it were metrics. That hides a real problem: ExcludeMetrics passes for any body that doesn't contain the metric names, so a 401 looks like proof the metrics are gone. Added a unit test for the matcher to lock that specific behavior down and isolate it.

Tested on a 3-node kind cluster on k8s 1.37.0: the failing spec passes in 7.8s, the full baseline suite is 59/59, and the metrics specs pass 10 runs back to back. Pointed at a blackholed address, the old helper blew the 90s budget after 135s and reported nothing useful. This new one stays in budget and reports "curl: (28) Connection timed out after 5002 milliseconds".

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #15177 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metrics availability checks with bounded request timeouts, preventing stalled checks from waiting indefinitely.
  * Failed metrics requests now surface command output and error details for clearer troubleshooting.
  * Remote command failures preserve captured output, making diagnostics more informative.
  * HTTP errors during secure metrics checks are now reported as failures.
* **Tests**
  * Expanded coverage for metrics matching, label-based matching, exclusion behavior, failure messages, and invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->