### PR TITLE
Align event-handler and reconcile logger names across controllers

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/admissioncheck.go
+++ b/pkg/controller/admissionchecks/multikueue/admissioncheck.go
@@ -149,7 +149,7 @@ func (a *ACReconciler) setupWithManager(mgr ctrl.Manager) error {
 		Watches(&kueue.MultiKueueConfig{}, &mkConfigHandler{client: a.client}).
 		Watches(&kueue.MultiKueueCluster{}, &mkClusterHandler{client: a.client}).
 		WithOptions(controller.Options{
-			LogConstructor: roletracker.NewLogConstructor(a.roleTracker, "multikueue-admissioncheck"),
+			LogConstructor: roletracker.NewLogConstructor(a.roleTracker, "multikueue-admissioncheck-reconciler"),
 		}).
 		Complete(a)
 }

--- a/pkg/controller/admissionchecks/multikueue/clusterqueue.go
+++ b/pkg/controller/admissionchecks/multikueue/clusterqueue.go
@@ -327,7 +327,7 @@ func (r *cqReconciler) setupWithManager(mgr ctrl.Manager) error {
 		Watches(&kueue.MultiKueueCluster{}, &cqClusterHandler{reconciler: r}).
 		WatchesRawSource(source.Channel(r.clusters.cqUpdateCh, remoteHandler)).
 		WithOptions(controller.Options{
-			LogConstructor: roletracker.NewLogConstructor(r.roleTracker, "multikueue-clusterqueue"),
+			LogConstructor: roletracker.NewLogConstructor(r.roleTracker, "multikueue-clusterqueue-reconciler"),
 		}).
 		Complete(r)
 }

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -1234,7 +1234,7 @@ func newClustersReconciler(
 		fsWatcher:                    fsWatcher,
 		adapters:                     adapters,
 		clusterProfileAccessProvider: cpAccessProvider,
-		logName:                      "multikueuecluster-reconciler",
+		logName:                      "multikueue-multikueuecluster-reconciler",
 		roleTracker:                  roleTracker,
 	}
 }
