### PR TITLE
Deduplicate AdmissionFairSharing entry-penalty settlement

### DIFF
--- a/pkg/cache/queue/afs/entry_penalties.go
+++ b/pkg/cache/queue/afs/entry_penalties.go
@@ -24,11 +24,17 @@ import (
 
 // PushPenalty records the entry penalty a Workload's reservation costs its
 // LocalQueue, replacing the Workload's previous record so a re-assumed Workload
-// cannot stack a second penalty. now stamps a newly created entry's LastUpdate so
-// the first decay elapses from the push rather than from the zero time; such an
-// entry carries StatusAccounted=false so the persisted status is still merged.
+// cannot stack a second penalty. A Workload that has already settled on this
+// LocalQueue is left unchanged, so admit → evict → re-admit cannot inflate
+// pending usage after the first charge. now stamps a newly created entry's
+// LastUpdate so the first decay elapses from the push rather than from the
+// zero time; such an entry carries StatusAccounted=false so the persisted
+// status is still merged.
 func (a *AfsUsageLedger) PushPenalty(lqKey utilqueue.LocalQueueReference, wlKey WorkloadReference, penalty corev1.ResourceList, now time.Time) {
 	a.entries.Update(lqKey, func(entry UsageLedgerEntry, found bool) UsageLedgerEntry {
+		if entry.HasSettledPenalty(wlKey) {
+			return entry
+		}
 		if !found {
 			entry.LastUpdate = now
 		}
@@ -75,4 +81,14 @@ func (a *AfsUsageLedger) HasPendingPenalty(lqKey utilqueue.LocalQueueReference) 
 		}
 	}
 	return false
+}
+
+// ForgetSettledPenalty drops the Workload's settled identity on this
+// LocalQueue so a replacement object (same namespace/name) or a later entry
+// after leaving the queue can be charged again. Without a record it is a
+// no-op and does not materialize an entry.
+func (a *AfsUsageLedger) ForgetSettledPenalty(lqKey utilqueue.LocalQueueReference, wlKey WorkloadReference) {
+	a.entries.UpdateIfPresent(lqKey, func(entry UsageLedgerEntry) UsageLedgerEntry {
+		return entry.withoutSettledPenalty(wlKey)
+	})
 }

--- a/pkg/cache/queue/afs/usage_ledger.go
+++ b/pkg/cache/queue/afs/usage_ledger.go
@@ -49,6 +49,11 @@ type UsageLedgerEntry struct {
 	// Workload's record, and rollback or deletion subtracts exactly what was
 	// recorded.
 	penaltyRecords map[WorkloadReference]corev1.ResourceList
+	// settledPenalties retains Workload identity after a penalty is folded
+	// into Resources. Settlement drops the pending record; without this set a
+	// later re-push (admit → evict → re-admit on the same LocalQueue) would
+	// fold a second charge. Entries are in-memory only, like penaltyRecords.
+	settledPenalties map[WorkloadReference]struct{}
 	// LastUpdate anchors the decay clock: when Resources was last decayed,
 	// or when the entry was created.
 	LastUpdate time.Time
@@ -67,6 +72,13 @@ func (e UsageLedgerEntry) PendingPenalty() corev1.ResourceList {
 // HasPenaltyRecord reports whether a penalty is recorded for the Workload.
 func (e UsageLedgerEntry) HasPenaltyRecord(wlKey WorkloadReference) bool {
 	_, found := e.penaltyRecords[wlKey]
+	return found
+}
+
+// HasSettledPenalty reports whether this LocalQueue has already folded an
+// entry penalty for the Workload.
+func (e UsageLedgerEntry) HasSettledPenalty(wlKey WorkloadReference) bool {
+	_, found := e.settledPenalties[wlKey]
 	return found
 }
 
@@ -113,6 +125,46 @@ func (e UsageLedgerEntry) WithoutPenalty(wlKey WorkloadReference) (UsageLedgerEn
 	}
 	e.pendingPenalty = aggregate
 	return e, recorded
+}
+
+// SettlePenalty removes the Workload's pending record and returns the amount
+// to fold into consumed history. A Workload is charged at most once per
+// LocalQueue: after the first fold the identity is kept, so a later re-push
+// (admit → evict → re-admit) returns nil and folds nothing.
+func (e UsageLedgerEntry) SettlePenalty(wlKey WorkloadReference) (UsageLedgerEntry, corev1.ResourceList) {
+	e, penalty := e.WithoutPenalty(wlKey)
+	if e.HasSettledPenalty(wlKey) {
+		return e, nil
+	}
+	if len(penalty) == 0 {
+		return e, nil
+	}
+	return e.withSettledPenalty(wlKey), penalty
+}
+
+// withSettledPenalty records that the Workload has already been charged on
+// this LocalQueue. It copies the shared map, matching withPenalty.
+func (e UsageLedgerEntry) withSettledPenalty(wlKey WorkloadReference) UsageLedgerEntry {
+	settled := maps.Clone(e.settledPenalties)
+	if settled == nil {
+		settled = make(map[WorkloadReference]struct{}, 1)
+	}
+	settled[wlKey] = struct{}{}
+	e.settledPenalties = settled
+	return e
+}
+
+// withoutSettledPenalty forgets a prior settlement so a replacement Workload
+// with the same name, or a later entry after leaving this LocalQueue, can be
+// charged again. It copies the shared map.
+func (e UsageLedgerEntry) withoutSettledPenalty(wlKey WorkloadReference) UsageLedgerEntry {
+	if _, found := e.settledPenalties[wlKey]; !found {
+		return e
+	}
+	settled := maps.Clone(e.settledPenalties)
+	delete(settled, wlKey)
+	e.settledPenalties = settled
+	return e
 }
 
 // AfsUsageLedger is the per-LocalQueue fair-sharing accounting cache.

--- a/pkg/cache/queue/afs/usage_ledger_test.go
+++ b/pkg/cache/queue/afs/usage_ledger_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
+	utilresource "sigs.k8s.io/kueue/pkg/util/resource"
 )
 
 func TestUpdate(t *testing.T) {
@@ -141,5 +142,160 @@ func TestEntryPenaltyHelpersDoNotMutateSharedMaps(t *testing.T) {
 	}
 	if snapshot.HasPenaltyRecord("ns/wl2") {
 		t.Error("a later write inserted a record into a fetched entry's map")
+	}
+}
+
+func TestSettlePenaltyDoesNotMutateSharedSettledMap(t *testing.T) {
+	lqKey := utilqueue.NewLocalQueueReference("default", "lq")
+	ledger := NewAfsUsageLedger()
+	ledger.PushPenalty(lqKey, "ns/wl1", corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")}, time.Now())
+	ledger.Update(lqKey, func(entry UsageLedgerEntry, _ bool) UsageLedgerEntry {
+		entry, _ = entry.SettlePenalty("ns/wl1")
+		return entry
+	})
+
+	snapshot, found := ledger.Get(lqKey)
+	if !found {
+		t.Fatal("expected the settlement to create an entry")
+	}
+
+	ledger.PushPenalty(lqKey, "ns/wl2", corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("3")}, time.Now())
+	ledger.Update(lqKey, func(entry UsageLedgerEntry, _ bool) UsageLedgerEntry {
+		entry, _ = entry.SettlePenalty("ns/wl2")
+		return entry
+	})
+	ledger.ForgetSettledPenalty(lqKey, "ns/wl1")
+
+	if !snapshot.HasSettledPenalty("ns/wl1") {
+		t.Error("a later write deleted a settled identity from a fetched entry's map")
+	}
+	if snapshot.HasSettledPenalty("ns/wl2") {
+		t.Error("a later write inserted a settled identity into a fetched entry's map")
+	}
+}
+
+// A Workload is charged at most once per LocalQueue. Settlement keeps enough
+// identity that a later re-push (admit → evict → re-admit) neither inflates
+// pending usage nor folds a second time.
+func TestSettlePenaltyDeduplicatesPerWorkload(t *testing.T) {
+	lqKey := utilqueue.NewLocalQueueReference("ns", "lq")
+	now := time.Now()
+	penalty := corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")}
+
+	ledger := NewAfsUsageLedger()
+	ledger.PushPenalty(lqKey, "ns/wl", penalty, now)
+
+	var first corev1.ResourceList
+	ledger.Update(lqKey, func(entry UsageLedgerEntry, _ bool) UsageLedgerEntry {
+		var folded corev1.ResourceList
+		entry, folded = entry.SettlePenalty("ns/wl")
+		first = folded
+		entry.Resources = utilresource.MergeResourceListKeepSum(entry.Resources, folded)
+		return entry
+	})
+	if got := first[corev1.ResourceCPU]; got.MilliValue() != 2_000 {
+		t.Fatalf("first SettlePenalty() folded %dm CPU, want 2000m", got.MilliValue())
+	}
+
+	entry, found := ledger.Get(lqKey)
+	if !found {
+		t.Fatal("expected a ledger entry after settlement")
+	}
+	if !entry.HasSettledPenalty("ns/wl") {
+		t.Fatal("expected the Workload identity to be retained after settlement")
+	}
+	if entry.HasPenaltyRecord("ns/wl") {
+		t.Fatal("expected the pending record to be dropped after settlement")
+	}
+	if ledger.HasPendingPenalty(lqKey) {
+		t.Fatalf("pending penalty after settlement: %v", ledger.PeekPenalty(lqKey))
+	}
+
+	// Re-push as the scheduler would on re-assume after eviction.
+	ledger.PushPenalty(lqKey, "ns/wl", penalty, now)
+	if ledger.HasPendingPenalty(lqKey) {
+		t.Fatalf("re-push after settlement inflated pending usage: %v", ledger.PeekPenalty(lqKey))
+	}
+
+	var second corev1.ResourceList
+	ledger.Update(lqKey, func(entry UsageLedgerEntry, _ bool) UsageLedgerEntry {
+		entry, second = entry.SettlePenalty("ns/wl")
+		entry.Resources = utilresource.MergeResourceListKeepSum(entry.Resources, second)
+		return entry
+	})
+	if len(second) != 0 {
+		t.Errorf("second SettlePenalty() folded %v, want nothing", second)
+	}
+	entry, _ = ledger.Get(lqKey)
+	if got := entry.Resources[corev1.ResourceCPU]; got.MilliValue() != 2_000 {
+		t.Errorf("consumed CPU after re-push and re-settle = %dm, want 2000m", got.MilliValue())
+	}
+
+	// A distinct Workload on the same LocalQueue is still charged once.
+	ledger.PushPenalty(lqKey, "ns/wl2", penalty, now)
+	ledger.Update(lqKey, func(entry UsageLedgerEntry, _ bool) UsageLedgerEntry {
+		var folded corev1.ResourceList
+		entry, folded = entry.SettlePenalty("ns/wl2")
+		entry.Resources = utilresource.MergeResourceListKeepSum(entry.Resources, folded)
+		return entry
+	})
+	entry, _ = ledger.Get(lqKey)
+	if got := entry.Resources[corev1.ResourceCPU]; got.MilliValue() != 4_000 {
+		t.Errorf("consumed CPU after a second Workload settled = %dm, want 4000m", got.MilliValue())
+	}
+	if !entry.HasSettledPenalty("ns/wl2") {
+		t.Error("expected the second Workload's identity to be retained")
+	}
+}
+
+// Forgetting the settled identity (deletion, LocalQueue move, finish) lets a
+// later entry for the same Workload name be charged again.
+func TestForgetSettledPenaltyAllowsNewCharge(t *testing.T) {
+	lqKey := utilqueue.NewLocalQueueReference("ns", "lq")
+	now := time.Now()
+	penalty := corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")}
+
+	ledger := NewAfsUsageLedger()
+	ledger.PushPenalty(lqKey, "ns/wl", penalty, now)
+	ledger.Update(lqKey, func(entry UsageLedgerEntry, _ bool) UsageLedgerEntry {
+		var folded corev1.ResourceList
+		entry, folded = entry.SettlePenalty("ns/wl")
+		entry.Resources = utilresource.MergeResourceListKeepSum(entry.Resources, folded)
+		return entry
+	})
+
+	ledger.ForgetSettledPenalty(lqKey, "ns/wl")
+	entry, _ := ledger.Get(lqKey)
+	if entry.HasSettledPenalty("ns/wl") {
+		t.Fatal("ForgetSettledPenalty() left the settled identity in place")
+	}
+
+	ledger.PushPenalty(lqKey, "ns/wl", penalty, now)
+	if !ledger.HasPendingPenalty(lqKey) {
+		t.Fatal("expected a new pending penalty after forgetting the settled identity")
+	}
+
+	var folded corev1.ResourceList
+	ledger.Update(lqKey, func(entry UsageLedgerEntry, _ bool) UsageLedgerEntry {
+		entry, folded = entry.SettlePenalty("ns/wl")
+		entry.Resources = utilresource.MergeResourceListKeepSum(entry.Resources, folded)
+		return entry
+	})
+	if got := folded[corev1.ResourceCPU]; got.MilliValue() != 2_000 {
+		t.Errorf("SettlePenalty() after forget folded %dm CPU, want 2000m", got.MilliValue())
+	}
+	entry, _ = ledger.Get(lqKey)
+	if got := entry.Resources[corev1.ResourceCPU]; got.MilliValue() != 4_000 {
+		t.Errorf("consumed CPU after a new charge = %dm, want 4000m", got.MilliValue())
+	}
+}
+
+// ForgetSettledPenalty must not create an entry for a LocalQueue that has none.
+func TestForgetSettledPenaltyDoesNotCreateEntry(t *testing.T) {
+	lqKey := utilqueue.NewLocalQueueReference("ns", "lq")
+	ledger := NewAfsUsageLedger()
+	ledger.ForgetSettledPenalty(lqKey, "ns/wl")
+	if _, found := ledger.Get(lqKey); found {
+		t.Error("ForgetSettledPenalty materialized a ledger entry for a LocalQueue that had none")
 	}
 }

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -1328,7 +1328,12 @@ func (r *WorkloadReconciler) Delete(e event.TypedDeleteEvent[*kueue.Workload]) b
 		// A Workload deleted before settling (e.g. a Job deleted while waiting
 		// for an AdmissionCheck) would leave its penalty pending forever,
 		// inflating the LocalQueue's fair-sharing usage until restart.
-		r.queues.AfsUsageLedger.SubPenalty(qutil.KeyFromWorkload(e.Object), queueafs.WorkloadReference(wlKey))
+		// Also drop the settled identity so a replacement object with the same
+		// namespace/name can be charged as a new entry.
+		lqKey := qutil.KeyFromWorkload(e.Object)
+		wlRef := queueafs.WorkloadReference(wlKey)
+		r.queues.AfsUsageLedger.SubPenalty(lqKey, wlRef)
+		r.queues.AfsUsageLedger.ForgetSettledPenalty(lqKey, wlRef)
 	}
 	return true
 }
