### PR TITLE
Allow updates of Workloads with legacy negative requests

### DIFF
--- a/pkg/webhooks/workload_webhook.go
+++ b/pkg/webhooks/workload_webhook.go
@@ -105,16 +105,26 @@ func (w *WorkloadWebhook) ValidateDelete(_ context.Context, _ *kueue.Workload) (
 }
 
 // ValidateWorkload validates obj. On update, oldObj is the workload's previous
-// state; it is nil on create. See validateReclaimablePods for why the previous
-// state is needed.
+// state; it is nil on create. The previous state is needed so
+// validateReclaimablePods and validateResourceList can let an unchanged legacy
+// value through instead of refusing the update that would let the object
+// converge (kueue#12670, kueue#14373).
 func ValidateWorkload(obj, oldObj *kueue.Workload) field.ErrorList {
 	var allErrs field.ErrorList
 	specPath := field.NewPath("spec")
 
+	var oldPodSets map[kueue.PodSetReference]*kueue.PodSet
+	if oldObj != nil {
+		oldPodSets = make(map[kueue.PodSetReference]*kueue.PodSet, len(oldObj.Spec.PodSets))
+		for i := range oldObj.Spec.PodSets {
+			oldPodSets[oldObj.Spec.PodSets[i].Name] = &oldObj.Spec.PodSets[i]
+		}
+	}
+
 	variableCountPodSets := 0
 	for i := range obj.Spec.PodSets {
 		ps := &obj.Spec.PodSets[i]
-		allErrs = append(allErrs, validatePodSet(ps, specPath.Child("podSets").Index(i))...)
+		allErrs = append(allErrs, validatePodSet(ps, oldPodSets[ps.Name], specPath.Child("podSets").Index(i))...)
 		if ps.MinCount != nil {
 			variableCountPodSets++
 		}
@@ -157,7 +167,7 @@ func ValidateWorkload(obj, oldObj *kueue.Workload) field.ErrorList {
 	return allErrs
 }
 
-func validatePodSet(ps *kueue.PodSet, path *field.Path) field.ErrorList {
+func validatePodSet(ps, oldPs *kueue.PodSet, path *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
 	// validate metadata labels and annotations
@@ -166,21 +176,34 @@ func validatePodSet(ps *kueue.PodSet, path *field.Path) field.ErrorList {
 		allErrs = append(allErrs, apivalidation.ValidateAnnotations(ps.Template.Annotations, path.Child("template", "metadata", "annotations"))...)
 	}
 
+	var oldInitContainers, oldContainers []corev1.Container
+	var oldPodResources *corev1.ResourceRequirements
+	if oldPs != nil {
+		oldInitContainers = oldPs.Template.Spec.InitContainers
+		oldContainers = oldPs.Template.Spec.Containers
+		oldPodResources = oldPs.Template.Spec.Resources
+	}
+
 	// validate initContainers
 	icPath := path.Child("template", "spec", "initContainers")
 	for ci := range ps.Template.Spec.InitContainers {
-		allErrs = append(allErrs, validateContainer(&ps.Template.Spec.InitContainers[ci], icPath.Index(ci))...)
+		allErrs = append(allErrs, validateContainer(&ps.Template.Spec.InitContainers[ci], containerAt(oldInitContainers, ci), icPath.Index(ci))...)
 	}
 	// validate containers
 	cPath := path.Child("template", "spec", "containers")
 	for ci := range ps.Template.Spec.Containers {
-		allErrs = append(allErrs, validateContainer(&ps.Template.Spec.Containers[ci], cPath.Index(ci))...)
+		allErrs = append(allErrs, validateContainer(&ps.Template.Spec.Containers[ci], containerAt(oldContainers, ci), cPath.Index(ci))...)
 	}
 	// validate pod-level resources
 	if ps.Template.Spec.Resources != nil {
 		resPath := path.Child("template", "spec", "resources")
-		allErrs = append(allErrs, validateResourceList(ps.Template.Spec.Resources.Requests, resPath.Child("requests"))...)
-		allErrs = append(allErrs, validateResourceList(ps.Template.Spec.Resources.Limits, resPath.Child("limits"))...)
+		var oldRequests, oldLimits corev1.ResourceList
+		if oldPodResources != nil {
+			oldRequests = oldPodResources.Requests
+			oldLimits = oldPodResources.Limits
+		}
+		allErrs = append(allErrs, validateResourceList(ps.Template.Spec.Resources.Requests, oldRequests, resPath.Child("requests"))...)
+		allErrs = append(allErrs, validateResourceList(ps.Template.Spec.Resources.Limits, oldLimits, resPath.Child("limits"))...)
 	}
 
 	if features.Enabled(features.TASValidateWorkloadSliceSize) {
@@ -190,16 +213,34 @@ func validatePodSet(ps *kueue.PodSet, path *field.Path) field.ErrorList {
 	return allErrs
 }
 
-func validateContainer(c *corev1.Container, path *field.Path) field.ErrorList {
-	requestErrors := validateResourceList(c.Resources.Requests, path.Child("resources", "requests"))
-	limitErrors := validateResourceList(c.Resources.Limits, path.Child("resources", "limits"))
+func validateContainer(c, old *corev1.Container, path *field.Path) field.ErrorList {
+	var oldRequests, oldLimits corev1.ResourceList
+	if old != nil {
+		oldRequests = old.Resources.Requests
+		oldLimits = old.Resources.Limits
+	}
+	requestErrors := validateResourceList(c.Resources.Requests, oldRequests, path.Child("resources", "requests"))
+	limitErrors := validateResourceList(c.Resources.Limits, oldLimits, path.Child("resources", "limits"))
 	return append(requestErrors, limitErrors...)
 }
 
+func containerAt(containers []corev1.Container, i int) *corev1.Container {
+	if i >= len(containers) {
+		return nil
+	}
+	return &containers[i]
+}
+
 // validateResourceList rejects the reserved pods key and, when enabled, negative quantities.
-func validateResourceList(resources corev1.ResourceList, path *field.Path) field.ErrorList {
+// Entries that are already on the object unchanged are left alone: refusing them
+// again would block the updates that write a condition, deactivate, or drop the
+// finalizer (kueue#14373).
+func validateResourceList(resources, old corev1.ResourceList, path *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	for name, quantity := range resources {
+		if before, carried := old[name]; carried && before.Cmp(quantity) == 0 {
+			continue
+		}
 		if name == corev1.ResourcePods {
 			allErrs = append(allErrs, field.Invalid(path.Key(string(name)), corev1.ResourcePods, "the key is reserved for internal kueue use"))
 		}

--- a/pkg/webhooks/workload_webhook.go
+++ b/pkg/webhooks/workload_webhook.go
@@ -187,12 +187,14 @@ func validatePodSet(ps, oldPs *kueue.PodSet, path *field.Path) field.ErrorList {
 	// validate initContainers
 	icPath := path.Child("template", "spec", "initContainers")
 	for ci := range ps.Template.Spec.InitContainers {
-		allErrs = append(allErrs, validateContainer(&ps.Template.Spec.InitContainers[ci], containerAt(oldInitContainers, ci), icPath.Index(ci))...)
+		c := &ps.Template.Spec.InitContainers[ci]
+		allErrs = append(allErrs, validateContainer(c, containerByName(oldInitContainers, c.Name), icPath.Index(ci))...)
 	}
 	// validate containers
 	cPath := path.Child("template", "spec", "containers")
 	for ci := range ps.Template.Spec.Containers {
-		allErrs = append(allErrs, validateContainer(&ps.Template.Spec.Containers[ci], containerAt(oldContainers, ci), cPath.Index(ci))...)
+		c := &ps.Template.Spec.Containers[ci]
+		allErrs = append(allErrs, validateContainer(c, containerByName(oldContainers, c.Name), cPath.Index(ci))...)
 	}
 	// validate pod-level resources
 	if ps.Template.Spec.Resources != nil {
@@ -224,11 +226,20 @@ func validateContainer(c, old *corev1.Container, path *field.Path) field.ErrorLi
 	return append(requestErrors, limitErrors...)
 }
 
-func containerAt(containers []corev1.Container, i int) *corev1.Container {
-	if i >= len(containers) {
+// containerByName returns the previous container with the same name, if any.
+// Identity is the name, not the slice position: reordering would otherwise
+// refuse an unchanged leftover, and a replacement at the same index would
+// inherit the exemption (kueue#14373).
+func containerByName(containers []corev1.Container, name string) *corev1.Container {
+	if name == "" {
 		return nil
 	}
-	return &containers[i]
+	for i := range containers {
+		if containers[i].Name == name {
+			return &containers[i]
+		}
+	}
+	return nil
 }
 
 // validateResourceList rejects the reserved pods key and, when enabled, negative quantities.

--- a/pkg/webhooks/workload_webhook_test.go
+++ b/pkg/webhooks/workload_webhook_test.go
@@ -62,6 +62,25 @@ func quotaReservedWithoutAdmission(now time.Time) *kueue.Workload {
 	return wl
 }
 
+const legacyNegativeGPU corev1.ResourceName = "example.com/gpu"
+
+// legacyNegativeRequestPodSet is a PodSet that already carries a negative
+// container request, the way one written before
+// WorkloadValidateResourcesAreNonNegative would look.
+func legacyNegativeRequestPodSet() kueue.PodSet {
+	return *utiltestingapi.MakePodSet("a", 1).
+		Request(corev1.ResourceCPU, "8").
+		Request(legacyNegativeGPU, "-3").
+		Obj()
+}
+
+func legacyNegativeRequestWorkload() *kueue.Workload {
+	return utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+		PodSets(legacyNegativeRequestPodSet()).
+		Finalizers(kueue.ResourceInUseFinalizerName).
+		Obj()
+}
+
 func TestValidateWorkload(t *testing.T) {
 	now := time.Now().Truncate(time.Second)
 	specPath := field.NewPath("spec")
@@ -1426,6 +1445,118 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 				PodSets(*utiltestingapi.MakePodSet("main", 1).Obj()).
 				Obj(),
 			wantErr: nil,
+		},
+		// A Workload written before WorkloadValidateResourcesAreNonNegative
+		// still carries the quantity. Refusing it on every update would
+		// strand it: an update is how it writes a condition, deactivates,
+		// and drops its finalizer (kueue#14373).
+		"a workload with a legacy negative request can write an Evicted condition": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadValidateResourcesAreNonNegative: true},
+			before:       legacyNegativeRequestWorkload(),
+			after: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(legacyNegativeRequestPodSet()).
+				Finalizers(kueue.ResourceInUseFinalizerName).
+				EvictedAt(now).
+				Obj(),
+			wantErr: nil,
+		},
+		"a workload with a legacy negative request can be deactivated": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadValidateResourcesAreNonNegative: true},
+			before:       legacyNegativeRequestWorkload(),
+			after: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(legacyNegativeRequestPodSet()).
+				Finalizers(kueue.ResourceInUseFinalizerName).
+				Active(false).
+				Obj(),
+			wantErr: nil,
+		},
+		"a reserved workload with a legacy negative request can be deactivated": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadValidateResourcesAreNonNegative: true},
+			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(legacyNegativeRequestPodSet()).
+				Finalizers(kueue.ResourceInUseFinalizerName).
+				ReserveQuotaAt(utiltestingapi.MakeAdmission("cluster-queue").
+					PodSets(kueue.PodSetAssignment{Name: "a"}).Obj(), now).
+				Obj(),
+			after: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(legacyNegativeRequestPodSet()).
+				Finalizers(kueue.ResourceInUseFinalizerName).
+				ReserveQuotaAt(utiltestingapi.MakeAdmission("cluster-queue").
+					PodSets(kueue.PodSetAssignment{Name: "a"}).Obj(), now).
+				Active(false).
+				Obj(),
+			wantErr: nil,
+		},
+		"a workload with a legacy negative request can drop its finalizer": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadValidateResourcesAreNonNegative: true},
+			before:       legacyNegativeRequestWorkload(),
+			after: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(legacyNegativeRequestPodSet()).
+				Obj(),
+			wantErr: nil,
+		},
+		"a workload with a legacy negative init-container request can drop its finalizer": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadValidateResourcesAreNonNegative: true},
+			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					InitContainers(utiltesting.SingleContainerForRequest(map[corev1.ResourceName]string{
+						legacyNegativeGPU: "-3",
+					})...).
+					Obj()).
+				Finalizers(kueue.ResourceInUseFinalizerName).
+				Obj(),
+			after: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					InitContainers(utiltesting.SingleContainerForRequest(map[corev1.ResourceName]string{
+						legacyNegativeGPU: "-3",
+					})...).
+					Obj()).
+				Obj(),
+			wantErr: nil,
+		},
+		"a workload with a legacy negative pod-level request can drop its finalizer": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadValidateResourcesAreNonNegative: true},
+			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					PodLevelRequest(legacyNegativeGPU, "-3").
+					Obj()).
+				Finalizers(kueue.ResourceInUseFinalizerName).
+				Obj(),
+			after: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					PodLevelRequest(legacyNegativeGPU, "-3").
+					Obj()).
+				Obj(),
+			wantErr: nil,
+		},
+		"changing a legacy negative request to another negative value is refused": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadValidateResourcesAreNonNegative: true},
+			before:       legacyNegativeRequestWorkload(),
+			after: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request(corev1.ResourceCPU, "8").
+					Request(legacyNegativeGPU, "-4").
+					Obj()).
+				Finalizers(kueue.ResourceInUseFinalizerName).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(podSetsPath.Index(0).Child("template", "spec", "containers").Index(0).Child("resources", "requests").Key(string(legacyNegativeGPU)), nil, ""),
+			}.ToAggregate(),
+		},
+		"introducing a new negative request beside a legacy one is refused": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadValidateResourcesAreNonNegative: true},
+			before:       legacyNegativeRequestWorkload(),
+			after: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request(corev1.ResourceCPU, "8").
+					Request(legacyNegativeGPU, "-3").
+					Request(corev1.ResourceMemory, "-1Gi").
+					Obj()).
+				Finalizers(kueue.ResourceInUseFinalizerName).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(podSetsPath.Index(0).Child("template", "spec", "containers").Index(0).Child("resources", "requests").Key(string(corev1.ResourceMemory)), nil, ""),
+			}.ToAggregate(),
 		},
 		// Refusing this update would leave the object undeletable.
 		"a workload whose quota reservation lost its admission can still drop its finalizer": {

--- a/pkg/webhooks/workload_webhook_test.go
+++ b/pkg/webhooks/workload_webhook_test.go
@@ -81,6 +81,17 @@ func legacyNegativeRequestWorkload() *kueue.Workload {
 		Obj()
 }
 
+func namedRequestContainer(name string, requests map[corev1.ResourceName]string) corev1.Container {
+	rl := make(corev1.ResourceList, len(requests))
+	for r, q := range requests {
+		rl[r] = resource.MustParse(q)
+	}
+	return corev1.Container{
+		Name: name,
+		Resources: corev1.ResourceRequirements{Requests: rl},
+	}
+}
+
 func TestValidateWorkload(t *testing.T) {
 	now := time.Now().Truncate(time.Second)
 	specPath := field.NewPath("spec")
@@ -1499,17 +1510,17 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadValidateResourcesAreNonNegative: true},
 			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
 				PodSets(*utiltestingapi.MakePodSet("a", 1).
-					InitContainers(utiltesting.SingleContainerForRequest(map[corev1.ResourceName]string{
+					InitContainers(namedRequestContainer("init", map[corev1.ResourceName]string{
 						legacyNegativeGPU: "-3",
-					})...).
+					})).
 					Obj()).
 				Finalizers(kueue.ResourceInUseFinalizerName).
 				Obj(),
 			after: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
 				PodSets(*utiltestingapi.MakePodSet("a", 1).
-					InitContainers(utiltesting.SingleContainerForRequest(map[corev1.ResourceName]string{
+					InitContainers(namedRequestContainer("init", map[corev1.ResourceName]string{
 						legacyNegativeGPU: "-3",
-					})...).
+					})).
 					Obj()).
 				Obj(),
 			wantErr: nil,
@@ -1556,6 +1567,90 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 				Obj(),
 			wantErr: field.ErrorList{
 				field.Invalid(podSetsPath.Index(0).Child("template", "spec", "containers").Index(0).Child("resources", "requests").Key(string(corev1.ResourceMemory)), nil, ""),
+			}.ToAggregate(),
+		},
+		"reordering containers keeps a leftover negative request allowed": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadValidateResourcesAreNonNegative: true},
+			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Containers(
+						namedRequestContainer("a", map[corev1.ResourceName]string{legacyNegativeGPU: "-3"}),
+						namedRequestContainer("b", map[corev1.ResourceName]string{legacyNegativeGPU: "1"}),
+					).
+					Obj()).
+				Obj(),
+			after: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Containers(
+						namedRequestContainer("b", map[corev1.ResourceName]string{legacyNegativeGPU: "1"}),
+						namedRequestContainer("a", map[corev1.ResourceName]string{legacyNegativeGPU: "-3"}),
+					).
+					Obj()).
+				Obj(),
+			wantErr: nil,
+		},
+		"a new container name at an old index does not inherit a leftover exemption": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadValidateResourcesAreNonNegative: true},
+			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Containers(
+						namedRequestContainer("a", map[corev1.ResourceName]string{legacyNegativeGPU: "-3"}),
+						namedRequestContainer("b", map[corev1.ResourceName]string{legacyNegativeGPU: "1"}),
+					).
+					Obj()).
+				Obj(),
+			after: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Containers(
+						namedRequestContainer("c", map[corev1.ResourceName]string{legacyNegativeGPU: "-3"}),
+						namedRequestContainer("b", map[corev1.ResourceName]string{legacyNegativeGPU: "1"}),
+					).
+					Obj()).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(podSetsPath.Index(0).Child("template", "spec", "containers").Index(0).Child("resources", "requests").Key(string(legacyNegativeGPU)), nil, ""),
+			}.ToAggregate(),
+		},
+		"reordering init containers keeps a leftover negative request allowed": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadValidateResourcesAreNonNegative: true},
+			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					InitContainers(
+						namedRequestContainer("a", map[corev1.ResourceName]string{legacyNegativeGPU: "-3"}),
+						namedRequestContainer("b", map[corev1.ResourceName]string{legacyNegativeGPU: "1"}),
+					).
+					Obj()).
+				Obj(),
+			after: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					InitContainers(
+						namedRequestContainer("b", map[corev1.ResourceName]string{legacyNegativeGPU: "1"}),
+						namedRequestContainer("a", map[corev1.ResourceName]string{legacyNegativeGPU: "-3"}),
+					).
+					Obj()).
+				Obj(),
+			wantErr: nil,
+		},
+		"a new init-container name at an old index does not inherit a leftover exemption": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadValidateResourcesAreNonNegative: true},
+			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					InitContainers(
+						namedRequestContainer("a", map[corev1.ResourceName]string{legacyNegativeGPU: "-3"}),
+						namedRequestContainer("b", map[corev1.ResourceName]string{legacyNegativeGPU: "1"}),
+					).
+					Obj()).
+				Obj(),
+			after: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					InitContainers(
+						namedRequestContainer("c", map[corev1.ResourceName]string{legacyNegativeGPU: "-3"}),
+						namedRequestContainer("b", map[corev1.ResourceName]string{legacyNegativeGPU: "1"}),
+					).
+					Obj()).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(podSetsPath.Index(0).Child("template", "spec", "initContainers").Index(0).Child("resources", "requests").Key(string(legacyNegativeGPU)), nil, ""),
 			}.ToAggregate(),
 		},
 		// Refusing this update would leave the object undeletable.


