### PR TITLE
Test CustomLabels cleanup and fix leaked workload label values

### DIFF
--- a/pkg/cache/scheduler/cache.go
+++ b/pkg/cache/scheduler/cache.go
@@ -618,6 +618,14 @@ func (c *Cache) DeleteClusterQueue(cq *kueue.ClusterQueue) {
 		}
 	}
 
+	// The custom label value cache is keyed by Workload and shared by every
+	// ClusterQueue, so entries for the Workloads this ClusterQueue still holds
+	// would outlive it and never be reclaimed: once the ClusterQueue is gone,
+	// DeleteWorkload can no longer reach them.
+	for wlKey := range curCq.Workloads {
+		c.customLabels.Delete(config.SourceKindWorkload, string(wlKey))
+	}
+
 	parent := curCq.Parent()
 
 	c.hm.DeleteClusterQueue(cqName)

--- a/pkg/cache/scheduler/custom_labels_cleanup_test.go
+++ b/pkg/cache/scheduler/custom_labels_cleanup_test.go
@@ -1,0 +1,200 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/google/go-cmp/cmp"
+	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+
+	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/metrics"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	testingmetrics "sigs.k8s.io/kueue/pkg/util/testing/metrics"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/pkg/workload"
+)
+
+func admittedWorkload(name, kindLabel string, cqName kueue.ClusterQueueReference, now time.Time) *utiltestingapi.WorkloadWrapper {
+	return utiltestingapi.MakeWorkload(name, "ns").
+		Label("kind", kindLabel).
+		Request(corev1.ResourceCPU, "1").
+		SimpleReserveQuota(cqName, "default", now).
+		AdmittedAt(true, now)
+}
+
+// customLabelsCleanupCache builds a cache configured with one ClusterQueue label
+// and one Workload label, mirroring the shape of a real configuration. The
+// Workload entry is the one at risk of accumulating values, since every workload
+// adds an entry to the store.
+func customLabelsCleanupCache(t *testing.T) (*Cache, *metrics.CustomLabels) {
+	t.Helper()
+	customLabels := metrics.NewCustomLabels([]configapi.ControllerMetricsCustomLabel{
+		utiltestingapi.MakeCustomLabel("team").SourceKind(configapi.SourceKindClusterQueue).Obj(),
+		utiltestingapi.MakeCustomLabel("wl_kind").SourceLabelKey("kind").
+			SourceKind(configapi.SourceKindWorkload).TrackedValues("training", "inference").Obj(),
+	})
+	t.Cleanup(func() {
+		metrics.InitMetricVectors(nil)
+	})
+	return New(utiltesting.NewFakeClient(), WithCustomLabels(customLabels)), customLabels
+}
+
+func makeCleanupClusterQueue(name string) *kueue.ClusterQueue {
+	return utiltestingapi.MakeClusterQueue(name).
+		ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "10").Obj()).
+		Label("team", "platform").
+		Obj()
+}
+
+// TestWorkloadCustomLabelsCleanup verifies that the cached custom label values of
+// a Workload are dropped from the store whenever the cache stops tracking that
+// Workload. The store is keyed by workload and shared by all ClusterQueues, so a
+// missed deletion keeps user-supplied label values alive for the lifetime of the
+// process.
+func TestWorkloadCustomLabelsCleanup(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.CustomMetricLabels, true)
+	now := time.Now()
+	wl1Key := workload.Key(admittedWorkload("wl1", "training", "cq", now).Obj())
+
+	cases := map[string]struct {
+		operation func(log logr.Logger, cache *Cache, cq *kueue.ClusterQueue) error
+		wantRefs  []string
+	}{
+		"workload deleted from the cache": {
+			operation: func(log logr.Logger, cache *Cache, _ *kueue.ClusterQueue) error {
+				return cache.DeleteWorkload(log, wl1Key)
+			},
+			wantRefs: []string{"ns/wl2"},
+		},
+		"workload finished": {
+			operation: func(log logr.Logger, cache *Cache, _ *kueue.ClusterQueue) error {
+				cache.AddOrUpdateWorkload(log, admittedWorkload("wl1", "training", "cq", now).Finished().Obj())
+				return nil
+			},
+			wantRefs: []string{"ns/wl2"},
+		},
+		"workload deactivated": {
+			operation: func(log logr.Logger, cache *Cache, _ *kueue.ClusterQueue) error {
+				cache.AddOrUpdateWorkload(log, admittedWorkload("wl1", "training", "cq", now).Active(false).Obj())
+				return nil
+			},
+			wantRefs: []string{"ns/wl2"},
+		},
+		// The workload is still tracked, just by another ClusterQueue: the entry
+		// must be re-stored rather than dropped when it moves.
+		"workload moved to another ClusterQueue": {
+			operation: func(log logr.Logger, cache *Cache, _ *kueue.ClusterQueue) error {
+				cache.AddOrUpdateWorkload(log, admittedWorkload("wl1", "training", "other-cq", now).Obj())
+				return nil
+			},
+			wantRefs: []string{"ns/wl1", "ns/wl2"},
+		},
+		"ClusterQueue holding the workloads deleted": {
+			operation: func(_ logr.Logger, cache *Cache, cq *kueue.ClusterQueue) error {
+				cache.DeleteClusterQueue(cq)
+				return nil
+			},
+			wantRefs: nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, log := utiltesting.ContextWithLog(t)
+			cache, customLabels := customLabelsCleanupCache(t)
+
+			cq := makeCleanupClusterQueue("cq")
+			for _, q := range []*kueue.ClusterQueue{cq, makeCleanupClusterQueue("other-cq")} {
+				if err := cache.AddClusterQueue(ctx, q); err != nil {
+					t.Fatalf("Failed to add ClusterQueue %s: %v", q.Name, err)
+				}
+			}
+			cache.AddOrUpdateWorkload(log, admittedWorkload("wl1", "training", "cq", now).Obj())
+			cache.AddOrUpdateWorkload(log, admittedWorkload("wl2", "inference", "cq", now).Obj())
+			if diff := cmp.Diff([]string{"ns/wl1", "ns/wl2"}, storedWorkloadRefs(customLabels)); diff != "" {
+				t.Fatalf("Unexpected stored workload references before the operation (-want +got):\n%s", diff)
+			}
+
+			if err := tc.operation(log, cache, cq); err != nil {
+				t.Fatalf("Operation failed: %v", err)
+			}
+
+			if diff := cmp.Diff(tc.wantRefs, storedWorkloadRefs(customLabels)); diff != "" {
+				t.Errorf("Unexpected stored workload references (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestDeleteClusterQueueClearsCustomLabelledSeries verifies that removing a
+// ClusterQueue removes its metric series whatever custom label values they
+// carry, so that no queue or workload metadata is left exposed at /metrics.
+func TestDeleteClusterQueueClearsCustomLabelledSeries(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.CustomMetricLabels, true)
+	ctx, log := utiltesting.ContextWithLog(t)
+	now := time.Now()
+
+	cache, customLabels := customLabelsCleanupCache(t)
+	cq := makeCleanupClusterQueue("cq")
+	customLabels.CQStore(kueue.ClusterQueueReference(cq.Name), cq.Labels, cq.Annotations)
+	if err := cache.AddClusterQueue(ctx, cq); err != nil {
+		t.Fatalf("Failed to add ClusterQueue: %v", err)
+	}
+	cache.AddOrUpdateWorkload(log, admittedWorkload("wl1", "training", "cq", now).Obj())
+	cache.AddOrUpdateWorkload(log, admittedWorkload("wl2", "inference", "cq", now).Obj())
+
+	cqSeries := map[string]string{"cluster_queue": cq.Name}
+	cqScopedMetrics := map[string]*prometheus.GaugeVec{
+		"kueue_admitted_active_workloads":  metrics.AdmittedActiveWorkloads,
+		"kueue_reserving_active_workloads": metrics.ReservingActiveWorkloads,
+		"kueue_cluster_queue_status":       metrics.ClusterQueueByStatus,
+	}
+
+	// Checked before the deletion so that the assertions below cannot pass just
+	// because a vector never held a series for this ClusterQueue.
+	for name, vec := range cqScopedMetrics {
+		if got := testingmetrics.CollectFilteredGaugeVec(vec, cqSeries); len(got) == 0 {
+			t.Fatalf("Expected %s to hold series for the ClusterQueue before the deletion", name)
+		}
+	}
+	// kueue_admitted_active_workloads splits per distinct workload label value.
+	if got := testingmetrics.CollectFilteredGaugeVec(metrics.AdmittedActiveWorkloads, cqSeries); len(got) != 2 {
+		t.Fatalf("Expected 2 kueue_admitted_active_workloads series before the deletion, got %v", got)
+	}
+
+	cache.DeleteClusterQueue(cq)
+
+	for name, vec := range cqScopedMetrics {
+		if got := testingmetrics.CollectFilteredGaugeVec(vec, cqSeries); len(got) != 0 {
+			t.Errorf("Expected no %s series for the deleted ClusterQueue, got %v", name, got)
+		}
+	}
+}
+
+func storedWorkloadRefs(cl *metrics.CustomLabels) []string {
+	refs := cl.StoredRefsForTest(configapi.SourceKindWorkload)
+	slices.Sort(refs)
+	return refs
+}

--- a/pkg/metrics/custom_labels.go
+++ b/pkg/metrics/custom_labels.go
@@ -180,6 +180,17 @@ func (cl *CustomLabels) Delete(kind configapi.SourceKind, ref string) {
 	cl.m[kind].delete(ref)
 }
 
+// StoredRefsForTest returns the object references currently held in the
+// in-memory label value cache for kind, in unspecified order. Exported only
+// for testing, so that packages driving the caches and controllers can assert
+// that cached label values are dropped once the source object is deleted.
+func (cl *CustomLabels) StoredRefsForTest(kind configapi.SourceKind) []string {
+	if !cl.enabled() || cl.m[kind] == nil {
+		return nil
+	}
+	return cl.m[kind].values.Keys()
+}
+
 func (cl *CustomLabels) enabled() bool {
 	return cl != nil && features.Enabled(features.CustomMetricLabels)
 }

--- a/pkg/metrics/custom_labels_test.go
+++ b/pkg/metrics/custom_labels_test.go
@@ -482,6 +482,7 @@ func TestLabelValsTracker(t *testing.T) {
 			expectedCounts: map[labelValsSet]int{
 				k1: 5,
 			},
+			expectedTotal: 5,
 		},
 		"decrement to 0": {
 			op: func(t *LabelValsTracker) {
@@ -588,7 +589,7 @@ func TestLabelValsTracker(t *testing.T) {
 				k1: 2,
 				k2: 7,
 			},
-			expectedTotal: 14,
+			expectedTotal: 9,
 		},
 	}
 
@@ -598,6 +599,291 @@ func TestLabelValsTracker(t *testing.T) {
 			tc.op(lvt)
 			if diff := cmp.Diff(tc.expectedCounts, lvt.counts); diff != "" {
 				t.Errorf("unexpected counts: %s", diff)
+			}
+			if diff := cmp.Diff(tc.expectedTotal, lvt.Total()); diff != "" {
+				t.Errorf("unexpected total: %s", diff)
+			}
+		})
+	}
+}
+
+var allSourceKinds = []configapi.SourceKind{
+	configapi.SourceKindClusterQueue,
+	configapi.SourceKindLocalQueue,
+	configapi.SourceKindCohort,
+	configapi.SourceKindWorkload,
+}
+
+// allSourceKindEntries defines one custom label per SourceKind, so that a test
+// can assert that operations on one kind leave the other kinds untouched.
+func allSourceKindEntries() []configapi.ControllerMetricsCustomLabel {
+	return []configapi.ControllerMetricsCustomLabel{
+		utiltestingapi.MakeCustomLabel("cq_team").SourceLabelKey("team").SourceKind(configapi.SourceKindClusterQueue).Obj(),
+		utiltestingapi.MakeCustomLabel("lq_team").SourceLabelKey("team").SourceKind(configapi.SourceKindLocalQueue).Obj(),
+		utiltestingapi.MakeCustomLabel("cohort_team").SourceLabelKey("team").SourceKind(configapi.SourceKindCohort).Obj(),
+		utiltestingapi.MakeCustomLabel("wl_kind").SourceLabelKey("kind").SourceKind(configapi.SourceKindWorkload).TrackedValues("training").Obj(),
+	}
+}
+
+// TestDeleteClearsStoredLabelValues verifies that Delete drops the cached label
+// values of the deleted object, and only of that object. Values sourced from
+// user-controlled objects (Workloads above all) would otherwise accumulate in
+// the store for the lifetime of the process.
+func TestDeleteClearsStoredLabelValues(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.CustomMetricLabels, true)
+
+	const (
+		keptRef    = "kept"
+		deletedRef = "deleted"
+	)
+	labels := map[string]string{"team": "platform", "kind": "training"}
+
+	tests := map[string]struct {
+		kind      configapi.SourceKind
+		deleteRef string
+		// wantRefs are the references still stored for kind after the delete.
+		wantRefs []string
+	}{
+		"ClusterQueue": {
+			kind:      configapi.SourceKindClusterQueue,
+			deleteRef: deletedRef,
+			wantRefs:  []string{keptRef},
+		},
+		"LocalQueue": {
+			kind:      configapi.SourceKindLocalQueue,
+			deleteRef: deletedRef,
+			wantRefs:  []string{keptRef},
+		},
+		"Cohort": {
+			kind:      configapi.SourceKindCohort,
+			deleteRef: deletedRef,
+			wantRefs:  []string{keptRef},
+		},
+		"Workload": {
+			kind:      configapi.SourceKindWorkload,
+			deleteRef: deletedRef,
+			wantRefs:  []string{keptRef},
+		},
+		"unknown reference": {
+			kind:      configapi.SourceKindWorkload,
+			deleteRef: "never-stored",
+			wantRefs:  []string{deletedRef, keptRef},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			cl := NewCustomLabels(allSourceKindEntries())
+			t.Cleanup(func() {
+				InitMetricVectors(nil)
+			})
+
+			// Store the same reference names under every kind, so that a delete
+			// leaking into another kind's store is visible.
+			for _, kind := range allSourceKinds {
+				cl.Store(kind, keptRef, labels, nil)
+				cl.Store(kind, deletedRef, labels, nil)
+			}
+
+			cl.Delete(tc.kind, tc.deleteRef)
+
+			if diff := cmp.Diff(tc.wantRefs, sortedRefs(cl, tc.kind)); diff != "" {
+				t.Errorf("Unexpected stored references for %s (-want +got):\n%s", tc.kind, diff)
+			}
+			// A reference with no entry reads back as the zero value list, never
+			// as the values it had before the delete.
+			if diff := cmp.Diff([]string{""}, cl.Get(tc.kind, tc.deleteRef)); diff != "" {
+				t.Errorf("Unexpected Get(%s, %s) (-want +got):\n%s", tc.kind, tc.deleteRef, diff)
+			}
+			for _, kind := range allSourceKinds {
+				if kind == tc.kind {
+					continue
+				}
+				if diff := cmp.Diff([]string{deletedRef, keptRef}, sortedRefs(cl, kind)); diff != "" {
+					t.Errorf("Unexpected stored references for %s (-want +got):\n%s", kind, diff)
+				}
+			}
+		})
+	}
+}
+
+// TestTypedDeleteClearsStoredLabelValues covers the typed convenience wrappers,
+// which the controllers call on delete events, and asserts each one addresses
+// its own SourceKind store.
+func TestTypedDeleteClearsStoredLabelValues(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.CustomMetricLabels, true)
+
+	const ref = "obj"
+	tests := map[string]struct {
+		kind   configapi.SourceKind
+		store  func(*CustomLabels)
+		delete func(*CustomLabels)
+	}{
+		"CQDelete": {
+			kind:   configapi.SourceKindClusterQueue,
+			store:  func(cl *CustomLabels) { cl.CQStore(kueue.ClusterQueueReference(ref), nil, nil) },
+			delete: func(cl *CustomLabels) { cl.CQDelete(kueue.ClusterQueueReference(ref)) },
+		},
+		"LQDelete": {
+			kind:   configapi.SourceKindLocalQueue,
+			store:  func(cl *CustomLabels) { cl.LQStore(utilqueue.LocalQueueReference(ref), nil, nil) },
+			delete: func(cl *CustomLabels) { cl.LQDelete(utilqueue.LocalQueueReference(ref)) },
+		},
+		"CohortDelete": {
+			kind:   configapi.SourceKindCohort,
+			store:  func(cl *CustomLabels) { cl.CohortStore(kueue.CohortReference(ref), nil, nil) },
+			delete: func(cl *CustomLabels) { cl.CohortDelete(kueue.CohortReference(ref)) },
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			cl := NewCustomLabels(allSourceKindEntries())
+			t.Cleanup(func() {
+				InitMetricVectors(nil)
+			})
+
+			// Every other kind is seeded directly; tc.kind is seeded through the
+			// typed wrapper, so a wrapper addressing the wrong store shows up as
+			// either a surviving entry under tc.kind or a missing one elsewhere.
+			for _, kind := range allSourceKinds {
+				if kind != tc.kind {
+					cl.Store(kind, ref, nil, nil)
+				}
+			}
+			tc.store(cl)
+			if diff := cmp.Diff([]string{ref}, sortedRefs(cl, tc.kind)); diff != "" {
+				t.Fatalf("Unexpected stored references for %s after the typed store (-want +got):\n%s", tc.kind, diff)
+			}
+
+			tc.delete(cl)
+
+			if got := sortedRefs(cl, tc.kind); len(got) != 0 {
+				t.Errorf("Expected no stored references for %s, got %v", tc.kind, got)
+			}
+			for _, kind := range allSourceKinds {
+				if kind == tc.kind {
+					continue
+				}
+				if diff := cmp.Diff([]string{ref}, sortedRefs(cl, kind)); diff != "" {
+					t.Errorf("Unexpected stored references for %s (-want +got):\n%s", kind, diff)
+				}
+			}
+		})
+	}
+}
+
+// TestDeleteResetsUpdateRequired verifies that a reference re-added after a
+// delete is treated as new: the stale values must not survive the delete and
+// suppress the re-report of its metrics.
+func TestDeleteResetsUpdateRequired(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.CustomMetricLabels, true)
+
+	labels := map[string]string{"team": "platform"}
+	cl := NewCustomLabels(allSourceKindEntries())
+	t.Cleanup(func() {
+		InitMetricVectors(nil)
+	})
+
+	cl.CQStore("cq", labels, nil)
+	if cl.UpdateRequired(configapi.SourceKindClusterQueue, "cq", labels, nil) {
+		t.Error("UpdateRequired() = true for unchanged values, want false")
+	}
+
+	cl.CQDelete("cq")
+
+	if !cl.UpdateRequired(configapi.SourceKindClusterQueue, "cq", labels, nil) {
+		t.Error("UpdateRequired() = false after delete, want true")
+	}
+	if cl.CQStore("cq", labels, nil) {
+		t.Error("CQStore() = true after delete, want false: the entry should be recorded as new")
+	}
+}
+
+func sortedRefs(cl *CustomLabels, kind configapi.SourceKind) []string {
+	refs := cl.StoredRefsForTest(kind)
+	slices.Sort(refs)
+	return refs
+}
+
+// TestLabelValsTrackerPopZeroCounts covers the mechanism that drops workload
+// label value combinations once the last workload carrying them is gone. It
+// both bounds the tracker's size and drives the deletion of the corresponding
+// pending-workload series.
+func TestLabelValsTrackerPopZeroCounts(t *testing.T) {
+	k1 := labelValsSet{vals: [MaxCustomLabelsForSourceKind]string{"v1"}, size: 1}
+	k2 := labelValsSet{vals: [MaxCustomLabelsForSourceKind]string{"v2"}, size: 1}
+	k3 := labelValsSet{vals: [MaxCustomLabelsForSourceKind]string{"v3"}, size: 1}
+
+	cases := map[string]struct {
+		op             func(*LabelValsTracker)
+		expectedPopped []labelValsSet
+		expectedCounts map[labelValsSet]int
+		expectedTotal  int
+	}{
+		"nothing to pop": {
+			op: func(tracker *LabelValsTracker) {
+				tracker.Incr(k1)
+			},
+			expectedPopped: nil,
+			expectedCounts: map[labelValsSet]int{k1: 1},
+			expectedTotal:  1,
+		},
+		"pops the sets drained to zero": {
+			op: func(tracker *LabelValsTracker) {
+				tracker.Incr(k1)
+				tracker.Incr(k2)
+				tracker.Incr(k3)
+				tracker.Decr(k1)
+				tracker.Decr(k3)
+			},
+			expectedPopped: []labelValsSet{k1, k3},
+			expectedCounts: map[labelValsSet]int{k2: 1},
+			expectedTotal:  1,
+		},
+		"pops sets left at zero by an over-decrement": {
+			op: func(tracker *LabelValsTracker) {
+				tracker.Incr(k1)
+				tracker.Add(k1, -5)
+			},
+			expectedPopped: []labelValsSet{k1},
+			expectedCounts: map[labelValsSet]int{},
+			expectedTotal:  0,
+		},
+		"a popped set is not popped twice": {
+			op: func(tracker *LabelValsTracker) {
+				tracker.Incr(k1)
+				tracker.Decr(k1)
+				for range tracker.PopZeroCounts() {
+				}
+			},
+			expectedPopped: nil,
+			expectedCounts: map[labelValsSet]int{},
+			expectedTotal:  0,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			tracker := NewLabelValsTracker()
+			tc.op(tracker)
+
+			var popped []labelValsSet
+			for ls := range tracker.PopZeroCounts() {
+				popped = append(popped, *ls)
+			}
+			slices.SortFunc(popped, func(a, b labelValsSet) int {
+				return slices.Compare(a.OrderedList(), b.OrderedList())
+			})
+
+			if diff := cmp.Diff(tc.expectedPopped, popped, cmp.AllowUnexported(labelValsSet{})); diff != "" {
+				t.Errorf("unexpected popped sets (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.expectedCounts, tracker.counts); diff != "" {
+				t.Errorf("unexpected counts (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.expectedTotal, tracker.Total()); diff != "" {
+				t.Errorf("unexpected total (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/test/integration/singlecluster/controller/core/custom_labels_test.go
+++ b/test/integration/singlecluster/controller/core/custom_labels_test.go
@@ -17,8 +17,11 @@ limitations under the License.
 package core
 
 import (
+	"slices"
+
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/component-base/metrics/testutil"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -28,6 +31,7 @@ import (
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/metrics"
+	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	testingmetrics "sigs.k8s.io/kueue/pkg/util/testing/metrics"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
@@ -1610,4 +1614,310 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})
+
+	ginkgo.When("CustomMetricLabels sources are deleted", func() {
+		var (
+			cq     *kueue.ClusterQueue
+			cohort *kueue.Cohort
+		)
+
+		ginkgo.BeforeEach(func() {
+			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.CustomMetricLabels, true)
+			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.LocalQueueMetrics, true)
+			controllersCfg := &config.Configuration{}
+			controllersCfg.Metrics.CustomLabels = []config.ControllerMetricsCustomLabel{
+				utiltestingapi.MakeCustomLabel("team_cq").SourceLabelKey("team").SourceKind(config.SourceKindClusterQueue).Obj(),
+				utiltestingapi.MakeCustomLabel("team_lq").SourceLabelKey("team").SourceKind(config.SourceKindLocalQueue).Obj(),
+				utiltestingapi.MakeCustomLabel("team_cohort").SourceLabelKey("team").SourceKind(config.SourceKindCohort).Obj(),
+				utiltestingapi.MakeCustomLabel("wl_kind").SourceLabelKey("workload-kind").SourceKind(config.SourceKindWorkload).TrackedValues("training").Obj(),
+			}
+			fwk.StartManager(ctx, cfg, managerAndControllerSetup(controllersCfg, runScheduler))
+			defaultFlavor = utiltestingapi.MakeResourceFlavor("default").Obj()
+			util.MustCreate(ctx, k8sClient, defaultFlavor)
+			ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "custom-labels-deleted-")
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, cohort, true)
+			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, defaultFlavor, true)
+			fwk.StopManager(ctx)
+			metrics.InitMetricVectors(nil)
+		})
+
+		ginkgo.It("should clear ClusterQueue series and stored label values when the ClusterQueue is deleted", func() {
+			cq = utiltestingapi.MakeClusterQueue("cq-deleted").
+				Label("team", "platform").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(defaultFlavor.Name).
+						Resource(corev1.ResourceCPU, "5").
+						Obj(),
+				).Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, cq)
+
+			lq := utiltestingapi.MakeLocalQueue("lq-deleted", ns.Name).
+				Label("team", "platform").
+				ClusterQueue(cq.Name).Obj()
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, lq)
+
+			admitted := utiltestingapi.MakeWorkload("wl-admitted", ns.Name).
+				Label("workload-kind", "training").
+				Queue(kueue.LocalQueueName(lq.Name)).
+				Request(corev1.ResourceCPU, "1").Obj()
+			util.MustCreate(ctx, k8sClient, admitted)
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, admitted)
+
+			// Requests more than the nominal quota, so it stays pending and keeps
+			// the pending-workload series alive until the ClusterQueue is gone.
+			pending := utiltestingapi.MakeWorkload("wl-pending", ns.Name).
+				Label("workload-kind", "training").
+				Queue(kueue.LocalQueueName(lq.Name)).
+				Request(corev1.ResourceCPU, "10").Obj()
+			util.MustCreate(ctx, k8sClient, pending)
+
+			ginkgo.By("verifying the ClusterQueue series and stored label values are present")
+			expectSeriesPresent(clusterQueueScopedMetrics(), map[string]string{"cluster_queue": cq.Name})
+			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 1, "platform", "training")
+			gomega.Expect(customMetricLabels.CQGet(kueue.ClusterQueueReference(cq.Name))).To(gomega.Equal([]string{"platform"}))
+
+			ginkgo.By("deleting the admitted workload and the ClusterQueue")
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, admitted, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+
+			ginkgo.By("verifying no series is left for the deleted ClusterQueue")
+			expectNoRemainingSeries(clusterQueueScopedMetrics(), map[string]string{"cluster_queue": cq.Name})
+
+			ginkgo.By("verifying the stored ClusterQueue label values are dropped")
+			gomega.Eventually(func() []string {
+				return customMetricLabels.StoredRefsForTest(config.SourceKindClusterQueue)
+			}, util.Timeout, util.Interval).ShouldNot(gomega.ContainElement(cq.Name))
+		})
+
+		ginkgo.It("should clear LocalQueue series and stored label values when the LocalQueue is deleted", func() {
+			cq = utiltestingapi.MakeClusterQueue("cq-lq-deleted").
+				Label("team", "platform").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(defaultFlavor.Name).
+						Resource(corev1.ResourceCPU, "5").
+						Obj(),
+				).Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, cq)
+
+			lq := utiltestingapi.MakeLocalQueue("lq-deleted", ns.Name).
+				Label("team", "platform").
+				ClusterQueue(cq.Name).Obj()
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, lq)
+
+			admitted := utiltestingapi.MakeWorkload("wl-admitted", ns.Name).
+				Label("workload-kind", "training").
+				Queue(kueue.LocalQueueName(lq.Name)).
+				Request(corev1.ResourceCPU, "1").Obj()
+			util.MustCreate(ctx, k8sClient, admitted)
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, admitted)
+
+			// Requests more than the nominal quota, so it stays pending and keeps
+			// the pending-workload series alive until the LocalQueue is gone.
+			pending := utiltestingapi.MakeWorkload("wl-pending", ns.Name).
+				Label("workload-kind", "training").
+				Queue(kueue.LocalQueueName(lq.Name)).
+				Request(corev1.ResourceCPU, "10").Obj()
+			util.MustCreate(ctx, k8sClient, pending)
+
+			ginkgo.By("verifying the LocalQueue series and stored label values are present")
+			expectSeriesPresent(localQueueScopedMetrics(), map[string]string{"name": lq.Name, "namespace": lq.Namespace})
+			util.ExpectLQAdmittedActiveWorkloadsGaugeMetric(lq, 1, "platform", "training")
+			gomega.Expect(customMetricLabels.LQGet(utilqueue.Key(lq))).To(gomega.Equal([]string{"platform"}))
+
+			ginkgo.By("deleting the admitted workload and the LocalQueue")
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, admitted, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, lq, true)
+
+			ginkgo.By("verifying no series is left for the deleted LocalQueue")
+			expectNoRemainingSeries(localQueueScopedMetrics(), map[string]string{"name": lq.Name, "namespace": lq.Namespace})
+
+			ginkgo.By("verifying the stored LocalQueue label values are dropped")
+			gomega.Eventually(func() []string {
+				return customMetricLabels.StoredRefsForTest(config.SourceKindLocalQueue)
+			}, util.Timeout, util.Interval).ShouldNot(gomega.ContainElement(string(utilqueue.Key(lq))))
+		})
+
+		ginkgo.It("should clear Cohort series and stored label values when the Cohort is deleted", func() {
+			cohort = utiltestingapi.MakeCohort("cohort-deleted").
+				Label("team", "data-eng").
+				Obj()
+			util.MustCreate(ctx, k8sClient, cohort)
+
+			cq = utiltestingapi.MakeClusterQueue("cq-cohort-deleted").
+				Label("team", "data-eng").
+				Cohort(kueue.CohortReference(cohort.Name)).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(defaultFlavor.Name).
+						Resource(corev1.ResourceCPU, "5").
+						Obj(),
+				).Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, cq)
+
+			lq := utiltestingapi.MakeLocalQueue("lq-cohort-deleted", ns.Name).
+				Label("team", "data-eng").
+				ClusterQueue(cq.Name).Obj()
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, lq)
+
+			wl := utiltestingapi.MakeWorkload("wl-cohort-deleted", ns.Name).
+				Label("workload-kind", "training").
+				Queue(kueue.LocalQueueName(lq.Name)).
+				Request(corev1.ResourceCPU, "1").Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+
+			ginkgo.By("verifying the Cohort series and stored label values are present")
+			expectSeriesPresent(cohortScopedMetrics(), map[string]string{"cohort": cohort.Name})
+			util.ExpectCohortSubtreeQuotaGaugeMetric(cohort.Name, defaultFlavor.Name, corev1.ResourceCPU.String(), 5, "data-eng")
+			gomega.Expect(customMetricLabels.CohortGet(kueue.CohortReference(cohort.Name))).To(gomega.Equal([]string{"data-eng"}))
+
+			ginkgo.By("deleting the workload, the LocalQueue, the ClusterQueue and the Cohort")
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, wl, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, lq, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, cohort, true)
+
+			ginkgo.By("verifying no series is left for the deleted Cohort")
+			expectNoRemainingSeries(cohortScopedMetrics(), map[string]string{"cohort": cohort.Name})
+
+			ginkgo.By("verifying the stored Cohort label values are dropped")
+			gomega.Eventually(func() []string {
+				return customMetricLabels.StoredRefsForTest(config.SourceKindCohort)
+			}, util.Timeout, util.Interval).ShouldNot(gomega.ContainElement(cohort.Name))
+		})
+
+		ginkgo.It("should drop the stored Workload label values when admitted workloads are deleted", func() {
+			cq = utiltestingapi.MakeClusterQueue("cq-wl-deleted").
+				Label("team", "platform").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(defaultFlavor.Name).
+						Resource(corev1.ResourceCPU, "5").
+						Obj(),
+				).Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, cq)
+
+			lq := utiltestingapi.MakeLocalQueue("lq-wl-deleted", ns.Name).
+				Label("team", "platform").
+				ClusterQueue(cq.Name).Obj()
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, lq)
+
+			kept := utiltestingapi.MakeWorkload("wl-kept", ns.Name).
+				Label("workload-kind", "training").
+				Queue(kueue.LocalQueueName(lq.Name)).
+				Request(corev1.ResourceCPU, "1").Obj()
+			util.MustCreate(ctx, k8sClient, kept)
+			// An untracked value is folded into UntrackedCustomLabelValue in the
+			// metric series, but is still stored per workload.
+			removed := utiltestingapi.MakeWorkload("wl-removed", ns.Name).
+				Label("workload-kind", "adhoc").
+				Queue(kueue.LocalQueueName(lq.Name)).
+				Request(corev1.ResourceCPU, "1").Obj()
+			util.MustCreate(ctx, k8sClient, removed)
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, kept, removed)
+
+			ginkgo.By("verifying both workloads are recorded in the custom label store")
+			gomega.Eventually(func() []string {
+				return customMetricLabels.StoredRefsForTest(config.SourceKindWorkload)
+			}, util.Timeout, util.Interval).Should(gomega.ConsistOf(
+				string(workload.Key(kept)), string(workload.Key(removed)),
+			))
+
+			ginkgo.By("deleting one of the workloads")
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, removed, true)
+
+			ginkgo.By("verifying only the deleted workload is dropped from the custom label store")
+			gomega.Eventually(func() []string {
+				return customMetricLabels.StoredRefsForTest(config.SourceKindWorkload)
+			}, util.Timeout, util.Interval).Should(gomega.ConsistOf(string(workload.Key(kept))))
+
+			ginkgo.By("deleting the remaining workload")
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, kept, true)
+
+			ginkgo.By("verifying no workload label values are left in the custom label store")
+			gomega.Eventually(func() []string {
+				return customMetricLabels.StoredRefsForTest(config.SourceKindWorkload)
+			}, util.Timeout, util.Interval).Should(gomega.BeEmpty())
+		})
+	})
 })
