### PR TITLE
Automated cherry pick of #15111: TAS: Enable PodSet slicing alongside PodSet grouping

### DIFF
--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -648,6 +648,80 @@ func TestFindTopologyAssignments(t *testing.T) {
 				},
 			},
 		},
+		"grouped with leader and sliced workers; multi-layer slicing constraints on workers": {
+			// Topology: block (b1) -> rack (r1, r2) -> hostname (x1, x2, x3, x4)
+			// Nodes: x1, x2 on r1; x3, x4 on r2. Each node has 5 CPU.
+			// Leader requests: 1 CPU (1 pod).
+			// Workers request: 2 CPU per pod, 8 pods total.
+			// Multi-layer constraints on workers:
+			//   - rack level: size 4
+			//   - hostname level: size 2
+			// Both leader and workers share PodSetGroupName "sameGroup", requiring block b1.
+			// Result:
+			//   - Leader: 1 pod on x1
+			//   - Workers: 2 pods on x1, 2 on x2 (satisfying rack r1 constraint of 4)
+			//              2 pods on x3, 2 on x4 (satisfying rack r2 constraint of 4)
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("b1-r1-x1").
+					Label(tasBlockLabel, "b1").Label(tasRackLabel, "r1").Label(corev1.LabelHostname, "x1").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("5"), corev1.ResourcePods: resource.MustParse("10")}).
+					Ready().Obj(),
+				*testingnode.MakeNode("b1-r1-x2").
+					Label(tasBlockLabel, "b1").Label(tasRackLabel, "r1").Label(corev1.LabelHostname, "x2").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("5"), corev1.ResourcePods: resource.MustParse("10")}).
+					Ready().Obj(),
+				*testingnode.MakeNode("b1-r2-x3").
+					Label(tasBlockLabel, "b1").Label(tasRackLabel, "r2").Label(corev1.LabelHostname, "x3").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("5"), corev1.ResourcePods: resource.MustParse("10")}).
+					Ready().Obj(),
+				*testingnode.MakeNode("b1-r2-x4").
+					Label(tasBlockLabel, "b1").Label(tasRackLabel, "r2").Label(corev1.LabelHostname, "x4").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("5"), corev1.ResourcePods: resource.MustParse("10")}).
+					Ready().Obj(),
+			},
+			levels: defaultThreeLevels,
+			podSets: []PodSetTestCase{
+				{
+					podSetName: "leader",
+					topologyRequest: &kueue.PodSetTopologyRequest{
+						Required:        new(tasBlockLabel),
+						PodSetGroupName: new("sameGroup"),
+					},
+					requests:        map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000},
+					podSetGroupName: new("sameGroup"),
+					count:           1,
+					wantAssignment: &tas.TopologyAssignment{
+						Levels: defaultOneLevel,
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 1, Values: []string{"x1"}},
+						},
+					},
+				},
+				{
+					podSetName: "workers",
+					topologyRequest: &kueue.PodSetTopologyRequest{
+						Required: new(tasBlockLabel),
+						PodsetSliceRequiredTopologyConstraints: []kueue.PodsetSliceRequiredTopologyConstraint{
+							{Topology: tasRackLabel, Size: 4},
+							{Topology: corev1.LabelHostname, Size: 2},
+						},
+						PodSetGroupName: new("sameGroup"),
+					},
+					requests:        map[corev1.ResourceName]int64{corev1.ResourceCPU: 2000},
+					podSetGroupName: new("sameGroup"),
+					count:           8,
+					wantAssignment: &tas.TopologyAssignment{
+						Levels: defaultOneLevel,
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 2, Values: []string{"x1"}},
+							{Count: 2, Values: []string{"x2"}},
+							{Count: 2, Values: []string{"x3"}},
+							{Count: 2, Values: []string{"x4"}},
+						},
+					},
+				},
+			},
+		},
 		"grouped with leader and sliced workers; replace unhealthy node with sliced workers": {
 			//         b1
 			//     /        \

--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -590,6 +590,146 @@ func TestFindTopologyAssignments(t *testing.T) {
 				},
 			}},
 		},