@@ -1502,18 +1507,28 @@ func (r *WorkloadReconciler) reconcileAfsPenaltiesOnUpdate(
 	// inactive with its reservation gone, or finished without admission — or it
 	// inflates the LocalQueue's fair-sharing usage until the object is deleted.
 	// An evicted Workload that stays active on the same LocalQueue keeps its
-	// record, and so does a deactivated Workload that still holds its
-	// reservation: reactivated in place, it can reach Admitted without another
-	// scheduler assume, and its penalty must still settle.
+	// pending record and its settled identity, so re-admission cannot charge
+	// a second entry penalty. A deactivated Workload that still holds its
+	// reservation keeps the pending record: reactivated in place, it can
+	// reach Admitted without another scheduler assume, and its penalty must
+	// still settle. Settled identity is also kept across deactivation so a
+	// later reactivate → admit does not double-charge.
 	wlRef := queueafs.WorkloadReference(workload.Key(e.ObjectNew))
 	if prevQueue != e.ObjectNew.Spec.QueueName {
-		r.queues.AfsUsageLedger.SubPenalty(qutil.NewLocalQueueReference(e.ObjectOld.Namespace, prevQueue), wlRef)
+		oldKey := qutil.NewLocalQueueReference(e.ObjectOld.Namespace, prevQueue)
+		r.queues.AfsUsageLedger.SubPenalty(oldKey, wlRef)
+		// Leaving this LocalQueue is a new entry if the Workload returns;
+		// forget so the old queue does not leak the identity.
+		r.queues.AfsUsageLedger.ForgetSettledPenalty(oldKey, wlRef)
 	}
 	inactiveUnreserved := !active && !workload.HasQuotaReservation(e.ObjectNew)
 	wasActiveOrReserved := workload.IsActive(e.ObjectOld) || workload.HasQuotaReservation(e.ObjectOld)
 	if (inactiveUnreserved && wasActiveOrReserved) ||
 		(status == workload.StatusFinished && prevStatus != workload.StatusFinished) {
 		r.queues.AfsUsageLedger.SubPenalty(qutil.KeyFromWorkload(e.ObjectNew), wlRef)
+	}
+	if status == workload.StatusFinished && prevStatus != workload.StatusFinished {
+		r.queues.AfsUsageLedger.ForgetSettledPenalty(qutil.KeyFromWorkload(e.ObjectNew), wlRef)
 	}
 }
 
