### PR TITLE
Automated cherry pick of #15176: Extract resource multiplication to a helper

### DIFF
--- a/pkg/util/resource/resource.go
+++ b/pkg/util/resource/resource.go
@@ -147,3 +147,12 @@ func isNativeResource(name corev1.ResourceName) bool {
 func isHugePageResourceName(name corev1.ResourceName) bool {
 	return strings.HasPrefix(string(name), corev1.ResourceHugePagesPrefix)
 }
+
+// MultiplyQuantity returns the product of two resource.Quantity values with arbitrary precision.
+func MultiplyQuantity(value, mul resource.Quantity) resource.Quantity {
+	value = value.DeepCopy()
+	mul = mul.DeepCopy()
+	product := inf.Dec{}
+	product.Mul(value.AsDec(), mul.AsDec())
+	return *resource.NewDecimalQuantity(product, value.Format)
+}

--- a/pkg/util/resource/resource_test.go
+++ b/pkg/util/resource/resource_test.go
@@ -442,3 +442,49 @@ func TestMergeKeepMaxOwnsItsResult(t *testing.T) {
 		})
 	}
 }
+
+func TestMultiplyQuantity(t *testing.T) {
+	cases := map[string]struct {
+		value resource.Quantity
+		mul   resource.Quantity
+		want  resource.Quantity
+	}{
+		"integer multiplication": {
+			value: resource.MustParse("2"),
+			mul:   resource.MustParse("3"),
+			want:  resource.MustParse("6"),
+		},
+		"multiplication by zero": {
+			value: resource.MustParse("10"),
+			mul:   resource.MustParse("0"),
+			want:  resource.MustParse("0"),
+		},
+		"milli quantity multiplication": {
+			value: resource.MustParse("500m"),
+			mul:   resource.MustParse("2"),
+			want:  resource.MustParse("1"),
+		},
+		"fractional multiplier": {
+			value: resource.MustParse("10"),
+			mul:   resource.MustParse("0.5"),
+			want:  resource.MustParse("5"),
+		},
+		"binary SI format preserved": {
+			value: resource.MustParse("1Gi"),
+			mul:   resource.MustParse("2"),
+			want:  resource.MustParse("2Gi"),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := MultiplyQuantity(tc.value, tc.mul)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("MultiplyQuantity() mismatch (-want +got):\n%s", diff)
+			}
+			if got.Format != tc.value.Format {
+				t.Errorf("MultiplyQuantity() format mismatch: got %v, want %v", got.Format, tc.value.Format)
+			}
+		})
+	}
+}

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"gopkg.in/inf.v0"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -618,13 +617,13 @@ func applyResourceTransformations(input corev1.ResourceList, transforms map[core
 		outputInputVal := inputQuantity
 		if mapping.MultiplyBy != "" {
 			if q, ok := input[mapping.MultiplyBy]; ok {
-				outputInputVal = multiplyResourceQuantities(inputQuantity, q)
+				outputInputVal = resource.MultiplyQuantity(inputQuantity, q)
 			}
 		}
 
 		outputs := make(corev1.ResourceList, len(mapping.Outputs))
 		for outputName, baseFactor := range mapping.Outputs {
-			outputs[outputName] = multiplyResourceQuantities(outputInputVal, baseFactor)
+			outputs[outputName] = resource.MultiplyQuantity(outputInputVal, baseFactor)
 		}
 		// Summed rather than assigned, so which order the input map is walked
 		// in does not decide which contribution to a name survives.
@@ -639,14 +638,6 @@ func applyResourceTransformations(input corev1.ResourceList, transforms map[core
 		}
 	}
 	return resource.MergeResourceListKeepSum(retained, generated)
-}
-
-func multiplyResourceQuantities(value, mul apiresource.Quantity) apiresource.Quantity {
-	value = value.DeepCopy()
-	mul = mul.DeepCopy()
-	product := inf.Dec{}
-	product.Mul(value.AsDec(), mul.AsDec())
-	return *apiresource.NewDecimalQuantity(product, value.Format)
 }
 
 func CanBePartiallyAdmitted(wl *kueue.Workload) bool {


### PR DESCRIPTION
Cherry pick of #15176 on release-0.18.

#15176: Extract resource multiplication to a helper

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```