+		"grouped with leader and sliced workers; hostname level slicing with lower leader requirement": {
+			// Leader requests 1 CPU.
+			// Workers request 2 CPU, sliceSize 2, sliceRequiredTopology hostname.
+			// Each node has 5 CPU.
+			// 1 leader + 2 workers = 1 + 2*2 = 5 CPU (fits on a node).
+			// 3 workers = 6 CPU (does not fit on a node).
+			// Total: 1 leader and 4 workers.
+			// Result: leader on x1 (1 pod), workers on x1 (2 pods) and x2 (2 pods).
+			featureGates: map[featuregate.Feature]bool{features.TASCacheNodeMatchResults: true},
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("b1-r1-x1").
+					Label(tasBlockLabel, "b1").Label(tasRackLabel, "r1").Label(corev1.LabelHostname, "x1").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("5"), corev1.ResourcePods: resource.MustParse("10")}).
+					Ready().Obj(),
+				*testingnode.MakeNode("b1-r1-x2").
+					Label(tasBlockLabel, "b1").Label(tasRackLabel, "r1").Label(corev1.LabelHostname, "x2").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("5"), corev1.ResourcePods: resource.MustParse("10")}).
+					Ready().Obj(),
+			},
+			levels: defaultThreeLevels,
+			podSets: []PodSetTestCase{
+				{
+					podSetName: "leader",
+					topologyRequest: &kueue.PodSetTopologyRequest{
+						Required:        new(tasBlockLabel),
+						PodSetGroupName: new("sameGroup"),
+					},
+					requests:        map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000},
+					podSetGroupName: new("sameGroup"),
+					count:           1,
+					wantAssignment: &tas.TopologyAssignment{
+						Levels: defaultOneLevel,
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 1, Values: []string{"x1"}},
+						},
+					},
+				},
+				{
+					podSetName: "workers",
+					topologyRequest: &kueue.PodSetTopologyRequest{
+						Required:                    new(tasBlockLabel),
+						PodSetSliceSize:             new(int32(2)),
+						PodSetSliceRequiredTopology: new(string(corev1.LabelHostname)),
+						PodSetGroupName:             new("sameGroup"),
+					},
+					requests:        map[corev1.ResourceName]int64{corev1.ResourceCPU: 2000},
+					podSetGroupName: new("sameGroup"),
+					count:           4,
+					wantAssignment: &tas.TopologyAssignment{
+						Levels: defaultOneLevel,
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 2, Values: []string{"x1"}},
+							{Count: 2, Values: []string{"x2"}},
+						},
+					},
+				},
+			},
+		},
+		"grouped with leader and sliced workers; replace unhealthy node with sliced workers": {
+			//         b1
+			//     /        \
+			//    r1        r2
+			//  / | \      /  \
+			// x1 x2 x3   x4  x5
+			//    ^(NotReady)
+			// Leader on x1 (1 pod, 1 CPU).
+			// Workers on x1 (2 pods, 2 CPU each) and x2 (2 pods, 2 CPU each).
+			// Slicing at hostname level: sliceSize 2, sliceRequiredTopology hostname.
+			// Node capacity: 5 CPU.
+			// 1 leader + 2 workers = 5 CPU (fits on x1).
+			// 3 workers = 6 CPU (does not fit on any node).
+			// x2 becomes NotReady. Missing 2 worker pods (1 slice of size 2).
+			// x1 has 500m CPU left (< 2000m request, cannot fit replacement).
+			// x3 has 5 CPU (can fit 2 workers together on hostname).
+			// x4 has 2 CPU, x5 has 2 CPU (each can only fit 1 worker, cannot fit a slice of 2).
+			// Replacement must place both workers together on x3 to satisfy hostname-level slicing.
+			featureGates: map[featuregate.Feature]bool{features.TASCacheNodeMatchResults: true},
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("b1-r1-x1").
+					Label(tasBlockLabel, "b1").Label(tasRackLabel, "r1").Label(corev1.LabelHostname, "x1").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m"), corev1.ResourcePods: resource.MustParse("10")}).
+					Ready().Obj(),
+				*testingnode.MakeNode("b1-r1-x2").
+					Label(tasBlockLabel, "b1").Label(tasRackLabel, "r1").Label(corev1.LabelHostname, "x2").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("5"), corev1.ResourcePods: resource.MustParse("10")}).
+					NotReady().Obj(),
+				*testingnode.MakeNode("b1-r1-x3").
+					Label(tasBlockLabel, "b1").Label(tasRackLabel, "r1").Label(corev1.LabelHostname, "x3").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("5"), corev1.ResourcePods: resource.MustParse("10")}).
+					Ready().Obj(),
+				*testingnode.MakeNode("b1-r2-x4").
+					Label(tasBlockLabel, "b1").Label(tasRackLabel, "r2").Label(corev1.LabelHostname, "x4").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2"), corev1.ResourcePods: resource.MustParse("10")}).
+					Ready().Obj(),
+				*testingnode.MakeNode("b1-r2-x5").
+					Label(tasBlockLabel, "b1").Label(tasRackLabel, "r2").Label(corev1.LabelHostname, "x5").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2"), corev1.ResourcePods: resource.MustParse("10")}).
+					Ready().Obj(),
+			},
+			levels: defaultThreeLevels,
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				Admission(utiltestingapi.MakeAdmission("cq", "leader", "workers").
+					PodSets(
+						utiltestingapi.MakePodSetAssignment("leader").
+							Count(1).
+							TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+								Domain(tas.TopologyDomainAssignment{Count: 1, Values: []string{"x1"}}).
+								Obj()).
+							Obj(),
+						utiltestingapi.MakePodSetAssignment("workers").
+							Count(4).
+							TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+								Domain(tas.TopologyDomainAssignment{Count: 2, Values: []string{"x1"}}).
+								Domain(tas.TopologyDomainAssignment{Count: 2, Values: []string{"x2"}}).
+								Obj()).
+							Obj(),
+					).
+					Obj()).
+				UnhealthyNodes("x2").
+				Obj(),
+			podSets: []PodSetTestCase{{
+				podSetName: "workers",
+				topologyRequest: &kueue.PodSetTopologyRequest{
+					Required:                    new(tasBlockLabel),
+					PodSetSliceSize:             new(int32(2)),
+					PodSetSliceRequiredTopology: new(string(corev1.LabelHostname)),
+					PodSetGroupName:             new("sameGroup"),
+				},
+				requests:        map[corev1.ResourceName]int64{corev1.ResourceCPU: 2000},
+				podSetGroupName: new("sameGroup"),
+				count:           4,
+				wantAssignment: &tas.TopologyAssignment{
+					Levels: defaultOneLevel,
+					Domains: []tas.TopologyDomainAssignment{
+						{Count: 2, Values: []string{"x1"}},
+						{Count: 2, Values: []string{"x3"}},
+					},
+				},
+			}},
+		},
 		"minimize the number of used racks before optimizing the number of nodes; BestFit": {
 			// Solution by optimizing the number of racks then nodes: [r3]: [x1,x6,x2,x4]
 			// Solution by optimizing the number of nodes: [r1,r2]: [x3,x5]

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -715,6 +715,7 @@ func LoadAndValidateFeatureGates(featureGateCLI string, featureGateMap map[strin
 	allErrs = append(allErrs, validateFeatureGateDependency(features.TASMultiLayerTopology, features.TopologyAwareScheduling)...)
 	allErrs = append(allErrs, validateFeatureGateDependency(features.TASRespectNodeAffinityPreferred, features.TopologyAwareScheduling)...)
 	allErrs = append(allErrs, validateFeatureGateDependency(features.TASRecomputeAssignmentWithinSchedulingCycle, features.TopologyAwareScheduling)...)
+	allErrs = append(allErrs, validateFeatureGateDependency(features.TASGroupedPodSetSlicing, features.TopologyAwareScheduling)...)
 	allErrs = append(allErrs, validateFeatureGateDependency(features.UnadmittedWorkloadsExplicitStatus, features.UnadmittedWorkloadsObservability)...)
 
 	// Excluding the PodSet name only means something once the hash itself is computed.

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -2147,6 +2147,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				string(features.TASReplaceNodeOnNodeTaints):                  false,
 				string(features.TASMultiLayerTopology):                       false,
 				string(features.TASRecomputeAssignmentWithinSchedulingCycle): false,
+				string(features.TASGroupedPodSetSlicing):                     false,
 			},
 			gatesToRestore: map[featuregate.Feature]bool{
 				features.TASProfileMixed:                  false,
@@ -2224,6 +2225,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				string(features.TASReplaceNodeOnNodeTaints):                  false,
 				string(features.TASMultiLayerTopology):                       false,
 				string(features.TASRecomputeAssignmentWithinSchedulingCycle): false,
+				string(features.TASGroupedPodSetSlicing):                     false,
 			},
 			gatesToRestore: map[featuregate.Feature]bool{
 				features.ElasticJobsViaWorkloadSlicesWithTAS: false,
@@ -2271,6 +2273,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				string(features.TASReplaceNodeOnNodeTaints):                  false,
 				string(features.TASMultiLayerTopology):                       false,
 				string(features.TASRecomputeAssignmentWithinSchedulingCycle): false,
+				string(features.TASGroupedPodSetSlicing):                     false,
 			},
 			gatesToRestore: map[featuregate.Feature]bool{
 				features.TASProfileMixed:                     false,
@@ -2411,6 +2414,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				string(features.TASReplaceNodeOnNodeTaints):                  false,
 				string(features.TASMultiLayerTopology):                       false,
 				string(features.TASRecomputeAssignmentWithinSchedulingCycle): false,
+				string(features.TASGroupedPodSetSlicing):                     false,
 			},
 			gatesToRestore: map[featuregate.Feature]bool{
 				features.TASHandleOverlappingFlavors:      true,
@@ -2452,6 +2456,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				string(features.TASReplaceNodeOnPodTermination):              false,
 				string(features.TASReplaceNodeOnNodeTaints):                  false,
 				string(features.TASMultiLayerTopology):                       false,
+				string(features.TASGroupedPodSetSlicing):                     false,
 			},
 			wantErr: field.ErrorList{
 				&field.Error{
@@ -2472,6 +2477,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				string(features.TASReplaceNodeOnNodeTaints):                  false,
 				string(features.TASMultiLayerTopology):                       false,
 				string(features.TASRecomputeAssignmentWithinSchedulingCycle): false,
+				string(features.TASGroupedPodSetSlicing):                     false,
 			},
 			gatesToRestore: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling:          true,
@@ -2503,6 +2509,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				string(features.TASBalancedPlacement):                        true,
 				string(features.TASMultiLayerTopology):                       false,
 				string(features.TASRecomputeAssignmentWithinSchedulingCycle): false,
+				string(features.TASGroupedPodSetSlicing):                     false,
 			},
 			gatesToRestore: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling:          true,
@@ -2534,6 +2541,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				string(features.TASReplaceNodeOnNodeTaints):                  true,
 				string(features.TASMultiLayerTopology):                       false,
 				string(features.TASRecomputeAssignmentWithinSchedulingCycle): false,
+				string(features.TASGroupedPodSetSlicing):                     false,
 			},
 			gatesToRestore: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling:          true,
@@ -2564,6 +2572,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				string(features.TASReplaceNodeOnNodeTaints):                  false,
 				string(features.TASMultiLayerTopology):                       true,
 				string(features.TASRecomputeAssignmentWithinSchedulingCycle): false,
+				string(features.TASGroupedPodSetSlicing):                     false,
 			},
 			gatesToRestore: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling:          true,
@@ -2595,6 +2604,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				string(features.TASRespectNodeAffinityPreferred):             true,
 				string(features.TASMultiLayerTopology):                       false,
 				string(features.TASRecomputeAssignmentWithinSchedulingCycle): false,
+				string(features.TASGroupedPodSetSlicing):                     false,
 			},
 			gatesToRestore: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling:          true,
@@ -2612,6 +2622,27 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 					Type:   field.ErrorTypeInvalid,
 					Field:  "featureGates",
 					Detail: "TASRespectNodeAffinityPreferred requires TopologyAwareScheduling to be enabled",
+				},
+			},
+		},
+		"TASGroupedPodSetSlicing requires TopologyAwareScheduling": {
+			featureGateMap: map[string]bool{
+				string(features.TASGroupedPodSetSlicing):                     true,
+				string(features.TopologyAwareScheduling):                     false,
+				string(features.TASProfileMixed):                             false,
+				string(features.TASHandleOverlappingFlavors):                 false,
+				string(features.TASFailedNodeReplacement):                    false,
+				string(features.TASFailedNodeReplacementFailFast):            false,
+				string(features.TASReplaceNodeOnPodTermination):              false,
+				string(features.TASReplaceNodeOnNodeTaints):                  false,
+				string(features.TASMultiLayerTopology):                       false,
+				string(features.TASRecomputeAssignmentWithinSchedulingCycle): false,
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:   field.ErrorTypeInvalid,
+					Field:  "featureGates",
+					Detail: "TASGroupedPodSetSlicing requires TopologyAwareScheduling to be enabled",
 				},
 			},
 		},
@@ -2670,6 +2701,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				string(features.TASReplaceNodeOnNodeTaints):                  false,
 				string(features.TASMultiLayerTopology):                       false,
 				string(features.TASRecomputeAssignmentWithinSchedulingCycle): false,
+				string(features.TASGroupedPodSetSlicing):                     false,
 			},
 			gatesToRestore: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling:          true,
@@ -2705,6 +2737,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				string(features.TASReplaceNodeOnNodeTaints):                  false,
 				string(features.TASMultiLayerTopology):                       false,
 				string(features.TASRecomputeAssignmentWithinSchedulingCycle): false,