@@ -1552,11 +1567,12 @@ func (r *WorkloadReconciler) updateAfsConsumedUsage(log logr.Logger, wl *kueue.W
 			storedLastUpdate = lastUpdate
 		}
 		newConsumed := afs.CalculateDecayedConsumed(old.Resources, newUsage, elapsed, r.admissionFSConfig.UsageHalfLifeTime.Seconds())
-		// Fold exactly the pushed amount and drop the record in the same write,
-		// so a repeated settlement folds nothing and other Workloads' pending
-		// penalties are untouched. No record (e.g. pushed before a manager
-		// restart) folds nothing; restart recovery is out of scope.
-		remaining, penalty := old.WithoutPenalty(wlKey)
+		// Fold exactly the pushed amount, drop the pending record, and retain
+		// the Workload identity so a later re-push after eviction folds
+		// nothing. Other Workloads' pending penalties are untouched. No
+		// record (e.g. pushed before a manager restart) folds nothing;
+		// restart recovery is out of scope.
+		remaining, penalty := old.SettlePenalty(wlKey)
 		settled = penalty
 		remaining.Resources = resource.MergeResourceListKeepSum(newConsumed, penalty)
 		remaining.LastUpdate = storedLastUpdate

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -1324,17 +1324,12 @@ func (r *WorkloadReconciler) Delete(e event.TypedDeleteEvent[*kueue.Workload]) b
 	// workload was in the queues and should be cleared from them.
 	r.queues.DeleteAndForgetWorkload(log, wlKey)
 
