### PR TITLE
Fix minCount handling for elastic partial scale-up workloads

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1822,12 +1822,22 @@ func (r *JobReconciler) prepareWorkload(ctx context.Context, job GenericJob, wl 
 		return err
 	}
 
+	// Elastic jobs only get their elastic annotation in prepareWorkloadSlice, so it must run before
+	// clearUnusableMinCounts: MinCountsUsable recognizes elastic workloads by that annotation and
+	// would otherwise drop the minCounts of elastic partial scale-up workloads before the annotation
+	// exists to protect them.
+	workloadSliceEnabled := WorkloadSliceEnabled(job)
+	if workloadSliceEnabled {
+		if err := prepareWorkloadSlice(ctx, r.client, job, wl); err != nil {
+			return err
+		}
+	}
+
 	wl.Spec.PodSets = clearUnusableMinCounts(wl.Spec.PodSets, wl)
 
-	if WorkloadSliceEnabled(job) {
-		return prepareWorkloadSlice(ctx, r.client, job, wl)
+	if !workloadSliceEnabled {
+		wl.Spec.Active = active
 	}
-	wl.Spec.Active = active
 	return nil
 }
 

--- a/pkg/webhooks/workload_webhook.go
+++ b/pkg/webhooks/workload_webhook.go
@@ -66,8 +66,10 @@ func (w *WorkloadWebhook) Default(ctx context.Context, wl *kueue.Workload) error
 	log := ctrl.LoggerFrom(ctx).WithName("workload-webhook")
 	log.V(5).Info("Applying defaults")
 
