### PR TITLE
[release-0.18] Require a logger when constructing workload Info

### DIFF
--- a/cmd/importer/pod/check.go
+++ b/cmd/importer/pod/check.go
@@ -134,7 +134,7 @@ func checkPodWorkload(ctx context.Context, c client.Client, importCache *cache.I
 	}
 	maps.Copy(wl.Labels, importCache.AddLabels)
 
-	info := workload.NewInfoWithLogger(ctrl.LoggerFrom(ctx), wl, importCache.WorkloadInfoOptions()...)
+	info := workload.NewInfo(ctrl.LoggerFrom(ctx), wl, importCache.WorkloadInfoOptions()...)
 	flavors, err := flavorAssignmentsForRequests(importCache.FlavorsByResourceForClusterQueue(kueue.ClusterQueueReference(cq.Name)), cq.Name, info.TotalRequests[0].Requests)
 	if err != nil {
 		return nil, err

--- a/cmd/importer/pod/import.go
+++ b/cmd/importer/pod/import.go
@@ -198,7 +198,7 @@ func admitWorkload(
 	workloadInfoOptions []workload.InfoOption,
 ) error {
 	update := func(wl *kueue.Workload) (bool, error) {
-		info := workload.NewInfoWithLogger(ctrl.LoggerFrom(ctx), wl, workloadInfoOptions...)
+		info := workload.NewInfo(ctrl.LoggerFrom(ctx), wl, workloadInfoOptions...)
 		admission := kueue.Admission{
 			ClusterQueue: kueue.ClusterQueueReference(cq.Name),
 			PodSetAssignments: []kueue.PodSetAssignment{

--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -66,6 +66,7 @@ var (
 )
 
 func Test_PushOrUpdate(t *testing.T) {
+	_, log := utiltesting.ContextWithLog(t)
 	now := time.Now()
 	minuteLater := now.Add(time.Minute)
 	fakeClock := testingclock.NewFakeClock(now)
@@ -82,7 +83,7 @@ func Test_PushOrUpdate(t *testing.T) {
 	}{
 		"workload doesn't have re-queue state": {
 			workload:     wlBase.Clone(),
-			wantWorkload: workload.NewInfo(wlBase.Clone().ResourceVersion("1").Obj()),
+			wantWorkload: workload.NewInfo(log, wlBase.Clone().ResourceVersion("1").Obj()),
 		},
 		"workload is still under the backoff waiting time": {
 			workload: wlBase.Clone().
@@ -97,7 +98,7 @@ func Test_PushOrUpdate(t *testing.T) {
 					Status: metav1.ConditionFalse,
 				}),
 			wantInAdmissibleWorkloads: inadmissibleWorkloads{
-				"default/workload-1": workload.NewInfo(wlBase.Clone().
+				"default/workload-1": workload.NewInfo(log, wlBase.Clone().
 					ResourceVersion("1").
 					RequeueState(ptr.To[int32](10), new(metav1.NewTime(minuteLater))).
 					Condition(metav1.Condition{
@@ -124,7 +125,7 @@ func Test_PushOrUpdate(t *testing.T) {
 					Status: metav1.ConditionFalse,
 				}),
 			wantInAdmissibleWorkloads: inadmissibleWorkloads{
-				"default/workload-1": workload.NewInfo(wlBase.Clone().
+				"default/workload-1": workload.NewInfo(log, wlBase.Clone().
 					ResourceVersion("1").
 					Condition(metav1.Condition{
 						Type:   kueue.WorkloadEvicted,
@@ -149,7 +150,7 @@ func Test_PushOrUpdate(t *testing.T) {
 					Type:   kueue.WorkloadRequeued,
 					Status: metav1.ConditionTrue,
 				}),
-			wantWorkload: workload.NewInfo(wlBase.Clone().
+			wantWorkload: workload.NewInfo(log, wlBase.Clone().
 				ResourceVersion("1").
 				Condition(metav1.Condition{
 					Type:   kueue.WorkloadEvicted,
@@ -165,20 +166,20 @@ func Test_PushOrUpdate(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			ctx, _ := utiltesting.ContextWithLog(t)
+			ctx, log := utiltesting.ContextWithLog(t)
 			cq := newClusterQueueImpl(ctx, nil, defaultOrdering, fakeClock)
 
 			if cq.PendingTotal() != 0 {
 				t.Error("ClusterQueue should be empty")
 			}
-			cq.PushOrUpdate(workload.NewInfo(tc.workload.DeepCopy()))
+			cq.PushOrUpdate(workload.NewInfo(log, tc.workload.DeepCopy()))
 			if cq.PendingTotal() != 1 {
 				t.Error("ClusterQueue should have one workload")
 			}
 
 			// Just used to validate the update operation.
 			updatedWl := tc.workload.Clone().ResourceVersion("1").Obj()
-			cq.PushOrUpdate(workload.NewInfo(updatedWl))
+			cq.PushOrUpdate(workload.NewInfo(log, updatedWl))
 			newWl := cq.Pop()
 			if newWl != nil && cq.PendingTotal() != 1 {
 				t.Errorf("unexpected count of pending workloads (want=%d, got=%d)", 1, cq.PendingTotal())
@@ -194,11 +195,11 @@ func Test_PushOrUpdate(t *testing.T) {
 }
 
 func Test_Pop(t *testing.T) {
-	ctx, _ := utiltesting.ContextWithLog(t)
+	ctx, log := utiltesting.ContextWithLog(t)
 	now := time.Now()
 	cq := newClusterQueueImpl(ctx, nil, defaultOrdering, testingclock.NewFakeClock(now))
-	wl1 := workload.NewInfo(utiltestingapi.MakeWorkload("workload-1", defaultNamespace).Creation(now).Obj())
-	wl2 := workload.NewInfo(utiltestingapi.MakeWorkload("workload-2", defaultNamespace).Creation(now.Add(time.Second)).Obj())
+	wl1 := workload.NewInfo(log, utiltestingapi.MakeWorkload("workload-1", defaultNamespace).Creation(now).Obj())
+	wl2 := workload.NewInfo(log, utiltestingapi.MakeWorkload("workload-2", defaultNamespace).Creation(now.Add(time.Second)).Obj())
 	if cq.Pop() != nil {
 		t.Error("ClusterQueue should be empty")
 	}
@@ -218,12 +219,12 @@ func Test_Pop(t *testing.T) {
 }
 
 func TestPushOrUpdateSkipsInflightWorkload(t *testing.T) {
-	ctx, _ := utiltesting.ContextWithLog(t)
+	ctx, log := utiltesting.ContextWithLog(t)
 	now := time.Now()
 	cq := newClusterQueueImpl(ctx, nil, defaultOrdering, testingclock.NewFakeClock(now))
 
 	wl := utiltestingapi.MakeWorkload("workload-1", defaultNamespace).Creation(now).Obj()
-	cq.PushOrUpdate(workload.NewInfo(wl))
+	cq.PushOrUpdate(workload.NewInfo(log, wl))
 
 	// Pop makes the workload inflight.
 	head := cq.Pop()
@@ -234,7 +235,7 @@ func TestPushOrUpdateSkipsInflightWorkload(t *testing.T) {
 	// Simulate a concurrent PushOrUpdate while the workload is inflight.
 	updatedWl := utiltestingapi.MakeWorkload("workload-1", defaultNamespace).
 		Creation(now).ResourceVersion("1").Obj()
-	cq.PushOrUpdate(workload.NewInfo(updatedWl))
+	cq.PushOrUpdate(workload.NewInfo(log, updatedWl))
 
 	// The workload should not be on the heap or in inadmissible.
 	activeWorkloads, _ := cq.Dump()
@@ -283,7 +284,7 @@ func TestPushOrUpdateGenerationChanged(t *testing.T) {
 
 			wl := utiltestingapi.MakeWorkload("workload-1", defaultNamespace).
 				Creation(now).Generation(1).Obj()
-			cq.PushOrUpdate(workload.NewInfo(wl))
+			cq.PushOrUpdate(workload.NewInfo(log, wl))
 
 			head := cq.Pop()
 			if head == nil {
@@ -291,12 +292,12 @@ func TestPushOrUpdateGenerationChanged(t *testing.T) {
 			}
 
 			// Simulate RequeueWorkload with info.Update: inadmissible entry gets new generation.
-			updatedInfo := workload.NewInfo(tc.updatedWorkload)
+			updatedInfo := workload.NewInfo(log, tc.updatedWorkload)
 			updatedInfo.LastEvaluatedGeneration = head.LastEvaluatedGeneration
 			cq.requeueIfNotPresent(log, updatedInfo, false, RequeueReasonGeneric, "")
 
 			// PushOrUpdate from informer event with the updated workload.
-			cq.PushOrUpdate(workload.NewInfo(tc.updatedWorkload))
+			cq.PushOrUpdate(workload.NewInfo(log, tc.updatedWorkload))
 
 			if active, _ := cq.Dump(); len(active) != tc.wantActiveWorkloads {
 				t.Errorf("got %d active workloads, want %d", len(active), tc.wantActiveWorkloads)
@@ -313,8 +314,8 @@ func Test_Delete(t *testing.T) {
 	cq := newClusterQueueImpl(ctx, nil, defaultOrdering, testingclock.NewFakeClock(time.Now()))
 	wl1 := utiltestingapi.MakeWorkload("workload-1", defaultNamespace).Obj()
 	wl2 := utiltestingapi.MakeWorkload("workload-2", defaultNamespace).Obj()
-	cq.PushOrUpdate(workload.NewInfo(wl1))
-	cq.PushOrUpdate(workload.NewInfo(wl2))
+	cq.PushOrUpdate(workload.NewInfo(log, wl1))
+	cq.PushOrUpdate(workload.NewInfo(log, wl2))
 	if cq.PendingTotal() != 2 {
 		t.Error("ClusterQueue should have two workload")
 	}
@@ -331,13 +332,13 @@ func Test_Delete(t *testing.T) {
 }
 
 func Test_Info(t *testing.T) {
-	ctx, _ := utiltesting.ContextWithLog(t)
+	ctx, log := utiltesting.ContextWithLog(t)
 	cq := newClusterQueueImpl(ctx, nil, defaultOrdering, testingclock.NewFakeClock(time.Now()))
 	wl := utiltestingapi.MakeWorkload("workload-1", defaultNamespace).Obj()
 	if info := cq.Info(workload.Key(wl)); info != nil {
 		t.Error("Workload should not exist")
 	}
-	cq.PushOrUpdate(workload.NewInfo(wl))
+	cq.PushOrUpdate(workload.NewInfo(log, wl))
 	if info := cq.Info(workload.Key(wl)); info == nil {
 		t.Error("Expected workload to exist")
 	}
@@ -349,10 +350,10 @@ func Test_AddFromLocalQueue(t *testing.T) {
 	wl := utiltestingapi.MakeWorkload("workload-1", defaultNamespace).Obj()
 	queue := &LocalQueue{
 		items: map[workload.Reference]*workload.Info{
-			workload.Reference(wl.Name): workload.NewInfo(wl),
+			workload.Reference(wl.Name): workload.NewInfo(log, wl),
 		},
 	}
-	cq.PushOrUpdate(workload.NewInfo(wl))
+	cq.PushOrUpdate(workload.NewInfo(log, wl))
 	if added := cq.AddFromLocalQueue(queue, nil, nil); added {
 		t.Error("expected workload not to be added")
 	}
@@ -402,10 +403,10 @@ func TestSnapshotDeterministicOrder(t *testing.T) {
 			cq := newClusterQueueImpl(ctx, nil, defaultOrdering, testingclock.NewFakeClock(now))
 
 			for _, w := range tc.workloads {
-				cq.PushOrUpdate(workload.NewInfo(w))
+				cq.PushOrUpdate(workload.NewInfo(log, w))
 			}
 			for _, w := range tc.inadmissibleWorkloads {
-				cq.requeueIfNotPresent(log, workload.NewInfo(w), false, RequeueReasonGeneric, "")
+				cq.requeueIfNotPresent(log, workload.NewInfo(log, w), false, RequeueReasonGeneric, "")
 			}
 
 			firstSnap := cq.Snapshot()
@@ -420,7 +421,7 @@ func TestSnapshotDeterministicOrder(t *testing.T) {
 
 func TestSnapshotFallsBackToBaseOrderingOnLocalQueueLookupError(t *testing.T) {
 	now := time.Now().Truncate(time.Second)
-	ctx, _ := utiltesting.ContextWithLog(t)
+	ctx, log := utiltesting.ContextWithLog(t)
 	lqLookupErr := errors.New("temporary LocalQueue lookup error")
 	cl := utiltesting.NewClientBuilder().
 		WithObjects(
@@ -458,11 +459,11 @@ func TestSnapshotFallsBackToBaseOrderingOnLocalQueueLookupError(t *testing.T) {
 	// before higher-usage, while base ordering puts higher-usage before
 	// unavailable and unavailable before lower-usage.
 	elements := []*workload.Info{
-		workload.NewInfo(utiltestingapi.MakeWorkload("higher-usage", defaultNamespace).
+		workload.NewInfo(log, utiltestingapi.MakeWorkload("higher-usage", defaultNamespace).
 			Queue("higher-usage").Priority(3).Creation(now).UID("uid-2").Obj()),
-		workload.NewInfo(utiltestingapi.MakeWorkload("lower-usage", defaultNamespace).
+		workload.NewInfo(log, utiltestingapi.MakeWorkload("lower-usage", defaultNamespace).
 			Queue("lower-usage").Priority(1).Creation(now).UID("uid-1").Obj()),
-		workload.NewInfo(utiltestingapi.MakeWorkload("unavailable", defaultNamespace).
+		workload.NewInfo(log, utiltestingapi.MakeWorkload("unavailable", defaultNamespace).
 			Queue("unavailable").Priority(2).Creation(now).UID("uid-3").Obj()),
 	}
 
@@ -492,7 +493,7 @@ func TestSnapshotStableWithConcurrentFSUpdates(t *testing.T) {
 	afsUsageLedger.SetForTest("default/lq1", corev1.ResourceList{resourceGPU: resource.MustParse("5")}, now)
 	afsUsageLedger.SetForTest("default/lq2", corev1.ResourceList{resourceGPU: resource.MustParse("5")}, now)
 
-	ctx, _ := utiltesting.ContextWithLog(t)
+	ctx, log := utiltesting.ContextWithLog(t)
 	cq, err := newClusterQueue(ctx, builder.Build(),
 		utiltestingapi.MakeClusterQueue("cq").AdmissionMode(kueue.UsageBasedAdmissionFairSharing).Obj(),
 		defaultOrdering,
@@ -508,7 +509,7 @@ func TestSnapshotStableWithConcurrentFSUpdates(t *testing.T) {
 		utiltestingapi.MakeWorkload("wl3", defaultNamespace).Queue("lq1").Creation(now).UID("uid-3").Obj(),
 		utiltestingapi.MakeWorkload("wl4", defaultNamespace).Queue("lq2").Creation(now).UID("uid-4").Obj(),
 	} {
-		cq.PushOrUpdate(workload.NewInfo(w))
+		cq.PushOrUpdate(workload.NewInfo(log, w))
 	}
 
 	// Toggle lq1 penalty between 0 and 100 to create mid-sort inconsistency.
@@ -544,7 +545,7 @@ func TestSnapshotStableWithConcurrentFSUpdates(t *testing.T) {
 
 func TestSnapshotUsesDefaultWeightForMissingLocalQueue(t *testing.T) {
 	now := time.Now().Truncate(time.Second)
-	ctx, _ := utiltesting.ContextWithLog(t)
+	ctx, log := utiltesting.ContextWithLog(t)
 	afsUsageLedger := queueafs.NewAfsUsageLedger()
 	afsUsageLedger.SetForTest("default/existing", corev1.ResourceList{resourceGPU: resource.MustParse("10")}, now)
 	afsUsageLedger.SetForTest("default/missing", corev1.ResourceList{resourceGPU: resource.MustParse("15")}, now)
@@ -571,7 +572,7 @@ func TestSnapshotUsesDefaultWeightForMissingLocalQueue(t *testing.T) {
 		utiltestingapi.MakeWorkload("missing-high-priority", defaultNamespace).
 			Queue("missing").Priority(2).Creation(now).UID("uid-2").Obj(),
 	} {
-		cq.PushOrUpdate(workload.NewInfo(wl))
+		cq.PushOrUpdate(workload.NewInfo(log, wl))
 	}
 
 	got := cq.Snapshot()
@@ -586,7 +587,7 @@ func TestSnapshotUsesDefaultWeightForMissingLocalQueue(t *testing.T) {
 // ClusterQueue lock, while RequeueIfNotPresent writes that field during a
 // BestEffortFIFO preemption requeue. Run with -race to detect regressions.
 func TestSnapshotConcurrentWithRequeueNoDataRace(t *testing.T) {
-	ctx, _ := utiltesting.ContextWithLog(t)
+	ctx, log := utiltesting.ContextWithLog(t)
 	cq, err := newClusterQueue(ctx, nil,
 		&kueue.ClusterQueue{
 			Spec: kueue.ClusterQueueSpec{
@@ -607,24 +608,31 @@ func TestSnapshotConcurrentWithRequeueNoDataRace(t *testing.T) {
 		utiltestingapi.MakeWorkload("wl3", defaultNamespace).Obj(),
 	}
 	for _, wl := range wls {
-		cq.PushOrUpdate(workload.NewInfo(wl))
+		cq.PushOrUpdate(workload.NewInfo(log, wl))
 	}
 
 	// Writer: continuously set the sticky workload via a preemption requeue.
+	// The writer must be joined, not just signalled: it logs through the
+	// t-bound logger, and testr panics if that happens after the test returns.
 	stop := make(chan struct{})
+	writerDone := make(chan struct{})
 	go func() {
+		defer close(writerDone)
 		for {
 			select {
 			case <-stop:
 				return
 			default:
 				for _, wl := range wls {
-					cq.RequeueIfNotPresent(ctx, workload.NewInfo(wl), RequeueReasonPendingPreemption, "")
+					cq.RequeueIfNotPresent(ctx, workload.NewInfo(log, wl), RequeueReasonPendingPreemption, "")
 				}
 			}
 		}
 	}()
-	defer close(stop)
+	defer func() {
+		close(stop)
+		<-writerDone
+	}()
 
 	// Reader: Snapshot reads the sticky workload through the comparator.
 	for range 1000 {
@@ -645,7 +653,7 @@ func TestSnapshotConcurrentWithRequeueNoDataRace(t *testing.T) {
 // followed by the rest in UID order. Any other permutation means the sort
 // observed the sticky workload changing mid-sort.
 func TestSnapshotConsistentUnderConcurrentStickyChange(t *testing.T) {
-	ctx, _ := utiltesting.ContextWithLog(t)
+	ctx, log := utiltesting.ContextWithLog(t)
 	cq, err := newClusterQueue(ctx, nil,
 		&kueue.ClusterQueue{
 			Spec: kueue.ClusterQueueSpec{
@@ -666,7 +674,7 @@ func TestSnapshotConsistentUnderConcurrentStickyChange(t *testing.T) {
 	for i, name := range names {
 		wl := utiltestingapi.MakeWorkload(name, defaultNamespace).
 			Creation(now).UID(types.UID(fmt.Sprintf("uid-%d", i))).Obj()
-		cq.PushOrUpdate(workload.NewInfo(wl))
+		cq.PushOrUpdate(workload.NewInfo(log, wl))
 		keys[i] = workload.Key(wl)
 	}
 
@@ -728,7 +736,7 @@ func TestSnapshotConsistentUnderConcurrentStickyChange(t *testing.T) {
 }
 
 func TestClusterQueueIsPreemptor(t *testing.T) {
-	ctx, _ := utiltesting.ContextWithLog(t)
+	ctx, log := utiltesting.ContextWithLog(t)
 	cq, err := newClusterQueue(ctx, nil, utiltestingapi.MakeClusterQueue("cq").Obj(), defaultOrdering, nil, nil)
 	if err != nil {
 		t.Fatalf("failed to create ClusterQueue: %v", err)
@@ -736,11 +744,11 @@ func TestClusterQueueIsPreemptor(t *testing.T) {
 
 	wl := utiltestingapi.MakeWorkload("wl", defaultNamespace).Obj()
 	wl.Generation = 1
-	wInfo := workload.NewInfo(wl)
+	wInfo := workload.NewInfo(log, wl)
 	wInfo.LastEvaluatedGeneration = 1
 
 	otherWl := utiltestingapi.MakeWorkload("other", defaultNamespace).Obj()
-	otherInfo := workload.NewInfo(otherWl)
+	otherInfo := workload.NewInfo(log, otherWl)
 
 	if cq.IsPreemptor(wInfo) {
 		t.Errorf("IsPreemptor(wInfo) = true, want false before requeue")
@@ -757,7 +765,7 @@ func TestClusterQueueIsPreemptor(t *testing.T) {
 
 	wlModified := wl.DeepCopy()
 	wlModified.Generation = 2
-	wInfoModified := workload.NewInfo(wlModified)
+	wInfoModified := workload.NewInfo(log, wlModified)
 
 	if cq.IsPreemptor(wInfoModified) {
 		t.Errorf("IsPreemptor(wInfoModified) = true, want false after workload generation changed")
@@ -773,7 +781,7 @@ func TestPendingResources(t *testing.T) {
 		ps := utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 			Request(corev1.ResourceCPU, cpu).
 			Request(corev1.ResourceMemory, memory)
-		return workload.NewInfo(utiltestingapi.MakeWorkload(name, defaultNamespace).
+		return workload.NewInfo(log, utiltestingapi.MakeWorkload(name, defaultNamespace).
 			PodSets(*ps.Obj()).
 			Creation(now).Obj())
 	}
@@ -886,7 +894,7 @@ func TestPendingResourcesAfterLocalQueueResync(t *testing.T) {
 			cq := newClusterQueueImpl(ctx, nil, defaultOrdering, testingclock.NewFakeClock(now))
 			ps := utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 				Request(corev1.ResourceCPU, "1")
-			wInfo := workload.NewInfo(utiltestingapi.MakeWorkload("workload", defaultNamespace).
+			wInfo := workload.NewInfo(log, utiltestingapi.MakeWorkload("workload", defaultNamespace).
 				PodSets(*ps.Obj()).
 				Creation(now).Obj())
 			key := workloadKey(wInfo)
@@ -930,7 +938,7 @@ func singleWorkloadCPU(wInfo *workload.Info) int64 {
 }
 
 func TestPendingInLocalQueueCountsInflight(t *testing.T) {
-	ctx, _ := utiltesting.ContextWithLog(t)
+	ctx, log := utiltesting.ContextWithLog(t)
 	now := time.Now()
 	cq := newClusterQueueImpl(ctx, nil, defaultOrdering, testingclock.NewFakeClock(now))
 
@@ -943,8 +951,8 @@ func TestPendingInLocalQueueCountsInflight(t *testing.T) {
 		Creation(now.Add(time.Second)).
 		Obj()
 
-	cq.PushOrUpdate(workload.NewInfo(inflightWl))
-	cq.PushOrUpdate(workload.NewInfo(otherWl))
+	cq.PushOrUpdate(workload.NewInfo(log, inflightWl))
+	cq.PushOrUpdate(workload.NewInfo(log, otherWl))
 
 	popped := cq.Pop()
 	if popped == nil {
@@ -977,13 +985,13 @@ func Test_DeleteFromLocalQueue(t *testing.T) {
 	inadmissibleWorkloads := []*kueue.Workload{wl3, wl4}
 
 	for _, w := range admissibleworkloads {
-		wInfo := workload.NewInfo(w)
+		wInfo := workload.NewInfo(log, w)
 		cq.PushOrUpdate(wInfo)
 		qImpl.AddOrUpdate(wInfo)
 	}
 
 	for _, w := range inadmissibleWorkloads {
-		wInfo := workload.NewInfo(w)
+		wInfo := workload.NewInfo(log, w)
 		cq.requeueIfNotPresent(log, wInfo, false, RequeueReasonGeneric, "")
 		qImpl.AddOrUpdate(wInfo)
 	}
@@ -1003,6 +1011,7 @@ func Test_DeleteFromLocalQueue(t *testing.T) {
 }
 
 func TestClusterQueueImpl(t *testing.T) {
+	_, log := utiltesting.ContextWithLog(t)
 	cl := utiltesting.NewFakeClient(
 		utiltesting.MakeNamespaceWrapper("ns1").Label("dep", "eng").Obj(),
 		utiltesting.MakeNamespaceWrapper("ns2").Label("dep", "sales").Obj(),
@@ -1055,27 +1064,27 @@ func TestClusterQueueImpl(t *testing.T) {
 		},
 		"re-queue inadmissible workload; workloads with requeueState can't re-queue": {
 			workloadsToAdd:                 []*kueue.Workload{workloads[0]},
-			inadmissibleWorkloadsToRequeue: []*workload.Info{workload.NewInfo(workloads[1]), workload.NewInfo(workloads[3])},
+			inadmissibleWorkloadsToRequeue: []*workload.Info{workload.NewInfo(log, workloads[1]), workload.NewInfo(log, workloads[3])},
 			wantActiveWorkloads:            []workload.Reference{workload.Key(workloads[0])},
 			wantPending:                    3,
 		},
 		"re-queue admissible workload that was inadmissible": {
 			workloadsToAdd:                 []*kueue.Workload{workloads[0]},
-			inadmissibleWorkloadsToRequeue: []*workload.Info{workload.NewInfo(workloads[1]), workload.NewInfo(workloads[3])},
-			admissibleWorkloadsToRequeue:   []*workload.Info{workload.NewInfo(workloads[1]), workload.NewInfo(workloads[3])},
+			inadmissibleWorkloadsToRequeue: []*workload.Info{workload.NewInfo(log, workloads[1]), workload.NewInfo(log, workloads[3])},
+			admissibleWorkloadsToRequeue:   []*workload.Info{workload.NewInfo(log, workloads[1]), workload.NewInfo(log, workloads[3])},
 			wantActiveWorkloads:            []workload.Reference{workload.Key(workloads[0]), workload.Key(workloads[1])},
 			wantPending:                    3,
 		},
 		"re-queue inadmissible workload and flush": {
 			workloadsToAdd:                    []*kueue.Workload{workloads[0]},
-			inadmissibleWorkloadsToRequeue:    []*workload.Info{workload.NewInfo(workloads[1]), workload.NewInfo(workloads[3])},
+			inadmissibleWorkloadsToRequeue:    []*workload.Info{workload.NewInfo(log, workloads[1]), workload.NewInfo(log, workloads[3])},
 			queueInadmissibleWorkloads:        true,
 			wantActiveWorkloads:               []workload.Reference{workload.Key(workloads[0]), workload.Key(workloads[1])},
 			wantPending:                       3,
 			wantInadmissibleWorkloadsRequeued: 1,
 		},
 		"re-queue multiple inadmissible workloads and count": {
-			inadmissibleWorkloadsToRequeue:    []*workload.Info{workload.NewInfo(workloads[0]), workload.NewInfo(workloads[1])},
+			inadmissibleWorkloadsToRequeue:    []*workload.Info{workload.NewInfo(log, workloads[0]), workload.NewInfo(log, workloads[1])},
 			queueInadmissibleWorkloads:        true,
 			wantActiveWorkloads:               []workload.Reference{workload.Key(workloads[0]), workload.Key(workloads[1])},
 			wantPending:                       2,
@@ -1086,7 +1095,7 @@ func TestClusterQueueImpl(t *testing.T) {
 		// stays inadmissible. Verify the count reflects only the one that moved.
 		"count only workloads that actually moved": {
 			workloadsToAdd:                    []*kueue.Workload{workloads[0]},
-			inadmissibleWorkloadsToRequeue:    []*workload.Info{workload.NewInfo(workloads[1]), workload.NewInfo(workloads[2])},
+			inadmissibleWorkloadsToRequeue:    []*workload.Info{workload.NewInfo(log, workloads[1]), workload.NewInfo(log, workloads[2])},
 			queueInadmissibleWorkloads:        true,
 			wantActiveWorkloads:               []workload.Reference{workload.Key(workloads[0]), workload.Key(workloads[1])},
 			wantPending:                       3,
@@ -1097,7 +1106,7 @@ func TestClusterQueueImpl(t *testing.T) {
 		// finds an empty inadmissible map and returns 0.
 		"workload already on heap is not made inadmissible": {
 			workloadsToAdd:                    []*kueue.Workload{workloads[1]},
-			inadmissibleWorkloadsToRequeue:    []*workload.Info{workload.NewInfo(workloads[1])},
+			inadmissibleWorkloadsToRequeue:    []*workload.Info{workload.NewInfo(log, workloads[1])},
 			queueInadmissibleWorkloads:        true,
 			wantActiveWorkloads:               []workload.Reference{workload.Key(workloads[1])},
 			wantPending:                       1,
@@ -1105,38 +1114,38 @@ func TestClusterQueueImpl(t *testing.T) {
 		},
 		"avoid re-queueing inadmissible workloads not matching namespace selector": {
 			workloadsToAdd:                 []*kueue.Workload{workloads[0]},
-			inadmissibleWorkloadsToRequeue: []*workload.Info{workload.NewInfo(workloads[2])},
+			inadmissibleWorkloadsToRequeue: []*workload.Info{workload.NewInfo(log, workloads[2])},
 			queueInadmissibleWorkloads:     true,
 			wantActiveWorkloads:            []workload.Reference{workload.Key(workloads[0])},
 			wantPending:                    2,
 		},
 		"update inadmissible workload": {
 			workloadsToAdd:                 []*kueue.Workload{workloads[0]},
-			inadmissibleWorkloadsToRequeue: []*workload.Info{workload.NewInfo(workloads[1])},
+			inadmissibleWorkloadsToRequeue: []*workload.Info{workload.NewInfo(log, workloads[1])},
 			workloadsToUpdate:              []*kueue.Workload{updatedWorkloads[1]},
 			wantActiveWorkloads:            []workload.Reference{workload.Key(workloads[0]), workload.Key(workloads[1])},
 			wantPending:                    2,
 		},
 		"delete inadmissible workload": {
 			workloadsToAdd:                 []*kueue.Workload{workloads[0]},
-			inadmissibleWorkloadsToRequeue: []*workload.Info{workload.NewInfo(workloads[1])},
+			inadmissibleWorkloadsToRequeue: []*workload.Info{workload.NewInfo(log, workloads[1])},
 			workloadsToDelete:              []*kueue.Workload{workloads[1]},
 			queueInadmissibleWorkloads:     true,
 			wantActiveWorkloads:            []workload.Reference{workload.Key(workloads[0])},
 			wantPending:                    1,
 		},
 		"update inadmissible workload without changes": {
-			inadmissibleWorkloadsToRequeue: []*workload.Info{workload.NewInfo(workloads[1])},
+			inadmissibleWorkloadsToRequeue: []*workload.Info{workload.NewInfo(log, workloads[1])},
 			workloadsToUpdate:              []*kueue.Workload{workloads[1]},
 			wantPending:                    1,
 		},
 		"requeue inadmissible workload twice": {
-			inadmissibleWorkloadsToRequeue: []*workload.Info{workload.NewInfo(workloads[1]), workload.NewInfo(workloads[1])},
+			inadmissibleWorkloadsToRequeue: []*workload.Info{workload.NewInfo(log, workloads[1]), workload.NewInfo(log, workloads[1])},
 			wantPending:                    1,
 		},
 		"update reclaimable pods in inadmissible": {
 			inadmissibleWorkloadsToRequeue: []*workload.Info{
-				workload.NewInfo(utiltestingapi.MakeWorkload("w", "").PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).Obj()),
+				workload.NewInfo(log, utiltestingapi.MakeWorkload("w", "").PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).Obj()),
 			},
 			workloadsToUpdate: []*kueue.Workload{
 				utiltestingapi.MakeWorkload("w", "").PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).
@@ -1167,7 +1176,7 @@ func TestClusterQueueImpl(t *testing.T) {
 			}
 
 			for _, w := range test.workloadsToAdd {
-				cq.PushOrUpdate(workload.NewInfo(w))
+				cq.PushOrUpdate(workload.NewInfo(log, w))
 			}
 
 			for _, w := range test.inadmissibleWorkloadsToRequeue {
@@ -1178,7 +1187,7 @@ func TestClusterQueueImpl(t *testing.T) {
 			}
 
 			for _, w := range test.workloadsToUpdate {
-				cq.PushOrUpdate(workload.NewInfo(w))
+				cq.PushOrUpdate(workload.NewInfo(log, w))
 			}
 
 			for _, w := range test.workloadsToDelete {
@@ -1209,7 +1218,7 @@ func TestQueueInadmissibleWorkloadsDuringScheduling(t *testing.T) {
 	cq.namespaceSelector = labels.Everything()
 	wl := utiltestingapi.MakeWorkload("workload-1", defaultNamespace).Obj()
 	cl := utiltesting.NewFakeClient(wl, utiltesting.MakeNamespace(defaultNamespace))
-	cq.PushOrUpdate(workload.NewInfo(wl))
+	cq.PushOrUpdate(workload.NewInfo(log, wl))
 
 	wantActiveWorkloads := []workload.Reference{workload.Key(wl)}
 
@@ -1240,6 +1249,7 @@ func TestQueueInadmissibleWorkloadsDuringScheduling(t *testing.T) {
 }
 
 func TestBackoffWaitingTimeExpired(t *testing.T) {
+	_, log := utiltesting.ContextWithLog(t)
 	now := time.Now()
 	minuteLater := now.Add(time.Minute)
 	minuteAgo := now.Add(-time.Minute)
@@ -1250,23 +1260,23 @@ func TestBackoffWaitingTimeExpired(t *testing.T) {
 		want         bool
 	}{
 		"workload still have Requeued=false": {
-			workloadInfo: workload.NewInfo(utiltestingapi.MakeWorkload("wl", "ns").Condition(metav1.Condition{
+			workloadInfo: workload.NewInfo(log, utiltestingapi.MakeWorkload("wl", "ns").Condition(metav1.Condition{
 				Type:   kueue.WorkloadRequeued,
 				Status: metav1.ConditionFalse,
 			}).Obj()),
 			want: false,
 		},
 		"workload doesn't have requeueState": {
-			workloadInfo: workload.NewInfo(utiltestingapi.MakeWorkload("wl", "ns").Obj()),
+			workloadInfo: workload.NewInfo(log, utiltestingapi.MakeWorkload("wl", "ns").Obj()),
 			want:         true,
 		},
 		"workload doesn't have an evicted condition with reason=PodsReadyTimeout": {
-			workloadInfo: workload.NewInfo(utiltestingapi.MakeWorkload("wl", "ns").
+			workloadInfo: workload.NewInfo(log, utiltestingapi.MakeWorkload("wl", "ns").
 				RequeueState(ptr.To[int32](10), nil).Obj()),
 			want: true,
 		},
 		"now already has exceeded requeueAt": {
-			workloadInfo: workload.NewInfo(utiltestingapi.MakeWorkload("wl", "ns").
+			workloadInfo: workload.NewInfo(log, utiltestingapi.MakeWorkload("wl", "ns").
 				RequeueState(ptr.To[int32](10), new(metav1.NewTime(minuteAgo))).
 				Condition(metav1.Condition{
 					Type:   kueue.WorkloadEvicted,
@@ -1276,7 +1286,7 @@ func TestBackoffWaitingTimeExpired(t *testing.T) {
 			want: true,
 		},
 		"now hasn't yet exceeded requeueAt": {
-			workloadInfo: workload.NewInfo(utiltestingapi.MakeWorkload("wl", "ns").
+			workloadInfo: workload.NewInfo(log, utiltestingapi.MakeWorkload("wl", "ns").
 				RequeueState(ptr.To[int32](10), new(metav1.NewTime(minuteLater))).
 				Condition(metav1.Condition{
 					Type:   kueue.WorkloadEvicted,
@@ -1364,7 +1374,7 @@ func TestBestEffortFIFORequeueIfNotPresent(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx, _ := utiltesting.ContextWithLog(t)
+			ctx, log := utiltesting.ContextWithLog(t)
 			cq, _ := newClusterQueue(ctx, nil,
 				&kueue.ClusterQueue{
 					Spec: kueue.ClusterQueueSpec{
@@ -1374,7 +1384,7 @@ func TestBestEffortFIFORequeueIfNotPresent(t *testing.T) {
 				workload.Ordering{PodsReadyRequeuingTimestamp: config.EvictionTimestamp},
 				nil, nil)
 			wl := utiltestingapi.MakeWorkload("workload-1", defaultNamespace).Obj()
-			info := workload.NewInfo(wl)
+			info := workload.NewInfo(log, wl)
 			info.LastAssignment = tc.lastAssignment
 			if ok := cq.RequeueIfNotPresent(ctx, info, tc.reason, ""); !ok {
 				t.Error("failed to requeue nonexistent workload")
@@ -1390,7 +1400,7 @@ func TestBestEffortFIFORequeueIfNotPresent(t *testing.T) {
 				t.Errorf("Unexpected sticky status (-want,+got):\n%s", diff)
 			}
 
-			if ok := cq.RequeueIfNotPresent(ctx, workload.NewInfo(wl), tc.reason, ""); ok {
+			if ok := cq.RequeueIfNotPresent(ctx, workload.NewInfo(log, wl), tc.reason, ""); ok {
 				t.Error("Re-queued a workload that was already present")
 			}
 		})
@@ -1398,7 +1408,7 @@ func TestBestEffortFIFORequeueIfNotPresent(t *testing.T) {
 }
 
 func TestBestEffortFIFOFailedPreemptionNotSticky(t *testing.T) {
-	ctx, _ := utiltesting.ContextWithLog(t)
+	ctx, log := utiltesting.ContextWithLog(t)
 	cq, err := newClusterQueue(ctx, nil,
 		&kueue.ClusterQueue{
 			Spec: kueue.ClusterQueueSpec{
@@ -1420,13 +1430,13 @@ func TestBestEffortFIFOFailedPreemptionNotSticky(t *testing.T) {
 
 	// When lowPriorityWl is requeued with PendingPreemption, it becomes sticky at the head
 	// even if a higher priority workload is pushed.
-	cq.PushOrUpdate(workload.NewInfo(lowPriorityWl))
+	cq.PushOrUpdate(workload.NewInfo(log, lowPriorityWl))
 	popped := cq.Pop()
 	if popped == nil || popped.Obj.Name != "low-wl" {
 		t.Fatalf("Expected low-wl to be popped first, got %v", popped)
 	}
 	cq.RequeueIfNotPresent(ctx, popped, RequeueReasonPendingPreemption, "")
-	cq.PushOrUpdate(workload.NewInfo(highPriorityWl))
+	cq.PushOrUpdate(workload.NewInfo(log, highPriorityWl))
 
 	// Because low-wl is sticky, it pops before high-wl despite lower priority.
 	poppedLow := cq.Pop()
@@ -1488,7 +1498,7 @@ func TestFIFOClusterQueue(t *testing.T) {
 		},
 	}
 	for _, w := range ws {
-		q.PushOrUpdate(workload.NewInfo(w))
+		q.PushOrUpdate(workload.NewInfo(log, w))
 	}
 	got := q.Pop()
 	if got == nil {
@@ -1497,7 +1507,7 @@ func TestFIFOClusterQueue(t *testing.T) {
 	if got.Obj.Name != "before" {
 		t.Errorf("Popped workload %q want %q", got.Obj.Name, "before")
 	}
-	wlInfo := workload.NewInfo(&kueue.Workload{
+	wlInfo := workload.NewInfo(log, &kueue.Workload{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "after",
 			CreationTimestamp: metav1.NewTime(now.Add(-time.Minute)),
@@ -1611,7 +1621,7 @@ func TestStrictFIFO(t *testing.T) {
 				// The default ordering:
 				tt.workloadOrdering = &workload.Ordering{PodsReadyRequeuingTimestamp: config.EvictionTimestamp}
 			}
-			ctx, _ := utiltesting.ContextWithLog(t)
+			ctx, log := utiltesting.ContextWithLog(t)
 			q, err := newClusterQueue(ctx, nil,
 				&kueue.ClusterQueue{
 					Spec: kueue.ClusterQueueSpec{
@@ -1624,8 +1634,8 @@ func TestStrictFIFO(t *testing.T) {
 				t.Fatalf("Failed creating ClusterQueue %v", err)
 			}
 
-			q.PushOrUpdate(workload.NewInfo(tt.w1))
-			q.PushOrUpdate(workload.NewInfo(tt.w2))
+			q.PushOrUpdate(workload.NewInfo(log, tt.w1))
+			q.PushOrUpdate(workload.NewInfo(log, tt.w2))
 
 			got := q.Pop()
 			if got == nil {
@@ -1655,7 +1665,7 @@ func TestStrictFIFORequeueIfNotPresent(t *testing.T) {
 
 	for reason, test := range tests {
 		t.Run(string(reason), func(t *testing.T) {
-			ctx, _ := utiltesting.ContextWithLog(t)
+			ctx, log := utiltesting.ContextWithLog(t)
 			cq, _ := newClusterQueue(ctx, nil,
 				&kueue.ClusterQueue{
 					Spec: kueue.ClusterQueueSpec{
@@ -1665,7 +1675,7 @@ func TestStrictFIFORequeueIfNotPresent(t *testing.T) {
 				workload.Ordering{PodsReadyRequeuingTimestamp: config.EvictionTimestamp},
 				nil, nil)
 			wl := utiltestingapi.MakeWorkload("workload-1", defaultNamespace).Obj()
-			if ok := cq.RequeueIfNotPresent(ctx, workload.NewInfo(wl), reason, ""); !ok {
+			if ok := cq.RequeueIfNotPresent(ctx, workload.NewInfo(log, wl), reason, ""); !ok {
 				t.Error("failed to requeue nonexistent workload")
 			}
 
@@ -1674,7 +1684,7 @@ func TestStrictFIFORequeueIfNotPresent(t *testing.T) {
 				t.Errorf("Got inadmissible after requeue %t, want %t", gotInadmissible, test.wantInadmissible)
 			}
 
-			if ok := cq.RequeueIfNotPresent(ctx, workload.NewInfo(wl), reason, ""); ok {
+			if ok := cq.RequeueIfNotPresent(ctx, workload.NewInfo(log, wl), reason, ""); ok {
 				t.Error("Re-queued a workload that was already present")
 			}
 		})
@@ -1829,6 +1839,7 @@ func TestFsAdmission(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			_, log := utiltesting.ContextWithLog(t)
 			builder := utiltesting.NewClientBuilder()
 			for _, lq := range tc.lqs {
 				builder = builder.WithObjects(&lq)
@@ -1842,7 +1853,7 @@ func TestFsAdmission(t *testing.T) {
 
 			cq, _ := newClusterQueue(t.Context(), client, tc.cq, defaultOrdering, tc.afsConfig, afsUsageLedger)
 			for _, wl := range tc.wls {
-				cq.PushOrUpdate(workload.NewInfo(&wl))
+				cq.PushOrUpdate(workload.NewInfo(log, &wl))
 			}
 
 			gotWl := cq.Pop()
@@ -1896,7 +1907,7 @@ func TestRecordInadmissibleHash(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			ctx, _ := utiltesting.ContextWithLog(t)
+			ctx, log := utiltesting.ContextWithLog(t)
 			now := time.Now()
 			cq := newClusterQueueImpl(ctx, nil, defaultOrdering, testingclock.NewFakeClock(now))
 			cq.queueingStrategy = kueue.BestEffortFIFO
@@ -1906,7 +1917,7 @@ func TestRecordInadmissibleHash(t *testing.T) {
 				wl := utiltestingapi.MakeWorkload(wlName, defaultNamespace).
 					Creation(now.Add(time.Duration(i)*time.Second)).
 					Request(corev1.ResourceCPU, "1").Obj()
-				info := workload.NewInfo(wl)
+				info := workload.NewInfo(log, wl)
 				info.SchedulingHash = hash
 				cq.PushOrUpdate(info)
 				i++
@@ -1950,7 +1961,7 @@ func TestPushOrUpdateRespectsInadmissibleHashes(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			ctx, _ := utiltesting.ContextWithLog(t)
+			ctx, log := utiltesting.ContextWithLog(t)
 			cq := newClusterQueueImpl(ctx, nil, defaultOrdering, testingclock.NewFakeClock(time.Now()))
 			cq.queueingStrategy = kueue.BestEffortFIFO
 
@@ -1960,7 +1971,7 @@ func TestPushOrUpdateRespectsInadmissibleHashes(t *testing.T) {
 
 			wl := utiltestingapi.MakeWorkload("wl", defaultNamespace).
 				Request(corev1.ResourceCPU, "1").Obj()
-			info := workload.NewInfo(wl)
+			info := workload.NewInfo(log, wl)
 			info.SchedulingHash = tc.pushHash
 			cq.PushOrUpdate(info)
 
@@ -1976,14 +1987,14 @@ func TestPushOrUpdateRespectsInadmissibleHashes(t *testing.T) {
 }
 
 func TestQueueInadmissibleWorkloadsClearsHashes(t *testing.T) {
-	ctx, _ := utiltesting.ContextWithLog(t)
+	ctx, log := utiltesting.ContextWithLog(t)
 	cq := newClusterQueueImpl(ctx, nil, defaultOrdering, testingclock.NewFakeClock(time.Now()))
 	cq.queueingStrategy = kueue.BestEffortFIFO
 	cq.namespaceSelector = labels.Everything()
 
 	wl := utiltestingapi.MakeWorkload("wl", defaultNamespace).
 		Request(corev1.ResourceCPU, "1").Obj()
-	info := workload.NewInfo(wl)
+	info := workload.NewInfo(log, wl)
 	info.SchedulingHash = "test-hash"
 	cq.PushOrUpdate(info)
 	cq.handleInadmissibleHash("test-hash", "dummy-reason")
@@ -2036,7 +2047,7 @@ func TestRequeueHashTriggerByReason(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			features.SetFeatureGateDuringTest(t, features.SchedulingEquivalenceHashing, true)
-			ctx, _ := utiltesting.ContextWithLog(t)
+			ctx, log := utiltesting.ContextWithLog(t)
 			cq, _ := newClusterQueue(ctx, nil,
 				&kueue.ClusterQueue{
 					Spec: kueue.ClusterQueueSpec{
@@ -2048,7 +2059,7 @@ func TestRequeueHashTriggerByReason(t *testing.T) {
 
 			wl := utiltestingapi.MakeWorkload("workload-1", defaultNamespace).
 				Request(corev1.ResourceCPU, "1").Obj()
-			info := workload.NewInfo(wl)
+			info := workload.NewInfo(log, wl)
 			info.SchedulingHash = "test-hash-abc"
 			cq.RequeueIfNotPresent(ctx, info, tc.reason, "WaitingForQuota")
 
@@ -2101,7 +2112,7 @@ func TestGetNoFitReason(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			ctx, _ := utiltesting.ContextWithLog(t)
+			ctx, log := utiltesting.ContextWithLog(t)
 			cq := newClusterQueueImpl(ctx, nil, defaultOrdering, testingclock.NewFakeClock(time.Now()))
 			cq.queueingStrategy = kueue.BestEffortFIFO
 
@@ -2115,7 +2126,7 @@ func TestGetNoFitReason(t *testing.T) {
 				})
 			}
 			wl := wlBuilder.Obj()
-			info := workload.NewInfo(wl)
+			info := workload.NewInfo(log, wl)
 			info.SchedulingHash = "test-hash"
 
 			cq.RequeueIfNotPresent(ctx, info, tc.requeueReason, QuotaReservedReason(tc.conditionReason))

--- a/pkg/cache/queue/inadmissible_workloads_test.go
+++ b/pkg/cache/queue/inadmissible_workloads_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/component-base/featuregate"
 
 	"sigs.k8s.io/kueue/pkg/features"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
@@ -86,8 +87,9 @@ func TestNewRequeuer(t *testing.T) {
 }
 
 func TestInadmissibleWorkloads_Get(t *testing.T) {
-	wl1 := workload.NewInfo(utiltestingapi.MakeWorkload("wl1", "ns1").Obj())
-	wl2 := workload.NewInfo(utiltestingapi.MakeWorkload("wl2", "ns2").Obj())
+	_, log := utiltesting.ContextWithLog(t)
+	wl1 := workload.NewInfo(log, utiltestingapi.MakeWorkload("wl1", "ns1").Obj())
+	wl2 := workload.NewInfo(log, utiltestingapi.MakeWorkload("wl2", "ns2").Obj())
 	key1 := workload.Key(wl1.Obj)
 	key2 := workload.Key(wl2.Obj)
 
@@ -135,8 +137,9 @@ func TestInadmissibleWorkloads_Get(t *testing.T) {
 }
 
 func TestInadmissibleWorkloads_Insert(t *testing.T) {
-	wl1 := workload.NewInfo(utiltestingapi.MakeWorkload("wl1", "ns1").Obj())
-	wl2 := workload.NewInfo(utiltestingapi.MakeWorkload("wl2", "ns2").Obj())
+	_, log := utiltesting.ContextWithLog(t)
+	wl1 := workload.NewInfo(log, utiltestingapi.MakeWorkload("wl1", "ns1").Obj())
+	wl2 := workload.NewInfo(log, utiltestingapi.MakeWorkload("wl2", "ns2").Obj())
 	key1 := workload.Key(wl1.Obj)
 	key2 := workload.Key(wl2.Obj)
 
@@ -192,8 +195,9 @@ func TestInadmissibleWorkloads_Insert(t *testing.T) {
 }
 
 func TestInadmissibleWorkloads_Delete(t *testing.T) {
-	wl1 := workload.NewInfo(utiltestingapi.MakeWorkload("wl1", "ns1").Obj())
-	wl2 := workload.NewInfo(utiltestingapi.MakeWorkload("wl2", "ns2").Obj())
+	_, log := utiltesting.ContextWithLog(t)
+	wl1 := workload.NewInfo(log, utiltestingapi.MakeWorkload("wl1", "ns1").Obj())
+	wl2 := workload.NewInfo(log, utiltestingapi.MakeWorkload("wl2", "ns2").Obj())
 	key1 := workload.Key(wl1.Obj)
 	key2 := workload.Key(wl2.Obj)
 
@@ -254,8 +258,9 @@ func TestInadmissibleWorkloads_Delete(t *testing.T) {
 }
 
 func TestInadmissibleWorkloads_Len(t *testing.T) {
-	wl1 := workload.NewInfo(utiltestingapi.MakeWorkload("wl1", "ns1").Obj())
-	wl2 := workload.NewInfo(utiltestingapi.MakeWorkload("wl2", "ns2").Obj())
+	_, log := utiltesting.ContextWithLog(t)
+	wl1 := workload.NewInfo(log, utiltestingapi.MakeWorkload("wl1", "ns1").Obj())
+	wl2 := workload.NewInfo(log, utiltestingapi.MakeWorkload("wl2", "ns2").Obj())
 	key1 := workload.Key(wl1.Obj)
 	key2 := workload.Key(wl2.Obj)
 
@@ -299,7 +304,8 @@ func TestInadmissibleWorkloads_Len(t *testing.T) {
 }
 
 func TestInadmissibleWorkloads_Empty(t *testing.T) {
-	wl1 := workload.NewInfo(utiltestingapi.MakeWorkload("wl1", "ns1").Obj())
+	_, log := utiltesting.ContextWithLog(t)
+	wl1 := workload.NewInfo(log, utiltestingapi.MakeWorkload("wl1", "ns1").Obj())
 	key1 := workload.Key(wl1.Obj)
 
 	testcases := []struct {

--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -516,7 +516,7 @@ func (m *Manager) addLocalQueueLocked(ctx context.Context, q *kueue.LocalQueue) 
 		}
 
 		workload.AdjustResources(ctx, m.client, &w)
-		wInfo := workload.NewInfoWithLogger(log, &w, m.workloadInfoOptions...)
+		wInfo := workload.NewInfo(log, &w, m.workloadInfoOptions...)
 		qImpl.AddOrUpdate(wInfo)
 	}
 
@@ -699,7 +699,7 @@ func (m *Manager) AddOrUpdateWorkloadWithoutLock(log logr.Logger, w *kueue.Workl
 		return ErrLocalQueueDoesNotExistOrInactive
 	}
 	allOptions := append(m.workloadInfoOptions, opts...)
-	wInfo := workload.NewInfoWithLogger(log, w, allOptions...)
+	wInfo := workload.NewInfo(log, w, allOptions...)
 
 	cq := m.hm.ClusterQueue(q.ClusterQueue)
 	// Rebuilding the Info would drop the flavor scan progress an earlier cycle recorded, so
@@ -1020,7 +1020,7 @@ func (m *Manager) queueSecondPass(ctx context.Context, w *kueue.Workload, iterat
 	defer m.Unlock()
 
 	log := ctrl.LoggerFrom(ctx)
-	wInfo := workload.NewInfoWithLogger(log, w, m.workloadInfoOptions...)
+	wInfo := workload.NewInfo(log, w, m.workloadInfoOptions...)
 	wInfo.SecondPassIteration = iteration
 	if m.secondPassQueue.queue(wInfo) {
 		log.V(3).Info("Workload queued for second pass of scheduling", "workload", workload.Key(w))

--- a/pkg/cache/queue/manager_test.go
+++ b/pkg/cache/queue/manager_test.go
@@ -208,7 +208,7 @@ func TestAddClusterQueueOrphans(t *testing.T) {
 // TestUpdateClusterQueue tests that a ClusterQueue transfers cohorts on update.
 // Inadmissible workloads should become active.
 func TestUpdateClusterQueue(t *testing.T) {
-	ctx, _ := utiltesting.ContextWithLog(t)
+	ctx, log := utiltesting.ContextWithLog(t)
 	clusterQueues := []*kueue.ClusterQueue{
 		utiltestingapi.MakeClusterQueue("cq1").Cohort("alpha").Obj(),
 		utiltestingapi.MakeClusterQueue("cq2").Cohort("beta").Obj(),
@@ -243,7 +243,7 @@ func TestUpdateClusterQueue(t *testing.T) {
 		if err := cl.Create(ctx, w); err != nil {
 			t.Fatalf("Failed adding workload to client: %v", err)
 		}
-		manager.RequeueWorkload(ctx, workload.NewInfo(w), RequeueReasonGeneric, "")
+		manager.RequeueWorkload(ctx, workload.NewInfo(log, w), RequeueReasonGeneric, "")
 	}
 
 	// Verify that all workloads are marked as inadmissible after creation.
@@ -298,7 +298,7 @@ func TestUpdateClusterQueue(t *testing.T) {
 }
 
 func TestResyncClusterQueueGaugeMetrics(t *testing.T) {
-	ctx, _ := utiltesting.ContextWithLog(t)
+	ctx, log := utiltesting.ContextWithLog(t)
 	defer metrics.InitMetricVectors(nil)
 
 	customLabels := metrics.NewCustomLabels([]configapi.ControllerMetricsCustomLabel{{Name: "team"}})
@@ -322,7 +322,7 @@ func TestResyncClusterQueueGaugeMetrics(t *testing.T) {
 	if err := fakeClient.Create(ctx, wl); err != nil {
 		t.Fatalf("Failed adding workload to client: %v", err)
 	}
-	manager.RequeueWorkload(ctx, workload.NewInfo(wl), RequeueReasonGeneric, "")
+	manager.RequeueWorkload(ctx, workload.NewInfo(log, wl), RequeueReasonGeneric, "")
 	manager.ResyncClusterQueueGaugeMetrics("cq1")
 
 	expectPending := func(team string, count int) {
@@ -361,7 +361,7 @@ func TestResyncClusterQueueGaugeMetrics(t *testing.T) {
 }
 
 func TestResyncLocalQueueGaugeMetrics(t *testing.T) {
-	ctx, _ := utiltesting.ContextWithLog(t)
+	ctx, log := utiltesting.ContextWithLog(t)
 	defer metrics.InitMetricVectors(nil)
 
 	features.SetFeatureGateDuringTest(t, features.LocalQueueMetrics, true)
@@ -390,7 +390,7 @@ func TestResyncLocalQueueGaugeMetrics(t *testing.T) {
 	if err := fakeClient.Create(ctx, wl); err != nil {
 		t.Fatalf("Failed adding workload to client: %v", err)
 	}
-	manager.RequeueWorkload(ctx, workload.NewInfo(wl), RequeueReasonGeneric, "")
+	manager.RequeueWorkload(ctx, workload.NewInfo(log, wl), RequeueReasonGeneric, "")
 	manager.ResyncLocalQueueGaugeMetrics(queue.Key(lq))
 
 	expectPending := func(team string, count int) {
@@ -540,7 +540,7 @@ func expectGaugeValue(t *testing.T, collector prometheus.Collector, labels map[s
 }
 
 func TestRequeueWorkloadsCohortCycle(t *testing.T) {
-	ctx, _ := utiltesting.ContextWithLog(t)
+	ctx, log := utiltesting.ContextWithLog(t)
 	cohorts := []*kueue.Cohort{
 		utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
 		utiltestingapi.MakeCohort("cohort-b").Parent("cohort-c").Obj(),
@@ -570,7 +570,7 @@ func TestRequeueWorkloadsCohortCycle(t *testing.T) {
 	}
 	// This test will pass with the removal of this line.
 	// Update once we find a solution to #3066.
-	manager.RequeueWorkload(ctx, workload.NewInfo(wl), RequeueReasonGeneric, "")
+	manager.RequeueWorkload(ctx, workload.NewInfo(log, wl), RequeueReasonGeneric, "")
 
 	// This method is where we do a cycle check. We call it to ensure
 	// it behaves properly when a cycle exists
@@ -694,6 +694,7 @@ func TestQueueInadmissibleWorkloads(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			_, log := utiltesting.ContextWithLog(t)
 			var moveWorkloadsLogCount int
 			logger := funcr.New(func(prefix, args string) {
 				if strings.Contains(args, "Attempting to move workloads") {
@@ -723,7 +724,7 @@ func TestQueueInadmissibleWorkloads(t *testing.T) {
 				if err := cl.Create(ctx, wl); err != nil {
 					t.Fatalf("Failed adding workload to client: %v", err)
 				}
-				manager.RequeueWorkload(ctx, workload.NewInfo(wl), RequeueReasonGeneric, "")
+				manager.RequeueWorkload(ctx, workload.NewInfo(log, wl), RequeueReasonGeneric, "")
 			}
 
 			// Reset the counter before testing. Setup operations also trigger the log.
@@ -1033,7 +1034,7 @@ func TestDeleteWorkload(t *testing.T) {
 
 		q := manager.localQueues[queue.Key(queues[0])]
 		if diff := gocmp.Diff(map[workload.Reference]*workload.Info{
-			workload.Key(wl2): workload.NewInfo(wl2),
+			workload.Key(wl2): workload.NewInfo(log, wl2),
 		}, q.items, ignoreSchedulingHash); diff != "" {
 			t.Errorf("Unexpected workloads found in local queue (-want,+got):\n%s", diff)
 		}
@@ -1085,7 +1086,7 @@ func TestDeleteAndForgetWorkload(t *testing.T) {
 
 		q := manager.localQueues[queue.Key(queues[0])]
 		if diff := gocmp.Diff(map[workload.Reference]*workload.Info{
-			workload.Key(wl2): workload.NewInfo(wl2),
+			workload.Key(wl2): workload.NewInfo(log, wl2),
 		}, q.items, ignoreSchedulingHash); diff != "" {
 			t.Errorf("Unexpected workloads found in local queue (-want,+got):\n%s", diff)
 		}
@@ -1292,7 +1293,7 @@ func TestRequeueWorkloadSchedulingHash(t *testing.T) {
 			// A recomputed hash must describe the Info the queue now holds. The
 			// reuse cases cannot be checked this way: what they keep is the probe.
 			if !tc.wantReuse {
-				if want := workload.NewInfo(info.Obj).SchedulingHash; info.SchedulingHash != want {
+				if want := workload.NewInfo(log, info.Obj).SchedulingHash; info.SchedulingHash != want {
 					t.Errorf("SchedulingHash = %q, want %q", info.SchedulingHash, want)
 				}
 			}
@@ -1494,7 +1495,7 @@ func TestRequeueWorkload(t *testing.T) {
 			if tc.inQueue {
 				_ = manager.AddOrUpdateWorkload(log, tc.workload)
 			}
-			info := workload.NewInfo(tc.workload)
+			info := workload.NewInfo(log, tc.workload)
 			if tc.popped {
 				go manager.CleanUpOnContext(ctx)
 				heads := manager.Heads(ctx)
@@ -1871,6 +1872,7 @@ var (
 // TestHeadAsync ensures that Heads call is blocked until the queues are filled
 // asynchronously.
 func TestHeadsAsync(t *testing.T) {
+	_, log := utiltesting.ContextWithLog(t)
 	now := time.Now().Truncate(time.Second)
 	clusterQueues := []*kueue.ClusterQueue{
 		utiltestingapi.MakeClusterQueue("fooCq").Obj(),
@@ -2007,7 +2009,7 @@ func TestHeadsAsync(t *testing.T) {
 				// Remove the initial workload from the manager.
 				mgr.Heads(ctx)
 				wg.Go(func() {
-					mgr.RequeueWorkload(ctx, workload.NewInfo(&wl), RequeueReasonFailedAfterNomination, "")
+					mgr.RequeueWorkload(ctx, workload.NewInfo(log, &wl), RequeueReasonFailedAfterNomination, "")
 				})
 			},
 			wantHeads: []Head{
@@ -2037,7 +2039,7 @@ func TestHeadsAsync(t *testing.T) {
 				// Remove the initial workload from the manager.
 				mgr.Heads(ctx)
 				wg.Go(func() {
-					mgr.RequeueWorkload(ctx, workload.NewInfo(&wl), RequeueReasonFailedAfterNomination, "")
+					mgr.RequeueWorkload(ctx, workload.NewInfo(log, &wl), RequeueReasonFailedAfterNomination, "")
 				})
 			},
 			wantHeads: []Head{
@@ -2071,7 +2073,7 @@ func TestHeadsAsync(t *testing.T) {
 				// Remove the initial workload from the manager.
 				mgr.Heads(ctx)
 				wg.Go(func() {
-					mgr.RequeueWorkload(ctx, workload.NewInfo(&wl), RequeueReasonFailedAfterNomination, "")
+					mgr.RequeueWorkload(ctx, workload.NewInfo(log, &wl), RequeueReasonFailedAfterNomination, "")
 				})
 			},
 			wantHeads: []Head{

--- a/pkg/cache/scheduler/clusterqueue.go
+++ b/pkg/cache/scheduler/clusterqueue.go
@@ -493,7 +493,7 @@ func (c *clusterQueue) addOrUpdateWorkload(log logr.Logger, w *kueue.Workload) {
 	if _, exist := c.Workloads[k]; exist {
 		c.deleteWorkload(log, k)
 	}
-	wi := workload.NewInfoWithLogger(log, w, c.workloadInfoOptions...)
+	wi := workload.NewInfo(log, w, c.workloadInfoOptions...)
 	c.Workloads[k] = wi
 	c.updateWorkloadUsage(log, wi, add)
 	if c.podsReadyTracking && !apimeta.IsStatusConditionTrue(w.Status.Conditions, kueue.WorkloadPodsReady) {

--- a/pkg/cache/scheduler/fair_sharing_test.go
+++ b/pkg/cache/scheduler/fair_sharing_test.go
@@ -819,7 +819,7 @@ func TestDominantResourceShare(t *testing.T) {
 				wl := utiltestingapi.MakeWorkload(fmt.Sprintf("workload-%d", i), "default-namespace").ReserveQuotaAt(admission.Obj(), now).Obj()
 
 				cache.AddOrUpdateWorkload(log, wl)
-				snapshot.AddWorkload(workload.NewInfo(wl))
+				snapshot.AddWorkload(workload.NewInfo(log, wl))
 				i++
 			}
 
@@ -967,7 +967,7 @@ func TestIsBorrowingOn(t *testing.T) {
 				wl := utiltestingapi.MakeWorkload(fmt.Sprintf("wl-%d", i), "default-namespace").
 					ReserveQuotaAt(admission.Obj(), now).Obj()
 				cache.AddOrUpdateWorkload(log, wl)
-				snapshot.AddWorkload(workload.NewInfo(wl))
+				snapshot.AddWorkload(workload.NewInfo(log, wl))
 				i++
 			}
 

--- a/pkg/cache/scheduler/snapshot_test.go
+++ b/pkg/cache/scheduler/snapshot_test.go
@@ -54,6 +54,7 @@ var snapCmpOpts = cmp.Options{
 }
 
 func TestSnapshot(t *testing.T) {
+	_, log := utiltesting.ContextWithLog(t)
 	now := time.Now().Truncate(time.Second)
 	testCases := map[string]struct {
 		cqs        []*kueue.ClusterQueue
@@ -97,7 +98,7 @@ func TestSnapshot(t *testing.T) {
 							FlavorFungibility:             defaultFlavorFungibility,
 							AllocatableResourceGeneration: 1,
 							Workloads: map[workload.Reference]*workload.Info{
-								"/alpha": workload.NewInfo(
+								"/alpha": workload.NewInfo(log,
 									utiltestingapi.MakeWorkload("alpha", "").
 										ReserveQuotaAt(&kueue.Admission{ClusterQueue: "a"}, now).Obj()),
 							},
@@ -111,7 +112,7 @@ func TestSnapshot(t *testing.T) {
 							FlavorFungibility:             defaultFlavorFungibility,
 							AllocatableResourceGeneration: 1,
 							Workloads: map[workload.Reference]*workload.Info{
-								"/beta": workload.NewInfo(
+								"/beta": workload.NewInfo(log,
 									utiltestingapi.MakeWorkload("beta", "").
 										ReserveQuotaAt(&kueue.Admission{ClusterQueue: "b"}, now).Obj()),
 							},
@@ -279,7 +280,7 @@ func TestSnapshot(t *testing.T) {
 								},
 								FlavorFungibility: defaultFlavorFungibility,
 								Workloads: map[workload.Reference]*workload.Info{
-									"/alpha": workload.NewInfo(utiltestingapi.MakeWorkload("alpha", "").
+									"/alpha": workload.NewInfo(log, utiltestingapi.MakeWorkload("alpha", "").
 										PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 5).
 											Request(corev1.ResourceCPU, "2").Obj()).
 										ReserveQuotaAt(utiltestingapi.MakeAdmission("a").
@@ -324,7 +325,7 @@ func TestSnapshot(t *testing.T) {
 								},
 								FlavorFungibility: defaultFlavorFungibility,
 								Workloads: map[workload.Reference]*workload.Info{
-									"/beta": workload.NewInfo(utiltestingapi.MakeWorkload("beta", "").
+									"/beta": workload.NewInfo(log, utiltestingapi.MakeWorkload("beta", "").
 										PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 5).
 											Request(corev1.ResourceCPU, "1").
 											Request("example.com/gpu", "2").
@@ -337,7 +338,7 @@ func TestSnapshot(t *testing.T) {
 												Obj()).
 											Obj(), now).
 										Obj()),
-									"/gamma": workload.NewInfo(utiltestingapi.MakeWorkload("gamma", "").
+									"/gamma": workload.NewInfo(log, utiltestingapi.MakeWorkload("gamma", "").
 										PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 5).
 											Request(corev1.ResourceCPU, "1").
 											Request("example.com/gpu", "1").
@@ -541,7 +542,7 @@ func TestSnapshot(t *testing.T) {
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        defaultWeight,
 								Workloads: map[workload.Reference]*workload.Info{
-									"/alpha": workload.NewInfo(utiltestingapi.MakeWorkload("alpha", "").
+									"/alpha": workload.NewInfo(log, utiltestingapi.MakeWorkload("alpha", "").
 										PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 5).
 											Request(corev1.ResourceCPU, "2").Obj()).
 										ReserveQuotaAt(utiltestingapi.MakeAdmission("a").
@@ -551,7 +552,7 @@ func TestSnapshot(t *testing.T) {
 												Obj()).
 											Obj(), now).
 										Obj()),
-									"/beta": workload.NewInfo(utiltestingapi.MakeWorkload("beta", "").
+									"/beta": workload.NewInfo(log, utiltestingapi.MakeWorkload("beta", "").
 										PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 5).
 											Request(corev1.ResourceCPU, "1").Obj()).
 										ReserveQuotaAt(utiltestingapi.MakeAdmission("a").
@@ -561,7 +562,7 @@ func TestSnapshot(t *testing.T) {
 												Obj()).
 											Obj(), now).
 										Obj()),
-									"/gamma": workload.NewInfo(utiltestingapi.MakeWorkload("gamma", "").
+									"/gamma": workload.NewInfo(log, utiltestingapi.MakeWorkload("gamma", "").
 										PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 5).
 											Request(corev1.ResourceCPU, "2").Obj()).
 										ReserveQuotaAt(utiltestingapi.MakeAdmission("a").

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -2070,7 +2070,7 @@ func (r *WorkloadReconciler) resolveGranularUnadmittedQuotaReservedCondition(
 			log.Error(err, "Invalid ClusterQueue NamespaceSelector", "clusterQueue", cq.Name)
 			return kueue.WorkloadQuotaReservedReasonMisconfigured, fmt.Sprintf("invalid namespace selector: %v", err), nil
 		}
-		wlInfo := workload.NewInfoWithLogger(ctrl.LoggerFrom(ctx), wl)
+		wlInfo := workload.NewInfo(ctrl.LoggerFrom(ctx), wl)
 		admissibilityErr = workload.ValidateAdmissibility(ctx, r.client, wlInfo, selector)
 		if admissibilityErr != nil && errors.Is(admissibilityErr, workload.ErrInternal) {
 			return "", "", admissibilityErr

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -627,7 +627,7 @@ func TestUpdateSettlesAfsEntryPenalty(t *testing.T) {
 			qManager := qcache.NewManagerForUnitTests(cl, cqCache, qcache.WithAdmissionFairSharing(afsConfig))
 			reconciler := NewWorkloadReconciler(cl, qManager, cqCache, recorder, WithAdmissionFairSharing(afsConfig))
 
-			ctx, _ := utiltesting.ContextWithLog(t)
+			ctx, log := utiltesting.ContextWithLog(t)
 			cq := utiltestingapi.MakeClusterQueue("cq").
 				AdmissionMode(kueue.UsageBasedAdmissionFairSharing).
 				Active(metav1.ConditionTrue).
@@ -641,7 +641,7 @@ func TestUpdateSettlesAfsEntryPenalty(t *testing.T) {
 
 			// Seed the per-Workload penalty record the scheduler would have
 			// pushed at assume time; the settlement folds exactly this record.
-			seeded := afs.CalculateEntryPenalty(workload.NewInfo(tc.newWl).SumTotalRequests(), afsConfig)
+			seeded := afs.CalculateEntryPenalty(workload.NewInfo(log, tc.newWl).SumTotalRequests(), afsConfig)
 			if len(seeded) == 0 {
 				t.Fatal("the seeded penalty is empty, so the settlement would subtract nothing and every case would pass")
 			}
@@ -665,6 +665,7 @@ func TestUpdateSettlesAfsEntryPenalty(t *testing.T) {
 }
 
 func TestReconcile(t *testing.T) {
+	_, log := utiltesting.ContextWithLog(t)
 	// the clock is primarily used with second rounded times
 	// use the current time trimmed.
 	now := time.Now().Truncate(time.Second)
@@ -1727,7 +1728,7 @@ func TestReconcile(t *testing.T) {
 					panic(err)
 				}
 				qManager.Heads(ctx) // Pop from active heap
-				wInfo := workload.NewInfo(wl)
+				wInfo := workload.NewInfo(log, wl)
 				qManager.RequeueWorkload(ctx, wInfo, qcache.RequeueReasonNoFit, qcache.QuotaReservedReasonWaitingForQuota)
 			},
 			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
@@ -1765,7 +1766,7 @@ func TestReconcile(t *testing.T) {
 					panic(err)
 				}
 				qManager.Heads(ctx) // Pop from active heap
-				wInfo := workload.NewInfo(wl)
+				wInfo := workload.NewInfo(log, wl)
 				qManager.RequeueWorkload(ctx, wInfo, qcache.RequeueReasonNoFit, qcache.QuotaReservedReasonWaitingForQuota)
 			},
 			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
@@ -1797,7 +1798,7 @@ func TestReconcile(t *testing.T) {
 					panic(err)
 				}
 				qManager.Heads(ctx) // Pop from active heap
-				wInfo := workload.NewInfo(wl)
+				wInfo := workload.NewInfo(log, wl)
 				qManager.RequeueWorkload(ctx, wInfo, qcache.RequeueReasonNoFit, qcache.QuotaReservedReasonWaitingForQuota)
 			},
 			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
@@ -1835,7 +1836,7 @@ func TestReconcile(t *testing.T) {
 					panic(err)
 				}
 				qManager.Heads(ctx) // Pop from active heap
-				wInfo := workload.NewInfo(wl)
+				wInfo := workload.NewInfo(log, wl)
 				qManager.RequeueWorkload(ctx, wInfo, qcache.RequeueReasonNoFit, qcache.QuotaReservedReasonWaitingForQuota)
 			},
 			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -3589,7 +3589,7 @@ func TestAssignFlavors(t *testing.T) {
 				for fg, val := range tc.featureGates {
 					features.SetFeatureGateDuringTest(t, fg, val)
 				}
-				wlInfo := workload.NewInfo(&kueue.Workload{
+				wlInfo := workload.NewInfo(log, &kueue.Workload{
 					Spec: kueue.WorkloadSpec{
 						PodSets: tc.wlPods,
 					},
@@ -3783,6 +3783,7 @@ func TestReclaimBeforePriorityPreemption(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			ctx, _ := utiltesting.ContextWithLog(t)
+			log := testr.NewWithOptions(t, testr.Options{Verbosity: 2})
 			resourceFlavors := map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor{
 				"uno": utiltestingapi.MakeResourceFlavor("uno").Obj(),
 				"due": utiltestingapi.MakeResourceFlavor("due").Obj(),
@@ -3810,7 +3811,7 @@ func TestReclaimBeforePriorityPreemption(t *testing.T) {
 					*utiltestingapi.MakeFlavorQuotas("tre").Resource("compute", "0").Resource("gpu", "0").Obj(),
 				).Obj()
 
-			wlInfo := workload.NewInfo(&kueue.Workload{
+			wlInfo := workload.NewInfo(log, &kueue.Workload{
 				Spec: kueue.WorkloadSpec{
 					PodSets: []kueue.PodSet{
 						tc.workloadRequests.PodSet,
@@ -3829,7 +3830,6 @@ func TestReclaimBeforePriorityPreemption(t *testing.T) {
 			if err := cache.AddClusterQueue(ctx, &otherCq); err != nil {
 				t.Fatalf("Failed to add CQ to cache")
 			}
-			log := testr.NewWithOptions(t, testr.Options{Verbosity: 2})
 			for _, rf := range resourceFlavors {
 				cache.AddOrUpdateResourceFlavor(log, rf)
 			}
@@ -3955,7 +3955,7 @@ func TestDeletedFlavors(t *testing.T) {
 				log := testr.NewWithOptions(t, testr.Options{
 					Verbosity: 2,
 				})
-				wlInfo := workload.NewInfo(&kueue.Workload{
+				wlInfo := workload.NewInfo(log, &kueue.Workload{
 					Spec: kueue.WorkloadSpec{
 						PodSets: tc.wlPods,
 					},
@@ -4090,6 +4090,7 @@ func TestHierarchical(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			ctx, _ := utiltesting.ContextWithLog(t)
+			log := testr.NewWithOptions(t, testr.Options{Verbosity: 2})
 			resourceFlavors := map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor{
 				"one":   utiltestingapi.MakeResourceFlavor("one").Obj(),
 				"two":   utiltestingapi.MakeResourceFlavor("two").Obj(),
@@ -4128,7 +4129,7 @@ func TestHierarchical(t *testing.T) {
 				*utiltestingapi.MakeFlavorQuotas("three").Resource(corev1.ResourceCPU, "0").Obj(),
 			).Obj()
 
-			wlInfo := workload.NewInfo(&kueue.Workload{
+			wlInfo := workload.NewInfo(log, &kueue.Workload{
 				Spec: kueue.WorkloadSpec{
 					PodSets: []kueue.PodSet{
 						tc.workloadRequests.PodSet,
@@ -4151,7 +4152,6 @@ func TestHierarchical(t *testing.T) {
 			if err := cache.AddClusterQueue(ctx, &otherCq); err != nil {
 				t.Fatalf("Failed to add CQ to cache")
 			}
-			log := testr.NewWithOptions(t, testr.Options{Verbosity: 2})
 			for _, rf := range resourceFlavors {
 				cache.AddOrUpdateResourceFlavor(log, rf)
 			}
@@ -4291,6 +4291,7 @@ func TestIsPreferred(t *testing.T) {
 }
 
 func TestWorkloadsTopologyRequests_ErrorBranches(t *testing.T) {
+	_, log := utiltesting.ContextWithLog(t)
 	cases := map[string]struct {
 		cq         schdcache.ClusterQueueSnapshot
 		assignment Assignment
@@ -4311,7 +4312,7 @@ func TestWorkloadsTopologyRequests_ErrorBranches(t *testing.T) {
 					Status: *NewStatus(),
 				}},
 			},
-			workload: *workload.NewInfo(&kueue.Workload{
+			workload: *workload.NewInfo(log, &kueue.Workload{
 				Spec: kueue.WorkloadSpec{
 					PodSets: []kueue.PodSet{
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
@@ -4337,7 +4338,7 @@ func TestWorkloadsTopologyRequests_ErrorBranches(t *testing.T) {
 					Status: *NewStatus(),
 				}},
 			},
-			workload: *workload.NewInfo(&kueue.Workload{
+			workload: *workload.NewInfo(log, &kueue.Workload{
 				Spec: kueue.WorkloadSpec{
 					PodSets: []kueue.PodSet{
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
@@ -4367,7 +4368,7 @@ func TestWorkloadsTopologyRequests_ErrorBranches(t *testing.T) {
 					Status: *NewStatus(),
 				}},
 			},
-			workload: *workload.NewInfo(&kueue.Workload{
+			workload: *workload.NewInfo(log, &kueue.Workload{
 				Spec: kueue.WorkloadSpec{
 					PodSets: []kueue.PodSet{
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
@@ -4404,6 +4405,7 @@ func TestWorkloadsTopologyRequests_ErrorBranches(t *testing.T) {
 }
 
 func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
+	_, log := utiltesting.ContextWithLog(t)
 	features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, true)
 	features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlicesWithTAS, true)
 
@@ -4430,7 +4432,7 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 					Status: *NewStatus(),
 				}},
 				representativeMode: new(Fit),
-				replaceWorkloadSlice: workload.NewInfo(&kueue.Workload{
+				replaceWorkloadSlice: workload.NewInfo(log, &kueue.Workload{
 					Status: kueue.WorkloadStatus{
 						Admission: &kueue.Admission{
 							PodSetAssignments: []kueue.PodSetAssignment{{
@@ -4441,7 +4443,7 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 					},
 				}),
 			},
-			workload: *workload.NewInfo(&kueue.Workload{
+			workload: *workload.NewInfo(log, &kueue.Workload{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"kueue.x-k8s.io/elastic-job": "true",
@@ -4472,7 +4474,7 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 					Status: *NewStatus(),
 				}},
 				representativeMode: new(Fit),
-				replaceWorkloadSlice: workload.NewInfo(&kueue.Workload{
+				replaceWorkloadSlice: workload.NewInfo(log, &kueue.Workload{
 					Status: kueue.WorkloadStatus{
 						Admission: &kueue.Admission{
 							PodSetAssignments: []kueue.PodSetAssignment{{
@@ -4483,7 +4485,7 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 					},
 				}),
 			},
-			workload: *workload.NewInfo(&kueue.Workload{
+			workload: *workload.NewInfo(log, &kueue.Workload{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"kueue.x-k8s.io/elastic-job": "true",
@@ -4514,7 +4516,7 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 					Status: *NewStatus(),
 				}},
 			},
-			workload: *workload.NewInfo(&kueue.Workload{
+			workload: *workload.NewInfo(log, &kueue.Workload{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"kueue.x-k8s.io/elastic-job": "true",
@@ -4544,7 +4546,7 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 					Count:  2,
 					Status: *NewStatus(),
 				}},
-				replaceWorkloadSlice: workload.NewInfo(&kueue.Workload{
+				replaceWorkloadSlice: workload.NewInfo(log, &kueue.Workload{
 					Status: kueue.WorkloadStatus{
 						Admission: &kueue.Admission{
 							PodSetAssignments: []kueue.PodSetAssignment{{
@@ -4555,7 +4557,7 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 					},
 				}),
 			},
-			workload: *workload.NewInfo(&kueue.Workload{
+			workload: *workload.NewInfo(log, &kueue.Workload{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"kueue.x-k8s.io/elastic-job": "true",
@@ -4585,7 +4587,7 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 					Status: *NewStatus(),
 				}},
 			},
-			workload: *workload.NewInfo(&kueue.Workload{
+			workload: *workload.NewInfo(log, &kueue.Workload{
 				Spec: kueue.WorkloadSpec{
 					PodSets: []kueue.PodSet{
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).
@@ -4610,7 +4612,7 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 					Status: *NewStatus(),
 				}},
 			},
-			workload: *workload.NewInfo(&kueue.Workload{
+			workload: *workload.NewInfo(log, &kueue.Workload{
 				Spec: kueue.WorkloadSpec{
 					PodSets: []kueue.PodSet{
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).
@@ -4651,6 +4653,7 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 }
 
 func TestAssignment_TotalRequestsFor(t *testing.T) {
+	_, log := utiltesting.ContextWithLog(t)
 	type fields struct {
 		PodSets              []PodSetAssignment
 		replaceWorkloadSlice *workload.Info
@@ -4682,7 +4685,7 @@ func TestAssignment_TotalRequestsFor(t *testing.T) {
 				},
 			},
 			args: args{
-				wl: workload.NewInfo(utiltestingapi.MakeWorkload("test", "default").
+				wl: workload.NewInfo(log, utiltestingapi.MakeWorkload("test", "default").
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).Obj()). // Has 2 pods.
 					Request(corev1.ResourceCPU, "1").
 					Request(corev1.ResourceMemory, "1Mi").
@@ -4711,7 +4714,7 @@ func TestAssignment_TotalRequestsFor(t *testing.T) {
 				},
 			},
 			args: args{
-				wl: workload.NewInfo(utiltestingapi.MakeWorkload("test", "default").
+				wl: workload.NewInfo(log, utiltestingapi.MakeWorkload("test", "default").
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).Obj()). // Has 2 pods.
 					Request(corev1.ResourceCPU, "1").
 					Request(corev1.ResourceMemory, "1Mi").
@@ -4738,14 +4741,14 @@ func TestAssignment_TotalRequestsFor(t *testing.T) {
 						Count: 71, // Assigned 1 pod.
 					},
 				},
-				replaceWorkloadSlice: workload.NewInfo(utiltestingapi.MakeWorkload("test", "default").
+				replaceWorkloadSlice: workload.NewInfo(log, utiltestingapi.MakeWorkload("test", "default").
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Obj()).
 					Request(corev1.ResourceCPU, "1").
 					Request(corev1.ResourceMemory, "1Mi").
 					Obj()),
 			},
 			args: args{
-				wl: workload.NewInfo(utiltestingapi.MakeWorkload("test", "default").
+				wl: workload.NewInfo(log, utiltestingapi.MakeWorkload("test", "default").
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 3).Obj()).
 					Request(corev1.ResourceCPU, "1").
 					Request(corev1.ResourceMemory, "1Mi").
@@ -4774,7 +4777,7 @@ func TestAssignment_TotalRequestsFor(t *testing.T) {
 				},
 			},
 			args: args{
-				wl: workload.NewInfo(utiltestingapi.MakeWorkload("test", "default").
+				wl: workload.NewInfo(log, utiltestingapi.MakeWorkload("test", "default").
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).Obj()).
 					Request(corev1.ResourceCPU, "1").
 					Request(corev1.ResourceMemory, "1Mi").
@@ -4814,7 +4817,7 @@ func TestAssignment_TotalRequestsFor(t *testing.T) {
 						Count: 3, // Changed: was 1, now 3
 					},
 				},
-				replaceWorkloadSlice: workload.NewInfo(utiltestingapi.MakeWorkload("test", "default").
+				replaceWorkloadSlice: workload.NewInfo(log, utiltestingapi.MakeWorkload("test", "default").
 					PodSets(
 						*utiltestingapi.MakePodSet("worker", 2).
 							Request(corev1.ResourceCPU, "1").
@@ -4828,7 +4831,7 @@ func TestAssignment_TotalRequestsFor(t *testing.T) {
 					Obj()),
 			},
 			args: args{
-				wl: workload.NewInfo(utiltestingapi.MakeWorkload("test", "default").
+				wl: workload.NewInfo(log, utiltestingapi.MakeWorkload("test", "default").
 					PodSets(
 						*utiltestingapi.MakePodSet("worker", 2).
 							Request(corev1.ResourceCPU, "1").
@@ -4867,6 +4870,7 @@ func TestAssignment_TotalRequestsFor(t *testing.T) {
 }
 
 func TestAssignment_ComputeTASNetUsage(t *testing.T) {
+	_, log := utiltesting.ContextWithLog(t)
 	tests := map[string]struct {
 		assignment    Assignment
 		wl            *workload.Info
@@ -4898,7 +4902,7 @@ func TestAssignment_ComputeTASNetUsage(t *testing.T) {
 					},
 				}},
 			},
-			wl: workload.NewInfo(&kueue.Workload{
+			wl: workload.NewInfo(log, &kueue.Workload{
 				Spec: kueue.WorkloadSpec{
 					PodSets: []kueue.PodSet{
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).
@@ -4952,7 +4956,7 @@ func TestAssignment_ComputeTASNetUsage(t *testing.T) {
 					},
 				}},
 			},
-			wl: workload.NewInfo(&kueue.Workload{
+			wl: workload.NewInfo(log, &kueue.Workload{
 				Spec: kueue.WorkloadSpec{
 					PodSets: []kueue.PodSet{
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).
@@ -5004,7 +5008,7 @@ func TestAssignment_ComputeTASNetUsage(t *testing.T) {
 					},
 				}},
 			},
-			wl: workload.NewInfo(&kueue.Workload{
+			wl: workload.NewInfo(log, &kueue.Workload{
 				Spec: kueue.WorkloadSpec{
 					PodSets: []kueue.PodSet{
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 3).
@@ -5056,7 +5060,7 @@ func TestAssignment_ComputeTASNetUsage(t *testing.T) {
 					},
 				}},
 			},
-			wl: workload.NewInfo(&kueue.Workload{
+			wl: workload.NewInfo(log, &kueue.Workload{
 				Spec: kueue.WorkloadSpec{
 					PodSets: []kueue.PodSet{
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).
@@ -5105,7 +5109,7 @@ func TestAssignment_ComputeTASNetUsage(t *testing.T) {
 					},
 				}},
 			},
-			wl: workload.NewInfo(&kueue.Workload{
+			wl: workload.NewInfo(log, &kueue.Workload{
 				Spec: kueue.WorkloadSpec{
 					PodSets: []kueue.PodSet{
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
@@ -5235,11 +5239,12 @@ func TestWorkloadsTopologyRequests_ZeroCountPodSetSkipped(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			_, log := utiltesting.ContextWithLog(t)
 			cq := schdcache.ClusterQueueSnapshot{
 				TASFlavors: map[kueue.ResourceFlavorReference]*schdcache.TASFlavorSnapshot{"tas": tasFlavor},
 			}
 			assignment := Assignment{PodSets: tc.podSets}
-			wl := workload.NewInfo(&kueue.Workload{
+			wl := workload.NewInfo(log, &kueue.Workload{
 				Spec: kueue.WorkloadSpec{PodSets: tc.wlPodSets},
 			})
 
@@ -5319,6 +5324,7 @@ func TestAssignFlavorsWithAllowedFlavors(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx, log := utiltesting.ContextWithLog(t)
 			features.SetFeatureGateDuringTest(t, features.ConcurrentAdmission, true)
 			wlBuilder := utiltestingapi.MakeWorkload("wl", "ns").
 				PodSets(*utiltestingapi.MakePodSet("main", 1).Request(corev1.ResourceCPU, "2").Obj())
@@ -5327,9 +5333,8 @@ func TestAssignFlavorsWithAllowedFlavors(t *testing.T) {
 			}
 			wl := wlBuilder.Obj()
 
-			wlInfo := workload.NewInfo(wl)
+			wlInfo := workload.NewInfo(log, wl)
 
-			ctx, log := utiltesting.ContextWithLog(t)
 			cache := schdcache.New(utiltesting.NewFakeClient())
 			if err := cache.AddClusterQueue(ctx, &cq); err != nil {
 				t.Fatalf("Failed to add CQ to cache: %v", err)
@@ -5362,6 +5367,7 @@ func TestAssignFlavorsWithAllowedFlavors(t *testing.T) {
 }
 
 func TestIsNoFitDueToCapacityAndLimits(t *testing.T) {
+	_, log := utiltesting.ContextWithLog(t)
 	resourceFlavors := map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor{
 		"flavor-a": utiltestingapi.MakeResourceFlavor("flavor-a").NodeLabel("type", "a").Obj(),
 		"flavor-b": utiltestingapi.MakeResourceFlavor("flavor-b").
@@ -5486,7 +5492,7 @@ func TestIsNoFitDueToCapacityAndLimits(t *testing.T) {
 				Request(corev1.ResourceCPU, "2").
 				NodeSelector(map[string]string{"type": "a"}).
 				Obj(),
-			replaceWl: workload.NewInfo(
+			replaceWl: workload.NewInfo(log,
 				utiltestingapi.MakeWorkload("wl-old", "ns").
 					PodSets(*utiltestingapi.MakePodSet("main", 1).Request(corev1.ResourceCPU, "1").Obj()).
 					Admission(utiltestingapi.MakeAdmission("cq", "main").
@@ -5758,6 +5764,7 @@ func TestIsNoFitDueToCapacityAndLimits(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx, log := utiltesting.ContextWithLog(t)
 			features.SetFeatureGateDuringTest(t, features.UnadmittedWorkloadsObservability, true)
 			for fg, val := range tc.featureGates {
 				features.SetFeatureGateDuringTest(t, fg, val)
@@ -5778,9 +5785,8 @@ func TestIsNoFitDueToCapacityAndLimits(t *testing.T) {
 				wlBuilder = wlBuilder.AllowedFlavors(tc.allowedFlavors...)
 			}
 			wl := wlBuilder.Obj()
-			wlInfo := workload.NewInfo(wl)
+			wlInfo := workload.NewInfo(log, wl)
 
-			ctx, log := utiltesting.ContextWithLog(t)
 			cache := schdcache.New(utiltesting.NewFakeClient())
 			if err := cache.AddClusterQueue(ctx, &testCQ); err != nil {
 				t.Fatalf("Failed to add CQ to cache: %v", err)
@@ -6027,7 +6033,7 @@ func TestAssignFlavors_LeaderWorkerSetTASFlavor(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx, log := utiltesting.ContextWithLog(t)
 
-			wlInfo := workload.NewInfo(&kueue.Workload{Spec: kueue.WorkloadSpec{PodSets: tc.wlPods}})
+			wlInfo := workload.NewInfo(log, &kueue.Workload{Spec: kueue.WorkloadSpec{PodSets: tc.wlPods}})
 
 			cache := schdcache.New(utiltesting.NewFakeClient())
 			if err := cache.AddClusterQueue(ctx, &tc.clusterQueue); err != nil {
@@ -6097,6 +6103,7 @@ func TestAssignFlavors_LeaderWorkerSetTASFlavor(t *testing.T) {
 }
 
 func TestWorkloadsTopologyRequests_RequiredTopologyRejectedForElasticWorkloadSlices(t *testing.T) {
+	_, log := utiltesting.ContextWithLog(t)
 	features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, true)
 	features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlicesWithTAS, true)
 
@@ -6106,7 +6113,7 @@ func TestWorkloadsTopologyRequests_RequiredTopologyRejectedForElasticWorkloadSli
 			{Name: "worker", Flavors: ResourceAssignment{"example.com/gpu": {Name: "tas", Mode: Fit, TriedFlavorIdx: -1}}, Count: 1, Status: *NewStatus()},
 		},
 	}
-	wl := workload.NewInfo(&kueue.Workload{
+	wl := workload.NewInfo(log, &kueue.Workload{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
 				"kueue.x-k8s.io/elastic-job": "true",
@@ -6255,8 +6262,8 @@ func newBookmarkSnapshot(
 }
 
 // bookmarkTestWorkload is a single pod requesting cpu on a required hostname topology.
-func bookmarkTestWorkload(request string) *workload.Info {
-	return workload.NewInfo(utiltestingapi.MakeWorkload("wl", "default").
+func bookmarkTestWorkload(log logr.Logger, request string) *workload.Info {
+	return workload.NewInfo(log, utiltestingapi.MakeWorkload("wl", "default").
 		PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 			RequiredTopologyRequest(corev1.LabelHostname).
 			Request(corev1.ResourceCPU, request).
@@ -6464,7 +6471,7 @@ func TestFlavorScanRecordsLastTriedFlavorIdx(t *testing.T) {
 				cqSnapshot.AddUsage(workload.Usage{TAS: tc.nodeUsage})
 			}
 
-			wlInfo := bookmarkTestWorkload(tc.request)
+			wlInfo := bookmarkTestWorkload(log, tc.request)
 			assigner := New(wlInfo, cqSnapshot, bookmarkTestFlavors(), false,
 				&testOracle{simulationResult: tc.simulationResult}, nil,
 				configapi.QuotaCheckBlockUndeclared, bookmarkTestCycle)
@@ -6544,7 +6551,7 @@ func TestRecomputeRecordsLastTriedFlavorIdx(t *testing.T) {
 			// Quota is generous at nomination, so both flavors are accepted on quota
 			// grounds and the pod fits an empty node.
 			cqSnapshot := newBookmarkSnapshot(ctx, t, log, "10", "0", fungibility)
-			wlInfo := bookmarkTestWorkload("3")
+			wlInfo := bookmarkTestWorkload(log, "3")
 			flavors := bookmarkTestFlavors()
 
 			// Nomination: quota fits, topology fits, and a placement is produced.

--- a/pkg/scheduler/preemption/fairsharing/ordering_test.go
+++ b/pkg/scheduler/preemption/fairsharing/ordering_test.go
@@ -230,7 +230,7 @@ func TestMakeClusterQueueOrdering(t *testing.T) {
 			candidateCQSet := sets.New(tc.candidateCQs...)
 			var candidates []*workload.Info
 			for i := range tc.admitted {
-				info := workload.NewInfo(&tc.admitted[i])
+				info := workload.NewInfo(log, &tc.admitted[i])
 				if candidateCQSet.Has(info.ClusterQueue) {
 					candidates = append(candidates, info)
 				}

--- a/pkg/scheduler/preemption/preemption_fair_log_test.go
+++ b/pkg/scheduler/preemption/preemption_fair_log_test.go
@@ -137,7 +137,7 @@ func newFsLogFixture(tb testing.TB, log logr.Logger, cqs []fsLogClusterQueue) fs
 
 	incoming := utiltestingapi.MakeWorkload("a-incoming", "").
 		Request(corev1.ResourceCPU, "3").Obj()
-	wlInfo := workload.NewInfo(incoming)
+	wlInfo := workload.NewInfo(setupLog, incoming)
 	wlInfo.ClusterQueue = "a"
 	assignment := singlePodSetAssignment(flavorassigner.ResourceAssignment{
 		corev1.ResourceCPU: &flavorassigner.FlavorAssignment{
@@ -162,7 +162,7 @@ func newFsLogFixture(tb testing.TB, log logr.Logger, cqs []fsLogClusterQueue) fs
 
 	candidates := make([]*workload.Info, 0, len(admitted))
 	for i := range admitted {
-		candidates = append(candidates, workload.NewInfo(&admitted[i]))
+		candidates = append(candidates, workload.NewInfo(setupLog, &admitted[i]))
 	}
 	return fsLogFixture{preemptionCtx: preemptionCtx, candidates: candidates}
 }

--- a/pkg/scheduler/preemption/preemption_fair_test.go
+++ b/pkg/scheduler/preemption/preemption_fair_test.go
@@ -1246,7 +1246,7 @@ func TestFairPreemptions(t *testing.T) {
 			if tc.assignmentFlavor != "" {
 				flavorName = tc.assignmentFlavor
 			}
-			wlInfo := workload.NewInfo(tc.incoming)
+			wlInfo := workload.NewInfo(log, tc.incoming)
 			wlInfo.ClusterQueue = tc.targetCQ
 			targets := preemptor.GetTargets(log, *wlInfo, singlePodSetAssignment(
 				flavorassigner.ResourceAssignment{
@@ -1312,6 +1312,7 @@ func TestFairPreemptionSkipsUnsatisfiableTournament(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			_, setupLog := utiltesting.ContextWithLog(t)
 			// Count the FairSharing V(4) log entries. The first strategy logs
 			// one collapsed entry per candidate ClusterQueue, carrying a
 			// strategyEvaluations array (so its args include targetNewShare);
@@ -1373,7 +1374,7 @@ func TestFairPreemptionSkipsUnsatisfiableTournament(t *testing.T) {
 
 			preemptor := New(cl, workload.Ordering{}, &utiltesting.EventRecorder{}, &config.FairSharing{},
 				false, clocktesting.NewFakeClock(now), nil, preemptexpectations.New(), nil)
-			wlInfo := workload.NewInfo(unitWl.Clone().Name("a_incoming").Obj())
+			wlInfo := workload.NewInfo(setupLog, unitWl.Clone().Name("a_incoming").Obj())
 			wlInfo.ClusterQueue = "a"
 			targets := preemptor.GetTargets(log, *wlInfo, singlePodSetAssignment(
 				flavorassigner.ResourceAssignment{

--- a/pkg/scheduler/preemption/preemption_hierarchical_test.go
+++ b/pkg/scheduler/preemption/preemption_hierarchical_test.go
@@ -1851,7 +1851,7 @@ func TestHierarchicalPreemptions(t *testing.T) {
 				if err != nil {
 					t.Fatalf("unexpected error while building snapshot: %v", err)
 				}
-				wlInfo := workload.NewInfo(tc.incoming)
+				wlInfo := workload.NewInfo(log, tc.incoming)
 				wlInfo.ClusterQueue = tc.targetCQ
 				targets := preemptor.GetTargets(log, *wlInfo, tc.assignment, snapshotWorkingCopy)
 				preempted, failed, err := preemptor.IssuePreemptions(ctx, cqCache, wlInfo, targets, snapshotWorkingCopy.ClusterQueue(wlInfo.ClusterQueue))

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -4139,7 +4139,7 @@ func TestPreemption(t *testing.T) {
 				if err != nil {
 					t.Fatalf("unexpected error while building snapshot: %v", err)
 				}
-				wlInfo := workload.NewInfo(tc.incoming)
+				wlInfo := workload.NewInfo(log, tc.incoming)
 				wlInfo.ClusterQueue = tc.targetCQ
 				targets := preemptor.GetTargets(log, *wlInfo, tc.assignment, snapshotWorkingCopy)
 				preempted, failed, err := preemptor.IssuePreemptions(ctx, cqCache, wlInfo, targets, snapshotWorkingCopy.ClusterQueue(wlInfo.ClusterQueue))
@@ -4356,7 +4356,7 @@ func TestPreemptionWhenWorkloadModifiedConcurrently(t *testing.T) {
 				if err != nil {
 					t.Fatalf("unexpected error while building snapshot: %v", err)
 				}
-				wlInfo := workload.NewInfo(tc.incoming)
+				wlInfo := workload.NewInfo(log, tc.incoming)
 				wlInfo.ClusterQueue = kueue.ClusterQueueReference(cq.Name)
 				targets := preemptor.GetTargets(log, *wlInfo, tc.assignment, snapshotWorkingCopy)
 				_, _, err = preemptor.IssuePreemptions(ctx, cqCache, wlInfo, targets, snapshotWorkingCopy.ClusterQueue(wlInfo.ClusterQueue))
@@ -4455,9 +4455,9 @@ func TestIssuePreemptionsCountsFailures(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error while building snapshot: %v", err)
 	}
-	wlInfo := workload.NewInfo(incomingWl)
+	wlInfo := workload.NewInfo(log, incomingWl)
 	wlInfo.ClusterQueue = cqName
-	targetInfo := workload.NewInfo(targetWl)
+	targetInfo := workload.NewInfo(log, targetWl)
 	targetInfo.ClusterQueue = cqName
 	targets := []*Target{{
 		WorkloadInfo: targetInfo,
@@ -4573,7 +4573,7 @@ func TestIssuePreemptionsSkipsDuplicate(t *testing.T) {
 				if err != nil {
 					t.Fatalf("unexpected error while building snapshot: %v", err)
 				}
-				wlInfo := workload.NewInfo(tc.incoming)
+				wlInfo := workload.NewInfo(log, tc.incoming)
 				wlInfo.ClusterQueue = kueue.ClusterQueueReference(cq.Name)
 				targets := preemptor.GetTargets(log, *wlInfo, tc.assignment, snapshot)
 
@@ -4611,39 +4611,40 @@ func targetKeyReason(key workload.Reference, reason string) string {
 	return fmt.Sprintf("%s:%s", key, reason)
 }
 func TestCandidatesOrdering(t *testing.T) {
+	_, log := utiltesting.ContextWithLog(t)
 	now := time.Now()
 
 	preemptorCq := "preemptor"
 
-	wlLowUsageLq := workload.NewInfo(utiltestingapi.MakeWorkload("low_lq_usage", "").
+	wlLowUsageLq := workload.NewInfo(log, utiltestingapi.MakeWorkload("low_lq_usage", "").
 		Queue("low_usage_lq").
 		ReserveQuotaAt(utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(preemptorCq)).Obj(), now).
 		Priority(1).
 		Obj())
 	wlLowUsageLq.LocalQueueFSUsage = new(0.1)
 
-	wlMidUsageLq := workload.NewInfo(utiltestingapi.MakeWorkload("mid_lq_usage", "").
+	wlMidUsageLq := workload.NewInfo(log, utiltestingapi.MakeWorkload("mid_lq_usage", "").
 		Queue("mid_usage_lq").
 		ReserveQuotaAt(utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(preemptorCq)).Obj(), now).
 		Priority(10).
 		Obj())
 	wlMidUsageLq.LocalQueueFSUsage = new(0.5)
 
-	wlHighUsageLqDifCQ := workload.NewInfo(utiltestingapi.MakeWorkload("high_lq_usage_different_cq", "").
+	wlHighUsageLqDifCQ := workload.NewInfo(log, utiltestingapi.MakeWorkload("high_lq_usage_different_cq", "").
 		Queue("high_usage_lq_different_cq").
 		ReserveQuotaAt(utiltestingapi.MakeAdmission("different_cq").Obj(), now).
 		Priority(1).
 		Obj())
 	wlHighUsageLqDifCQ.LocalQueueFSUsage = new(1.0)
 
-	wlLowUsageSameNameLq := workload.NewInfo(utiltestingapi.MakeWorkload("low_same_name_lq_usage", "team-a").
+	wlLowUsageSameNameLq := workload.NewInfo(log, utiltestingapi.MakeWorkload("low_same_name_lq_usage", "team-a").
 		Queue("default").
 		ReserveQuotaAt(utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(preemptorCq)).Obj(), now).
 		Priority(-10).
 		Obj())
 	wlLowUsageSameNameLq.LocalQueueFSUsage = new(0.1)
 
-	wlHighUsageSameNameLq := workload.NewInfo(utiltestingapi.MakeWorkload("high_same_name_lq_usage", "team-b").
+	wlHighUsageSameNameLq := workload.NewInfo(log, utiltestingapi.MakeWorkload("high_same_name_lq_usage", "team-b").
 		Queue("default").
 		ReserveQuotaAt(utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(preemptorCq)).Obj(), now).
 		Priority(10).
@@ -4657,11 +4658,11 @@ func TestCandidatesOrdering(t *testing.T) {
 	}{
 		"workloads sorted by priority": {
 			candidates: []workload.Info{
-				*workload.NewInfo(utiltestingapi.MakeWorkload("high", "").
+				*workload.NewInfo(log, utiltestingapi.MakeWorkload("high", "").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(preemptorCq)).Obj(), now).
 					Priority(10).
 					Obj()),
-				*workload.NewInfo(utiltestingapi.MakeWorkload("low", "").
+				*workload.NewInfo(log, utiltestingapi.MakeWorkload("low", "").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(preemptorCq)).Obj(), now).
 					Priority(-10).
 					Obj()),
@@ -4670,12 +4671,12 @@ func TestCandidatesOrdering(t *testing.T) {
 		},
 		"workloads sorted by effective priority with boost": {
 			candidates: []workload.Info{
-				*workload.NewInfo(utiltestingapi.MakeWorkload("high-boost", "").
+				*workload.NewInfo(log, utiltestingapi.MakeWorkload("high-boost", "").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(preemptorCq)).Obj(), now).
 					Priority(10).
 					Annotation(controllerconstants.PriorityBoostAnnotationKey, "100").
 					Obj()),
-				*workload.NewInfo(utiltestingapi.MakeWorkload("low-boost", "").
+				*workload.NewInfo(log, utiltestingapi.MakeWorkload("low-boost", "").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(preemptorCq)).Obj(), now).
 					Priority(10).
 					Annotation(controllerconstants.PriorityBoostAnnotationKey, "5").
@@ -4686,11 +4687,11 @@ func TestCandidatesOrdering(t *testing.T) {
 		},
 		"workload missing priority boost defaults to zero": {
 			candidates: []workload.Info{
-				*workload.NewInfo(utiltestingapi.MakeWorkload("missing-boost", "").
+				*workload.NewInfo(log, utiltestingapi.MakeWorkload("missing-boost", "").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(preemptorCq)).Obj(), now).
 					Priority(10).
 					Obj()),
-				*workload.NewInfo(utiltestingapi.MakeWorkload("has-boost", "").
+				*workload.NewInfo(log, utiltestingapi.MakeWorkload("has-boost", "").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(preemptorCq)).Obj(), now).
 					Priority(10).
 					Annotation(controllerconstants.PriorityBoostAnnotationKey, "5").
@@ -4701,12 +4702,12 @@ func TestCandidatesOrdering(t *testing.T) {
 		},
 		"invalid priority boost defaults to zero": {
 			candidates: []workload.Info{
-				*workload.NewInfo(utiltestingapi.MakeWorkload("invalid-boost", "").
+				*workload.NewInfo(log, utiltestingapi.MakeWorkload("invalid-boost", "").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(preemptorCq)).Obj(), now).
 					Priority(10).
 					Annotation(controllerconstants.PriorityBoostAnnotationKey, "invalid").
 					Obj()),
-				*workload.NewInfo(utiltestingapi.MakeWorkload("valid-boost", "").
+				*workload.NewInfo(log, utiltestingapi.MakeWorkload("valid-boost", "").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(preemptorCq)).Obj(), now).
 					Priority(10).
 					Annotation(controllerconstants.PriorityBoostAnnotationKey, "5").
@@ -4717,11 +4718,11 @@ func TestCandidatesOrdering(t *testing.T) {
 		},
 		"evicted workload first": {
 			candidates: []workload.Info{
-				*workload.NewInfo(utiltestingapi.MakeWorkload("other", "").
+				*workload.NewInfo(log, utiltestingapi.MakeWorkload("other", "").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(preemptorCq)).Obj(), now).
 					Priority(10).
 					Obj()),
-				*workload.NewInfo(utiltestingapi.MakeWorkload("evicted", "").
+				*workload.NewInfo(log, utiltestingapi.MakeWorkload("evicted", "").
 					Condition(metav1.Condition{
 						Type:               kueue.WorkloadEvicted,
 						Status:             metav1.ConditionTrue,
@@ -4733,11 +4734,11 @@ func TestCandidatesOrdering(t *testing.T) {
 		},
 		"workload from different CQ first": {
 			candidates: []workload.Info{
-				*workload.NewInfo(utiltestingapi.MakeWorkload("preemptorCq", "").
+				*workload.NewInfo(log, utiltestingapi.MakeWorkload("preemptorCq", "").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(preemptorCq)).Obj(), now).
 					Priority(10).
 					Obj()),
-				*workload.NewInfo(utiltestingapi.MakeWorkload("other", "").
+				*workload.NewInfo(log, utiltestingapi.MakeWorkload("other", "").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission("other").Obj(), now).
 					Priority(10).
 					Obj()),
@@ -4746,13 +4747,13 @@ func TestCandidatesOrdering(t *testing.T) {
 		},
 		"old workloads last": {
 			candidates: []workload.Info{
-				*workload.NewInfo(utiltestingapi.MakeWorkload("older", "").
+				*workload.NewInfo(log, utiltestingapi.MakeWorkload("older", "").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(preemptorCq)).Obj(), now.Add(-time.Second)).
 					Obj()),
-				*workload.NewInfo(utiltestingapi.MakeWorkload("younger", "").
+				*workload.NewInfo(log, utiltestingapi.MakeWorkload("younger", "").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(preemptorCq)).Obj(), now.Add(time.Second)).
 					Obj()),
-				*workload.NewInfo(utiltestingapi.MakeWorkload("current", "").
+				*workload.NewInfo(log, utiltestingapi.MakeWorkload("current", "").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(preemptorCq)).Obj(), now).
 					Obj()),
 			},
@@ -4783,7 +4784,6 @@ func TestCandidatesOrdering(t *testing.T) {
 			featureGates:   map[featuregate.Feature]bool{features.AdmissionFairSharing: true},
 		}}
 
-	_, log := utiltesting.ContextWithLog(t)
 	for _, tc := range cases {
 		features.SetFeatureGatesDuringTest(t, tc.featureGates)
 		slices.SortFunc(tc.candidates, func(a, b workload.Info) int {

--- a/pkg/scheduler/scheduler_afs_test.go
+++ b/pkg/scheduler/scheduler_afs_test.go
@@ -1072,9 +1072,10 @@ func TestShouldApplyEntryPenalty(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			_, log := utiltesting.ContextWithLog(t)
 			s := &Scheduler{admissionFairSharing: tc.afsConfig}
 			e := &entry{
-				Head: qcache.Head{Info: *workload.NewInfo(tc.wl)},
+				Head: qcache.Head{Info: *workload.NewInfo(log, tc.wl)},
 				clusterQueueSnapshot: &schdcache.ClusterQueueSnapshot{
 					AdmissionScope: kueue.AdmissionScope{AdmissionMode: tc.admissionMode},
 				},

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -9241,7 +9241,7 @@ func TestResourcesToReserve(t *testing.T) {
 				Borrowing: tc.borrowing,
 				Usage:     workload.Usage{Quota: tc.assignmentUsage},
 			}
-			e := &entry{assignment: assignment, Head: qcache.Head{Info: *workload.NewInfo(
+			e := &entry{assignment: assignment, Head: qcache.Head{Info: *workload.NewInfo(log,
 				&kueue.Workload{},
 			)}}
 			cl := utiltesting.NewClientBuilder().
@@ -9815,8 +9815,8 @@ func TestFitsDedupsOverlappingVictims(t *testing.T) {
 		t.Fatal("ClusterQueue snapshot missing")
 	}
 
-	victimInfo := workload.NewInfo(victimWL)
-	otherInfo := workload.NewInfo(otherWL)
+	victimInfo := workload.NewInfo(log, victimWL)
+	otherInfo := workload.NewInfo(log, otherWL)
 	snapshot.AddWorkload(victimInfo)
 	snapshot.AddWorkload(otherInfo)
 

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -348,12 +348,8 @@ func (p *PodSetResources) ScaledTo(newCount int32) *PodSetResources {
 	return ret
 }
 
-func NewInfo(w *kueue.Workload, opts ...InfoOption) *Info {
-	return NewInfoWithLogger(klog.Background(), w, opts...)
-}
-
-// NewInfoWithLogger builds an Info, computing the scheduling hash with log.
-func NewInfoWithLogger(log logr.Logger, w *kueue.Workload, opts ...InfoOption) *Info {
+// NewInfo builds an Info, computing the scheduling hash with log.
+func NewInfo(log logr.Logger, w *kueue.Workload, opts ...InfoOption) *Info {
 	info := &Info{}
 	info.Update(log, w, opts...)
 	return info

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -1187,10 +1187,11 @@ func TestNewInfo(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			_, log := utiltesting.ContextWithLog(t)
 			for fg, enabled := range tc.featureGates {
 				features.SetFeatureGateDuringTest(t, fg, enabled)
 			}
-			info := NewInfo(&tc.workload, tc.infoOptions...)
+			info := NewInfo(log, &tc.workload, tc.infoOptions...)
 			if diff := cmp.Diff(info, &tc.wantInfo, cmpopts.IgnoreFields(Info{}, "Obj", "SchedulingHash"), cmp.Comparer(resources.Equal)); diff != "" {
 				t.Errorf("NewInfo(_) = (-want,+got):\n%s", diff)
 			}
@@ -1285,7 +1286,7 @@ func TestUpdateWithRebuild(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			_, log := utiltesting.ContextWithLog(t)
-			info := NewInfo(tc.initial, tc.initialOptions...)
+			info := NewInfo(log, tc.initial, tc.initialOptions...)
 			if len(tc.updateOptions) == 0 {
 				if diff := cmp.Diff(tc.wantRequests, info.TotalRequests, cmpopts.IgnoreFields(PodSetResources{}, "Flavors"), cmp.Comparer(resources.Equal)); diff == "" {
 					t.Fatal("precondition failed: initial TotalRequests should differ from expected post-rebuild state")
@@ -2828,7 +2829,8 @@ func TestWithPreprocessedDRAResources(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			info := NewInfo(&tc.workload, WithPreprocessedDRAResources(tc.draResources, nil))
+			_, log := utiltesting.ContextWithLog(t)
+			info := NewInfo(log, &tc.workload, WithPreprocessedDRAResources(tc.draResources, nil))
 
 			if diff := cmp.Diff(tc.wantInfo.TotalRequests, info.TotalRequests, cmp.Comparer(resources.Equal)); diff != "" {
 				t.Errorf("Unexpected TotalRequests (-want,+got):\n%s", diff)
@@ -2909,7 +2911,8 @@ func TestWithPreprocessedDRAResourcesReplacesExtendedResources(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			info := NewInfo(&tc.workload, WithPreprocessedDRAResources(tc.draResources, tc.replacedExtendedResources))
+			_, log := utiltesting.ContextWithLog(t)
+			info := NewInfo(log, &tc.workload, WithPreprocessedDRAResources(tc.draResources, tc.replacedExtendedResources))
 
 			if diff := cmp.Diff(tc.wantInfo.TotalRequests, info.TotalRequests, cmp.Comparer(resources.Equal)); diff != "" {
 				t.Errorf("Unexpected TotalRequests (-want,+got):\n%s", diff)
@@ -4171,9 +4174,9 @@ func TestSchedulingHash(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			_, log := utiltesting.ContextWithLog(t)
 			features.SetFeatureGatesDuringTest(t, tc.featureGates)
-			info1 := NewInfo(tc.wl1)
+			info1 := NewInfo(log, tc.wl1)
 			info1.updateSchedulingHash(log)
-			info2 := NewInfo(tc.wl2)
+			info2 := NewInfo(log, tc.wl2)
 			info2.updateSchedulingHash(log)
 			if info1.SchedulingHash == "" {
 				t.Error("SchedulingHash should not be empty")
@@ -4194,10 +4197,10 @@ func TestSchedulingHash(t *testing.T) {
 		})
 		wl := utiltestingapi.MakeWorkload("wl", "ns").
 			Request("example.com/gpu", "1").Obj()
-		before := NewInfo(wl)
+		before := NewInfo(log, wl)
 		before.updateSchedulingHash(log)
 
-		after := NewInfo(wl, WithPreprocessedDRAResources(
+		after := NewInfo(log, wl, WithPreprocessedDRAResources(
 			map[kueue.PodSetReference]corev1.ResourceList{
 				kueue.DefaultPodSetName: {
 					"gpu": resource.MustParse("1"),
@@ -4219,6 +4222,7 @@ func TestSchedulingHash(t *testing.T) {
 }
 
 func TestUpdateSchedulingHashReuse(t *testing.T) {
+	_, log := utiltesting.ContextWithLog(t)
 	features.SetFeatureGatesDuringTest(t, map[featuregate.Feature]bool{
 		features.SchedulingEquivalenceHashing: true,
 	})
@@ -4253,27 +4257,27 @@ func TestUpdateSchedulingHashReuse(t *testing.T) {
 		wantReuse bool
 	}{
 		"same UID and ResourceVersion keeps the hash": {
-			info:      NewInfo(workload("uid", "1", 1)),
+			info:      NewInfo(log, workload("uid", "1", 1)),
 			reread:    workload("uid", "1", 2),
 			wantReuse: true,
 		},
 		"changed ResourceVersion recomputes the hash": {
-			info:   NewInfo(workload("uid", "1", 1)),
+			info:   NewInfo(log, workload("uid", "1", 1)),
 			reread: workload("uid", "2", 2),
 		},
 		"changed UID recomputes the hash": {
-			info:   NewInfo(workload("uid", "1", 1)),
+			info:   NewInfo(log, workload("uid", "1", 1)),
 			reread: workload("other", "1", 2),
 		},
 		// Objects that never round-tripped through the API server share the
 		// empty ResourceVersion, which says nothing about their shape.
 		"absent ResourceVersion on both sides recomputes the hash": {
-			info:   NewInfo(workload("uid", "", 1)),
+			info:   NewInfo(log, workload("uid", "", 1)),
 			reread: workload("uid", "", 2),
 		},
 		"an Info holding no hash computes one": {
 			// Requests match, so only the missing hash can force the recompute.
-			info:   withoutHash(NewInfo(workload("uid", "1", 1))),
+			info:   withoutHash(NewInfo(log, workload("uid", "1", 1))),
 			reread: workload("uid", "1", 2),
 		},
 		"an Info holding no object computes one": {
@@ -4283,7 +4287,7 @@ func TestUpdateSchedulingHashReuse(t *testing.T) {
 		// The requeue path carries DRA-preprocessed requests over deliberately,
 		// which leaves the version check to decide alone.
 		"preserved TotalRequests leave the decision to the version check": {
-			info: NewInfo(workload("uid", "1", 1)),
+			info: NewInfo(log, workload("uid", "1", 1)),
 			reread: utiltestingapi.MakeWorkload("wl", "ns").UID("uid").ResourceVersion("1").
 				Priority(2).Request(corev1.ResourceCPU, "2").Obj(),
 			opts:      []InfoOption{WithPreserveTotalRequests()},
@@ -4292,7 +4296,7 @@ func TestUpdateSchedulingHashReuse(t *testing.T) {
 		// The requeue path drops the DRA options when NeedsDRAReconcile turns
 		// false, which it can do at an unchanged ResourceVersion.
 		"dropped DRA preprocessing recomputes the hash": {
-			info:   NewInfo(draWorkload, draOptions...),
+			info:   NewInfo(log, draWorkload, draOptions...),
 			reread: draWorkload,
 		},
 	}
@@ -4324,7 +4328,7 @@ func TestUpdateSchedulingHashReuse(t *testing.T) {
 		features.SetFeatureGatesDuringTest(t, map[featuregate.Feature]bool{
 			features.SchedulingEquivalenceHashing: false,
 		})
-		info := NewInfo(workload("uid", "1", 1))
+		info := NewInfo(log, workload("uid", "1", 1))
 		info.Update(log, workload("uid", "1", 2))
 		if info.SchedulingHash != SchedulingHashUnknown {
 			t.Errorf("SchedulingHash = %q, want %q", info.SchedulingHash, SchedulingHashUnknown)
@@ -4767,6 +4771,7 @@ func TestCalcFSUsageFromResourcesWithNonPositiveWeight(t *testing.T) {
 }
 
 func TestSumTotalRequestsWithDRAFromAdmission(t *testing.T) {
+	_, log := utiltesting.ContextWithLog(t)
 	fakeClock := testingclock.NewFakeClock(time.Now())
 	now := fakeClock.Now()
 	wl := utiltestingapi.MakeWorkload("test-wl", "default").
@@ -4786,7 +4791,7 @@ func TestSumTotalRequestsWithDRAFromAdmission(t *testing.T) {
 				).Obj(), now,
 		).Obj()
 
-	info := NewInfo(wl)
+	info := NewInfo(log, wl)
 	sumReqs := info.SumTotalRequests()
 
 	// Verify CPU is present
@@ -4927,6 +4932,7 @@ func TestCalcLocalQueueFSUsage(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			_, log := utiltesting.ContextWithLog(t)
 			wl := utiltestingapi.MakeWorkload("wl", "ns").Queue("lq").Obj()
 			cl := utiltesting.NewClientBuilder().
 				WithInterceptorFuncs(interceptor.Funcs{
@@ -4936,7 +4942,7 @@ func TestCalcLocalQueueFSUsage(t *testing.T) {
 				}).
 				Build()
 
-			info := NewInfo(wl)
+			info := NewInfo(log, wl)
 
 			resWeights := map[corev1.ResourceName]float64{corev1.ResourceCPU: 5.0}
 

--- a/pkg/workloadslicing/workloadslicing_test.go
+++ b/pkg/workloadslicing/workloadslicing_test.go
@@ -1193,6 +1193,7 @@ func TestNormalizeActiveSlices(t *testing.T) {
 }
 
 func TestReplacedWorkloadSlice(t *testing.T) {
+	_, log := utiltesting.ContextWithLog(t)
 	type args struct {
 		wl   *workload.Info
 		snap *schdcache.Snapshot
@@ -1216,20 +1217,20 @@ func TestReplacedWorkloadSlice(t *testing.T) {
 		"EdgeCase_SnapshotIsNil": {
 			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			args: args{
-				wl: workload.NewInfo(utiltestingapi.MakeWorkload("test", "default").Obj()),
+				wl: workload.NewInfo(log, utiltestingapi.MakeWorkload("test", "default").Obj()),
 			},
 		},
 		"WorkloadWithoutReplacementAnnotation": {
 			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			args: args{
-				wl:   workload.NewInfo(utiltestingapi.MakeWorkload("test", "default").Obj()),
+				wl:   workload.NewInfo(log, utiltestingapi.MakeWorkload("test", "default").Obj()),
 				snap: &schdcache.Snapshot{},
 			},
 		},
 		"ReplacedWorkloadIsNotFound_MissingClusterQueue": {
 			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			args: args{
-				wl: workload.NewInfo(utiltestingapi.MakeWorkload("test-new", "default").
+				wl: workload.NewInfo(log, utiltestingapi.MakeWorkload("test-new", "default").
 					Annotation(WorkloadSliceReplacementFor, "test-old").
 					Obj()),
 				snap: &schdcache.Snapshot{
@@ -1242,7 +1243,7 @@ func TestReplacedWorkloadSlice(t *testing.T) {
 		"EdgeCase_ReplacedWorkloadIsNotFound_NotInClusterQueue": {
 			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			args: args{
-				wl: workload.NewInfo(utiltestingapi.MakeWorkload("test-new", "default").
+				wl: workload.NewInfo(log, utiltestingapi.MakeWorkload("test-new", "default").
 					Annotation(WorkloadSliceReplacementFor, "test-old").
 					Admission(utiltestingapi.MakeAdmission("default").Obj()).
 					Obj()),
@@ -1258,7 +1259,7 @@ func TestReplacedWorkloadSlice(t *testing.T) {
 		"ReplacedWorkloadIsFound": {
 			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			args: args{
-				wl: workload.NewInfo(utiltestingapi.MakeWorkload("test-new", "default").
+				wl: workload.NewInfo(log, utiltestingapi.MakeWorkload("test-new", "default").
 					Annotation(WorkloadSliceReplacementFor, "test-old").
 					Admission(utiltestingapi.MakeAdmission("default").Obj()).
 					Obj()),
@@ -1268,23 +1269,23 @@ func TestReplacedWorkloadSlice(t *testing.T) {
 						map[kueue.ClusterQueueReference]*schdcache.ClusterQueueSnapshot{
 							"default": {
 								Workloads: map[workload.Reference]*workload.Info{
-									"test-old": workload.NewInfo(utiltestingapi.MakeWorkload("test-old", "default").Obj()),
+									"test-old": workload.NewInfo(log, utiltestingapi.MakeWorkload("test-old", "default").Obj()),
 								},
 							},
 						}),
 				},
 			},
 			want: want{
-				wl: workload.NewInfo(utiltestingapi.MakeWorkload("test-old", "default").Obj()),
+				wl: workload.NewInfo(log, utiltestingapi.MakeWorkload("test-old", "default").Obj()),
 				targets: []*preemption.Target{
-					{WorkloadInfo: workload.NewInfo(utiltestingapi.MakeWorkload("test-old", "default").Obj())},
+					{WorkloadInfo: workload.NewInfo(log, utiltestingapi.MakeWorkload("test-old", "default").Obj())},
 				},
 			},
 		},
 		"CrossNamespaceReplacementIsRejected": {
 			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			args: args{
-				wl: workload.NewInfo(utiltestingapi.MakeWorkload("test-new", "other-ns").
+				wl: workload.NewInfo(log, utiltestingapi.MakeWorkload("test-new", "other-ns").
 					Annotation(WorkloadSliceReplacementFor, "default/test-old").
 					Admission(utiltestingapi.MakeAdmission("shared-cq").Obj()).
 					Obj()),
@@ -1294,7 +1295,7 @@ func TestReplacedWorkloadSlice(t *testing.T) {
 						map[kueue.ClusterQueueReference]*schdcache.ClusterQueueSnapshot{
 							"shared-cq": {
 								Workloads: map[workload.Reference]*workload.Info{
-									"default/test-old": workload.NewInfo(utiltestingapi.MakeWorkload("test-old", "default").Obj()),
+									"default/test-old": workload.NewInfo(log, utiltestingapi.MakeWorkload("test-old", "default").Obj()),
 								},
 							},
 						},

--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/component-base/metrics/testutil"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
@@ -1671,8 +1672,8 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing", "featur
 			util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 2)
 			util.ExpectReservingActiveWorkloadsMetric(cq1, 2)
 
-			wlHighAInfo := workload.NewInfo(wlHighA)
-			wlLowBInfo := workload.NewInfo(wlLowB)
+			wlHighAInfo := workload.NewInfo(ctrl.LoggerFrom(ctx), wlHighA)
+			wlLowBInfo := workload.NewInfo(ctrl.LoggerFrom(ctx), wlLowB)
 			ginkgo.By("Checking that the scheduler sees higher recent usage for lq-a")
 			gomega.Eventually(func(g gomega.Gomega) {
 				lqAUsage, err := wlHighAInfo.CalcLocalQueueFSUsage(


### PR DESCRIPTION
(cherry picked from commit 33290a4b29c4b95527c29c0a5cd20f4864b546f3)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

cheery-pick of https://github.com/kubernetes-sigs/kueue/pull/15064

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