-	if afs.Enabled(r.admissionFSConfig) {
-		// A Workload deleted before settling (e.g. a Job deleted while waiting
-		// for an AdmissionCheck) would leave its penalty pending forever,
-		// inflating the LocalQueue's fair-sharing usage until restart.
-		// Also drop the settled identity so a replacement object with the same
-		// namespace/name can be charged as a new entry.
-		lqKey := qutil.KeyFromWorkload(e.Object)
-		wlRef := queueafs.WorkloadReference(wlKey)
-		r.queues.AfsUsageLedger.SubPenalty(lqKey, wlRef)
-		r.queues.AfsUsageLedger.ForgetSettledPenalty(lqKey, wlRef)
-	}
+	// A Workload deleted before settling (e.g. a Job deleted while waiting
+	// for an AdmissionCheck) would leave its penalty pending forever,
+	// inflating the LocalQueue's fair-sharing usage until restart.
+	// Also drop the settled identity so a replacement object with the same
+	// namespace/name can be charged as a new entry.
+	r.dropAfsPenaltyAccounting(e.Object)
 	return true
 }
 
@@ -1367,6 +1362,16 @@ func (r *WorkloadReconciler) Update(e event.TypedUpdateEvent[*kueue.Workload]) b
 		log = log.WithValues("unhealthyNodes", nodeNames)
 	}
 	log.V(2).Info("Workload update event")