+
+// The metric vectors below are keyed by an object kind that carries custom
+// labels: none of them may hold a series once the object it is keyed by is
+// deleted, whatever custom label values that series carries. They are resolved
+// through functions because InitMetricVectors replaces the vectors whenever the
+// custom label configuration changes.
+func clusterQueueScopedMetrics() map[string]prometheus.Collector {
+	return map[string]prometheus.Collector{
+		"kueue_pending_workloads":                  metrics.PendingWorkloads,
+		"kueue_cluster_queue_status":               metrics.ClusterQueueByStatus,
+		"kueue_cluster_queue_info":                 metrics.ClusterQueueInfo,
+		"kueue_admitted_active_workloads":          metrics.AdmittedActiveWorkloads,
+		"kueue_reserving_active_workloads":         metrics.ReservingActiveWorkloads,
+		"kueue_admitted_workloads_total":           metrics.AdmittedWorkloadsTotal,
+		"kueue_quota_reserved_workloads_total":     metrics.QuotaReservedWorkloadsTotal,
+		"kueue_cluster_queue_nominal_quota":        metrics.ClusterQueueResourceNominalQuota,
+		"kueue_cluster_queue_resource_usage":       metrics.ClusterQueueResourceUsage,
+		"kueue_cluster_queue_resource_reservation": metrics.ClusterQueueResourceReservations,
+	}
+}
+
+func localQueueScopedMetrics() map[string]prometheus.Collector {
+	return map[string]prometheus.Collector{
+		"kueue_local_queue_pending_workloads":          metrics.LocalQueuePendingWorkloads,
+		"kueue_local_queue_status":                     metrics.LocalQueueByStatus,
+		"kueue_local_queue_admitted_active_workloads":  metrics.LocalQueueAdmittedActiveWorkloads,
+		"kueue_local_queue_reserving_active_workloads": metrics.LocalQueueReservingActiveWorkloads,
+		"kueue_local_queue_admitted_workloads_total":   metrics.LocalQueueAdmittedWorkloadsTotal,
+		"kueue_local_queue_resource_usage":             metrics.LocalQueueResourceUsage,
+		"kueue_local_queue_resource_reservation":       metrics.LocalQueueResourceReservations,
+	}
+}
+
+func cohortScopedMetrics() map[string]prometheus.Collector {
+	return map[string]prometheus.Collector{
+		"kueue_cohort_info":                              metrics.CohortInfo,
+		"kueue_cohort_subtree_quota":                     metrics.CohortSubtreeQuota,
+		"kueue_cohort_subtree_resource_reservations":     metrics.CohortSubtreeResourceReservations,
+		"kueue_cohort_subtree_admitted_active_workloads": metrics.CohortSubtreeAdmittedActiveWorkloads,
+	}
+}
+
+// expectSeriesPresent guards the cleanup assertions from becoming vacuous: it
+// pins down that every listed vector really does hold a series for the object
+// before that object is deleted.
+func expectSeriesPresent(collectors map[string]prometheus.Collector, lbls map[string]string) {
+	ginkgo.GinkgoHelper()
+	gomega.Eventually(func(g gomega.Gomega) {
+		_, missing := partitionBySeries(collectors, lbls)
+		g.Expect(missing).To(gomega.BeEmpty(), "metrics holding no series matching %v", lbls)
+	}, util.Timeout, util.Interval).Should(gomega.Succeed())
+}
+
+func expectNoRemainingSeries(collectors map[string]prometheus.Collector, lbls map[string]string) {
+	ginkgo.GinkgoHelper()
+	gomega.Eventually(func(g gomega.Gomega) {
+		holding, _ := partitionBySeries(collectors, lbls)
+		g.Expect(holding).To(gomega.BeEmpty(), "metrics still holding series matching %v", lbls)
+	}, util.Timeout, util.Interval).Should(gomega.Succeed())
+}
+
+// partitionBySeries splits the collectors by whether they currently hold at
+// least one series matching lbls. Both sides are returned so that a failure
+// names every offending metric at once instead of only the first.
+func partitionBySeries(collectors map[string]prometheus.Collector, lbls map[string]string) (holding, missing []string) {
+	for name, collector := range collectors {
+		if len(testingmetrics.CollectFilteredGaugeVec(collector, lbls)) > 0 {
+			holding = append(holding, name)
+		} else {
+			missing = append(missing, name)
+		}
+	}
+	slices.Sort(holding)
+	slices.Sort(missing)
+	return holding, missing
+}