### PR DESCRIPTION
Fixes #14373

/kind bug

```release-note
Fix Workload updates failing for objects that still carry legacy negative resource requests; existing invalid values are grandfathered so lifecycle operations (evict, deactivate, finalizer removal) can proceed.
```

#### What this PR does / why we need it:

`ValidateWorkloadUpdate` revalidates the whole Workload. After non-negative resource validation became Beta/on by default, legacy negative requests already on the object are refused on every update — including Evicted condition, deactivate, and finalizer removal — so the Workload can stick in Terminating.

This ratchets validation like the overhead path: only reject newly introduced or changed invalid values; allow existing legacy invalid values so lifecycle ops work.

#### Special notes for your reviewer:

Draft until human review. Author: roshpr. Kubernetes CLA applies.
Unchanged resource-list entries, including a reserved `pods` key already on the object, are grandfathered on update so lifecycle operations are not blocked by the same Terminating-stuck problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## AI summary

Workload updates now allow unchanged legacy negative resource requests and limits in containers, init containers, and pod-level resources. New or modified invalid values remain rejected, allowing eviction, deactivation, and finalizer removal to proceed.

### Suggested release note

**Workloads:** Fixed a bug that blocked lifecycle updates for Workloads with unchanged legacy negative resource requests when the `WorkloadValidateResourcesAreNonNegative` feature gate was enabled. Kueue now allows unchanged values while rejecting new or modified invalid values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->