+
+	// A SharedInformer may deliver delete+create of the same namespaced name
+	// as one Update with a new UID (client-go SharedInformer contract). The
+	// Delete handler is not invoked for that sequence, so drop the old
+	// object's AFS records before the replacement is queued. Otherwise
+	// PushPenalty would treat UID B as a re-admission of UID A and skip B's
+	// first entry penalty.
+	if e.ObjectOld.UID != e.ObjectNew.UID {
+		r.dropAfsPenaltyAccounting(e.ObjectOld)
+	}
 
 	wlCopy := e.ObjectNew.DeepCopy()
 	wlKey := workload.Key(e.ObjectNew)
@@ -1530,6 +1535,19 @@ func (r *WorkloadReconciler) reconcileAfsPenaltiesOnUpdate(
 	if status == workload.StatusFinished && prevStatus != workload.StatusFinished {
 		r.queues.AfsUsageLedger.ForgetSettledPenalty(qutil.KeyFromWorkload(e.ObjectNew), wlRef)
 	}
+}
+
+// dropAfsPenaltyAccounting removes pending and settled AFS records for wl.
+// Call when the object is gone: an explicit Delete, or an Update whose UID
+// changed because delete+create of the same namespaced name was coalesced.
+func (r *WorkloadReconciler) dropAfsPenaltyAccounting(wl *kueue.Workload) {
+	if !afs.Enabled(r.admissionFSConfig) {
+		return
+	}
+	lqKey := qutil.KeyFromWorkload(wl)
+	wlRef := queueafs.WorkloadReference(workload.Key(wl))
+	r.queues.AfsUsageLedger.SubPenalty(lqKey, wlRef)
+	r.queues.AfsUsageLedger.ForgetSettledPenalty(lqKey, wlRef)
 }
 
 func (r *WorkloadReconciler) Generic(e event.TypedGenericEvent[*kueue.Workload]) bool {

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -2595,4 +2595,114 @@ func TestRepeatedAfsSettlementFoldsPenaltyOnce(t *testing.T) {
 	if qManager.AfsUsageLedger.HasPendingPenalty(lqKey) {
 		t.Errorf("penalty still pending after settlement: %v", qManager.AfsUsageLedger.PeekPenalty(lqKey))
 	}
+	if !entry.HasSettledPenalty(queueafs.WorkloadReference(workload.Key(wl))) {
+		t.Error("expected the Workload identity to be retained after settlement")
+	}
+}
+
+// Admit → evict → re-admit must not fold a second entry penalty for the same
+// Workload and LocalQueue. Settlement used to drop the Workload identity, so a
+// later re-push was treated as a new charge.
+func TestAdmitEvictReadmitDoesNotDoubleChargeAfsEntryPenalty(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	lqKey := utilqueue.NewLocalQueueReference("ns", "lq")
+
+	makeWl := func() *utiltestingapi.WorkloadWrapper {
+		return utiltestingapi.MakeWorkload("wl", "ns").
+			Queue("lq").
+			Active(true).
+			Request(corev1.ResourceCPU, "4")
+	}
+	makeAdmission := func() *kueue.Admission {
+		return utiltestingapi.MakeAdmission("cq").
+			PodSets(utiltestingapi.MakePodSetAssignment("main").Assignment(corev1.ResourceCPU, "rf", "4").Obj()).
+			Obj()
+	}
+	pending := makeWl().Obj()
+	admitted := makeWl().
+		ReserveQuotaAt(makeAdmission(), now).
+		AdmittedAt(true, now).
+		Obj()
+
+	afsConfig := &configapi.AdmissionFairSharing{
+		UsageHalfLifeTime:     metav1.Duration{Duration: time.Minute},
+		UsageSamplingInterval: metav1.Duration{Duration: time.Second},
+	}
+	cl := utiltesting.NewClientBuilder().Build()
+	recorder := &utiltesting.EventRecorder{}
+	cqCache := schdcache.New(cl, schdcache.WithAdmissionFairSharing(afsConfig))
+	qManager := qcache.NewManagerForUnitTests(cl, cqCache, qcache.WithAdmissionFairSharing(afsConfig))
+	reconciler := NewWorkloadReconciler(cl, qManager, cqCache, recorder, WithAdmissionFairSharing(afsConfig))
+
+	ctx, _ := utiltesting.ContextWithLog(t)
+	cq := utiltestingapi.MakeClusterQueue("cq").
+		AdmissionMode(kueue.UsageBasedAdmissionFairSharing).
+		Active(metav1.ConditionTrue).
+		Obj()
+	setupClusterQueue(ctx, t, cl, qManager, cqCache, cq, false)
+	lq := utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj()
+	setupLocalQueue(ctx, t, cl, qManager, lq, false)
+	if err := cqCache.AddLocalQueue(lq); err != nil {
+		t.Fatalf("couldn't add the local queue to the scheduler cache: %v", err)
+	}
+
+	seeded := afs.CalculateEntryPenalty(workload.NewInfo(admitted).SumTotalRequests(reconciler.resourceFormatter), afsConfig)
+	if len(seeded) == 0 {
+		t.Fatal("the seeded penalty is empty, so the settlement would fold nothing and the test would pass")
+	}
+	wlRef := queueafs.WorkloadReference(workload.Key(admitted))
+	qManager.AfsUsageLedger.PushPenalty(lqKey, wlRef, seeded, now)
+
+	reconciler.Update(event.TypedUpdateEvent[*kueue.Workload]{
+		ObjectOld: pending.DeepCopy(),
+		ObjectNew: admitted.DeepCopy(),
+	})
+
+	entry, found := qManager.AfsUsageLedger.Get(lqKey)
+	if !found {
+		t.Fatal("expected an AfsUsageLedger entry after the first admission")
+	}
+	firstCPU := entry.Resources[corev1.ResourceCPU]
+	if firstCPU.IsZero() {
+		t.Fatal("first admission did not fold the entry penalty into consumed usage")
+	}
+	if !entry.HasSettledPenalty(wlRef) {
+		t.Fatal("expected the Workload identity to be retained after the first settlement")
+	}
+
+	reconciler.Update(event.TypedUpdateEvent[*kueue.Workload]{
+		ObjectOld: admitted.DeepCopy(),
+		ObjectNew: pending.DeepCopy(),
+	})
+
+	entry, _ = qManager.AfsUsageLedger.Get(lqKey)
+	if !entry.HasSettledPenalty(wlRef) {
+		t.Fatal("eviction dropped the settled identity; re-admission would double-charge")
+	}
+	if qManager.AfsUsageLedger.HasPendingPenalty(lqKey) {
+		t.Errorf("eviction re-created a pending penalty: %v", qManager.AfsUsageLedger.PeekPenalty(lqKey))
+	}
+
+	// Re-assume after eviction: the scheduler would PushPenalty again because
+	// the Workload no longer holds a reservation.
+	qManager.AfsUsageLedger.PushPenalty(lqKey, wlRef, seeded, now)
+	if qManager.AfsUsageLedger.HasPendingPenalty(lqKey) {
+		t.Errorf("re-push after settlement inflated pending usage: %v", qManager.AfsUsageLedger.PeekPenalty(lqKey))
+	}
+
+	reconciler.Update(event.TypedUpdateEvent[*kueue.Workload]{
+		ObjectOld: pending.DeepCopy(),
+		ObjectNew: admitted.DeepCopy(),
+	})
+
+	entry, found = qManager.AfsUsageLedger.Get(lqKey)
+	if !found {
+		t.Fatal("expected an AfsUsageLedger entry after re-admission")
+	}
+	if got := entry.Resources[corev1.ResourceCPU]; got.Cmp(firstCPU) != 0 {
+		t.Errorf("consumed CPU after admit → evict → re-admit = %s, want %s (folded once)", got.String(), firstCPU.String())
+	}
+	if qManager.AfsUsageLedger.HasPendingPenalty(lqKey) {
+		t.Errorf("penalty still pending after re-admission: %v", qManager.AfsUsageLedger.PeekPenalty(lqKey))
+	}
 }

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -2628,11 +2628,18 @@ func TestAdmitEvictReadmitDoesNotDoubleChargeAfsEntryPenalty(t *testing.T) {
 		UsageHalfLifeTime:     metav1.Duration{Duration: time.Minute},
 		UsageSamplingInterval: metav1.Duration{Duration: time.Second},
 	}
+	fakeClock := testingclock.NewFakeClock(now)
 	cl := utiltesting.NewClientBuilder().Build()
 	recorder := &utiltesting.EventRecorder{}
 	cqCache := schdcache.New(cl, schdcache.WithAdmissionFairSharing(afsConfig))
-	qManager := qcache.NewManagerForUnitTests(cl, cqCache, qcache.WithAdmissionFairSharing(afsConfig))
-	reconciler := NewWorkloadReconciler(cl, qManager, cqCache, recorder, WithAdmissionFairSharing(afsConfig))
+	qManager := qcache.NewManagerForUnitTests(cl, cqCache,
+		qcache.WithClock(fakeClock),
+		qcache.WithAdmissionFairSharing(afsConfig),
+		qcache.WithPreemptionExpectations(preemptexpectations.New()))
+	reconciler := NewWorkloadReconciler(cl, qManager, cqCache, recorder,
+		WithAdmissionFairSharing(afsConfig),
+		WithPreemptionExpectations(preemptexpectations.New()))
+	reconciler.clock = fakeClock
 
 	ctx, _ := utiltesting.ContextWithLog(t)
 	cq := utiltestingapi.MakeClusterQueue("cq").

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -2713,3 +2713,123 @@ func TestAdmitEvictReadmitDoesNotDoubleChargeAfsEntryPenalty(t *testing.T) {
 		t.Errorf("penalty still pending after re-admission: %v", qManager.AfsUsageLedger.PeekPenalty(lqKey))
 	}
 }