+				string(features.TASGroupedPodSetSlicing):                     false,
 			},
 			gatesToRestore: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling:          true,
@@ -2740,6 +2773,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				string(features.TASMultiLayerTopology):            true,
 				string(features.TASRespectNodeAffinityPreferred):  true,
 				string(features.TASHandleOverlappingFlavors):      true,
+				string(features.TASGroupedPodSetSlicing):          true,
 			},
 			gatesToRestore: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling:          true,

--- a/pkg/controller/jobframework/tas_validation.go
+++ b/pkg/controller/jobframework/tas_validation.go
@@ -73,6 +73,19 @@ func ValidateTASPodSetRequest(replicaPath *field.Path, replicaMetadata *metav1.O
 	if podSetGroupNameFound {
 		allErrs = append(allErrs, validatePodSetGroupNameAnnotation(podSetGroupNameValue, annotationsPath.Key(kueue.PodSetGroupName))...)
 
+		if !features.Enabled(features.TASGroupedPodSetSlicing) {
+			if sliceSizeFound {
+				allErrs = append(allErrs, field.Forbidden(annotationsPath.Key(kueue.PodSetGroupName), fmt.Sprintf("may not be set when '%s' is specified", kueue.PodSetSliceSizeAnnotation)))
+			}
+
+			if sliceRequiredFound {
+				allErrs = append(
+					allErrs,
+					field.Forbidden(annotationsPath.Key(kueue.PodSetGroupName), fmt.Sprintf("may not be set when '%s' is specified", kueue.PodSetSliceRequiredTopologyAnnotation)),
+				)
+			}
+		}
+
 		if !preferredFound && !requiredFound {
 			allErrs = append(
 				allErrs,
@@ -331,8 +344,8 @@ func validateSliceRequiredTopologyConstraintsAnnotation(
 			fmt.Sprintf("may not be set when '%s' is specified", kueue.PodSetSliceSizeAnnotation)))
 	}
 
-	// Incompatible with podset-group-name.
-	if podSetGroupNameFound {
+	// Incompatible with podset-group-name when TASGroupedPodSetSlicing is disabled.
+	if podSetGroupNameFound && !features.Enabled(features.TASGroupedPodSetSlicing) {
 		allErrs = append(allErrs, field.Forbidden(annotationsPath.Key(kueue.PodSetGroupName),
 			fmt.Sprintf("may not be set when '%s' is specified", kueue.PodSetSliceRequiredTopologyConstraintsAnnotation)))
 	}

--- a/pkg/controller/jobframework/tas_validation.go
+++ b/pkg/controller/jobframework/tas_validation.go
@@ -73,14 +73,6 @@ func ValidateTASPodSetRequest(replicaPath *field.Path, replicaMetadata *metav1.O
 	if podSetGroupNameFound {
 		allErrs = append(allErrs, validatePodSetGroupNameAnnotation(podSetGroupNameValue, annotationsPath.Key(kueue.PodSetGroupName))...)
 
-		if sliceSizeFound {
-			allErrs = append(allErrs, field.Forbidden(annotationsPath.Key(kueue.PodSetGroupName), fmt.Sprintf("may not be set when '%s' is specified", kueue.PodSetSliceSizeAnnotation)))
-		}
-
-		if sliceRequiredFound {
-			allErrs = append(allErrs, field.Forbidden(annotationsPath.Key(kueue.PodSetGroupName), fmt.Sprintf("may not be set when '%s' is specified", kueue.PodSetSliceRequiredTopologyAnnotation)))
-		}
-
 		if !preferredFound && !requiredFound {
 			allErrs = append(
 				allErrs,

--- a/pkg/controller/jobframework/tas_validation_test.go
+++ b/pkg/controller/jobframework/tas_validation_test.go
@@ -161,6 +161,62 @@ func TestValidateSliceRequiredTopologyConstraintsAnnotation(t *testing.T) {
 	}
 }
 
+func TestValidateTASPodSetRequest_GroupingWithSlicing(t *testing.T) {
+	replicaPath := field.NewPath("spec", "template", "metadata")
+
+	testCases := map[string]struct {
+		annotations map[string]string
+		wantErrNum  int
+	}{
+		"valid: podset grouping with 2-level slicing and required topology": {
+			annotations: map[string]string{
+				kueue.PodSetGroupName:                       "group1",
+				kueue.PodSetRequiredTopologyAnnotation:      "cloud.com/block",
+				kueue.PodSetSliceRequiredTopologyAnnotation: "cloud.com/rack",
+				kueue.PodSetSliceSizeAnnotation:             "4",
+			},
+			wantErrNum: 0,
+		},
+		"valid: podset grouping with 2-level slicing and preferred topology": {
+			annotations: map[string]string{
+				kueue.PodSetGroupName:                       "group1",
+				kueue.PodSetPreferredTopologyAnnotation:     "cloud.com/block",
+				kueue.PodSetSliceRequiredTopologyAnnotation: "cloud.com/rack",
+				kueue.PodSetSliceSizeAnnotation:             "4",
+			},
+			wantErrNum: 0,
+		},
+		"invalid: podset grouping with 2-level slicing but neither required nor preferred topology": {
+			annotations: map[string]string{
+				kueue.PodSetGroupName:                       "group1",
+				kueue.PodSetSliceRequiredTopologyAnnotation: "cloud.com/rack",
+				kueue.PodSetSliceSizeAnnotation:             "4",
+			},
+			wantErrNum: 1,
+		},
+		"invalid: podset grouping with slice size missing slice required topology": {
+			annotations: map[string]string{
+				kueue.PodSetGroupName:                  "group1",
+				kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block",
+				kueue.PodSetSliceSizeAnnotation:        "4",
+			},
+			wantErrNum: 1,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			meta := &metav1.ObjectMeta{
+				Annotations: tc.annotations,
+			}
+			errs := ValidateTASPodSetRequest(replicaPath, meta)
+			if got := len(errs); got != tc.wantErrNum {
+				t.Errorf("ValidateTASPodSetRequest() returned %d errors, want %d:\n%v", got, tc.wantErrNum, errs)
+			}
+		})
+	}
+}
+
 func TestValidateSliceSizeAnnotationUpperBound(t *testing.T) {
 	replicaPath := field.NewPath("spec", "template", "metadata")
 

--- a/pkg/controller/jobframework/tas_validation_test.go
+++ b/pkg/controller/jobframework/tas_validation_test.go
@@ -109,14 +109,29 @@ func TestValidateSliceRequiredTopologyConstraintsAnnotation(t *testing.T) {
 			},
 			wantErrNum: 2, // forbidden with slice-required-topology AND slice-size
 		},
-		"invalid: with podset-group-name": {
-			featureGates: map[featuregate.Feature]bool{features.TASMultiLayerTopology: true},
+		"invalid: with podset-group-name when TASGroupedPodSetSlicing is disabled": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TASMultiLayerTopology:   true,
+				features.TASGroupedPodSetSlicing: false,
+			},
 			annotations: map[string]string{
 				kueue.PodSetRequiredTopologyAnnotation:                 "cloud.com/block",
 				kueue.PodSetSliceRequiredTopologyConstraintsAnnotation: `[{"topology":"cloud.com/rack","size":16}]`,
 				kueue.PodSetGroupName:                                  "group1",
 			},
-			wantErrNum: 1, // podset-group-name forbidden with constraints
+			wantErrNum: 1, // podset-group-name forbidden with constraints when feature gate is disabled
+		},
+		"valid: with podset-group-name when TASGroupedPodSetSlicing is enabled": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TASMultiLayerTopology:   true,
+				features.TASGroupedPodSetSlicing: true,
+			},
+			annotations: map[string]string{
+				kueue.PodSetRequiredTopologyAnnotation:                 "cloud.com/block",
+				kueue.PodSetSliceRequiredTopologyConstraintsAnnotation: `[{"topology":"cloud.com/rack","size":16}]`,
+				kueue.PodSetGroupName:                                  "group1",
+			},
+			wantErrNum: 0,
 		},
 		"invalid: feature gate disabled": {
 			featureGates: map[featuregate.Feature]bool{
@@ -165,10 +180,14 @@ func TestValidateTASPodSetRequest_GroupingWithSlicing(t *testing.T) {
 	replicaPath := field.NewPath("spec", "template", "metadata")
 
 	testCases := map[string]struct {
-		annotations map[string]string
-		wantErrNum  int
+		featureGates map[featuregate.Feature]bool
+		annotations  map[string]string
+		wantErrNum   int
 	}{
 		"valid: podset grouping with 2-level slicing and required topology": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TASGroupedPodSetSlicing: true,
+			},
 			annotations: map[string]string{
 				kueue.PodSetGroupName:                       "group1",
 				kueue.PodSetRequiredTopologyAnnotation:      "cloud.com/block",
@@ -178,6 +197,9 @@ func TestValidateTASPodSetRequest_GroupingWithSlicing(t *testing.T) {
 			wantErrNum: 0,
 		},
 		"valid: podset grouping with 2-level slicing and preferred topology": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TASGroupedPodSetSlicing: true,
+			},
 			annotations: map[string]string{
 				kueue.PodSetGroupName:                       "group1",
 				kueue.PodSetPreferredTopologyAnnotation:     "cloud.com/block",
@@ -186,7 +208,45 @@ func TestValidateTASPodSetRequest_GroupingWithSlicing(t *testing.T) {
 			},
 			wantErrNum: 0,
 		},
+		"valid: podset grouping with multi-layer slicing and required topology": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TASGroupedPodSetSlicing: true,
+			},
+			annotations: map[string]string{
+				kueue.PodSetGroupName:                                  "group1",
+				kueue.PodSetRequiredTopologyAnnotation:                 "cloud.com/block",
+				kueue.PodSetSliceRequiredTopologyConstraintsAnnotation: `[{"topology":"cloud.com/rack","size":4}]`,
+			},
+			wantErrNum: 0,
+		},
+		"invalid: podset grouping with 2-level slicing when TASGroupedPodSetSlicing is disabled": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TASGroupedPodSetSlicing: false,
+			},
+			annotations: map[string]string{
+				kueue.PodSetGroupName:                       "group1",
+				kueue.PodSetRequiredTopologyAnnotation:      "cloud.com/block",
+				kueue.PodSetSliceRequiredTopologyAnnotation: "cloud.com/rack",
+				kueue.PodSetSliceSizeAnnotation:             "4",
+			},
+			wantErrNum: 2,
+		},
+		"invalid: podset grouping with multi-layer slicing when TASGroupedPodSetSlicing is disabled": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TASMultiLayerTopology:   true,
+				features.TASGroupedPodSetSlicing: false,
+			},
+			annotations: map[string]string{
+				kueue.PodSetGroupName:                                  "group1",
+				kueue.PodSetRequiredTopologyAnnotation:                 "cloud.com/block",
+				kueue.PodSetSliceRequiredTopologyConstraintsAnnotation: `[{"topology":"cloud.com/rack","size":4}]`,
+			},
+			wantErrNum: 1,
+		},
 		"invalid: podset grouping with 2-level slicing but neither required nor preferred topology": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TASGroupedPodSetSlicing: true,
