### PR TITLE
Default admissionFairSharing.usageHalfLifeTime to 1h

### DIFF
--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -671,8 +671,9 @@ type FairSharing struct {
 }
 
 type AdmissionFairSharing struct {
-	// usageHalfLifeTime indicates the time after which the current usage will decay by a half
-	// If set to 0, usage will be reset to 0 immediately.
+	// usageHalfLifeTime indicates the time after which the current usage will decay by a half.
+	// Defaults to 1h. Jobs that run for longer are usually better served by a longer
+	// half-life, such as 12h or 24h.
 	UsageHalfLifeTime metav1.Duration `json:"usageHalfLifeTime"`
 
 	// usageSamplingInterval indicates how often Kueue updates consumedResources in FairSharingStatus

--- a/apis/config/v1beta1/defaults.go
+++ b/apis/config/v1beta1/defaults.go
@@ -130,6 +130,7 @@ func SetDefaults_Configuration(cfg *Configuration) {
 		fs.PreemptionStrategies = []PreemptionStrategy{LessThanOrEqualToFinalShare, LessThanInitialShare}
 	}
 	if afs := cfg.AdmissionFairSharing; afs != nil {
+		afs.UsageHalfLifeTime.Duration = cmp.Or(afs.UsageHalfLifeTime.Duration, time.Hour)
 		afs.UsageSamplingInterval.Duration = cmp.Or(afs.UsageSamplingInterval.Duration, 5*time.Minute)
 	}
 

--- a/apis/config/v1beta1/defaults_test.go
+++ b/apis/config/v1beta1/defaults_test.go
@@ -666,6 +666,57 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				WaitForPodsReady: &WaitForPodsReady{},
 			},
 		},
+		"defaulting admissionFairSharing": {
+			original: &Configuration{
+				InternalCertManagement: &InternalCertManagement{
+					Enable: new(false),
+				},
+				AdmissionFairSharing: &AdmissionFairSharing{},
+			},
+			want: &Configuration{
+				Namespace:         new(DefaultNamespace),
+				ControllerManager: defaultCtrlManagerConfigurationSpec,
+				InternalCertManagement: &InternalCertManagement{
+					Enable: new(false),
+				},
+				ClientConnection:             defaultClientConnection,
+				Integrations:                 defaultIntegrations,
+				MultiKueue:                   defaultMultiKueue,
+				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
+				AdmissionFairSharing: &AdmissionFairSharing{
+					UsageHalfLifeTime:     metav1.Duration{Duration: time.Hour},
+					UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
+				},
+				WaitForPodsReady: &WaitForPodsReady{},
+			},
+		},
+		"respecting provided admissionFairSharing values": {
+			original: &Configuration{
+				InternalCertManagement: &InternalCertManagement{
+					Enable: new(false),
+				},
+				AdmissionFairSharing: &AdmissionFairSharing{
+					UsageHalfLifeTime:     metav1.Duration{Duration: 24 * time.Hour},
+					UsageSamplingInterval: metav1.Duration{Duration: time.Minute},
+				},
+			},
+			want: &Configuration{
+				Namespace:         new(DefaultNamespace),
+				ControllerManager: defaultCtrlManagerConfigurationSpec,
+				InternalCertManagement: &InternalCertManagement{
+					Enable: new(false),
+				},
+				ClientConnection:             defaultClientConnection,
+				Integrations:                 defaultIntegrations,
+				MultiKueue:                   defaultMultiKueue,
+				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
+				AdmissionFairSharing: &AdmissionFairSharing{
+					UsageHalfLifeTime:     metav1.Duration{Duration: 24 * time.Hour},
+					UsageSamplingInterval: metav1.Duration{Duration: time.Minute},
+				},
+				WaitForPodsReady: &WaitForPodsReady{},
+			},
+		},
 	}
 
 	for name, tc := range testCases {

--- a/apis/config/v1beta2/configuration_types.go
+++ b/apis/config/v1beta2/configuration_types.go
@@ -821,8 +821,9 @@ type FairSharing struct {
 }
 
 type AdmissionFairSharing struct {
-	// usageHalfLifeTime indicates the time after which the current usage will decay by a half
-	// If set to 0, usage will be reset to 0 immediately.
+	// usageHalfLifeTime indicates the time after which the current usage will decay by a half.
+	// Defaults to 1h. Jobs that run for longer are usually better served by a longer
+	// half-life, such as 12h or 24h.
 	UsageHalfLifeTime metav1.Duration `json:"usageHalfLifeTime"`
 
 	// usageSamplingInterval indicates how often Kueue updates consumedResources in FairSharingStatus

--- a/apis/config/v1beta2/defaults.go
+++ b/apis/config/v1beta2/defaults.go
@@ -145,6 +145,7 @@ func SetDefaults_Configuration(cfg *Configuration) {
 	}
 
 	if afs := cfg.AdmissionFairSharing; afs != nil {
+		afs.UsageHalfLifeTime.Duration = cmp.Or(afs.UsageHalfLifeTime.Duration, time.Hour)
 		afs.UsageSamplingInterval.Duration = cmp.Or(afs.UsageSamplingInterval.Duration, 5*time.Minute)
 	}
 	cfg.VisibilityServer = cmp.Or(cfg.VisibilityServer, &VisibilityServerConfiguration{})

--- a/apis/config/v1beta2/defaults_test.go
+++ b/apis/config/v1beta2/defaults_test.go
@@ -736,6 +736,61 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				WaitForPodsReady: defaultWaitForPodsReady,
 			},
 		},