+
+// A SharedInformer can report delete+create of the same namespaced name as
+// Update(oldUID, newUID). The replacement must not inherit the previous
+// object's settled marker, or its first admission would skip the entry penalty.
+func TestDifferentUIDUpdateDoesNotInheritSettledAfsEntryPenalty(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	lqKey := utilqueue.NewLocalQueueReference("ns", "lq")
+
+	makeWl := func(uid types.UID) *utiltestingapi.WorkloadWrapper {
+		return utiltestingapi.MakeWorkload("wl", "ns").
+			UID(uid).
+			Queue("lq").
+			Active(true).
+			Request(corev1.ResourceCPU, "4")
+	}
+	makeAdmission := func() *kueue.Admission {
+		return utiltestingapi.MakeAdmission("cq").
+			PodSets(utiltestingapi.MakePodSetAssignment("main").Assignment(corev1.ResourceCPU, "rf", "4").Obj()).
+			Obj()
+	}
+	pendingA := makeWl("uid-a").Obj()
+	admittedA := makeWl("uid-a").
+		ReserveQuotaAt(makeAdmission(), now).
+		AdmittedAt(true, now).
+		Obj()
+	pendingB := makeWl("uid-b").Obj()
+	admittedB := makeWl("uid-b").
+		ReserveQuotaAt(makeAdmission(), now).
+		AdmittedAt(true, now).
+		Obj()
+
+	afsConfig := &configapi.AdmissionFairSharing{
+		UsageHalfLifeTime:     metav1.Duration{Duration: time.Minute},
+		UsageSamplingInterval: metav1.Duration{Duration: time.Second},
+	}
+	fakeClock := testingclock.NewFakeClock(now)
+	cl := utiltesting.NewClientBuilder().Build()
+	recorder := &utiltesting.EventRecorder{}
+	cqCache := schdcache.New(cl, schdcache.WithAdmissionFairSharing(afsConfig))
+	qManager := qcache.NewManagerForUnitTests(cl, cqCache,
+		qcache.WithClock(fakeClock),
+		qcache.WithAdmissionFairSharing(afsConfig),
+		qcache.WithPreemptionExpectations(preemptexpectations.New()))
+	reconciler := NewWorkloadReconciler(cl, qManager, cqCache, recorder,
+		WithAdmissionFairSharing(afsConfig),
+		WithPreemptionExpectations(preemptexpectations.New()))
+	reconciler.clock = fakeClock
+
+	ctx, _ := utiltesting.ContextWithLog(t)
+	cq := utiltestingapi.MakeClusterQueue("cq").
+		AdmissionMode(kueue.UsageBasedAdmissionFairSharing).
+		Active(metav1.ConditionTrue).
+		Obj()
+	setupClusterQueue(ctx, t, cl, qManager, cqCache, cq, false)
+	lq := utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj()
+	setupLocalQueue(ctx, t, cl, qManager, lq, false)
+	if err := cqCache.AddLocalQueue(lq); err != nil {
+		t.Fatalf("couldn't add the local queue to the scheduler cache: %v", err)
+	}
+
+	seeded := afs.CalculateEntryPenalty(workload.NewInfo(admittedA).SumTotalRequests(reconciler.resourceFormatter), afsConfig)
+	if len(seeded) == 0 {
+		t.Fatal("the seeded penalty is empty, so the settlement would fold nothing and the test would pass")
+	}
+	wlRef := queueafs.WorkloadReference(workload.Key(admittedA))
+	qManager.AfsUsageLedger.PushPenalty(lqKey, wlRef, seeded, now)
+
+	reconciler.Update(event.TypedUpdateEvent[*kueue.Workload]{
+		ObjectOld: pendingA.DeepCopy(),
+		ObjectNew: admittedA.DeepCopy(),
+	})
+
+	entry, found := qManager.AfsUsageLedger.Get(lqKey)
+	if !found {
+		t.Fatal("expected an AfsUsageLedger entry after the first admission")
+	}
+	firstCPU := entry.Resources[corev1.ResourceCPU]
+	if firstCPU.IsZero() {
+		t.Fatal("first admission did not fold the entry penalty into consumed usage")
+	}
+	if !entry.HasSettledPenalty(wlRef) {
+		t.Fatal("expected UID A's settled identity after the first settlement")
+	}
+
+	reconciler.Update(event.TypedUpdateEvent[*kueue.Workload]{
+		ObjectOld: admittedA.DeepCopy(),
+		ObjectNew: pendingB.DeepCopy(),
+	})
+
+	entry, _ = qManager.AfsUsageLedger.Get(lqKey)
+	if entry.HasSettledPenalty(wlRef) {
+		t.Fatal("Update from UID A to UID B retained A's settled marker")
+	}
+	if qManager.AfsUsageLedger.HasPendingPenalty(lqKey) {
+		t.Errorf("UID replacement left a pending penalty: %v", qManager.AfsUsageLedger.PeekPenalty(lqKey))
+	}
+
+	qManager.AfsUsageLedger.PushPenalty(lqKey, wlRef, seeded, now)
+	if !qManager.AfsUsageLedger.HasPendingPenalty(lqKey) {
+		t.Fatal("PushPenalty for UID B was suppressed by A's settled marker")
+	}
+
+	reconciler.Update(event.TypedUpdateEvent[*kueue.Workload]{
+		ObjectOld: pendingB.DeepCopy(),
+		ObjectNew: admittedB.DeepCopy(),
+	})
+
+	entry, found = qManager.AfsUsageLedger.Get(lqKey)
+	if !found {
+		t.Fatal("expected an AfsUsageLedger entry after UID B's admission")
+	}
+	wantCPU := firstCPU.DeepCopy()
+	wantCPU.Add(firstCPU)
+	if got := entry.Resources[corev1.ResourceCPU]; got.Cmp(wantCPU) != 0 {
+		t.Errorf("consumed CPU after UID replacement = %s, want %s (both first-entry penalties)", got.String(), wantCPU.String())
+	}
+	if !entry.HasSettledPenalty(wlRef) {
+		t.Error("expected UID B's settled identity after its first admission")
+	}
+}


### PR DESCRIPTION
Fixes #15221

/kind bug

```release-note
Deduplicate AdmissionFairSharing entry-penalty settlement so admit → evict → re-admit no longer double-charges the same Workload/LocalQueue path.
```

#### What this PR does / why we need it:

Entry-penalty settlement was not deduplicated per Workload + LocalQueue, so admit → evict → re-admit could double-charge AdmissionFairSharing accounting.

This keeps settlement identity so the same Workload/LocalQueue path is not charged twice, with unit coverage for the admit/evict/re-admit path.

#### Special notes for your reviewer:

Draft until human review. Author: roshpr. Kubernetes CLA applies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## AI summary

AFS now prevents duplicate entry-penalty charges when a Workload is admitted, evicted, and admitted again to the same LocalQueue.

When a Workload UID changes, Kueue removes the previous pending and settled records. The replacement Workload can receive its own entry penalty. Unit tests cover both cases.

### Suggested release note

AFS: Fixed duplicate entry-penalty charges when a Workload was evicted and admitted again. Kueue now charges the Workload only once per LocalQueue while allowing UID replacements to receive a new charge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->