+			},
 			annotations: map[string]string{
 				kueue.PodSetGroupName:                       "group1",
 				kueue.PodSetSliceRequiredTopologyAnnotation: "cloud.com/rack",
@@ -195,6 +255,9 @@ func TestValidateTASPodSetRequest_GroupingWithSlicing(t *testing.T) {
 			wantErrNum: 1,
 		},
 		"invalid: podset grouping with slice size missing slice required topology": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TASGroupedPodSetSlicing: true,
+			},
 			annotations: map[string]string{
 				kueue.PodSetGroupName:                  "group1",
 				kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block",
@@ -206,6 +269,9 @@ func TestValidateTASPodSetRequest_GroupingWithSlicing(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
+			if tc.featureGates != nil {
+				features.SetFeatureGatesDuringTest(t, tc.featureGates)
+			}
 			meta := &metav1.ObjectMeta{
 				Annotations: tc.annotations,
 			}

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
@@ -412,6 +412,9 @@ func TestValidateCreate(t *testing.T) {
 			}.ToAggregate(),
 		},
 		"valid slice topology request - grouping requested together with slicing": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TASGroupedPodSetSlicing: true,
+			},
 			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
 				Queue("test-queue").
 				LeaderTemplate(corev1.PodTemplateSpec{
@@ -438,6 +441,9 @@ func TestValidateCreate(t *testing.T) {
 				Obj(),
 		},
 		"valid slice topology request - grouping with unsliced leader and sliced workers": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TASGroupedPodSetSlicing: true,
+			},
 			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
 				Queue("test-queue").
 				LeaderTemplate(corev1.PodTemplateSpec{

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
@@ -411,7 +411,7 @@ func TestValidateCreate(t *testing.T) {
 					Key("kueue.x-k8s.io/podset-slice-size"), "must be set when 'kueue.x-k8s.io/podset-slice-required-topology' is specified"),
 			}.ToAggregate(),
 		},
-		"invalid slice topology request - grouping requested together with slicing": {
+		"valid slice topology request - grouping requested together with slicing": {
 			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
 				Queue("test-queue").
 				LeaderTemplate(corev1.PodTemplateSpec{
@@ -436,16 +436,30 @@ func TestValidateCreate(t *testing.T) {
 					},
 				}).
 				Obj(),
-			wantErr: field.ErrorList{
-				field.Forbidden(field.NewPath("spec.leaderWorkerTemplate.leaderTemplate.metadata.annotations").
-					Key("kueue.x-k8s.io/podset-group-name"), "may not be set when 'kueue.x-k8s.io/podset-slice-size' is specified"),
-				field.Forbidden(field.NewPath("spec.leaderWorkerTemplate.leaderTemplate.metadata.annotations").
-					Key("kueue.x-k8s.io/podset-group-name"), "may not be set when 'kueue.x-k8s.io/podset-slice-required-topology' is specified"),
-				field.Forbidden(field.NewPath("spec.leaderWorkerTemplate.workerTemplate.metadata.annotations").
-					Key("kueue.x-k8s.io/podset-group-name"), "may not be set when 'kueue.x-k8s.io/podset-slice-size' is specified"),
-				field.Forbidden(field.NewPath("spec.leaderWorkerTemplate.workerTemplate.metadata.annotations").
-					Key("kueue.x-k8s.io/podset-group-name"), "may not be set when 'kueue.x-k8s.io/podset-slice-required-topology' is specified"),
-			}.ToAggregate(),
+		},
+		"valid slice topology request - grouping with unsliced leader and sliced workers": {
+			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
+				Queue("test-queue").
+				LeaderTemplate(corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							kueue.PodSetGroupName:                  "groupname",
+							kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block",
+						},
+					},
+				}).
+				Size(5).
+				WorkerTemplate(corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							kueue.PodSetGroupName:                       "groupname",
+							kueue.PodSetRequiredTopologyAnnotation:      "cloud.com/block",
+							kueue.PodSetSliceRequiredTopologyAnnotation: "cloud.com/rack",
+							kueue.PodSetSliceSizeAnnotation:             "2",
+						},
+					},
+				}).
+				Obj(),
 		},
 		"valid PodSet group name request": {
 			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -586,6 +586,11 @@ const (
 	// to complete to prevent quota stealing and thrashing during desynchronized evictions.
 	PrioritizePreemptorWorkloads featuregate.Feature = "PrioritizePreemptorWorkloads"
 
+	// owner: @pajakd
+	//
+	// Enable PodSet slicing alongside PodSet grouping in TAS.
+	TASGroupedPodSetSlicing featuregate.Feature = "TASGroupedPodSetSlicing"
+
 	// owner: @ivnovakov
 	//
 	// pr: https://github.com/kubernetes-sigs/kueue/pull/13279#discussion_r3655384989
@@ -961,6 +966,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 
 	TASCacheTopologyTree: {
+		{Version: version.MustParse("0.19"), Default: false, PreRelease: featuregate.Alpha},
+	},
+
+	TASGroupedPodSetSlicing: {
 		{Version: version.MustParse("0.19"), Default: false, PreRelease: featuregate.Alpha},
 	},
 

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -529,6 +529,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.14"
+- name: TASGroupedPodSetSlicing
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.19"
 - name: TASHandleOverlappingFlavors
   versionedSpecs:
   - default: true

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -529,6 +529,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.14"
+- name: TASGroupedPodSetSlicing
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.19"
 - name: TASHandleOverlappingFlavors
   versionedSpecs:
   - default: true

--- a/test/e2e/config/default/controller_manager_config.yaml
+++ b/test/e2e/config/default/controller_manager_config.yaml
@@ -41,6 +41,7 @@ featureGates:
   ElasticJobsViaWorkloadSlices: true
   ConcurrentAdmission: true
   MultiKueueManagerQuotaAutomation: true
+  TASGroupedPodSetSlicing: true
 tls:
   minVersion: "VersionTLS12"
   # this is the default ciphersuite for golang 1.26

--- a/test/e2e/config/default/values.yaml
+++ b/test/e2e/config/default/values.yaml
@@ -36,6 +36,8 @@ featureGates:
   enabled: true
 - name: ConcurrentAdmission
   enabled: true
+- name: TASGroupedPodSetSlicing
+  enabled: true
 managerConfig:
   controllerManagerConfigYaml: |-
     apiVersion: config.kueue.x-k8s.io/v1beta2

--- a/test/e2e/config/extended/controller_manager_config.yaml
+++ b/test/e2e/config/extended/controller_manager_config.yaml
@@ -44,6 +44,7 @@ featureGates:
   ElasticJobsViaWorkloadSlices: true
   ConcurrentAdmission: true
   MultiKueueManagerQuotaAutomation: true
+  TASGroupedPodSetSlicing: true
 tls:
   minVersion: "VersionTLS12"
   # this is the default ciphersuite for golang 1.26

--- a/test/e2e/tas/extended/leaderworkerset_test.go
+++ b/test/e2e/tas/extended/leaderworkerset_test.go
@@ -545,4 +545,124 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for LeaderWorkerSet", ginkgo.La
 		},
 		)
 	})
