### PR TITLE
Fix stale reclaimablePods in UnsetQuotaReservationWithCondition

### DIFF
--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -862,7 +862,7 @@ func SetConditionAndUpdate(ctx context.Context,
 }
 
 // UnsetQuotaReservationWithCondition sets the QuotaReserved condition to false, clears
-// the admission and set the WorkloadRequeued status.
+// the admission and reclaimable pods, and sets the WorkloadRequeued status.
 // Returns whether any change was done.
 func UnsetQuotaReservationWithCondition(wl *kueue.Workload, reason, message string, now time.Time) bool {
 	condition := metav1.Condition{
@@ -876,6 +876,10 @@ func UnsetQuotaReservationWithCondition(wl *kueue.Workload, reason, message stri
 	changed := apimeta.SetStatusCondition(&wl.Status.Conditions, condition)
 	if wl.Status.Admission != nil {
 		wl.Status.Admission = nil
+		if len(wl.Status.ReclaimablePods) > 0 {
+			wl.Status.ReclaimablePods = nil
+			changed = true
+		}
 		changed = true
 	}
 

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -2916,6 +2917,54 @@ func TestSetQuotaReservation(t *testing.T) {
 	}
 }
 
+
+func TestUnsetQuotaReservationWithCondition(t *testing.T) {
+	now := time.Now()
+	admission := utiltestingapi.MakeAdmission("test-queue").Obj()
+
+	wl := utiltestingapi.MakeWorkload("test", "default").
+		Admission(admission).
+		ReclaimablePods(kueue.ReclaimablePod{Name: "ps1", Count: 2}).
+		Condition(metav1.Condition{
+			Type:               kueue.WorkloadQuotaReserved,
+			Status:             metav1.ConditionTrue,
+			Reason:             "QuotaReserved",
+			Message:            "Quota reserved",
+			LastTransitionTime: metav1.NewTime(now),
+		}).
+		Obj()
+
+	// Invariant: while workload has quota reservation, reclaimablePods is preserved.
+	if !HasQuotaReservation(wl) {
+		t.Fatalf("HasQuotaReservation() = false, want true before unsetting")
+	}
+	if len(wl.Status.ReclaimablePods) == 0 {
+		t.Fatalf("len(wl.Status.ReclaimablePods) = 0, want non-empty before unsetting")
+	}
+
+	changed := UnsetQuotaReservationWithCondition(wl, "Evicted", "Workload evicted", now)
+	if !changed {
+		t.Errorf("UnsetQuotaReservationWithCondition() returned false, want true")
+	}
+
+	// Invariant: after UnsetQuotaReservationWithCondition, quota reservation is removed and reclaimablePods is cleared.
+	if HasQuotaReservation(wl) {
+		t.Errorf("HasQuotaReservation() = true, want false after unsetting")
+	}
+
+	if wl.Status.Admission != nil {
+		t.Errorf("wl.Status.Admission = %v, want nil", wl.Status.Admission)
+	}
+
+	if len(wl.Status.ReclaimablePods) > 0 {
+		t.Errorf("wl.Status.ReclaimablePods = %v, want empty", wl.Status.ReclaimablePods)
+	}
+
+	cond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadQuotaReserved)
+	if cond == nil || cond.Status != metav1.ConditionFalse {
+		t.Errorf("WorkloadQuotaReserved condition status = %v, want ConditionFalse", cond)
+	}
+}
 func TestSetRequeueState(t *testing.T) {
 	baseTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
 	futureTime := baseTime.Add(5 * time.Minute)


### PR DESCRIPTION
**Problem:**
When a JobSet pod is restarted (e.g., due to node eviction) without Kueue performing quota requeue, the `reclaimablePods` field can become stale. This causes ClusterQueue to under-count usage and over-admit workloads.

**Root cause:**
`UnsetQuotaReservationWithCondition` clears QuotaReserved condition and admission but not reclaimablePods. After eviction/requeue cycles, reclaimablePods retains stale data. ClusterQueue calculates `flavorsUsage` by subtracting `raw/count × reclaimablePods` from sum of podSetAssignments. Stale reclaimablePods causes under-counting.

**Example scenario:**
1. JobSet A admits 10 pods, all pods become reclaimable
2. JobSet A is evicted, `UnsetQuotaReservationWithCondition` is called
3. Without fix: reclaimablePods still has 10 pods marked as reclaimable
4. JobSet A restarts pods (without requeue), admission is restored
5. Without fix: reclaimablePods stays at 10, ClusterQueue thinks 10 pods are still reclaimable
6. ClusterQueue admits 10 extra pods from JobSet B (under-counts usage by 10)

**Fix:**
Modified `UnsetQuotaReservationWithCondition` to also clear reclaimablePods when admission is cleared:
```go
if wl.Status.Admission != nil {
    wl.Status.Admission = nil
    if len(wl.Status.ReclaimablePods) > 0 {
        wl.Status.ReclaimablePods = nil
        changed = true
    }
    changed = true
}
```

**How tested:**
- Added `TestUnsetQuotaReservationWithCondition` to verify reclaimablePods are cleared when quota reservation is removed
- All existing tests pass

**Links:**
- Issue: https://github.com/kubernetes-sigs/kueue/issues/14609
- Related PR: https://github.com/kubernetes-sigs/kueue/pull/14667 (approved by tomsen02)

AI disclosure: This fix was created with AI agent assistance operated by KR-Ravindra.
