### PR TITLE
Remove unused external framework adapter constructor

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/externalframeworks/adapter.go
+++ b/pkg/controller/admissionchecks/multikueue/externalframeworks/adapter.go
@@ -48,13 +48,6 @@ var (
 	_ jobframework.MultiKueueWatcher = (*Adapter)(nil)
 )
 
-// NewAdapter creates a new adapter for the given GVK.
-func NewAdapter(gvk schema.GroupVersionKind) jobframework.MultiKueueAdapter {
-	return &Adapter{
-		gvk: gvk,
-	}
-}
-
 // SyncJob synchronizes a job resource between the local and remote clusters.
 // It ensures that the remote cluster has a corresponding object for the local job,
 // creating it if necessary, and updates the status of the local object based on the remote object.

--- a/pkg/controller/admissionchecks/multikueue/externalframeworks/adapter_test.go
+++ b/pkg/controller/admissionchecks/multikueue/externalframeworks/adapter_test.go
@@ -426,8 +426,8 @@ func TestAdapter_GetEmptyList(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			adapter := NewAdapter(tt.gvk)
-			result := adapter.(*Adapter).GetEmptyList()
+			adapter := &Adapter{gvk: tt.gvk}
+			result := adapter.GetEmptyList()
 
 			// Verify the result is an UnstructuredList
 			unstructuredList, ok := result.(*unstructured.UnstructuredList)
@@ -506,12 +506,12 @@ func TestAdapter_WorkloadKeysFor(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			adapter := NewAdapter(tt.gvk)
+			adapter := &Adapter{gvk: tt.gvk}
 			tt.object.SetGroupVersionKind(tt.gvk)
 			tt.object.SetName("test-job")
 			tt.object.SetNamespace("test-ns")
 
-			result, err := adapter.(*Adapter).WorkloadKeysFor(tt.object)
+			result, err := adapter.WorkloadKeysFor(tt.object)
 
 			if tt.wantErrMsg != "" {
 				if err == nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area multikueue

#### What this PR does / why we need it:

Removes the unused exported `externalframeworks.NewAdapter` constructor. The production path creates adapters through `NewAdapters`, while the only `NewAdapter` callers were unit tests in the same package. Those tests now construct `Adapter` directly.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

This PR was prepared with assistance from an AI coding tool.

Tested with:

`go test ./pkg/controller/admissionchecks/multikueue/externalframeworks`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal adapter construction without changing its behavior or user-visible functionality.
  * Existing adapter operations and test expectations remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->