+
+	ginkgo.When("creating a LeaderWorkerSet with leader grouped with sliced workers", func() {
+		ginkgo.It("should place sliced worker pods and leader based on topology constraints", func() {
+			const (
+				replicas = int32(1)
+				size     = int32(5)
+			)
+
+			podsTotalCount := replicas * size
+
+			lws := leaderworkersettesting.MakeLeaderWorkerSet("lws", ns.Name).
+				Replicas(replicas).
+				Size(size).
+				Queue(localQueue.Name).
+				WorkerTemplate(corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							kueue.PodSetRequiredTopologyAnnotation:      utiltesting.DefaultBlockTopologyLevel,
+							kueue.PodSetSliceRequiredTopologyAnnotation: utiltesting.DefaultRackTopologyLevel,
+							kueue.PodSetSliceSizeAnnotation:             "2",
+							kueue.PodSetGroupName:                       "same-group",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "c",
+								Image: util.GetAgnHostImage(),
+								Args:  util.BehaviorWaitForDeletion,
+								Resources: corev1.ResourceRequirements{
+									Limits: map[corev1.ResourceName]resource.Quantity{
+										corev1.ResourceCPU: resource.MustParse("200m"),
+										extraResource:      resource.MustParse("1"),
+									},
+									Requests: map[corev1.ResourceName]resource.Quantity{
+										corev1.ResourceCPU: resource.MustParse("200m"),
+										extraResource:      resource.MustParse("1"),
+									},
+								},
+							},
+						},
+					},
+				}).
+				LeaderTemplate(corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							kueue.PodSetRequiredTopologyAnnotation: utiltesting.DefaultBlockTopologyLevel,
+							kueue.PodSetGroupName:                  "same-group",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "c",
+								Image: util.GetAgnHostImage(),
+								Args:  util.BehaviorWaitForDeletion,
+								Resources: corev1.ResourceRequirements{
+									Limits: map[corev1.ResourceName]resource.Quantity{
+										corev1.ResourceCPU: resource.MustParse("200m"),
+									},
+									Requests: map[corev1.ResourceName]resource.Quantity{
+										corev1.ResourceCPU: resource.MustParse("200m"),
+									},
+								},
+							},
+						},
+					},
+				}).
+				TerminationGracePeriod(1).
+				Obj()
+			ginkgo.By("Creating a LeaderWorkerSet", func() {
+				util.MustCreate(ctx, k8sClient, lws)
+			})
+
+			ginkgo.By("Waiting for replicas to be ready", func() {
+				createdLeaderWorkerSet := &leaderworkersetv1.LeaderWorkerSet{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
+					g.Expect(createdLeaderWorkerSet.Status.ReadyReplicas).To(gomega.Equal(replicas))
+					g.Expect(createdLeaderWorkerSet.Status.Conditions).To(utiltesting.HaveConditionStatusTrueAndReason("Available", "AllGroupsReady"))
+				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			pods := &corev1.PodList{}
+			ginkgo.By("ensure all pods are scheduled", func() {
+				listOpts := &client.ListOptions{
+					FieldSelector: fields.OneTermNotEqualSelector("spec.nodeName", ""),
+				}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name), listOpts)).To(gomega.Succeed())
+					g.Expect(pods.Items).Should(gomega.HaveLen(int(podsTotalCount)))
+				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("verify the assignment of pods are as expected with rank-based ordering", func() {
+				gomega.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name))).To(gomega.Succeed())
+				gotAssignment := make(map[string]string, podsTotalCount)
+				for _, pod := range pods.Items {
+					index := fmt.Sprintf("%s/%s", pod.Labels[leaderworkersetv1.GroupIndexLabelKey], pod.Labels[leaderworkersetv1.WorkerIndexLabelKey])
+					gotAssignment[index] = pod.Spec.NodeName
+				}
+				gomega.Expect(gotAssignment).Should(gomega.Or(
+					gomega.BeComparableTo(map[string]string{
+						"0/0": "kind-worker",
+						"0/1": "kind-worker",
+						"0/2": "kind-worker2",
+						"0/3": "kind-worker3",
+						"0/4": "kind-worker4",
+					}),
+					gomega.BeComparableTo(map[string]string{
+						"0/0": "kind-worker5",
+						"0/1": "kind-worker5",
+						"0/2": "kind-worker6",
+						"0/3": "kind-worker7",
+						"0/4": "kind-worker8",
+					}),
+				))
+			})
+		})
+	})
 })

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -3692,6 +3692,438 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				})
 			})
 		})