--- a/test/integration/singlecluster/controller/core/suite_test.go
+++ b/test/integration/singlecluster/controller/core/suite_test.go
@@ -48,6 +48,10 @@ var (
 	ctx       context.Context
 	fwk       *framework.Framework
 	qManager  *qcache.Manager
+	// customMetricLabels is the instance handed to the controllers, caches and
+	// scheduler by managerAndControllerSetup. Tests read it to assert that the
+	// cached label values of deleted objects are dropped.
+	customMetricLabels *metrics.CustomLabels
 )
 
 func TestAPIs(t *testing.T) {
@@ -122,6 +126,7 @@ func managerAndControllerSetup(
 		if features.Enabled(features.CustomMetricLabels) && len(controllersCfg.Metrics.CustomLabels) > 0 {
 			customLabels = metrics.NewCustomLabels(controllersCfg.Metrics.CustomLabels)
 		}
+		customMetricLabels = customLabels
 
 		cacheOpts := []schdcache.Option{
 			schdcache.WithResourceMetrics(controllersCfg.Metrics.EnableClusterQueueResources),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/kind bug
/kind testing

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
There were no tests checking that the CustomLabels store and the metric series get cleared once the objects behind them are deleted. That matters most for Workloads, since the store is keyed by workload and the values come straight off user supplied labels and annotations.

Writing the ClusterQueue case exposed to me a leak. DeleteClusterQueue drops the queue from the hierarchy manager w/o touching the workload entries it still holds. That store is shared by every ClusterQueue, so once the queue is gone DeleteWorkload can't reach them any more, it returns ErrCqNotFound and quits, and values now sit in memory until the process restarts. The finalizer normally keeps the ClusterQueue alive until the cache reports it empty so this is hard to hit today, but the cache shouldn't be relying on a controller to stay leak free. Purging those entries in DeleteClusterQueue now in this ticket.

On the testing front, pkg/metrics covers Delete per SourceKind and through the CQ/LQ/Cohort wrappers, and PopZeroCounts dropping label combinations once the last workload carrying them is now gone. TestLabelValsTracker had an expectedTotal field that nothing ever asserted, so I wired it up, and two of the values in it turned out to be wrong once it started running.

pkg/cache/scheduler gets custom_labels_cleanup_test.go for the five ways a workload stops being tracked by the cache. The int tests assert on the live CustomLabels instance and on every ClusterQueue, LocalQueue and Cohort scoped vector, filtered on object key alone so that the existing metrics are covered aswell. Each spec checks the series are there before the delete, otherwise the cleanup assertion passes for free.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #15202 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

____
Disclosure : I used AI Assistance to create some of the unit and int tests, I have reviewed them and mutation tested them by breaking the path to confirm that the right test actually fails in each scenario.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custom metric label data is now cleared when workloads, cluster queues, local queues, cohorts, or other tracked sources are deleted.
  * Removing a cluster queue now also removes associated workload label data and metric series, preventing stale entries from remaining.
  * Workload label data is correctly restored when workloads move to another cluster queue.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->