-	// drop minCounts if PartialAdmission is not enabled
-	if !features.Enabled(features.PartialAdmission) {
+	// Drop minCounts unless a feature that honors them is enabled for this Workload: classic
+	// PartialAdmission, or elastic partial scale-up (KEP-12100) for elastic jobs. minCounts of a
+	// disabled feature must not reach the scheduler.
+	if !workload.MinCountsUsable(wl) {
 		for i := range wl.Spec.PodSets {
 			wl.Spec.PodSets[i].MinCount = nil
 		}
@@ -120,11 +122,18 @@ func ValidateWorkload(obj, oldObj *kueue.Workload) field.ErrorList {
 		}
 	}
 
-	if variableCountPodSets > 1 {
+	// KEP-12100 partial replica scale-up lets an elastic job that opted into the partial scale-up
+	// strategy produce Workloads with minCounts: the first slice carries one minCount podSet and
+	// scale-up probes carry several. Those shapes are only valid while the partial scale-up gate is
+	// on; otherwise the two rules below stay in force.
+	elasticPartialScaleUp := features.Enabled(features.ElasticJobsViaWorkloadSlicesWithPartialReplicaScaleUp) &&
+		workloadslicing.Enabled(obj)
+
+	if variableCountPodSets > 1 && !elasticPartialScaleUp {
 		allErrs = append(allErrs, field.Invalid(specPath.Child("podSets"), variableCountPodSets, "at most one podSet can use minCount"))
 	}
 
-	if variableCountPodSets > 0 && workloadslicing.Enabled(obj) {
+	if variableCountPodSets > 0 && !elasticPartialScaleUp && workloadslicing.Enabled(obj) {
 		allErrs = append(allErrs, field.Invalid(specPath.Child("podSets"), variableCountPodSets, "partial admission and elastic job cannot be used together"))
 	}
 

--- a/pkg/webhooks/workload_webhook.go
+++ b/pkg/webhooks/workload_webhook.go
@@ -122,10 +122,8 @@ func ValidateWorkload(obj, oldObj *kueue.Workload) field.ErrorList {
 		}
 	}
 
-	// KEP-12100 partial replica scale-up lets an elastic job that opted into the partial scale-up
-	// strategy produce Workloads with minCounts: the first slice carries one minCount podSet and
-	// scale-up probes carry several. Those shapes are only valid while the partial scale-up gate is
-	// on; otherwise the two rules below stay in force.
+	// KEP-12100: elastic partial scale-up allows elastic Workloads to use minCount podSets,
+	// so both checks below are skipped for them.
 	elasticPartialScaleUp := features.Enabled(features.ElasticJobsViaWorkloadSlicesWithPartialReplicaScaleUp) &&
 		workloadslicing.Enabled(obj)
 

--- a/pkg/webhooks/workload_webhook_test.go
+++ b/pkg/webhooks/workload_webhook_test.go
@@ -705,6 +705,46 @@ func TestValidateWorkload(t *testing.T) {
 				field.Invalid(specPath.Child("podSets"), 1, ""),
 			}.ToAggregate(),
 		},
+		"elastic partial scale-up first-create shape (one minCount podSet) is accepted": {
+			featureGates: map[featuregate.Feature]bool{
+				features.ElasticJobsViaWorkloadSlices:                          true,
+				features.ElasticJobsViaWorkloadSlicesWithPartialReplicaScaleUp: true,
+			},
+			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+				PodSets(*utiltestingapi.MakePodSet("main", 10).SetMinimumCount(5).Obj()).
+				Obj(),
+			wantErr: nil,
+		},
+		"elastic partial scale-up probe shape (multiple minCount podSets) is accepted": {
+			featureGates: map[featuregate.Feature]bool{
+				features.ElasticJobsViaWorkloadSlices:                          true,
+				features.ElasticJobsViaWorkloadSlicesWithPartialReplicaScaleUp: true,
+			},
+			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+				PodSets(
+					*utiltestingapi.MakePodSet("group-a", 10).SetMinimumCount(5).Obj(),
+					*utiltestingapi.MakePodSet("group-b", 10).SetMinimumCount(5).Obj(),
+				).
+				Obj(),
+			wantErr: nil,
+		},
+		"non-elastic multiple minCount podSets stay rejected with the partial scale-up gate on": {
+			featureGates: map[featuregate.Feature]bool{
+				features.ElasticJobsViaWorkloadSlices:                          true,
+				features.ElasticJobsViaWorkloadSlicesWithPartialReplicaScaleUp: true,
+			},
+			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("group-a", 10).SetMinimumCount(5).Obj(),
+					*utiltestingapi.MakePodSet("group-b", 10).SetMinimumCount(5).Obj(),
+				).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(specPath.Child("podSets"), 2, ""),
+			}.ToAggregate(),
+		},
 		"non-negative subGroupCount is accepted without warning": {
 			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).PodSets(
 				*utiltestingapi.MakePodSet("main", 1).SubGroupCount(new(int32(0))).Obj(),
@@ -1447,6 +1487,79 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.wantWarnings, gotWarnings); diff != "" {
 				t.Errorf("ValidateUpdate() warnings mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestWorkloadWebhookDefault(t *testing.T) {
+	elasticWorkload := func() *kueue.Workload {
+		return utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+			Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			PodSets(*utiltestingapi.MakePodSet("main", 10).SetMinimumCount(5).Obj()).
+			Obj()
+	}
+	plainWorkload := func() *kueue.Workload {
+		return utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+			PodSets(*utiltestingapi.MakePodSet("main", 10).SetMinimumCount(5).Obj()).
+			Obj()
+	}
+
+	cases := map[string]struct {
+		featureGates map[featuregate.Feature]bool
+		workload     *kueue.Workload
+		wantCleared  bool
+	}{
+		"PartialAdmission off, plain workload: minCount cleared": {
+			featureGates: map[featuregate.Feature]bool{features.PartialAdmission: false},
+			workload:     plainWorkload(),
+			wantCleared:  true,
+		},
+		"PartialAdmission on, plain workload: minCount kept": {
+			featureGates: map[featuregate.Feature]bool{features.PartialAdmission: true},
+			workload:     plainWorkload(),
+			wantCleared:  false,
+		},
+		"PartialAdmission off, partial scale-up on, elastic workload: minCount kept": {
+			featureGates: map[featuregate.Feature]bool{
+				features.PartialAdmission:                                      false,
+				features.ElasticJobsViaWorkloadSlices:                          true,
+				features.ElasticJobsViaWorkloadSlicesWithPartialReplicaScaleUp: true,
+			},
+			workload:    elasticWorkload(),
+			wantCleared: false,
+		},
+		"PartialAdmission off, partial scale-up off, elastic workload: minCount cleared": {
+			featureGates: map[featuregate.Feature]bool{
+				features.PartialAdmission:                                      false,
+				features.ElasticJobsViaWorkloadSlices:                          true,
+				features.ElasticJobsViaWorkloadSlicesWithPartialReplicaScaleUp: false,
+			},
+			workload:    elasticWorkload(),
+			wantCleared: true,
+		},
+		"PartialAdmission off, partial scale-up on, plain workload: minCount cleared": {
+			featureGates: map[featuregate.Feature]bool{
+				features.PartialAdmission:                                      false,
+				features.ElasticJobsViaWorkloadSlices:                          true,
+				features.ElasticJobsViaWorkloadSlicesWithPartialReplicaScaleUp: true,
+			},
+			workload:    plainWorkload(),
+			wantCleared: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
+			wl := tc.workload.DeepCopy()
+			if err := (&WorkloadWebhook{}).Default(t.Context(), wl); err != nil {
+				t.Fatalf("Default() returned error: %v", err)
+			}
+			for _, ps := range wl.Spec.PodSets {
+				if cleared := ps.MinCount == nil; cleared != tc.wantCleared {
+					t.Errorf("podSet %q: minCount cleared = %v, want %v", ps.Name, cleared, tc.wantCleared)
+				}
 			}
 		})
 	}

--- a/test/integration/singlecluster/controller/jobs/rayclusterwebhook/elastic_partial_scaleup_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayclusterwebhook/elastic_partial_scaleup_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/integration/singlecluster/controller/jobs/rayclusterwebhook/elastic_partial_scaleup_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayclusterwebhook/elastic_partial_scaleup_test.go
@@ -1,0 +1,349 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rayclusterwebhook
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	corev1 "k8s.io/api/core/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/constants"
+	"sigs.k8s.io/kueue/pkg/features"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	testingraycluster "sigs.k8s.io/kueue/pkg/util/testingjobs/raycluster"
+	"sigs.k8s.io/kueue/pkg/workload"
+	workloadfinish "sigs.k8s.io/kueue/pkg/workload/finish"
+	"sigs.k8s.io/kueue/pkg/workloadslicing"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+// Regression coverage for KEP-12100 partial replica scale-up with production wiring: the
+// RayCluster reconciler, the Workload webhooks, the scheduler and the API server all run together
+// in the same process (exactly how a deployed kueue-manager is wired, modulo container packaging).
+// This is the scenario a production user hits when they enable the feature for an elastic
+// RayCluster. See https://github.com/kubernetes-sigs/kueue/issues/15249.
+
+// podSetForWorkerGroup returns the Workload podSet that corresponds to a RayCluster worker
+// group, resolving the name the same way the RayCluster integration does.
+func podSetForWorkerGroup(wl *kueue.Workload, groupName string) *kueue.PodSet {
+	podSetName := kueue.NewPodSetReference(groupName)
+	for i := range wl.Spec.PodSets {
+		if wl.Spec.PodSets[i].Name == podSetName {
+			return &wl.Spec.PodSets[i]
+		}
+	}
+	return nil
+}
+
+// expectWorkloadAdmitted waits until the given Workload holds a quota reservation and is admitted.
+func expectWorkloadAdmitted(obj client.Object) {
+	gomega.Eventually(func(g gomega.Gomega) {
+		var wl kueue.Workload
+		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(obj), &wl)).Should(gomega.Succeed())
+		g.Expect(workload.IsAdmitted(&wl)).Should(gomega.BeTrue())
+	}, util.Timeout, util.Interval).Should(gomega.Succeed())
+}
+
+var _ = ginkgo.Describe("KEP-12100 partial scale-up RayCluster end to end (PartialAdmission on)", ginkgo.Ordered, func() {
+	var (
+		ns             *corev1.Namespace
+		resourceFlavor *kueue.ResourceFlavor
+		clusterQueue   *kueue.ClusterQueue
+		localQueue     *kueue.LocalQueue
+	)
+
+	ginkgo.BeforeAll(func() {
+		gomega.Expect(utilfeature.DefaultMutableFeatureGate.SetFromMap(map[string]bool{
+			string(features.ElasticJobsViaWorkloadSlices):                          true,
+			string(features.ElasticJobsViaWorkloadSlicesWithPartialReplicaScaleUp): true,
+			string(features.PartialAdmission):                                      true,
+		})).Should(gomega.Succeed())
+		fwk.StartManager(ctx, cfg, managerAndSchedulerSetup())
+	})
+	ginkgo.AfterAll(func() {
+		fwk.StopManager(ctx)
+		gomega.Expect(utilfeature.DefaultMutableFeatureGate.SetFromMap(map[string]bool{
+			string(features.ElasticJobsViaWorkloadSlices):                          false,
+			string(features.ElasticJobsViaWorkloadSlicesWithPartialReplicaScaleUp): false,
+		})).Should(gomega.Succeed())
+	})
+
+	ginkgo.BeforeEach(func() {
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "core-")
+
+		resourceFlavor = utiltestingapi.MakeResourceFlavor("default").Obj()
+		util.MustCreate(ctx, k8sClient, resourceFlavor)
+
+		clusterQueue = utiltestingapi.MakeClusterQueue("default").
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas(resourceFlavor.Name).Resource(corev1.ResourceCPU, "6").Obj()).
+			Obj()
+		util.MustCreate(ctx, k8sClient, clusterQueue)
+
+		localQueue = utiltestingapi.MakeLocalQueue("default", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+		util.MustCreate(ctx, k8sClient, localQueue)
+	})
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, localQueue, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, resourceFlavor, true)
+	})
+
+	ginkgo.It("creates a Workload for the elastic partial scale-up RayCluster and keeps the partial minCount", func() {
+		testRayCluster := testingraycluster.MakeCluster("partial-scale-up", ns.Name).
+			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			SetAnnotation(constants.ElasticJobScaleUpStrategyAnnotationKey, constants.ElasticJobScaleUpStrategyPartial).
+			Queue(localQueue.Name).
+			Request(rayv1.HeadNode, corev1.ResourceCPU, "1").
+			RequestWorkerGroup(corev1.ResourceCPU, "1").
+			Obj()
+
+		ginkgo.By("creating the elastic RayCluster with the partial scale-up strategy")
+		util.MustCreate(ctx, k8sClient, testRayCluster)
+
+		ginkgo.By("a Workload is created for the RayCluster")
+		var wl kueue.Workload
+		gomega.Eventually(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+			g.Expect(workloads.Items).Should(gomega.HaveLen(1))
+			wl = workloads.Items[0]
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("the Workload is elastic and the worker podSet keeps the partial minCount")
+		gomega.Expect(wl.Annotations[workloadslicing.EnabledAnnotationKey]).Should(gomega.Equal(workloadslicing.EnabledAnnotationValue))
+		workerPS := podSetForWorkerGroup(&wl, "workers-group-0")
+		gomega.Expect(workerPS).ShouldNot(gomega.BeNil())
+		gomega.Expect(workerPS.MinCount).ShouldNot(gomega.BeNil())
+		gomega.Expect(*workerPS.MinCount).Should(gomega.Equal(workerPS.Count))
+		ginkgo.By("the Workload is admitted by the scheduler")
+		expectWorkloadAdmitted(&wl)
+	})
+
+	ginkgo.It("keeps minCount on every worker podSet when the RayCluster has multiple worker groups", func() {
+		testRayCluster := testingraycluster.MakeCluster("partial-scale-up-multi", ns.Name).
+			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			SetAnnotation(constants.ElasticJobScaleUpStrategyAnnotationKey, constants.ElasticJobScaleUpStrategyPartial).
+			Queue(localQueue.Name).
+			Request(rayv1.HeadNode, corev1.ResourceCPU, "1").
+			RequestWorkerGroup(corev1.ResourceCPU, "1").
+			Obj()
+
+		ginkgo.By("adding a second worker group")
+		secondWorker := testRayCluster.Spec.WorkerGroupSpecs[0].DeepCopy()
+		secondWorker.GroupName = "workers-group-1"
+		secondWorkerReplicas := int32(2)
+		secondWorker.Replicas = &secondWorkerReplicas
+		testRayCluster.Spec.WorkerGroupSpecs = append(testRayCluster.Spec.WorkerGroupSpecs, *secondWorker)
+
+		ginkgo.By("creating the elastic RayCluster with the partial scale-up strategy")
+		util.MustCreate(ctx, k8sClient, testRayCluster)
+
+		ginkgo.By("a Workload with one podSet per group is created")
+		var wl kueue.Workload
+		gomega.Eventually(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+			g.Expect(workloads.Items).Should(gomega.HaveLen(1))
+			wl = workloads.Items[0]
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("every worker podSet keeps its partial minCount")
+		for _, groupName := range []string{"workers-group-0", "workers-group-1"} {
+			workerPS := podSetForWorkerGroup(&wl, groupName)
+			gomega.Expect(workerPS).ShouldNot(gomega.BeNil())
+			gomega.Expect(workerPS.MinCount).ShouldNot(gomega.BeNil())
+			gomega.Expect(*workerPS.MinCount).Should(gomega.Equal(workerPS.Count))
+		}
+		ginkgo.By("the Workload is admitted by the scheduler")
+		expectWorkloadAdmitted(&wl)
+	})
+
+	ginkgo.It("scales an admitted elastic RayCluster up through a partial scale-up probe slice", func() {
+		testRayCluster := testingraycluster.MakeCluster("partial-scale-up-probe", ns.Name).
+			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			SetAnnotation(constants.ElasticJobScaleUpStrategyAnnotationKey, constants.ElasticJobScaleUpStrategyPartial).
+			Queue(localQueue.Name).
+			Request(rayv1.HeadNode, corev1.ResourceCPU, "1").
+			RequestWorkerGroup(corev1.ResourceCPU, "1").
+			ScaleFirstWorkerGroup(1).
+			Obj()
+
+		ginkgo.By("creating the elastic RayCluster with one worker replica")
+		util.MustCreate(ctx, k8sClient, testRayCluster)
+
+		ginkgo.By("the initial Workload slice is admitted")
+		var firstWl kueue.Workload
+		gomega.Eventually(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+			g.Expect(workloads.Items).Should(gomega.HaveLen(1))
+			firstWl = workloads.Items[0]
+			g.Expect(workload.IsAdmitted(&firstWl)).Should(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("scaling the worker replicas from 1 to 4")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testRayCluster), testRayCluster)).Should(gomega.Succeed())
+			testRayCluster.Spec.WorkerGroupSpecs[0].Replicas = ptr.To[int32](4)
+			g.Expect(k8sClient.Update(ctx, testRayCluster)).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("the probe slice replaces the initial slice and is admitted")
+		var newWl kueue.Workload
+		gomega.Eventually(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+			g.Expect(workloads.Items).Should(gomega.HaveLen(2))
+
+			finishedOld := false
+			admittedNew := false
+			for i := range workloads.Items {
+				slice := &workloads.Items[i]
+				if workloadfinish.IsFinished(slice) {
+					finishedOld = true
+					g.Expect(slice.Name).Should(gomega.Equal(firstWl.Name))
+				} else {
+					admittedNew = true
+					g.Expect(workload.IsAdmitted(slice)).Should(gomega.BeTrue())
+					newWl = *slice
+				}
+			}
+			g.Expect(finishedOld && admittedNew).Should(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("the probe slice is linked to the initial slice and carries the partial minCount")
+		gomega.Expect(newWl.Annotations[workloadslicing.WorkloadSliceReplacementFor]).Should(gomega.Equal(string(workload.Key(&firstWl))))
+		gomega.Expect(newWl.Annotations[kueue.WorkloadSliceNameAnnotation]).ShouldNot(gomega.BeEmpty())
+		workerPS := podSetForWorkerGroup(&newWl, "workers-group-0")
+		gomega.Expect(workerPS).ShouldNot(gomega.BeNil())
+		gomega.Expect(workerPS.Count).Should(gomega.Equal(int32(4)))
+		gomega.Expect(workerPS.MinCount).ShouldNot(gomega.BeNil())
+		gomega.Expect(*workerPS.MinCount).Should(gomega.Equal(int32(2)))
+	})
+
+	ginkgo.It("control: a plain elastic RayCluster (no partial strategy) still gets its Workload created", func() {
+		testRayCluster := testingraycluster.MakeCluster("plain-elastic", ns.Name).
+			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			Queue(localQueue.Name).
+			Request(rayv1.HeadNode, corev1.ResourceCPU, "1").
+			RequestWorkerGroup(corev1.ResourceCPU, "1").
+			Obj()
+
+		ginkgo.By("creating the elastic RayCluster without the partial scale-up strategy")
+		util.MustCreate(ctx, k8sClient, testRayCluster)
+
+		ginkgo.By("the Workload is created and carries no minCount")
+		var wl kueue.Workload
+		gomega.Eventually(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+			g.Expect(workloads.Items).Should(gomega.HaveLen(1))
+			wl = workloads.Items[0]
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		gomega.Expect(wl.Annotations[workloadslicing.EnabledAnnotationKey]).Should(gomega.Equal(workloadslicing.EnabledAnnotationValue))
+		for i := range wl.Spec.PodSets {
+			gomega.Expect(wl.Spec.PodSets[i].MinCount).Should(gomega.BeNil())
+		}
+		ginkgo.By("the Workload is admitted by the scheduler")
+		expectWorkloadAdmitted(&wl)
+	})
+})
+
+// With PartialAdmission off, minCounts are only honored for elastic partial scale-up workloads.
+// The reconciler must attach the elastic annotation before it decides whether minCounts are usable,
+// and the mutating webhook must not wipe them; otherwise the partial scale-up feature silently
+// degrades to an atomic workload even though its feature gate is on.
+var _ = ginkgo.Describe("KEP-12100 partial scale-up RayCluster end to end (PartialAdmission off)", ginkgo.Ordered, func() {
+	var (
+		ns             *corev1.Namespace
+		resourceFlavor *kueue.ResourceFlavor
+		clusterQueue   *kueue.ClusterQueue
+		localQueue     *kueue.LocalQueue
+	)
+
+	ginkgo.BeforeAll(func() {
+		gomega.Expect(utilfeature.DefaultMutableFeatureGate.SetFromMap(map[string]bool{
+			string(features.ElasticJobsViaWorkloadSlices):                          true,
+			string(features.ElasticJobsViaWorkloadSlicesWithPartialReplicaScaleUp): true,
+			string(features.PartialAdmission):                                      false,
+		})).Should(gomega.Succeed())
+		fwk.StartManager(ctx, cfg, managerAndSchedulerSetup())
+	})
+	ginkgo.AfterAll(func() {
+		fwk.StopManager(ctx)
+		gomega.Expect(utilfeature.DefaultMutableFeatureGate.SetFromMap(map[string]bool{
+			string(features.ElasticJobsViaWorkloadSlices):                          false,
+			string(features.ElasticJobsViaWorkloadSlicesWithPartialReplicaScaleUp): false,
+			string(features.PartialAdmission):                                      true,
+		})).Should(gomega.Succeed())
+	})
+
+	ginkgo.BeforeEach(func() {
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "core-")
+
+		resourceFlavor = utiltestingapi.MakeResourceFlavor("default").Obj()
+		util.MustCreate(ctx, k8sClient, resourceFlavor)
+
+		clusterQueue = utiltestingapi.MakeClusterQueue("default").
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas(resourceFlavor.Name).Resource(corev1.ResourceCPU, "6").Obj()).
+			Obj()
+		util.MustCreate(ctx, k8sClient, clusterQueue)
+
+		localQueue = utiltestingapi.MakeLocalQueue("default", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+		util.MustCreate(ctx, k8sClient, localQueue)
+	})
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, localQueue, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, resourceFlavor, true)
+	})
+
+	ginkgo.It("keeps the partial minCount on the created Workload", func() {
+		testRayCluster := testingraycluster.MakeCluster("partial-scale-up", ns.Name).
+			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			SetAnnotation(constants.ElasticJobScaleUpStrategyAnnotationKey, constants.ElasticJobScaleUpStrategyPartial).
+			Queue(localQueue.Name).
+			Request(rayv1.HeadNode, corev1.ResourceCPU, "1").
+			RequestWorkerGroup(corev1.ResourceCPU, "1").
+			Obj()
+
+		ginkgo.By("creating the elastic RayCluster with the partial scale-up strategy")
+		util.MustCreate(ctx, k8sClient, testRayCluster)
+
+		ginkgo.By("a Workload is created and the worker podSet still carries the partial minCount")
+		var wl kueue.Workload
+		gomega.Eventually(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+			g.Expect(workloads.Items).Should(gomega.HaveLen(1))
+			wl = workloads.Items[0]
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		workerPS := podSetForWorkerGroup(&wl, "workers-group-0")
+		gomega.Expect(workerPS).ShouldNot(gomega.BeNil())
+		gomega.Expect(workerPS.MinCount).ShouldNot(gomega.BeNil())
+		gomega.Expect(*workerPS.MinCount).Should(gomega.Equal(workerPS.Count))
+		ginkgo.By("the Workload is admitted by the scheduler")
+		expectWorkloadAdmitted(&wl)
+	})
+})