+		ginkgo.When("2-level TAS with PodSet grouping", func() {
+			const (
+				resourceGPU = "example.com/gpu"
+			)
+			var (
+				nodes []corev1.Node
+			)
+			ginkgo.BeforeEach(func() {
+				// Block b1 has 24 GPUs (x1: 12, x2: 12), sufficient for leader (1) + workers (20).
+				// Block b2 has 20 GPUs (x3: 10, x4: 10), sufficient for workers (20) alone, but not leader (1) + workers (20).
+				nodes = []corev1.Node{
+					*testingnode.MakeNode("x1").
+						Label("node-group", "tas").
+						Label(utiltesting.DefaultBlockTopologyLevel, "b1").
+						Label(utiltesting.DefaultRackTopologyLevel, "r1").
+						Label(corev1.LabelHostname, "x1").
+						StatusAllocatable(corev1.ResourceList{
+							resourceGPU:           resource.MustParse("12"),
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
+							corev1.ResourcePods:   resource.MustParse("20"),
+						}).
+						Ready().
+						Obj(),
+					*testingnode.MakeNode("x2").
+						Label("node-group", "tas").
+						Label(utiltesting.DefaultBlockTopologyLevel, "b1").
+						Label(utiltesting.DefaultRackTopologyLevel, "r1").
+						Label(corev1.LabelHostname, "x2").
+						StatusAllocatable(corev1.ResourceList{
+							resourceGPU:           resource.MustParse("12"),
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
+							corev1.ResourcePods:   resource.MustParse("20"),
+						}).
+						Ready().
+						Obj(),
+					*testingnode.MakeNode("x3").
+						Label("node-group", "tas").
+						Label(utiltesting.DefaultBlockTopologyLevel, "b2").
+						Label(utiltesting.DefaultRackTopologyLevel, "r2").
+						Label(corev1.LabelHostname, "x3").
+						StatusAllocatable(corev1.ResourceList{
+							resourceGPU:           resource.MustParse("10"),
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
+							corev1.ResourcePods:   resource.MustParse("20"),
+						}).
+						Ready().
+						Obj(),
+					*testingnode.MakeNode("x4").
+						Label("node-group", "tas").
+						Label(utiltesting.DefaultBlockTopologyLevel, "b2").
+						Label(utiltesting.DefaultRackTopologyLevel, "r2").
+						Label(corev1.LabelHostname, "x4").
+						StatusAllocatable(corev1.ResourceList{
+							resourceGPU:           resource.MustParse("10"),
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
+							corev1.ResourcePods:   resource.MustParse("20"),
+						}).
+						Ready().
+						Obj(),
+				}
+				util.CreateNodesWithStatus(ctx, k8sClient, nodes)
+
+				topology = utiltestingapi.MakeDefaultThreeLevelTopology("default")
+				util.MustCreate(ctx, k8sClient, topology)
+
+				tasFlavor = utiltestingapi.MakeResourceFlavor("tas-flavor").
+					NodeLabel("node-group", "tas").
+					TopologyName("default").Obj()
+				util.MustCreate(ctx, k8sClient, tasFlavor)
+
+				clusterQueue = utiltestingapi.MakeClusterQueue("cluster-queue").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas(tasFlavor.Name).
+						Resource(resourceGPU, "44").
+						Resource(corev1.ResourceCPU, "10").
+						Obj()).
+					Obj()
+				util.MustCreate(ctx, k8sClient, clusterQueue)
+				util.ExpectClusterQueuesToBeActive(ctx, k8sClient, clusterQueue)
+
+				localQueue = utiltestingapi.MakeLocalQueue("local-queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+				util.MustCreate(ctx, k8sClient, localQueue)
+			})
+
+			ginkgo.AfterEach(func() {
+				gomega.Expect(util.DeleteAllJobsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+				gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+				gomega.Expect(util.DeleteObject(ctx, k8sClient, localQueue)).Should(gomega.Succeed())
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, tasFlavor, true)
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, topology, true)
+				for _, node := range nodes {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, &node, true)
+				}
+			})
+
+			ginkgo.It("place the leader and workers with required block level and sliced hostname level in block b1 when total GPUs exceed b2 capacity", func() {
+				var wl1 *kueue.Workload
+
+				ginkgo.By("creating a workload with grouping and 2-level slicing requiring 21 GPUs", func() {
+					wl1 = utiltestingapi.MakeWorkload("wl-grouped-sliced-b1", ns.Name).
+						PodSets(
+							*utiltestingapi.MakePodSet("leader", 1).
+								PodSetGroup("group-2level").
+								RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+								Request(resourceGPU, "1").
+								Obj(),
+							*utiltestingapi.MakePodSet("worker", 20).
+								PodSetGroup("group-2level").
+								RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+								SliceRequiredTopologyRequest(corev1.LabelHostname).
+								SliceSizeTopologyRequest(5).
+								Request(resourceGPU, "1").
+								Obj()).
+						Queue(kueue.LocalQueueName(localQueue.Name)).Obj()
+					util.MustCreate(ctx, k8sClient, wl1)
+				})
+
+				ginkgo.By("verify the workload is admitted in block b1", func() {
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl1), wl1)).To(gomega.Succeed())
+					gomega.Expect(wl1.Status.Admission.PodSetAssignments[0].TopologyAssignment).ShouldNot(gomega.BeNil())
+					gomega.Expect(wl1.Status.Admission.PodSetAssignments[1].TopologyAssignment).ShouldNot(gomega.BeNil())
+
+					leaderTA := utiltas.InternalFrom(wl1.Status.Admission.PodSetAssignments[0].TopologyAssignment)
+					workerTA := utiltas.InternalFrom(wl1.Status.Admission.PodSetAssignments[1].TopologyAssignment)
+
+					gomega.Expect(leaderTA.Levels).To(gomega.Equal([]string{corev1.LabelHostname}))
+					gomega.Expect(workerTA.Levels).To(gomega.Equal([]string{corev1.LabelHostname}))
+
+					// Total pods assigned match requests
+					gomega.Expect(assignedPodCount(wl1.Status.Admission.PodSetAssignments[0].TopologyAssignment)).To(gomega.Equal(int32(1)))
+					gomega.Expect(assignedPodCount(wl1.Status.Admission.PodSetAssignments[1].TopologyAssignment)).To(gomega.Equal(int32(20)))
+
+					// Verify leader and workers are placed together in block b1 (the only block with capacity >= 21 GPUs).
+					// Workers are sliced at hostname level with slice size 5, so on nodes x1 (12 GPUs) and x2 (12 GPUs)
+					// they are placed 10 + 10.
+					gomega.Expect(wl1.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(
+						utiltas.V1Beta2From(&utiltas.TopologyAssignment{
+							Levels: []string{corev1.LabelHostname},
+							Domains: []utiltas.TopologyDomainAssignment{
+								{Count: 1, Values: []string{"x1"}},
+							},
+						}),
+					))
+					gomega.Expect(wl1.Status.Admission.PodSetAssignments[1].TopologyAssignment).Should(gomega.BeComparableTo(
+						utiltas.V1Beta2From(&utiltas.TopologyAssignment{
+							Levels: []string{corev1.LabelHostname},
+							Domains: []utiltas.TopologyDomainAssignment{
+								{Count: 10, Values: []string{"x1"}},
+								{Count: 10, Values: []string{"x2"}},
+							},
+						}),
+					))
+				})
+			})
+
+			ginkgo.It("place the leader and workers in block b2 when 19 workers with slice size 5 and 1 leader fit best in b2", func() {
+				var wl *kueue.Workload
+
+				ginkgo.By("creating a workload with 1 leader and 19 workers with slice size 5", func() {
+					wl = utiltestingapi.MakeWorkload("wl-grouped-sliced-19-workers", ns.Name).
+						PodSets(
+							*utiltestingapi.MakePodSet("leader", 1).
+								PodSetGroup("group-2level").
+								RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+								Request(resourceGPU, "1").
+								Obj(),
+							*utiltestingapi.MakePodSet("worker", 19).
+								PodSetGroup("group-2level").
+								RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+								SliceRequiredTopologyRequest(corev1.LabelHostname).
+								SliceSizeTopologyRequest(5).
+								Request(resourceGPU, "1").
+								Obj()).
+						Queue(kueue.LocalQueueName(localQueue.Name)).Obj()
+					util.MustCreate(ctx, k8sClient, wl)
+				})
+
+				ginkgo.By("verifying the workload is admitted in block b2 with 15 sliced worker pods assigned", func() {
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
+					gomega.Expect(wl.Status.Admission.PodSetAssignments[0].TopologyAssignment).ShouldNot(gomega.BeNil())
+					gomega.Expect(wl.Status.Admission.PodSetAssignments[1].TopologyAssignment).ShouldNot(gomega.BeNil())
+
+					leaderTA := utiltas.InternalFrom(wl.Status.Admission.PodSetAssignments[0].TopologyAssignment)
+					workerTA := utiltas.InternalFrom(wl.Status.Admission.PodSetAssignments[1].TopologyAssignment)
+
+					gomega.Expect(leaderTA.Levels).To(gomega.Equal([]string{corev1.LabelHostname}))
+					gomega.Expect(workerTA.Levels).To(gomega.Equal([]string{corev1.LabelHostname}))
+
+					// Leader pod assigned matches request
+					gomega.Expect(assignedPodCount(wl.Status.Admission.PodSetAssignments[0].TopologyAssignment)).To(gomega.Equal(int32(1)))
+					// 19 workers with slice size 5 yields 3 full slices = 15 pods assigned
+					gomega.Expect(assignedPodCount(wl.Status.Admission.PodSetAssignments[1].TopologyAssignment)).To(gomega.Equal(int32(15)))
+
+					for _, domain := range workerTA.Domains {
+						gomega.Expect(domain.Count % 5).To(gomega.Equal(int32(0)))
+					}
+
+					// Verify best-fit places leader and workers in block b2 (closer fit: 3 slices in b2 vs 4 in b1)
+					nodeMap := make(map[string]*corev1.Node, len(nodes))
+					for i := range nodes {
+						nodeMap[nodes[i].Name] = &nodes[i]
+					}
+					leaderBlock := nodeMap[leaderTA.Domains[0].Values[0]].Labels[utiltesting.DefaultBlockTopologyLevel]
+					gomega.Expect(leaderBlock).To(gomega.Equal("b2"))
+					for _, domain := range workerTA.Domains {
+						workerBlock := nodeMap[domain.Values[0]].Labels[utiltesting.DefaultBlockTopologyLevel]
+						gomega.Expect(workerBlock).To(gomega.Equal("b2"))
+					}
+				})
+			})
+
+			ginkgo.It("place the leader and workers in block b2 when the leader requires no GPUs and 20 workers fit exactly in b2", func() {
+				var wl *kueue.Workload
+
+				ginkgo.By("creating a workload with 1 leader (0 GPUs) and 20 workers (1 GPU each, slice size 5)", func() {
+					wl = utiltestingapi.MakeWorkload("wl-grouped-sliced-no-gpu-leader", ns.Name).
+						PodSets(
+							*utiltestingapi.MakePodSet("leader", 1).
+								PodSetGroup("group-2level").
+								RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+								Request(corev1.ResourceCPU, "100m").
+								Obj(),
+							*utiltestingapi.MakePodSet("worker", 20).
+								PodSetGroup("group-2level").
+								RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+								SliceRequiredTopologyRequest(corev1.LabelHostname).
+								SliceSizeTopologyRequest(5).
+								Request(resourceGPU, "1").
+								Obj()).
+						Queue(kueue.LocalQueueName(localQueue.Name)).Obj()
+					util.MustCreate(ctx, k8sClient, wl)
+				})
+
+				ginkgo.By("verifying the workload is admitted in block b2 with all 20 worker pods assigned", func() {
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
+					gomega.Expect(wl.Status.Admission.PodSetAssignments[0].TopologyAssignment).ShouldNot(gomega.BeNil())
+					gomega.Expect(wl.Status.Admission.PodSetAssignments[1].TopologyAssignment).ShouldNot(gomega.BeNil())
+
+					leaderTA := utiltas.InternalFrom(wl.Status.Admission.PodSetAssignments[0].TopologyAssignment)
+					workerTA := utiltas.InternalFrom(wl.Status.Admission.PodSetAssignments[1].TopologyAssignment)
+
+					gomega.Expect(leaderTA.Levels).To(gomega.Equal([]string{corev1.LabelHostname}))
+					gomega.Expect(workerTA.Levels).To(gomega.Equal([]string{corev1.LabelHostname}))
+
+					// Total pods assigned match requests
+					gomega.Expect(assignedPodCount(wl.Status.Admission.PodSetAssignments[0].TopologyAssignment)).To(gomega.Equal(int32(1)))
+					gomega.Expect(assignedPodCount(wl.Status.Admission.PodSetAssignments[1].TopologyAssignment)).To(gomega.Equal(int32(20)))
+
+					// All worker domain counts are multiples of slice size (5)
+					for _, domain := range workerTA.Domains {
+						gomega.Expect(domain.Count % 5).To(gomega.Equal(int32(0)))
+					}
+
+					// Verify best-fit places leader and workers in block b2 (exact 20 GPUs fit vs 24 GPUs in b1)
+					nodeMap := make(map[string]*corev1.Node, len(nodes))
+					for i := range nodes {
+						nodeMap[nodes[i].Name] = &nodes[i]
+					}
+					leaderBlock := nodeMap[leaderTA.Domains[0].Values[0]].Labels[utiltesting.DefaultBlockTopologyLevel]
+					gomega.Expect(leaderBlock).To(gomega.Equal("b2"))
+					for _, domain := range workerTA.Domains {
+						workerBlock := nodeMap[domain.Values[0]].Labels[utiltesting.DefaultBlockTopologyLevel]
+						gomega.Expect(workerBlock).To(gomega.Equal("b2"))
+					}
+				})
+			})
+
+			ginkgo.It("should not admit workload when leader and sliced workers cannot fit together in any single required block domain", func() {
+				var wl *kueue.Workload
+
+				ginkgo.By("creating a workload requiring 26 GPUs in the same group where max block capacity is 24", func() {
+					// Block b1 has 24 GPUs, Block b2 has 20 GPUs. Total quota is 44 GPUs.
+					// Workload requires 1 leader (1 GPU) + 25 workers (1 GPU each, slice size 5) = 26 GPUs.
+					// Since neither block can fit 26 GPUs, the workload cannot be admitted even though
+					// cluster quota is sufficient.
+					wl = utiltestingapi.MakeWorkload("wl-grouped-sliced-overflow", ns.Name).
+						PodSets(
+							*utiltestingapi.MakePodSet("leader", 1).
+								PodSetGroup("group-2level").
+								RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+								Request(resourceGPU, "1").
+								Obj(),
+							*utiltestingapi.MakePodSet("worker", 25).
+								PodSetGroup("group-2level").
+								RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+								SliceRequiredTopologyRequest(corev1.LabelHostname).
+								SliceSizeTopologyRequest(5).
+								Request(resourceGPU, "1").
+								Obj()).
+						Queue(kueue.LocalQueueName(localQueue.Name)).Obj()
+					util.MustCreate(ctx, k8sClient, wl)
+				})
+
+				ginkgo.By("verifying the workload is not admitted", func() {
+					util.ExpectWorkloadsToBePending(ctx, k8sClient, wl)
+				})
+			})
+
+			ginkgo.It("place multiple grouped and sliced workloads on separate blocks when each block fits only one workload", func() {
+				var wl1, wl2 *kueue.Workload
+
+				ginkgo.By("creating two workloads each requiring 16 GPUs (1 leader + 15 workers with slice size 5)", func() {
+					// Block b1 has 24 GPUs, Block b2 has 20 GPUs.
+					// Each workload requires 16 GPUs.
+					// Neither block can fit both (32 > 24 and 32 > 20).
+					// The two workloads must be admitted onto different blocks.
+					wl1 = utiltestingapi.MakeWorkload("wl-grouped-sliced-1", ns.Name).
+						PodSets(
+							*utiltestingapi.MakePodSet("leader", 1).
+								PodSetGroup("group-2level-1").
+								RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+								Request(resourceGPU, "1").
+								Obj(),
+							*utiltestingapi.MakePodSet("worker", 15).
+								PodSetGroup("group-2level-1").
+								RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+								SliceRequiredTopologyRequest(corev1.LabelHostname).
+								SliceSizeTopologyRequest(5).
+								Request(resourceGPU, "1").
+								Obj()).
+						Queue(kueue.LocalQueueName(localQueue.Name)).Obj()
+					util.MustCreate(ctx, k8sClient, wl1)
+
+					wl2 = utiltestingapi.MakeWorkload("wl-grouped-sliced-2", ns.Name).
+						PodSets(
+							*utiltestingapi.MakePodSet("leader", 1).
+								PodSetGroup("group-2level-2").
+								RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+								Request(resourceGPU, "1").
+								Obj(),
+							*utiltestingapi.MakePodSet("worker", 15).
+								PodSetGroup("group-2level-2").
+								RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+								SliceRequiredTopologyRequest(corev1.LabelHostname).
+								SliceSizeTopologyRequest(5).
+								Request(resourceGPU, "1").
+								Obj()).
+						Queue(kueue.LocalQueueName(localQueue.Name)).Obj()
+					util.MustCreate(ctx, k8sClient, wl2)
+				})
+
+				var nodeMap map[string]*corev1.Node
+				ginkgo.By("verifying both workloads are admitted onto different blocks", func() {
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1, wl2)
+					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl1), wl1)).To(gomega.Succeed())
+					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl2), wl2)).To(gomega.Succeed())
+
+					nodeMap = make(map[string]*corev1.Node, len(nodes))
+					for i := range nodes {
+						nodeMap[nodes[i].Name] = &nodes[i]
+					}
+
+					wl1LeaderTA := utiltas.InternalFrom(wl1.Status.Admission.PodSetAssignments[0].TopologyAssignment)
+					wl2LeaderTA := utiltas.InternalFrom(wl2.Status.Admission.PodSetAssignments[0].TopologyAssignment)
+					wl1WorkerTA := utiltas.InternalFrom(wl1.Status.Admission.PodSetAssignments[1].TopologyAssignment)
+					wl2WorkerTA := utiltas.InternalFrom(wl2.Status.Admission.PodSetAssignments[1].TopologyAssignment)
+
+					wl1LeaderBlock := nodeMap[wl1LeaderTA.Domains[0].Values[0]].Labels[utiltesting.DefaultBlockTopologyLevel]
+					wl2LeaderBlock := nodeMap[wl2LeaderTA.Domains[0].Values[0]].Labels[utiltesting.DefaultBlockTopologyLevel]
+
+					// One in b1, one in b2
+					gomega.Expect(wl1LeaderBlock).NotTo(gomega.Equal(wl2LeaderBlock))
+
+					// Verify worker domains for wl1 are all in wl1LeaderBlock, and for wl2 all in wl2LeaderBlock
+					for _, domain := range wl1WorkerTA.Domains {
+						gomega.Expect(nodeMap[domain.Values[0]].Labels[utiltesting.DefaultBlockTopologyLevel]).To(gomega.Equal(wl1LeaderBlock))
+						gomega.Expect(domain.Count % 5).To(gomega.Equal(int32(0)))
+					}
+					for _, domain := range wl2WorkerTA.Domains {
+						gomega.Expect(nodeMap[domain.Values[0]].Labels[utiltesting.DefaultBlockTopologyLevel]).To(gomega.Equal(wl2LeaderBlock))
+						gomega.Expect(domain.Count % 5).To(gomega.Equal(int32(0)))
+					}
+				})
+			})
+
+			ginkgo.It("fall back across blocks when preferred block topology cannot fit all slices, while respecting required hostname slice topology", func() {
+				var wl *kueue.Workload
+
+				ginkgo.By("creating a workload requiring 36 GPUs with preferred block and slice size 5 requiring hostname", func() {
+					// b1 has 24 GPUs, b2 has 20 GPUs. Total cluster capacity is 44 GPUs.
+					// 36 GPUs (1 leader + 35 workers) cannot fit in b1 or b2 alone.
+					// Because block is preferred, the scheduler falls back to the parent level,
+					// placing slices across both blocks while still packing workers in multiples of 5 on hostnames.
+					wl = utiltestingapi.MakeWorkload("wl-preferred-grouped-sliced-fallback", ns.Name).
+						PodSets(
+							*utiltestingapi.MakePodSet("leader", 1).
+								PodSetGroup("group-pref").
+								PreferredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+								Request(resourceGPU, "1").
+								Obj(),
+							*utiltestingapi.MakePodSet("worker", 35).
+								PodSetGroup("group-pref").
+								PreferredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+								SliceRequiredTopologyRequest(corev1.LabelHostname).
+								SliceSizeTopologyRequest(5).
+								Request(resourceGPU, "1").
+								Obj()).
+						Queue(kueue.LocalQueueName(localQueue.Name)).Obj()
+					util.MustCreate(ctx, k8sClient, wl)
+				})
+
+				ginkgo.By("verifying the workload is admitted spanning across blocks with slice size preserved", func() {
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
+
+					workerTA := utiltas.InternalFrom(wl.Status.Admission.PodSetAssignments[1].TopologyAssignment)
+					gomega.Expect(assignedPodCount(wl.Status.Admission.PodSetAssignments[1].TopologyAssignment)).To(gomega.Equal(int32(35)))
+
+					nodeMap := make(map[string]*corev1.Node, len(nodes))
+					for i := range nodes {
+						nodeMap[nodes[i].Name] = &nodes[i]
+					}
+
+					blocksUsed := make(map[string]bool)
+					for _, domain := range workerTA.Domains {
+						gomega.Expect(domain.Count % 5).To(gomega.Equal(int32(0)))
+						block := nodeMap[domain.Values[0]].Labels[utiltesting.DefaultBlockTopologyLevel]
+						blocksUsed[block] = true
+					}
+					// Workload spans both blocks
+					gomega.Expect(blocksUsed).To(gomega.HaveKey("b1"))
+					gomega.Expect(blocksUsed).To(gomega.HaveKey("b2"))
+				})
+			})
+		})
 		ginkgo.When("PodSet slice size does not divide the PodSet count", func() {
 			// When a slice-topology PodSet's slice size does not evenly divide its
 			// count, the scheduler places floor(count/sliceSize)*sliceSize pods but

--- a/test/integration/singlecluster/webhook/jobs/leaderworkerset_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/leaderworkerset_webhook_test.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/leaderworkerset"
 	"sigs.k8s.io/kueue/pkg/features"
@@ -107,6 +108,31 @@ var _ = ginkgo.Describe("LeaderWorkerSet Webhook", func() {
 					g.Expect(k8sClient.Update(ctx, createdLws)).To(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
+		})
+
+		ginkgo.It("should allow LeaderWorkerSet with grouping and slicing", func() {
+			lws := testingleaderworkerset.MakeLeaderWorkerSet("lws", ns.Name).
+				Queue("user-queue").
+				Size(5).
+				LeaderTemplate(corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "c",
+								Image: "pause",
+							},
+						},
+					},
+				}).
+				LeaderTemplateSpecAnnotation(kueue.PodSetGroupName, "test-group").
+				LeaderTemplateSpecAnnotation(kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
+				WorkerTemplateSpecAnnotation(kueue.PodSetGroupName, "test-group").
+				WorkerTemplateSpecAnnotation(kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
+				WorkerTemplateSpecAnnotation(kueue.PodSetSliceRequiredTopologyAnnotation, "cloud.com/rack").
+				WorkerTemplateSpecAnnotation(kueue.PodSetSliceSizeAnnotation, "2").
+				RolloutStrategy(leaderworkersetv1.RollingUpdateStrategyType).
+				Obj()
+			util.MustCreate(ctx, k8sClient, lws)
 		})
 
 		ginkgo.When("the LWSImmutableGroupSize feature gate is disabled", func() {

--- a/test/integration/singlecluster/webhook/jobs/leaderworkerset_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/leaderworkerset_webhook_test.go
@@ -110,29 +110,93 @@ var _ = ginkgo.Describe("LeaderWorkerSet Webhook", func() {
 			})
 		})
 
-		ginkgo.It("should allow LeaderWorkerSet with grouping and slicing", func() {
-			lws := testingleaderworkerset.MakeLeaderWorkerSet("lws", ns.Name).
-				Queue("user-queue").
-				Size(5).
-				LeaderTemplate(corev1.PodTemplateSpec{
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{
-							{
-								Name:  "c",
-								Image: "pause",
+		ginkgo.When("the TASGroupedPodSetSlicing feature gate is enabled", func() {
+			ginkgo.BeforeEach(func() {
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.TASGroupedPodSetSlicing, true)
+			})
+
+			ginkgo.It("should allow LeaderWorkerSet with grouping and slicing", func() {
+				lws := testingleaderworkerset.MakeLeaderWorkerSet("lws", ns.Name).
+					Queue("user-queue").
+					Size(5).
+					LeaderTemplate(corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "c",
+									Image: "pause",
+								},
 							},
 						},
-					},
-				}).
-				LeaderTemplateSpecAnnotation(kueue.PodSetGroupName, "test-group").
-				LeaderTemplateSpecAnnotation(kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
-				WorkerTemplateSpecAnnotation(kueue.PodSetGroupName, "test-group").
-				WorkerTemplateSpecAnnotation(kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
-				WorkerTemplateSpecAnnotation(kueue.PodSetSliceRequiredTopologyAnnotation, "cloud.com/rack").
-				WorkerTemplateSpecAnnotation(kueue.PodSetSliceSizeAnnotation, "2").
-				RolloutStrategy(leaderworkersetv1.RollingUpdateStrategyType).
-				Obj()
-			util.MustCreate(ctx, k8sClient, lws)
+					}).
+					LeaderTemplateSpecAnnotation(kueue.PodSetGroupName, "test-group").
+					LeaderTemplateSpecAnnotation(kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
+					WorkerTemplateSpecAnnotation(kueue.PodSetGroupName, "test-group").
+					WorkerTemplateSpecAnnotation(kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
+					WorkerTemplateSpecAnnotation(kueue.PodSetSliceRequiredTopologyAnnotation, "cloud.com/rack").
+					WorkerTemplateSpecAnnotation(kueue.PodSetSliceSizeAnnotation, "2").
+					RolloutStrategy(leaderworkersetv1.RollingUpdateStrategyType).
+					Obj()
+				util.MustCreate(ctx, k8sClient, lws)
+			})
+
+			ginkgo.It("should allow LeaderWorkerSet with grouping and multi-layer slicing constraints", func() {
+				lws := testingleaderworkerset.MakeLeaderWorkerSet("lws-multi-layer", ns.Name).
+					Queue("user-queue").
+					Size(5).
+					LeaderTemplate(corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "c",
+									Image: "pause",
+								},
+							},
+						},
+					}).
+					LeaderTemplateSpecAnnotation(kueue.PodSetGroupName, "test-group").
+					LeaderTemplateSpecAnnotation(kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
+					WorkerTemplateSpecAnnotation(kueue.PodSetGroupName, "test-group").
+					WorkerTemplateSpecAnnotation(kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
+					WorkerTemplateSpecAnnotation(kueue.PodSetSliceRequiredTopologyConstraintsAnnotation, `[{"topology":"cloud.com/rack","size":2}]`).
+					RolloutStrategy(leaderworkersetv1.RollingUpdateStrategyType).
+					Obj()
+				util.MustCreate(ctx, k8sClient, lws)
+			})
+		})
+
+		ginkgo.When("the TASGroupedPodSetSlicing feature gate is disabled", func() {
+			ginkgo.BeforeEach(func() {
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.TASGroupedPodSetSlicing, false)
+			})
+
+			ginkgo.It("should reject LeaderWorkerSet with grouping and slicing", func() {
+				lws := testingleaderworkerset.MakeLeaderWorkerSet("lws-disabled", ns.Name).
+					Queue("user-queue").
+					Size(5).
+					LeaderTemplate(corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "c",
+									Image: "pause",
+								},
+							},
+						},
+					}).
+					LeaderTemplateSpecAnnotation(kueue.PodSetGroupName, "test-group").
+					LeaderTemplateSpecAnnotation(kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
+					WorkerTemplateSpecAnnotation(kueue.PodSetGroupName, "test-group").
+					WorkerTemplateSpecAnnotation(kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
+					WorkerTemplateSpecAnnotation(kueue.PodSetSliceRequiredTopologyAnnotation, "cloud.com/rack").
+					WorkerTemplateSpecAnnotation(kueue.PodSetSliceSizeAnnotation, "2").
+					RolloutStrategy(leaderworkersetv1.RollingUpdateStrategyType).
+					Obj()
+				gomega.Expect(k8sClient.Create(ctx, lws)).Should(gomega.SatisfyAll(
+					utiltesting.BeForbiddenError(),
+					gomega.MatchError(gomega.ContainSubstring(kueue.PodSetGroupName)),
+				))
+			})
 		})
 
 		ginkgo.When("the LWSImmutableGroupSize feature gate is disabled", func() {


### PR DESCRIPTION
Cherry pick of #15111 on release-0.19.

#15111: TAS: Enable PodSet slicing alongside PodSet grouping

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind feature
/area tas

#### What this PR does / why we need it:
Cherry pick of #15111 onto release-0.19.
In this cherry-pick, the new `TASGroupedPodSetSlicing` feature gate is disabled by default (`Default: false`).

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
Parts of this PR were prepared with the assistance of an AI.
The `TASGroupedPodSetSlicing` feature gate is disabled by default on this release branch.

#### Does this PR introduce a user-facing change?
```release-note
TAS: Added support for PodSet slicing alongside PodSet grouping, allowing workloads such as LeaderWorkerSet to co-locate grouped leader PodSets with sliced worker PodSets. This behavior is gated by the TASGroupedPodSetSlicing feature gate.
```