### PR TITLE
Add indexers for DynamicQuotaOrchestrator distribution

### DIFF
--- a/pkg/controller/core/indexer/indexer.go
+++ b/pkg/controller/core/indexer/indexer.go
@@ -48,6 +48,9 @@ const (
 	DeviceClassExtendedResourceNameIndex        = "spec.extendedResourceName"
 	WorkloadExtendedResourceKey                 = "spec.extendedResources"
 	DynamicQuotaOrchestratorCapacityProviderKey = "spec.capacityDiscovery.providers.name"
+	DynamicQuotaOrchestratorIsDistributingKey   = "spec.capacityDistribution.isDistributing"
+	ClusterQueueCohortKey                       = "spec.cohortName"
+	CohortParentKey                             = "spec.parentName"
 	// WorkloadSliceNameKey is an index for pods by their workload slice name annotation.
 	// Used to find pods belonging to an elastic workload slice chain.
 	WorkloadSliceNameKey = "metadata.workloadSliceName"
@@ -290,6 +293,36 @@ func IndexDynamicQuotaOrchestratorCapacityProvider(obj client.Object) []string {
 	return providers
 }
 
+// IndexDynamicQuotaOrchestratorIsDistributing indexes DynamicQuotaOrchestrator by whether it has capacity distribution configured.
+func IndexDynamicQuotaOrchestratorIsDistributing(obj client.Object) []string {
+	dqo, ok := obj.(*kueuealpha.DynamicQuotaOrchestrator)
+	if !ok {
+		return nil
+	}
+	if dqo.Spec.CapacityDistribution != nil {
+		return []string{"true"}
+	}
+	return nil
+}
+
+// IndexClusterQueueCohort indexes ClusterQueue by spec.cohortName.
+func IndexClusterQueueCohort(obj client.Object) []string {
+	cq, ok := obj.(*kueue.ClusterQueue)
+	if !ok || cq == nil || cq.Spec.CohortName == "" {
+		return nil
+	}
+	return []string{string(cq.Spec.CohortName)}
+}
+
+// IndexCohortParent indexes Cohort by spec.parentName.
+func IndexCohortParent(obj client.Object) []string {
+	cohort, ok := obj.(*kueue.Cohort)
+	if !ok || cohort == nil || cohort.Spec.ParentName == "" {
+		return nil
+	}
+	return []string{string(cohort.Spec.ParentName)}
+}
+
 // Setup sets the index with the given fields for core apis.
 func Setup(ctx context.Context, indexer client.FieldIndexer) error {
 	if err := indexer.IndexField(ctx, &kueue.Workload{}, WorkloadQueueKey, IndexWorkloadQueue); err != nil {
@@ -344,6 +377,15 @@ func Setup(ctx context.Context, indexer client.FieldIndexer) error {
 	if features.Enabled(features.DynamicQuotaOrchestration) {
 		if err := indexer.IndexField(ctx, &kueuealpha.DynamicQuotaOrchestrator{}, DynamicQuotaOrchestratorCapacityProviderKey, IndexDynamicQuotaOrchestratorCapacityProvider); err != nil {
 			return fmt.Errorf("setting index on capacity provider for DynamicQuotaOrchestrator: %w", err)
+		}
+		if err := indexer.IndexField(ctx, &kueuealpha.DynamicQuotaOrchestrator{}, DynamicQuotaOrchestratorIsDistributingKey, IndexDynamicQuotaOrchestratorIsDistributing); err != nil {
+			return fmt.Errorf("setting index on isDistributing for DynamicQuotaOrchestrator: %w", err)
+		}
+		if err := indexer.IndexField(ctx, &kueue.ClusterQueue{}, ClusterQueueCohortKey, IndexClusterQueueCohort); err != nil {
+			return fmt.Errorf("setting index on cohort for ClusterQueue: %w", err)
+		}
+		if err := indexer.IndexField(ctx, &kueue.Cohort{}, CohortParentKey, IndexCohortParent); err != nil {
+			return fmt.Errorf("setting index on parent for Cohort: %w", err)
 		}
 	}
 	return nil

--- a/pkg/controller/core/indexer/indexer_test.go
+++ b/pkg/controller/core/indexer/indexer_test.go
@@ -697,3 +697,115 @@ func TestIndexDynamicQuotaOrchestratorCapacityProvider(t *testing.T) {
 		})
 	}
 }
+
+func TestIndexDynamicQuotaOrchestratorIsDistributing(t *testing.T) {
+	cases := map[string]struct {
+		obj  client.Object
+		want []string
+	}{
+		"not DynamicQuotaOrchestrator": {
+			obj:  &kueue.Workload{},
+			want: nil,
+		},
+		"discovery-only DQO": {
+			obj:  &kueuealpha.DynamicQuotaOrchestrator{},
+			want: nil,
+		},
+		"distributing DQO": {
+			obj: &kueuealpha.DynamicQuotaOrchestrator{
+				Spec: kueuealpha.DynamicQuotaOrchestratorSpec{
+					CapacityDistribution: &kueuealpha.CapacityDistribution{
+						SubtreeRootQuotaRef: kueuealpha.CapacityDistributionSubtreeRootRef{
+							Kind: kueuealpha.CohortSubtreeRootRefKind,
+							Name: "root",
+						},
+					},
+				},
+			},
+			want: []string{"true"},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := indexer.IndexDynamicQuotaOrchestratorIsDistributing(tc.obj)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestIndexClusterQueueCohort(t *testing.T) {
+	cases := map[string]struct {
+		obj  client.Object
+		want []string
+	}{
+		"not ClusterQueue": {
+			obj:  &kueue.Workload{},
+			want: nil,
+		},
+		"typed nil ClusterQueue": {
+			obj:  (*kueue.ClusterQueue)(nil),
+			want: nil,
+		},
+		"empty cohort": {
+			obj:  &kueue.ClusterQueue{},
+			want: nil,
+		},
+		"with cohort": {
+			obj: &kueue.ClusterQueue{
+				Spec: kueue.ClusterQueueSpec{
+					CohortName: "my-cohort",
+				},
+			},
+			want: []string{"my-cohort"},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := indexer.IndexClusterQueueCohort(tc.obj)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestIndexCohortParent(t *testing.T) {
+	cases := map[string]struct {
+		obj  client.Object
+		want []string
+	}{
+		"not Cohort": {
+			obj:  &kueue.Workload{},
+			want: nil,
+		},
+		"typed nil Cohort": {
+			obj:  (*kueue.Cohort)(nil),
+			want: nil,
+		},
+		"empty parent": {
+			obj:  &kueue.Cohort{},
+			want: nil,
+		},
+		"with parent": {
+			obj: &kueue.Cohort{
+				Spec: kueue.CohortSpec{
+					ParentName: "root-cohort",
+				},
+			},
+			want: []string{"root-cohort"},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := indexer.IndexCohortParent(tc.obj)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/util/testing/client.go
+++ b/pkg/util/testing/client.go
@@ -53,7 +53,11 @@ func NewClientBuilder(addToSchemes ...func(s *runtime.Scheme) error) *fake.Clien
 		WithIndex(&kueue.LocalQueue{}, indexer.QueueClusterQueueKey, indexer.IndexQueueClusterQueue).
 		WithIndex(&kueue.Workload{}, indexer.WorkloadQueueKey, indexer.IndexWorkloadQueue).
 		WithIndex(&kueue.Workload{}, indexer.WorkloadClusterQueueKey, indexer.IndexWorkloadClusterQueue).
-		WithIndex(&kueue.Workload{}, indexer.OwnerReferenceUID, indexer.IndexOwnerUID)
+		WithIndex(&kueue.Workload{}, indexer.OwnerReferenceUID, indexer.IndexOwnerUID).
+		WithIndex(&kueuealpha.DynamicQuotaOrchestrator{}, indexer.DynamicQuotaOrchestratorCapacityProviderKey, indexer.IndexDynamicQuotaOrchestratorCapacityProvider).
+		WithIndex(&kueuealpha.DynamicQuotaOrchestrator{}, indexer.DynamicQuotaOrchestratorIsDistributingKey, indexer.IndexDynamicQuotaOrchestratorIsDistributing).
+		WithIndex(&kueue.ClusterQueue{}, indexer.ClusterQueueCohortKey, indexer.IndexClusterQueueCohort).
+		WithIndex(&kueue.Cohort{}, indexer.CohortParentKey, indexer.IndexCohortParent)
 }
 
 type builderIndexer struct {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR is **Part 1 of 3** implementing Phase 2 (Quota Distribution) of [KEP-12382: Dynamic Quota Orchestration](https://github.com/kubernetes-sigs/kueue/tree/main/keps/12382-dynamic-quota-orchestration).

It registers three new field indexers required for efficient hierarchy traversal and conflict detection during quota distribution:

1. **`spec.capacityDistribution.isDistributing` (`DynamicQuotaOrchestratorIsDistributingKey`)**:
   - **Why needed**: Distributing DQOs must evaluate conflicts against other active distributing orchestrators in the cluster (detecting ancestor conflicts, same-root precedence conflicts, and queue ownership overlaps per KEP-12382). This indexer allows the controller and event mappers to query only orchestrators that have `spec.capacityDistribution` configured, avoiding full cluster-wide scans and filtering of discovery-only DQOs.

2. **`spec.cohortName` on ClusterQueue (`ClusterQueueCohortKey`)**:
   - **Why needed**: When a DQO distributes capacity across a Cohort subtree, the controller must resolve all member ClusterQueues under that Cohort and its descendants (`resolveSubtree`). In Kueue, ClusterQueues reference their parent Cohort via `spec.cohortName`, but Cohorts do not maintain a list of member queues in their spec. This indexer enables $O(1)$ lookups of all ClusterQueues under a given Cohort during subtree traversal without listing all ClusterQueues in the cluster.

3. **`spec.parentName` on Cohort (`CohortParentKey`)**:
   - **Why needed**: Hierarchical Cohorts define a child-to-parent relationship via `spec.parentName`. Parent Cohorts do not track their children in spec. To traverse downwards through the cohort tree from a subtree root, the controller needs to discover direct child Cohorts for any given parent. This indexer enables direct lookup of child Cohorts during BFS subtree resolution without scanning the entire Cohort namespace.

Additionally, this PR:
- Gates indexer registration behind the `DynamicQuotaOrchestration` feature gate in `pkg/controller/core/indexer/indexer.go`.
- Registers the indexers in `pkg/util/testing/client.go` so fake test clients properly support `client.MatchingFields`.
- Adds table-driven unit tests in `pkg/controller/core/indexer/indexer_test.go`.

#### Which issue(s) this PR fixes:

Part of #12382

#### Special notes for your reviewer:

This is the foundational PR in the stacked series for DQO Phase 2:
- **Part 1 (this PR)**: Indexers & test client builder registration (`dqo-phase2-part1-indexers`)
- **Part 2**: Quota distribution logic, proportional math, soft validation, and unit tests (`dqo-phase2-part2-distribution-logic`)
- **Part 3**: Reconciler watches and integration tests (`dqo-phase2-part3-reconciler`)

*AI Disclosure: AI-assisted tooling was used in the preparation and review of this pull request in accordance with the Kubernetes AI policy.*

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added indexing support for dynamic quota distribution status, cluster queue cohorts, and cohort parent relationships.
  * Enabled more efficient lookups and filtering for these resources.

* **Tests**
  * Added coverage for valid, empty, nil, and unrelated resource cases.

* **Chores**
  * Updated test client setup to include the new indexes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->