--- a/test/integration/singlecluster/controller/jobs/rayclusterwebhook/elastic_partial_scaleup_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayclusterwebhook/elastic_partial_scaleup_test.go
@@ -63,7 +63,7 @@ func expectWorkloadAdmitted(obj client.Object) {
 	}, util.Timeout, util.Interval).Should(gomega.Succeed())
 }
 
-var _ = ginkgo.Describe("KEP-12100 partial scale-up RayCluster end to end (PartialAdmission on)", ginkgo.Ordered, func() {
+var _ = ginkgo.Describe("KEP-12100 partial scale-up RayCluster end to end (PartialAdmission on)", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	var (
 		ns             *corev1.Namespace
 		resourceFlavor *kueue.ResourceFlavor
@@ -81,10 +81,6 @@ var _ = ginkgo.Describe("KEP-12100 partial scale-up RayCluster end to end (Parti
 	})
 	ginkgo.AfterAll(func() {
 		fwk.StopManager(ctx)
-		gomega.Expect(utilfeature.DefaultMutableFeatureGate.SetFromMap(map[string]bool{
-			string(features.ElasticJobsViaWorkloadSlices):                          false,
-			string(features.ElasticJobsViaWorkloadSlicesWithPartialReplicaScaleUp): false,
-		})).Should(gomega.Succeed())
 	})
 
 	ginkgo.BeforeEach(func() {
@@ -273,7 +269,7 @@ var _ = ginkgo.Describe("KEP-12100 partial scale-up RayCluster end to end (Parti
 // The reconciler must attach the elastic annotation before it decides whether minCounts are usable,
 // and the mutating webhook must not wipe them; otherwise the partial scale-up feature silently
 // degrades to an atomic workload even though its feature gate is on.
-var _ = ginkgo.Describe("KEP-12100 partial scale-up RayCluster end to end (PartialAdmission off)", ginkgo.Ordered, func() {
+var _ = ginkgo.Describe("KEP-12100 partial scale-up RayCluster end to end (PartialAdmission off)", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	var (
 		ns             *corev1.Namespace
 		resourceFlavor *kueue.ResourceFlavor
@@ -291,11 +287,6 @@ var _ = ginkgo.Describe("KEP-12100 partial scale-up RayCluster end to end (Parti
 	})
 	ginkgo.AfterAll(func() {
 		fwk.StopManager(ctx)
-		gomega.Expect(utilfeature.DefaultMutableFeatureGate.SetFromMap(map[string]bool{
-			string(features.ElasticJobsViaWorkloadSlices):                          false,
-			string(features.ElasticJobsViaWorkloadSlicesWithPartialReplicaScaleUp): false,
-			string(features.PartialAdmission):                                      true,
-		})).Should(gomega.Succeed())
 	})
 
 	ginkgo.BeforeEach(func() {

--- a/test/integration/singlecluster/controller/jobs/rayclusterwebhook/elastic_partial_scaleup_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayclusterwebhook/elastic_partial_scaleup_test.go
@@ -28,6 +28,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/util/podset"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingraycluster "sigs.k8s.io/kueue/pkg/util/testingjobs/raycluster"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -41,18 +42,6 @@ import (
 // in the same process (exactly how a deployed kueue-manager is wired, modulo container packaging).
 // This is the scenario a production user hits when they enable the feature for an elastic
 // RayCluster. See https://github.com/kubernetes-sigs/kueue/issues/15249.
-
-// podSetForWorkerGroup returns the Workload podSet that corresponds to a RayCluster worker
-// group, resolving the name the same way the RayCluster integration does.
-func podSetForWorkerGroup(wl *kueue.Workload, groupName string) *kueue.PodSet {
-	podSetName := kueue.NewPodSetReference(groupName)
-	for i := range wl.Spec.PodSets {
-		if wl.Spec.PodSets[i].Name == podSetName {
-			return &wl.Spec.PodSets[i]
-		}
-	}
-	return nil
-}
 
 // expectWorkloadAdmitted waits until the given Workload holds a quota reservation and is admitted.
 func expectWorkloadAdmitted(obj client.Object) {
@@ -127,7 +116,7 @@ var _ = ginkgo.Describe("KEP-12100 partial scale-up RayCluster end to end (Parti
 
 		ginkgo.By("the Workload is elastic and the worker podSet keeps the partial minCount")
 		gomega.Expect(wl.Annotations[workloadslicing.EnabledAnnotationKey]).Should(gomega.Equal(workloadslicing.EnabledAnnotationValue))
-		workerPS := podSetForWorkerGroup(&wl, "workers-group-0")
+		workerPS := podset.FindPodSetByName(wl.Spec.PodSets, kueue.NewPodSetReference("workers-group-0"))
 		gomega.Expect(workerPS).ShouldNot(gomega.BeNil())
 		gomega.Expect(workerPS.MinCount).ShouldNot(gomega.BeNil())
 		gomega.Expect(*workerPS.MinCount).Should(gomega.Equal(workerPS.Count))
@@ -165,7 +154,7 @@ var _ = ginkgo.Describe("KEP-12100 partial scale-up RayCluster end to end (Parti
 
 		ginkgo.By("every worker podSet keeps its partial minCount")
 		for _, groupName := range []string{"workers-group-0", "workers-group-1"} {
-			workerPS := podSetForWorkerGroup(&wl, groupName)
+			workerPS := podset.FindPodSetByName(wl.Spec.PodSets, kueue.NewPodSetReference(groupName))
 			gomega.Expect(workerPS).ShouldNot(gomega.BeNil())
 			gomega.Expect(workerPS.MinCount).ShouldNot(gomega.BeNil())
 			gomega.Expect(*workerPS.MinCount).Should(gomega.Equal(workerPS.Count))
@@ -207,30 +196,29 @@ var _ = ginkgo.Describe("KEP-12100 partial scale-up RayCluster end to end (Parti
 		ginkgo.By("the probe slice replaces the initial slice and is admitted")
 		var newWl kueue.Workload
 		gomega.Eventually(func(g gomega.Gomega) {
-			workloads := &kueue.WorkloadList{}
-			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+			var workloads kueue.WorkloadList
+			g.Expect(k8sClient.List(ctx, &workloads, client.InNamespace(ns.Name))).Should(gomega.Succeed())
 			g.Expect(workloads.Items).Should(gomega.HaveLen(2))
-
-			finishedOld := false
-			admittedNew := false
 			for i := range workloads.Items {
-				slice := &workloads.Items[i]
-				if workloadfinish.IsFinished(slice) {
-					finishedOld = true
-					g.Expect(slice.Name).Should(gomega.Equal(firstWl.Name))
-				} else {
-					admittedNew = true
-					g.Expect(workload.IsAdmitted(slice)).Should(gomega.BeTrue())
-					newWl = *slice
+				if workloads.Items[i].Name == firstWl.Name {
+					continue
 				}
+				g.Expect(workload.IsAdmitted(&workloads.Items[i])).Should(gomega.BeTrue())
+				newWl = workloads.Items[i]
 			}
-			g.Expect(finishedOld && admittedNew).Should(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("the initial slice is marked finished")
+		gomega.Eventually(func(g gomega.Gomega) {
+			var oldWl kueue.Workload
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&firstWl), &oldWl)).Should(gomega.Succeed())
+			g.Expect(workloadfinish.IsFinished(&oldWl)).Should(gomega.BeTrue())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 		ginkgo.By("the probe slice is linked to the initial slice and carries the partial minCount")
 		gomega.Expect(newWl.Annotations[workloadslicing.WorkloadSliceReplacementFor]).Should(gomega.Equal(string(workload.Key(&firstWl))))
 		gomega.Expect(newWl.Annotations[kueue.WorkloadSliceNameAnnotation]).ShouldNot(gomega.BeEmpty())
-		workerPS := podSetForWorkerGroup(&newWl, "workers-group-0")
+		workerPS := podset.FindPodSetByName(newWl.Spec.PodSets, kueue.NewPodSetReference("workers-group-0"))
 		gomega.Expect(workerPS).ShouldNot(gomega.BeNil())
 		gomega.Expect(workerPS.Count).Should(gomega.Equal(int32(4)))
 		gomega.Expect(workerPS.MinCount).ShouldNot(gomega.BeNil())
@@ -330,7 +318,7 @@ var _ = ginkgo.Describe("KEP-12100 partial scale-up RayCluster end to end (Parti
 			g.Expect(workloads.Items).Should(gomega.HaveLen(1))
 			wl = workloads.Items[0]
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-		workerPS := podSetForWorkerGroup(&wl, "workers-group-0")
+		workerPS := podset.FindPodSetByName(wl.Spec.PodSets, kueue.NewPodSetReference("workers-group-0"))
 		gomega.Expect(workerPS).ShouldNot(gomega.BeNil())
 		gomega.Expect(workerPS.MinCount).ShouldNot(gomega.BeNil())
 		gomega.Expect(*workerPS.MinCount).Should(gomega.Equal(workerPS.Count))

--- a/test/integration/singlecluster/controller/jobs/rayclusterwebhook/suite_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayclusterwebhook/suite_test.go
@@ -36,7 +36,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	jobcontrollers "sigs.k8s.io/kueue/pkg/controller/jobs"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/raycluster"
-	"sigs.k8s.io/kueue/pkg/controller/jobs/rayjob"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/scheduler"
 	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
@@ -73,33 +72,6 @@ var _ = ginkgo.AfterSuite(func() {
 	fwk.Teardown()
 })
 
-func managerSetup(opts ...jobframework.Option) framework.ManagerSetup {
-	return func(ctx context.Context, mgr manager.Manager) {
-		integrationManager := jobcontrollers.NewIntegrationManager()
-		opts = append(opts, jobframework.WithIntegrationManager(integrationManager))
-		reconciler, err := raycluster.NewReconciler(
-			ctx,
-			mgr.GetClient(),
-			mgr.GetFieldIndexer(),
-			mgr.GetEventRecorder(constants.JobControllerName),
-			opts...)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		err = indexer.Setup(ctx, mgr.GetFieldIndexer())
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		err = raycluster.SetupIndexes(ctx, mgr.GetFieldIndexer())
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		err = rayjob.SetupIndexes(ctx, mgr.GetFieldIndexer())
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		err = reconciler.SetupWithManager(mgr)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		err = raycluster.SetupRayClusterWebhook(mgr, opts...)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		failedWebhook, err := webhooks.Setup(mgr, nil)
-		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
-		integrationManager.EnableIntegration(rayjob.FrameworkName)
-	}
-}
-
 func managerAndSchedulerSetup(opts ...jobframework.Option) framework.ManagerSetup {
 	return func(ctx context.Context, mgr manager.Manager) {
 		// Production wiring: the RayCluster (defaulting/validating) webhooks need
@@ -131,9 +103,10 @@ func managerAndSchedulerSetup(opts ...jobframework.Option) framework.ManagerSetu
 
 		err = raycluster.SetupIndexes(ctx, mgr.GetFieldIndexer())
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		r, _ := raycluster.NewReconciler(ctx, mgr.GetClient(), mgr.GetFieldIndexer(),
+		r, err := raycluster.NewReconciler(ctx, mgr.GetClient(), mgr.GetFieldIndexer(),
 			mgr.GetEventRecorder(constants.JobControllerName), opts...)
-		_ = r.SetupWithManager(mgr)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = r.SetupWithManager(mgr)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		err = raycluster.SetupRayClusterWebhook(mgr, opts...)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/test/integration/singlecluster/controller/jobs/rayclusterwebhook/suite_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayclusterwebhook/suite_test.go
@@ -14,6 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package rayclusterwebhook holds the end-to-end integration suite for elastic partial
+// scale-up (KEP-12100) on RayClusters, running the RayCluster reconciler, the Workload
+// webhooks, the elastic-jobs controllers and the scheduler together against real webhook
+// configurations, exactly like a deployed kueue-manager.
+//
+// The suite is a separate package because this scenario needs the real mutating Workload
+// webhook: it is the component that must preserve the minCounts the reconciler attaches to
+// the prepared workload slice (and would erase them if the annotation ordering regressed).
+// The existing raycluster controller suite installs no webhook configurations, and enabling
+// the full webhook manifest there fails every create with unregistered job webhook handlers
+// (e.g. mrayjob.kb.io); the webhook/core suite covers Workload shapes only and never goes
+// through the RayCluster reconciler.
 package rayclusterwebhook
 
 import (

--- a/test/integration/singlecluster/controller/jobs/rayclusterwebhook/suite_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayclusterwebhook/suite_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rayclusterwebhook
+
+import (
+	"context"
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	config "sigs.k8s.io/kueue/apis/config/v1beta2"
+	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
+	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	"sigs.k8s.io/kueue/pkg/constants"
+	"sigs.k8s.io/kueue/pkg/controller/core"
+	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
+	"sigs.k8s.io/kueue/pkg/controller/elasticjobs"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	jobcontrollers "sigs.k8s.io/kueue/pkg/controller/jobs"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/raycluster"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/rayjob"
+	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/scheduler"
+	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
+	"sigs.k8s.io/kueue/pkg/webhooks"
+	"sigs.k8s.io/kueue/test/integration/framework"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	ctx       context.Context
+	fwk       *framework.Framework
+)
+
+func TestAPIs(t *testing.T) {
+	util.RunSuite(t, "RayCluster Elastic Partial Scale-Up Suite (Production Wiring)")
+}
+
+var _ = ginkgo.BeforeSuite(func() {
+	fwk = &framework.Framework{
+		DepCRDPaths: []string{util.RayOperatorCrds},
+		// Production wiring: install the real webhook configurations so that
+		// Workload creates go through the validating webhook exactly like in a
+		// deployed kueue-manager.
+		WebhookPath: util.WebhookPath,
+	}
+
+	cfg = fwk.Init()
+	ctx, k8sClient = fwk.SetupClient(cfg)
+})
+
+var _ = ginkgo.AfterSuite(func() {
+	fwk.Teardown()
+})
+
+func managerSetup(opts ...jobframework.Option) framework.ManagerSetup {
+	return func(ctx context.Context, mgr manager.Manager) {
+		integrationManager := jobcontrollers.NewIntegrationManager()
+		opts = append(opts, jobframework.WithIntegrationManager(integrationManager))
+		reconciler, err := raycluster.NewReconciler(
+			ctx,
+			mgr.GetClient(),
+			mgr.GetFieldIndexer(),
+			mgr.GetEventRecorder(constants.JobControllerName),
+			opts...)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = indexer.Setup(ctx, mgr.GetFieldIndexer())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = raycluster.SetupIndexes(ctx, mgr.GetFieldIndexer())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = rayjob.SetupIndexes(ctx, mgr.GetFieldIndexer())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = reconciler.SetupWithManager(mgr)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = raycluster.SetupRayClusterWebhook(mgr, opts...)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		failedWebhook, err := webhooks.Setup(mgr, nil)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
+		integrationManager.EnableIntegration(rayjob.FrameworkName)
+	}
+}
+
+func managerAndSchedulerSetup(opts ...jobframework.Option) framework.ManagerSetup {
+	return func(ctx context.Context, mgr manager.Manager) {
+		// Production wiring: the RayCluster (defaulting/validating) webhooks need
+		// the full jobframework options (integration manager, queues, cache) to
+		// avoid nil dereferences when the API server actually calls them.
+		integrationManager := jobcontrollers.NewIntegrationManager()
+		opts = append(opts, jobframework.WithIntegrationManager(integrationManager))
+
+		err := indexer.Setup(ctx, mgr.GetFieldIndexer())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		cCache := schdcache.New(mgr.GetClient())
+		preemptionExpectations := preemptexpectations.New()
+		queueOptions := []qcache.Option{qcache.WithPreemptionExpectations(preemptionExpectations)}
+		queues := util.NewManagerForIntegrationTests(ctx, mgr.GetClient(), cCache, queueOptions...)
+		opts = append(opts, jobframework.WithQueues(queues), jobframework.WithCache(cCache))
+
+		failedCtrl, err := core.SetupControllers(
+			mgr,
+			queues,
+			cCache,
+			&config.Configuration{},
+			core.SetupControllersOpts{PreemptionExpectations: preemptionExpectations},
+		)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
+
+		failedWebhook, err := webhooks.Setup(mgr, nil)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
+
+		err = raycluster.SetupIndexes(ctx, mgr.GetFieldIndexer())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		r, _ := raycluster.NewReconciler(ctx, mgr.GetClient(), mgr.GetFieldIndexer(),
+			mgr.GetEventRecorder(constants.JobControllerName), opts...)
+		_ = r.SetupWithManager(mgr)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = raycluster.SetupRayClusterWebhook(mgr, opts...)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		if features.Enabled(features.ElasticJobsViaWorkloadSlices) {
+			failedCtrl, err := elasticjobs.SetupWithManager(mgr, &config.Configuration{}, nil)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
+		}
+
+		sched := scheduler.New(
+			queues,
+			cCache,
+			mgr.GetClient(),
+			mgr.GetEventRecorder(constants.AdmissionName),
+			scheduler.WithPreemptionExpectations(preemptionExpectations),
+		)
+		err = sched.Start(ctx)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}
+}

--- a/test/integration/singlecluster/webhook/core/elastic_partial_scaleup_test.go
+++ b/test/integration/singlecluster/webhook/core/elastic_partial_scaleup_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/integration/singlecluster/webhook/core/elastic_partial_scaleup_test.go
+++ b/test/integration/singlecluster/webhook/core/elastic_partial_scaleup_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/kueue/pkg/features"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/pkg/workloadslicing"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+// Regression coverage for the KEP-12100 partial scale-up Workload shapes.
+//
+// The elastic-job reconcilers (e.g. the RayCluster controller with the
+// ElasticJobScaleUpStrategy=partial annotation) produce Workloads that carry
+// the workload-slicing enabled annotation together with podSets that set
+// minCount. This suite exercises the real API server with the Workload
+// mutating and validating webhooks installed (see util.WebhookPath in the
+// suite setup): those shapes must be admitted while the partial scale-up
+// feature gate is on, with and without the classic PartialAdmission gate, and
+// must stay rejected while the partial scale-up gate is off.
+// See https://github.com/kubernetes-sigs/kueue/issues/15249.
+var _ = ginkgo.Describe("Workload webhooks admit KEP-12100 partial scale-up shapes", ginkgo.Ordered, func() {
+	var (
+		ns *corev1.Namespace
+	)
+
+	ginkgo.BeforeEach(func() {
+		fwk.StartManager(ctx, cfg, managerSetup)
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "core-")
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		fwk.StopManager(ctx)
+	})
+
+	ginkgo.It("accepts the first-create shape (one minCount podSet) with the partial scale-up gate on", func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ElasticJobsViaWorkloadSlices, true)
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ElasticJobsViaWorkloadSlicesWithPartialReplicaScaleUp, true)
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.PartialAdmission, true)
+
+		wl := utiltestingapi.MakeWorkload("elastic-partial-first-create", ns.Name).
+			Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			PodSets(
+				*utiltestingapi.MakePodSet("head", 1).
+					Request(corev1.ResourceCPU, "1").
+					Obj(),
+				*utiltestingapi.MakePodSet("workers-group-0", 4).
+					SetMinimumCount(4).
+					Request(corev1.ResourceCPU, "1").
+					Obj(),
+			).
+			Obj()
+
+		ginkgo.By("creating the Workload")
+		gomega.Expect(k8sClient.Create(ctx, wl)).Should(gomega.Succeed())
+
+		ginkgo.By("the minCount survives the mutating webhook")
+		gomega.Expect(wl.Spec.PodSets[1].MinCount).ShouldNot(gomega.BeNil())
+		gomega.Expect(*wl.Spec.PodSets[1].MinCount).Should(gomega.Equal(int32(4)))
+	})
+
+	ginkgo.It("accepts the scale-up probe shape (multiple minCount podSets) with the partial scale-up gate on", func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ElasticJobsViaWorkloadSlices, true)
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ElasticJobsViaWorkloadSlicesWithPartialReplicaScaleUp, true)
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.PartialAdmission, true)
+
+		wl := utiltestingapi.MakeWorkload("elastic-partial-probe", ns.Name).
+			Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			PodSets(
+				*utiltestingapi.MakePodSet("workers-group-0", 8).
+					SetMinimumCount(5).
+					Request(corev1.ResourceCPU, "1").
+					Obj(),
+				*utiltestingapi.MakePodSet("workers-group-1", 6).
+					SetMinimumCount(3).
+					Request(corev1.ResourceCPU, "1").
+					Obj(),
+			).
+			Obj()
+
+		ginkgo.By("creating the Workload")
+		gomega.Expect(k8sClient.Create(ctx, wl)).Should(gomega.Succeed())
+
+		ginkgo.By("all minCounts survive the mutating webhook")
+		gomega.Expect(wl.Spec.PodSets[0].MinCount).ShouldNot(gomega.BeNil())
+		gomega.Expect(wl.Spec.PodSets[1].MinCount).ShouldNot(gomega.BeNil())
+	})
+
+	ginkgo.It("accepts the partial shapes with PartialAdmission off and preserves minCount", func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ElasticJobsViaWorkloadSlices, true)
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ElasticJobsViaWorkloadSlicesWithPartialReplicaScaleUp, true)
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.PartialAdmission, false)
+
+		wl := utiltestingapi.MakeWorkload("elastic-partial-no-pa", ns.Name).
+			Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			PodSets(
+				*utiltestingapi.MakePodSet("head", 1).
+					Request(corev1.ResourceCPU, "1").
+					Obj(),
+				*utiltestingapi.MakePodSet("workers-group-0", 4).
+					SetMinimumCount(4).
+					Request(corev1.ResourceCPU, "1").
+					Obj(),
+			).
+			Obj()
+
+		ginkgo.By("creating the Workload")
+		gomega.Expect(k8sClient.Create(ctx, wl)).Should(gomega.Succeed())
+
+		ginkgo.By("the partial minCount is honored without PartialAdmission and survives the webhooks")
+		gomega.Expect(wl.Spec.PodSets[1].MinCount).ShouldNot(gomega.BeNil())
+		gomega.Expect(*wl.Spec.PodSets[1].MinCount).Should(gomega.Equal(int32(4)))
+	})
+
+	ginkgo.It("rejects elastic minCount shapes while the partial scale-up gate is off", func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ElasticJobsViaWorkloadSlices, true)
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ElasticJobsViaWorkloadSlicesWithPartialReplicaScaleUp, false)
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.PartialAdmission, true)
+
+		wl := utiltestingapi.MakeWorkload("elastic-partial-gate-off", ns.Name).
+			Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			PodSets(
+				*utiltestingapi.MakePodSet("head", 1).
+					Request(corev1.ResourceCPU, "1").
+					Obj(),
+				*utiltestingapi.MakePodSet("workers-group-0", 4).
+					SetMinimumCount(4).
+					Request(corev1.ResourceCPU, "1").
+					Obj(),
+			).
+			Obj()
+
+		ginkgo.By("creating the Workload")
+		err := k8sClient.Create(ctx, wl)
+		gomega.Expect(err).Should(gomega.HaveOccurred())
+		gomega.Expect(err).Should(utiltesting.BeForbiddenError())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("partial admission and elastic job cannot be used together"))
+	})
+})

--- a/test/integration/singlecluster/webhook/core/elastic_partial_scaleup_test.go
+++ b/test/integration/singlecluster/webhook/core/elastic_partial_scaleup_test.go
@@ -39,7 +39,7 @@ import (
 // feature gate is on, with and without the classic PartialAdmission gate, and
 // must stay rejected while the partial scale-up gate is off.
 // See https://github.com/kubernetes-sigs/kueue/issues/15249.
-var _ = ginkgo.Describe("Workload webhooks admit KEP-12100 partial scale-up shapes", ginkgo.Ordered, func() {
+var _ = ginkgo.Describe("Workload webhooks admit KEP-12100 partial scale-up shapes", func() {
 	var (
 		ns *corev1.Namespace
 	)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The Workload webhooks reject or corrupt the shapes the reconcilers produce for
KEP-12100 partial replica scale-up, so the feature is unusable end to end.
With `PartialAdmission` enabled (the default), the validating webhook rejects
every create with "`partial admission and elastic job cannot be used
together`"; with it disabled, `minCount` is stripped and partial scale-up
silently degrades to atomic admission. See #15249 for the full reproduction.

The scheduler already decides `minCount` usability with a single predicate,
`workload.MinCountsUsable`, which also guards the reconciler's clearing step.
The bug is that the reconciler runs that step before the elastic annotation
exists, and the two webhook gatekeepers use their own narrower predicates.
This PR aligns all three with the shared predicate:

1. `reconciler.go`, `prepareWorkload`: `prepareWorkloadSlice`, which attaches
   the elastic-job annotation, now runs before `clearUnusableMinCounts`.
   `MinCountsUsable` recognizes elastic workloads by that annotation, so
   clearing first dropped the minCounts of elastic partial scale-up workloads
   before the annotation existed to protect them.
2. `workload_webhook.go`, mutating `Default`: the wipe predicate changes from
   a bare `!PartialAdmission` to `!workload.MinCountsUsable(wl)`, that is,
   `PartialAdmission` on, or the partial scale-up gate on and the Workload
   elastic. minCounts of a disabled feature never reach the scheduler.
3. `workload_webhook.go`, `ValidateWorkload`: the two legacy rules are relaxed
   when the partial scale-up gate is on and the Workload is elastic.

The exemption is narrow: within the system, minCounts are only produced by
the RayCluster integration, per worker group with minReplicas set, while
the job opts in via the `elastic-job-scale-up-strategy=partial` annotation
and the partial scale-up gate is on. The strategy annotation is job-scoped
and does not reach Workloads, so the exemption is keyed off the same
granularity as `MinCountsUsable`. Every other combination keeps the legacy
behavior: with `PartialAdmission` off, minCounts of plain workloads and of
elastic workloads while the gate is off are still wiped; with `PartialAdmission`
on, a single-`minCount` plain `podSet` remains the classic partial admission
shape, and an elastic workload with minCounts while the gate is off is still
rejected.

#### Which issue(s) this PR fixes:

Fixes #15249

#### Special notes for your reviewer:

- The three changes are one chain, and each one alone leaves a dead end:
  fixing only the reconciler ordering still 403s with `PartialAdmission` on;
  only relaxing the validating webhook still wipes minCounts with
  `PartialAdmission` off; only fixing `Default` leaves the reconciler ordering
  bug in place.
- The exemption is elastic-granularity rather than strategy-granularity
  because the strategy annotation is job-scoped and never reaches the
  Workload, so a hand-crafted elastic Workload with minCounts would also pass
  while the gate is on. Making the exemption strategy-precise would require
  propagating the annotation to Workloads, which changes the KEP contract; I
  kept that out of scope. Happy to change it if you prefer.
- Validation of `minCount` values (negative, `minCount` > `count`) is unchanged:
  the Workload webhook never validated them, including for classic partial
  admission.
- Tests, all with a red/green check against the pre-change code:
  - Unit tests: a predicate matrix for `Default` (five cases covering
    `PartialAdmission` on/off, elastic/plain, gate on/off, including the
    boundaries where a plain workload is still cleared with the gate on and
    an elastic workload is still cleared with the gate off). The
    `PartialAdmission`-off elastic case fails against the pre-change predicate,
    which cleared minCounts.
  - Unit tests for `ValidateWorkload`: the first-create shape and the
    multi-`podSet` probe shape are accepted, non-elastic multiple `minCount`
    `podSets` stay rejected with the gate on. The acceptance cases fail against
    the pre-change webhook, which rejected both shapes.
  - Integration in webhook/core: the first-create shape and the probe shape
    are accepted with the partial scale-up gate on; both shapes are accepted
    with `PartialAdmission` off and `minCount` is preserved; elastic `minCount`
    shapes are rejected while the gate is off.
  - New production-wiring suite for RayCluster, with the reconciler, the
    webhooks, the scheduler and the API server in one process, mirroring a
    deployed manager:
    - creation under the default gates (`PartialAdmission` on), single and
      multiple worker groups, with minCounts kept and the Workload admitted
      by the scheduler: fails against the pre-change code, where the
      validating webhook rejects the Workload and none is ever created;
    - `PartialAdmission` off keeps minCounts end to end: fails against the
      pre-change code, where the reconciler ordering strips them;
    - control spec, plain elastic RayCluster without `minCount`: passes on main
      as a regression guard;
    - scale-up probe chain: admit a one-replica slice, scale workers to four,
      the probe slice appears with the replacement annotation and
      `count=4/minCount=2`, the previous slice finishes and the probe slice
      is admitted. Fails against the pre-change code, where the probe
      Workload is rejected and never created.
  - Stability: eight consecutive suite runs pass, six in default order and
    two randomized with different seeds, 5/5 specs each.
- go test on the touched packages, gofmt and go vet are clean.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

This PR was written in part with the assistance of generative AI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for partial replica scale-up on elastic workloads using workload slicing.
  - Elastic workloads can preserve minimum replica counts during partial scale-up, including configurations with multiple worker groups.
  - Partial scale-up configurations work with or without partial admission enabled.

- **Bug Fixes**
  - Fixed validation and reconciliation behavior that could discard eligible minimum replica counts.
  - Workloads not using partial scale-up continue to follow existing validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