@@ -1274,7 +1274,7 @@ func (c *clustersReconciler) setupWithManager(mgr ctrl.Manager) error {
 		WatchesRawSource(source.Channel(c.fsWatcher.reconcile, fsWatcherHndl)).
 		WithEventFilter(c).
 		WithOptions(controller.Options{
-			LogConstructor: roletracker.NewLogConstructor(c.roleTracker, "multikueue-cluster"),
+			LogConstructor: roletracker.NewLogConstructor(c.roleTracker, "multikueue-multikueuecluster-reconciler"),
 		})
 	if features.Enabled(features.MultiKueueClusterProfile) {
 		systemNamespacePredicate := predicate.NewPredicateFuncs(func(obj client.Object) bool {

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -1196,7 +1196,7 @@ func (w *wlReconciler) setupWithManager(mgr ctrl.Manager) error {
 	c, err := builder.
 		WithEventFilter(w).
 		WithOptions(controller.Options{
-			LogConstructor: roletracker.NewLogConstructor(w.roleTracker, "multikueue-workload"),
+			LogConstructor: roletracker.NewLogConstructor(w.roleTracker, "multikueue-workload-reconciler"),
 		}).
 		Build(w)
 	if err != nil {
@@ -1227,7 +1227,7 @@ func (w *wlReconciler) setupWithManager(mgr ctrl.Manager) error {
 			gvk := adapter.GVK()
 			h := &localJobHandler{client: w.client, gvk: gvk, eventsBatchPeriod: w.eventsBatchPeriod}
 			if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
-				log := ctrl.LoggerFrom(ctx).WithName("multikueue-workload")
+				log := ctrl.LoggerFrom(ctx).WithName("multikueue-workload-reconciler")
 				jobframework.WaitForAPI(ctx, mgr, log, gvk, func() {
 					if err := c.Watch(source.Kind(mgr.GetCache(), emptyJob, h)); err != nil {
 						log.Error(err, "Unable to watch local job for MultiKueue spec sync", "gvk", gvk)

--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -891,7 +891,7 @@ func (c *Controller) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&kueue.AdmissionCheck{}, ach).
 		Watches(&kueue.ProvisioningRequestConfig{}, prch).
 		WithOptions(controller.Options{
-			LogConstructor: roletracker.NewLogConstructor(c.roleTracker, "provisioning-workload"),
+			LogConstructor: roletracker.NewLogConstructor(c.roleTracker, "provisioning-workload-reconciler"),
 		}).
 		Complete(c)
 	if err != nil {
@@ -911,7 +911,7 @@ func (c *Controller) SetupWithManager(mgr ctrl.Manager) error {
 		For(&kueue.AdmissionCheck{}).
 		Watches(&kueue.ProvisioningRequestConfig{}, prcACh).
 		WithOptions(controller.Options{
-			LogConstructor: roletracker.NewLogConstructor(c.roleTracker, "provisioning-admissioncheck"),
+			LogConstructor: roletracker.NewLogConstructor(c.roleTracker, "provisioning-admissioncheck-reconciler"),
 		}).
 		Complete(acReconciler)
 }

--- a/pkg/controller/core/clusterqueue_controller.go
+++ b/pkg/controller/core/clusterqueue_controller.go
@@ -135,7 +135,7 @@ func NewClusterQueueReconciler(
 	}
 	return &ClusterQueueReconciler{
 		client:                client,
-		logName:               "cluster-queue-reconciler",
+		logName:               "clusterqueue-reconciler",
 		qManager:              qMgr,
 		cache:                 cache,
 		nonCQObjectUpdateCh:   make(chan event.TypedGenericEvent[iter.Seq[kueue.ClusterQueueReference]], updateChBuffer),

--- a/pkg/controller/core/clusterqueue_controller_test.go
+++ b/pkg/controller/core/clusterqueue_controller_test.go
@@ -229,7 +229,7 @@ func TestUpdateCqStatusIfChanged(t *testing.T) {
 			}
 			r := &ClusterQueueReconciler{
 				client:   cl,
-				logName:  "cluster-queue-reconciler",
+				logName:  "clusterqueue-reconciler",
 				cache:    cqCache,
 				qManager: qManager,
 			}
@@ -307,7 +307,7 @@ func TestClusterQueueReconcile(t *testing.T) {
 
 			r := &ClusterQueueReconciler{
 				client:   cl,
-				logName:  "cluster-queue-reconciler",
+				logName:  "clusterqueue-reconciler",
 				cache:    cqCache,
 				qManager: qManager,
 			}

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -125,7 +125,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&corev1.Pod{}, &lwsPodHandler{}).
 		Watches(&appsv1.StatefulSet{}, &lwsStsHandler{}).
 		WithOptions(controller.Options{
-			LogConstructor: roletracker.NewLogConstructor(r.roleTracker, controllerName),
+			LogConstructor: roletracker.NewLogConstructor(r.roleTracker, "leaderworkerset-reconciler"),
 		}).
 		Complete(r)
 }

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler.go
@@ -383,7 +383,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		WithEventFilter(r).
 		Watches(&corev1.Pod{}, &podHandler{}).
 		WithOptions(controller.Options{
-			LogConstructor: roletracker.NewLogConstructor(r.roleTracker, controllerName),
+			LogConstructor: roletracker.NewLogConstructor(r.roleTracker, "statefulset-reconciler"),
 		}).
 		Complete(r)
 }

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler.go
@@ -78,8 +78,6 @@ type Reconciler struct {
 	customLabels                 *metrics.CustomLabels
 }
 
-const controllerName = "statefulset"
-
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 	log.V(2).Info("Reconcile StatefulSet")

--- a/pkg/controller/tas/node_controller.go
+++ b/pkg/controller/tas/node_controller.go
@@ -258,7 +258,7 @@ func newNodeReconciler(
 	return &nodeReconciler{
 		client:      client,
 		cache:       cache,
-		logName:     TASNodeController,
+		logName:     "tas-node-reconciler",
 		clock:       clock.RealClock{},
 		recorder:    recorder,
 		roleTracker: roleTracker,

--- a/pkg/controller/tas/pod_usage_controller.go
+++ b/pkg/controller/tas/pod_usage_controller.go
@@ -286,6 +286,6 @@ func (r *PodUsageReconciler) SetupWithManager(mgr ctrl.Manager) (string, error) 
 			NeedLeaderElection:      new(false),
 			MaxConcurrentReconciles: mgr.GetControllerOptions().GroupKindConcurrency[corev1.SchemeGroupVersion.WithKind("Pod").GroupKind().String()],
 		}).
-		WithLogConstructor(roletracker.NewLogConstructor(r.roleTracker, TASPodUsageController)).
+		WithLogConstructor(roletracker.NewLogConstructor(r.roleTracker, "tas-pod-usage-reconciler")).
 		Complete(r)
 }

--- a/pkg/controller/tas/resource_flavor.go
+++ b/pkg/controller/tas/resource_flavor.go
@@ -65,7 +65,7 @@ var _ predicate.TypedPredicate[*kueue.ResourceFlavor] = (*rfReconciler)(nil)
 
 func newRfReconciler(c client.Client, queues *qcache.Manager, cache *schdcache.Cache, recorder events.EventRecorder, roleTracker *roletracker.RoleTracker) *rfReconciler {
 	return &rfReconciler{
-		logName:      TASResourceFlavorController,
+		logName:      "tas-resourceflavor-reconciler",
 		client:       c,
 		queues:       queues,
 		cache:        cache,
@@ -93,7 +93,7 @@ func (r *rfReconciler) setupWithManager(mgr ctrl.Manager, cache *schdcache.Cache
 			NeedLeaderElection:      new(false),
 			MaxConcurrentReconciles: mgr.GetControllerOptions().GroupKindConcurrency[kueue.SchemeGroupVersion.WithKind("ResourceFlavor").GroupKind().String()],
 		}).
-		WithLogConstructor(roletracker.NewLogConstructor(r.roleTracker, TASResourceFlavorController)).
+		WithLogConstructor(roletracker.NewLogConstructor(r.roleTracker, "tas-resourceflavor-reconciler")).
 		Complete(core.WithLeadingManager(mgr, r, &kueue.ResourceFlavor{}, cfg))
 }
 

--- a/pkg/controller/tas/topology_controller.go
+++ b/pkg/controller/tas/topology_controller.go
@@ -62,7 +62,7 @@ var _ predicate.TypedPredicate[*kueue.Topology] = (*topologyReconciler)(nil)
 
 func newTopologyReconciler(c client.Client, queues *qcache.Manager, cache *schdcache.Cache, roleTracker *roletracker.RoleTracker) *topologyReconciler {
 	return &topologyReconciler{
-		logName:          TASTopologyController,
+		logName:          "tas-topology-reconciler",
 		client:           c,
 		queues:           queues,
 		cache:            cache,
@@ -88,7 +88,7 @@ func (r *topologyReconciler) setupWithManager(mgr ctrl.Manager, cfg *configapi.C
 			NeedLeaderElection:      new(false),
 			MaxConcurrentReconciles: mgr.GetControllerOptions().GroupKindConcurrency[kueue.SchemeGroupVersion.WithKind("Topology").GroupKind().String()],
 		}).
-		WithLogConstructor(roletracker.NewLogConstructor(r.roleTracker, TASTopologyController)).
+		WithLogConstructor(roletracker.NewLogConstructor(r.roleTracker, "tas-topology-reconciler")).
 		Watches(&kueue.ResourceFlavor{}, &resourceFlavorHandler{}).
 		Complete(core.WithLeadingManager(mgr, r, &kueue.Topology{}, cfg))
 }

--- a/site/content/en/community/contribution_guidelines/testing.md
+++ b/site/content/en/community/contribution_guidelines/testing.md
@@ -356,7 +356,7 @@ Kueue runs as a regular pod on a worker node, and in e2e tests there are 2 repli
 
 For each log message you can from which file and line the message is coming from:
 ```log
-2025-02-03T15:51:51.502425029Z stderr F 2025-02-03T15:51:51.502117824Z	LEVEL(-2)	cluster-queue-reconciler	core/clusterqueue_controller.go:341	ClusterQueue update event	{"clusterQueue": {"name":"cluster-queue"}}
+2025-02-03T15:51:51.502425029Z stderr F 2025-02-03T15:51:51.502117824Z	LEVEL(-2)	clusterqueue-reconciler	core/clusterqueue_controller.go:341	ClusterQueue update event	{"clusterQueue": {"name":"cluster-queue"}}
 ```
 
 ---


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Several controllers log under two different logger names: the event handlers (`Create`, `Update`, `Delete`, `Generic`) use `logName`, while the reconcile loop uses `LogConstructor`. For example the ClusterQueue controller used `cluster-queue-reconciler` for events and `clusterqueue-reconciler` for reconciles, so filtering by `logger == "clusterqueue-reconciler"` silently dropped the event-handler lines. The same mismatch existed in the MultiKueueCluster, LeaderWorkerSet, StatefulSet and TAS node controllers.

This PR makes `logName` equal to `LogConstructor` everywhere and applies one naming rule: `<kind>-reconciler` for core controllers and `<subcomponent>-<kind>-reconciler` for the `multikueue`, `provisioning` and `tas` controllers.

| Controller | Before (events / reconcile) | After |
|---|---|---|
| ClusterQueue | `cluster-queue-reconciler` / `clusterqueue-reconciler` | `clusterqueue-reconciler` |
| MultiKueueCluster | `multikueuecluster-reconciler` / `multikueue-cluster` | `multikueue-multikueuecluster-reconciler` |
| MultiKueue Workload | `multikueue-workload` | `multikueue-workload-reconciler` |
| MultiKueue ClusterQueue | `multikueue-clusterqueue` | `multikueue-clusterqueue-reconciler` |
| MultiKueue AdmissionCheck | `multikueue-admissioncheck` | `multikueue-admissioncheck-reconciler` |
| Provisioning Workload | `provisioning-workload` | `provisioning-workload-reconciler` |
| Provisioning AdmissionCheck | `provisioning-admissioncheck` | `provisioning-admissioncheck-reconciler` |
| LeaderWorkerSet | `leaderworkerset-reconciler` / `leaderworkerset` | `leaderworkerset-reconciler` |
| StatefulSet | `statefulset-reconciler` / `statefulset` | `statefulset-reconciler` |
| TAS Node | `tas-node-controller` / `tas-node-reconciler` | `tas-node-reconciler` |
| TAS Topology | `tas-topology-controller` | `tas-topology-reconciler` |
| TAS ResourceFlavor | `tas-resource-flavor-controller` | `tas-resourceflavor-reconciler` |
| TAS Pod usage | `tas-pod-usage-controller` | `tas-pod-usage-reconciler` |

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

- The `TAS*Controller` constants are left untouched since they are also used as controller registration names; only the logger strings change.
- The `tas-topology-ungater` and `ElasticJobUngater` loggers are not renamed since they are not `<kind>` reconcilers.
- The `v0.18` versioned docs are left as-is since they describe the released behavior.

#### Does this PR introduce a user-facing change?

```release-note
Observability: Aligned controller logger names so that event-handler and reconcile logs of the same controller share one name. Core controllers use `<kind>-reconciler` (for example `clusterqueue-reconciler`), and the `multikueue`, `provisioning` and `tas` controllers use `<subcomponent>-<kind>-reconciler` (for example `multikueue-workload-reconciler`, `tas-node-reconciler`). Log filters that match on the previous logger names need to be updated.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized logger names across cluster queue, admission check, workload, topology, resource flavor, and related controllers.
  * Controller log output now uses consistent reconciler-oriented identifiers for clearer recognition and filtering.

* **Documentation**
  * Updated the log analysis example to reflect the standardized cluster queue reconciler name.

* **Tests**
  * Updated affected test setups to use the revised logger naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->