### PR TITLE
kueuectl: Skip listing all workloads when --for target is not found

### DIFF
--- a/cmd/kueuectl/app/list/list_workload.go
+++ b/cmd/kueuectl/app/list/list_workload.go
@@ -110,6 +110,9 @@ func NewWorkloadCmd(clientGetter clientgetter.ClientGetter, streams genericioopt
 			if err != nil {
 				return err
 			}
+			if len(o.UserSpecifiedForObject) > 0 && o.forObject == nil {
+				return nil
+			}
 			return o.Run(cmd.Context())
 		},
 	}

--- a/cmd/kueuectl/app/list/list_workload_test.go
+++ b/cmd/kueuectl/app/list/list_workload_test.go
@@ -999,6 +999,38 @@ metadata: {}
 			args:    []string{"--status", "unknown"},
 			wantErr: `invalid status value (unknown). Must be "all", "pending", "quotareserved", "admitted" or "finished"`,
 		},
+		"should print not found error and no workloads with missing resource filter target": {
+			args: []string{"--for", "job.batch/missing-job"},
+			apiResourceLists: []*metav1.APIResourceList{
+				{
+					GroupVersion: "batch/v1",
+					APIResources: []metav1.APIResource{
+						{
+							SingularName: "job",
+							Kind:         "Job",
+							Group:        "batch",
+						},
+					},
+				},
+			},
+			objs: []runtime.Object{
+				utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).
+					Label(constants.JobUIDLabel, "job-test-uid").
+					OwnerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job-test", "job-test-uid").
+					Queue("lq1").
+					Active(true).
+					Admission(utiltestingapi.MakeAdmission("cq1").Obj()).
+					Creation(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)).
+					Obj(),
+			},
+			mapperKinds: []schema.GroupVersionKind{
+				batchv1.SchemeGroupVersion.WithKind("Job"),
+			},
+			job: []runtime.Object{
+				&batchv1.JobList{},
+			},
+			wantOutErr: fmt.Sprintf("No resources found in %s namespace.\n", metav1.NamespaceDefault),
+		},
 		"should print not found error": {
 			wantOutErr: fmt.Sprintf("No resources found in %s namespace.\n", metav1.NamespaceDefault),
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`kueuectl list workload --for TYPE/NAME` with a name that does not exist printed "No resources found" and then listed every workload in the namespace. `Complete` returned nil without resolving the target, so `Run` never added the `kueue.x-k8s.io/job-uid` label selector and listed everything. This PR returns early when `--for` was specified but no object was resolved, matching the guard already used by `kueuectl list pods`.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

- `--for` is optional for `list workload`, so the guard also checks that `--for` was actually given; a plain `kueuectl list workload` still lists all workloads.

#### Does this PR introduce a user-facing change?

```release-note
kueuectl: Fixed a bug where `kueuectl list workload --for TYPE/NAME` listed all workloads in the namespace when the referenced resource did not exist. It now prints only "No resources found".
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## AI summary

Fixed `kueuectl list workload --for TYPE/NAME` so it does not list unrelated workloads when the target resource is missing. The command prints “No resources found” and exits successfully. Unfiltered workload listing remains unchanged.

### Suggested release note

CLI: Fixed a bug that caused `kueuectl list workload --for TYPE/NAME` to list all workloads when the referenced resource did not exist. Now the command prints “No resources found” instead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->