+		"defaulting admissionFairSharing": {
+			original: &Configuration{
+				InternalCertManagement: &InternalCertManagement{
+					Enable: new(false),
+				},
+				AdmissionFairSharing: &AdmissionFairSharing{},
+			},
+			want: &Configuration{
+				QuotaReleaseStrategy: new(QuotaReleaseOnTerminating),
+				Namespace:            new(DefaultNamespace),
+				ControllerManager:    defaultCtrlManagerConfigurationSpec,
+				InternalCertManagement: &InternalCertManagement{
+					Enable: new(false),
+				},
+				ClientConnection:             defaultClientConnection,
+				Integrations:                 defaultIntegrations,
+				MultiKueue:                   defaultMultiKueue,
+				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
+				AdmissionFairSharing: &AdmissionFairSharing{
+					UsageHalfLifeTime:     metav1.Duration{Duration: time.Hour},
+					UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
+				},
+				VisibilityServer: defaultVisibilityServer,
+				WaitForPodsReady: defaultWaitForPodsReady,
+			},
+		},
+		"respecting provided admissionFairSharing values": {
+			original: &Configuration{
+				InternalCertManagement: &InternalCertManagement{
+					Enable: new(false),
+				},
+				AdmissionFairSharing: &AdmissionFairSharing{
+					UsageHalfLifeTime:     metav1.Duration{Duration: 24 * time.Hour},
+					UsageSamplingInterval: metav1.Duration{Duration: time.Minute},
+				},
+			},
+			want: &Configuration{
+				QuotaReleaseStrategy: new(QuotaReleaseOnTerminating),
+				Namespace:            new(DefaultNamespace),
+				ControllerManager:    defaultCtrlManagerConfigurationSpec,
+				InternalCertManagement: &InternalCertManagement{
+					Enable: new(false),
+				},
+				ClientConnection:             defaultClientConnection,
+				Integrations:                 defaultIntegrations,
+				MultiKueue:                   defaultMultiKueue,
+				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
+				AdmissionFairSharing: &AdmissionFairSharing{
+					UsageHalfLifeTime:     metav1.Duration{Duration: 24 * time.Hour},
+					UsageSamplingInterval: metav1.Duration{Duration: time.Minute},
+				},
+				VisibilityServer: defaultVisibilityServer,
+				WaitForPodsReady: defaultWaitForPodsReady,
+			},
+		},
 	}
 
 	for name, tc := range testCases {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -52,6 +52,7 @@ import (
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/util/admissionfairsharing"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	"sigs.k8s.io/kueue/pkg/util/waitforpodsready"
 
@@ -981,6 +982,47 @@ objectRetentionPolicies:
 				}
 			}
 		})
+	}
+}
+
+// Without a half-life the usage decay never advances, so admission ordering silently
+// falls back to the non-fair-sharing path.
+func TestLoadAdmissionFairSharingDefaults(t *testing.T) {
+	testScheme := runtime.NewScheme()
+	if err := configapi.AddToScheme(testScheme); err != nil {
+		t.Fatal(err)
+	}
+
+	configFile := filepath.Join(t.TempDir(), "afs.yaml")
+	if err := os.WriteFile(configFile, []byte(`
+apiVersion: config.kueue.x-k8s.io/v1beta2
+kind: Configuration
+admissionFairSharing: {}
+`), os.FileMode(0600)); err != nil {
+		t.Fatal(err)
+	}
+
+	_, cfg, err := Load(testScheme, configFile)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	want := &configapi.AdmissionFairSharing{
+		UsageHalfLifeTime:     metav1.Duration{Duration: time.Hour},
+		UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
+	}
+	if diff := cmp.Diff(want, cfg.AdmissionFairSharing); diff != "" {
+		t.Errorf("Unexpected admissionFairSharing (-want +got):\n%s", diff)
+	}
+
+	penalty := admissionfairsharing.CalculateEntryPenalty(
+		corev1.ResourceList{corev1.ResourceCPU: resourcev1.MustParse("10")},
+		cfg.AdmissionFairSharing,
+	)
+	busy := admissionfairsharing.CalculateUsage(nil, penalty, 1, nil)
+	idle := admissionfairsharing.CalculateUsage(nil, nil, 1, nil)
+	if busy <= idle {
+		t.Errorf("Queue that just admitted 10 CPU must rank above an idle queue, got busy=%v idle=%v", busy, idle)
 	}
 }
 

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -464,7 +464,7 @@ func validateAdmissionFairSharing(c *configapi.Configuration) field.ErrorList {
 	}
 	if afs.UsageSamplingInterval.Duration <= 0 {
 		allErrs = append(allErrs, field.Invalid(afsPath.Child("usageSamplingInterval"),
-			afs.UsageHalfLifeTime, "must be greater than 0"))
+			afs.UsageSamplingInterval, "must be greater than 0"))
 	}
 	for resName, weight := range afs.ResourceWeights {
 		if weight < 0 {

--- a/site/content/en/docs/concepts/admission_fair_sharing.md
+++ b/site/content/en/docs/concepts/admission_fair_sharing.md
@@ -43,8 +43,8 @@ For example, if Tenant A has low historical usage and Tenant B has high usage, b
 
 The following parameters can be configured in Kueue's configuration `.admissionFairSharing`:
 
-- `usageHalfLifeTime`: Controls how quickly historical usage decays
-- `usageSamplingInterval`: How frequently usage is sampled
+- `usageHalfLifeTime`: Controls how quickly historical usage decays. Defaults to `1h`.
+- `usageSamplingInterval`: How frequently usage is sampled. Defaults to `5m`.
 - `resourceWeights`: Relative importance of different resource types
 
 #### Example configuration:

--- a/site/content/en/docs/reference/kueue-config.v1beta1.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta1.md
@@ -187,8 +187,9 @@ of Kueue-managed objects. A nil value disables all automatic deletions.</p>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta"><code>k8s.io/apimachinery/pkg/apis/meta/v1.Duration</code></a>
 </td>
 <td>
-   <p>usageHalfLifeTime indicates the time after which the current usage will decay by a half
-If set to 0, usage will be reset to 0 immediately.</p>
+   <p>usageHalfLifeTime indicates the time after which the current usage will decay by a half.
+Defaults to 1h. Jobs that run for longer are usually better served by a longer
+half-life, such as 12h or 24h.</p>
 </td>
 </tr>
 <tr><td><code>usageSamplingInterval</code> <B>[Required]</B><br/>

--- a/site/content/en/docs/reference/kueue-config.v1beta2.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta2.md
@@ -190,8 +190,9 @@ of Kueue-managed objects. A nil value disables all automatic deletions.</p>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta"><code>k8s.io/apimachinery/pkg/apis/meta/v1.Duration</code></a>
 </td>
 <td>
-   <p>usageHalfLifeTime indicates the time after which the current usage will decay by a half
-If set to 0, usage will be reset to 0 immediately.</p>
+   <p>usageHalfLifeTime indicates the time after which the current usage will decay by a half.
+Defaults to 1h. Jobs that run for longer are usually better served by a longer
+half-life, such as 12h or 24h.</p>
 </td>
 </tr>
 <tr><td><code>usageSamplingInterval</code> <B>[Required]</B><br/>


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Admission Fair Sharing needs three opt-ins. The feature gate, an `admissionFairSharing` block in the Configuration, and `admissionMode: UsageBasedAdmissionFairSharing` on a ClusterQueue. Do all three and admission order still does not change. A LocalQueue running hot is admitted ahead of one that has been idle, with nothing logged or rejected.

`usageHalfLifeTime` has no default, so leaving it out lands on `0s`. A zero half-life makes `calculateAlphaRate` return 0, which zeroes both the entry penalty and the decayed consumption. Every LocalQueue reports usage 0, all queues tie, and ordering falls back to the non-fair-sharing path.

This defaults it the way its sibling `usageSamplingInterval` already is. 1h is what the issue thread settled on, and the conservative end of what is in use, against 168h in this repo's commented example and 30m in openshift/kueue-operator. Happy to move it in review.

Two smaller fixes ride along. The doc comment claimed 0 resets usage immediately, which describes a decay rate of 1, not the 0 the guard returns. And the `usageSamplingInterval` validation error printed the other field's value.

#### Which issue(s) this PR fixes:

Fixes #11134

#### Special notes for your reviewer:

The new test asserts both the default and the resulting queue order. It fails on main and passes here.

```
git worktree add --detach /tmp/red upstream/main
cp pkg/config/config_test.go /tmp/red/pkg/config/config_test.go
go -C /tmp/red test ./pkg/config/... -run TestLoadAdmissionFairSharingDefaults

--- FAIL: TestLoadAdmissionFairSharingDefaults
    - UsageHalfLifeTime: v1.Duration{Duration: s"1h0m0s"},
    + UsageHalfLifeTime: v1.Duration{},
    Queue that just admitted 10 CPU must rank above an idle queue, got busy=0 idle=0

go test ./pkg/config/... -run TestLoadAdmissionFairSharingDefaults
ok  sigs.k8s.io/kueue/pkg/config  1.136s
```

With the default in place the same queue scores 1.12 against the idle queue's 0, so the idle one is admitted first. Defaulting is also covered in both config API versions.

This PR was written in part with the assistance of generative AI.

#### Does this PR introduce a user-facing change?

```release-note
`admissionFairSharing.usageHalfLifeTime` now defaults to 1h. Unset, it previously stayed at 0s, making usage-based admission fair sharing a no-op.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Admission Fair Sharing now defaults to a 1-hour usage half-life when unspecified.
  - Existing defaults remain preserved when custom values are provided.
- **Bug Fixes**
  - Corrected validation messaging for invalid usage sampling intervals.
- **Documentation**
  - Clarified default values and configuration guidance for usage decay and sampling intervals.
  - Added recommendations for longer half-lives for long-running jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->