### PR TITLE
TAS: defer failed-node replacement eviction when in-flight preemptions may free capacity

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -449,6 +449,9 @@ func (s *Scheduler) processEntry(
 	mode := e.assignment.RepresentativeMode()
 
 	if features.Enabled(features.TASFailedNodeReplacementFailFast) && workload.HasTopologyAssignmentWithUnhealthyNode(e.Obj) && mode != flavorassigner.Fit {
+		if s.tryDeferFailedTASReplacement(ctx, log, e, snapshot, cq) {
+			return
+		}
 		s.handleFailedTASReplacement(ctx, log, e)
 		return
 	}
@@ -546,6 +549,65 @@ func (s *Scheduler) processEntry(
 	if err := s.admit(ctx, e, cq, oldWorkloadSlice); err != nil {
 		e.inadmissibleMsg = fmt.Sprintf("Failed to admit workload: %v", err)
 	}
+}
+
+// tryDeferFailedTASReplacement reports whether a failed TAS replacement should
+// be deferred instead of fail-fast evicted. If in-flight evictions (workloads
+// already marked Evicted, but still holding usage in the snapshot) may free a
+// suitable placement shortly, we simulate their removal, recompute the
+// assignment, and defer with PendingPreemption semantics when the replacement
+// then fits. Otherwise fail-fast eviction is preserved.
+func (s *Scheduler) tryDeferFailedTASReplacement(ctx context.Context, log logr.Logger, e *entry, snapshot *schdcache.Snapshot, cq *schdcache.ClusterQueueSnapshot) bool {
+	victims := inFlightEvictionVictims(snapshot)
+	if len(victims) == 0 {
+		return false
+	}
+	log.V(3).Info("Checking whether in-flight evictions free a suitable placement for the failed TAS replacement", "victims", len(victims))
+	// To get the projected cluster state after the in-flight evictions complete,
+	// simulate the removal of their workloads. The simulation is reverted below
+	// as the snapshot is shared across the scheduling cycle.
+	revertRemoval := snapshot.SimulateWorkloadRemoval(victims)
+	// Clear the flavor scan state so that the recomputation starts from the
+	// first flavor again, mirroring updateAssignmentIfNeeded.
+	e.FlavorScanState = nil
+	e.NominationMapping = e.readResourceToFlavorMapping()
+	newAssignment, newTargets := s.getAssignments(ctx, &e.Info, snapshot)
+	e.NominationMapping = nil
+	revertRemoval()
+	if newAssignment.RepresentativeMode() != flavorassigner.Fit {
+		return false
+	}
+	e.recordAssignment(newAssignment, newTargets)
+	e.assignment.SetRepresentativeMode(flavorassigner.DeferredFit)
+	e.inadmissibleMsg = "Workload has an unhealthy node, but will fit after in-flight evictions complete"
+	e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads
+	e.requeueReason = qcache.RequeueReasonPendingPreemption
+	// Clear the flavor scan state to force a full re-evaluation of all flavors
+	// in the next cycle, mirroring the DeferredFit branch.
+	e.FlavorScanState = nil
+	// Reserve the net usage of the recomputed assignment, mirroring the
+	// DeferredFit branch, so that the placement the replacement will claim
+	// once the evictions complete is not admitted to another workload later
+	// in the same cycle.
+	snapshot.AddUsage(cq, e.assignmentUsage(log))
+	log.V(2).Info("Deferring failed TAS replacement; waiting for in-flight evictions to free capacity")
+	return true
+}
+
+// inFlightEvictionVictims returns the workloads that are marked Evicted but
+// still hold usage in the snapshot, i.e. the victims of in-flight evictions
+// that are expected to free capacity once they complete.
+func inFlightEvictionVictims(snapshot *schdcache.Snapshot) []*workload.Info {
+	var victims []*workload.Info
+	for _, cq := range snapshot.ClusterQueues() {
+		for _, w := range cq.Workloads {
+			usage := w.Usage()
+			if workloadevict.IsEvicted(w.Obj) && (len(usage.Quota.Assigned) > 0 || len(usage.TAS) > 0) {
+				victims = append(victims, w)
+			}
+		}
+	}
+	return victims
 }
 
 func (s *Scheduler) handleFailedTASReplacement(ctx context.Context, log logr.Logger, e *entry) {
@@ -1210,7 +1272,12 @@ func (s *Scheduler) requeueAndUpdate(ctx context.Context, e entry) {
 	if s.queues.QueueSecondPassIfNeeded(ctx, e.Obj, e.SecondPassIteration) {
 		log.V(2).
 			Info("Workload re-queued for second pass", "workload", klog.KObj(e.Obj), "clusterQueue", klog.KRef("", string(e.ClusterQueue)), "queue", klog.KRef(e.Obj.Namespace, string(e.Obj.Spec.QueueName)), "requeueReason", e.requeueReason, "status", e.status)
-		s.recorder.Eventf(e.Obj, nil, corev1.EventTypeWarning, "SecondPassFailed", "SecondPassFailed", api.TruncateEventMessage(e.inadmissibleMsg))
+		// Workloads requeued with PendingPreemption are intentionally waiting
+		// for in-flight preemptions to complete, so their second-pass requeue
+		// is not a failure and should not emit a SecondPassFailed event.
+		if e.requeueReason != qcache.RequeueReasonPendingPreemption {
+			s.recorder.Eventf(e.Obj, nil, corev1.EventTypeWarning, "SecondPassFailed", "SecondPassFailed", api.TruncateEventMessage(e.inadmissibleMsg))
+		}
 		return
 	}
 

--- a/pkg/scheduler/scheduler_tas_test.go
+++ b/pkg/scheduler/scheduler_tas_test.go
@@ -984,6 +984,247 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 		},
+		// The second pass looks for a replacement domain for the pod on the
+		// unhealthy node x0. Only x6 has enough capacity for the 2-core
+		// replacement, but x6 is occupied by a healthy admitted workload that
+		// is not being evicted, so there is no in-flight eviction to wait for
+		// and the workload is fail-fast evicted.
+		"workload with unhealthyNode annotation; second pass; preferred; no fit; FailFast; no in-flight preemption": {
+			nodes:           defaultNodes,
+			admissionChecks: []kueue.AdmissionCheck{defaultProvCheck},
+			topologies:      []kueue.Topology{defaultThreeLevelTopology},
+			resourceFlavors: []kueue.ResourceFlavor{defaultTASThreeLevelFlavor},
+			clusterQueues:   []kueue.ClusterQueue{defaultClusterQueue},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("healthy-occupier", "default").
+					Queue("tas-main").
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "2").
+						Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("tas-main").
+							PodSets(utiltestingapi.MakePodSetAssignment("one").
+								Assignment(corev1.ResourceCPU, "tas-default", "2000m").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x6"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(), now,
+					).
+					AdmittedAt(true, now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("foo", "default").
+					UnhealthyNodes("x0").
+					Queue("tas-main").
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						PreferredTopologyRequest(tasRackLabel).
+						Request(corev1.ResourceCPU, "2").
+						Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("tas-main").
+							PodSets(utiltestingapi.MakePodSetAssignment("one").
+								Assignment(corev1.ResourceCPU, "tas-default", "2000m").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(), now,
+					).
+					AdmittedAt(true, now).
+					Obj(),
+			},
+			wantNewAssignments: map[workload.Reference]kueue.Admission{
+				"default/foo": *utiltestingapi.MakeAdmission("tas-main").
+					PodSets(utiltestingapi.MakePodSetAssignment("one").
+						Assignment(corev1.ResourceCPU, "tas-default", "2000m").
+						TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+							Obj()).
+						Obj()).
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				utiltesting.MakeEventRecord("default", "foo", "EvictedDueToNodeFailures", corev1.EventTypeNormal).
+					Message("Workload was evicted as there was no replacement for unhealthy node(s): x0").
+					Obj(),
+			},
+		},
+		// The in-flight eviction victim is on x1, which has only 1 core.
+		// Simulating its removal does not help: x1 still cannot fit the 2-core
+		// replacement and x6 remains occupied by a healthy admitted workload,
+		// so the recomputed assignment is still not a fit and the workload is
+		// fail-fast evicted.
+		"workload with unhealthyNode annotation; second pass; preferred; no fit; FailFast; in-flight preemption in a different domain": {
+			nodes:           defaultNodes,
+			admissionChecks: []kueue.AdmissionCheck{defaultProvCheck},
+			topologies:      []kueue.Topology{defaultThreeLevelTopology},
+			resourceFlavors: []kueue.ResourceFlavor{defaultTASThreeLevelFlavor},
+			clusterQueues:   []kueue.ClusterQueue{defaultClusterQueue},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("healthy-occupier", "default").
+					Queue("tas-main").
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "2").
+						Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("tas-main").
+							PodSets(utiltestingapi.MakePodSetAssignment("one").
+								Assignment(corev1.ResourceCPU, "tas-default", "2000m").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x6"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(), now,
+					).
+					AdmittedAt(true, now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("victim", "default").
+					Queue("tas-main").
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "1").
+						Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("tas-main").
+							PodSets(utiltestingapi.MakePodSetAssignment("one").
+								Assignment(corev1.ResourceCPU, "tas-default", "1000m").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(), now,
+					).
+					AdmittedAt(true, now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadEvicted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Preempted",
+						Message:            "Preempted to accommodate a workload",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadPreempted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "InClusterQueue",
+						Message:            "Preempted to accommodate a workload",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Preempted", Count: 1}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("foo", "default").
+					UnhealthyNodes("x0").
+					Queue("tas-main").
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						PreferredTopologyRequest(tasRackLabel).
+						Request(corev1.ResourceCPU, "2").
+						Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("tas-main").
+							PodSets(utiltestingapi.MakePodSetAssignment("one").
+								Assignment(corev1.ResourceCPU, "tas-default", "2000m").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(), now,
+					).
+					AdmittedAt(true, now).
+					Obj(),
+			},
+			wantNewAssignments: map[workload.Reference]kueue.Admission{
+				"default/foo": *utiltestingapi.MakeAdmission("tas-main").
+					PodSets(utiltestingapi.MakePodSetAssignment("one").
+						Assignment(corev1.ResourceCPU, "tas-default", "2000m").
+						TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+							Obj()).
+						Obj()).
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				utiltesting.MakeEventRecord("default", "foo", "EvictedDueToNodeFailures", corev1.EventTypeNormal).
+					Message("Workload was evicted as there was no replacement for unhealthy node(s): x0").
+					Obj(),
+			},
+		},
+		// The in-flight preemption victim occupies x6, the only node that can
+		// fit the 2-core replacement. Simulating its removal frees x6, so the
+		// recomputed assignment fits and the workload is requeued with
+		// PendingPreemption semantics instead of being fail-fast evicted,
+		// keeping its reservation until the eviction completes.
+		"workload with unhealthyNode annotation; second pass; preferred; no fit; in-flight preemption frees capacity; deferred": {
+			nodes:           defaultNodes,
+			admissionChecks: []kueue.AdmissionCheck{defaultProvCheck},
+			topologies:      []kueue.Topology{defaultThreeLevelTopology},
+			resourceFlavors: []kueue.ResourceFlavor{defaultTASThreeLevelFlavor},
+			clusterQueues:   []kueue.ClusterQueue{defaultClusterQueue},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("victim", "default").
+					Queue("tas-main").
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "2").
+						Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("tas-main").
+							PodSets(utiltestingapi.MakePodSetAssignment("one").
+								Assignment(corev1.ResourceCPU, "tas-default", "2000m").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x6"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(), now,
+					).
+					AdmittedAt(true, now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadEvicted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Preempted",
+						Message:            "Preempted to accommodate a workload",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadPreempted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "InClusterQueue",
+						Message:            "Preempted to accommodate a workload",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Preempted", Count: 1}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("foo", "default").
+					UnhealthyNodes("x0").
+					Queue("tas-main").
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						PreferredTopologyRequest(tasRackLabel).
+						Request(corev1.ResourceCPU, "2").
+						Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("tas-main").
+							PodSets(utiltestingapi.MakePodSetAssignment("one").
+								Assignment(corev1.ResourceCPU, "tas-default", "2000m").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(), now,
+					).
+					AdmittedAt(true, now).
+					Obj(),
+			},
+			wantNewAssignments: map[workload.Reference]kueue.Admission{
+				"default/foo": *utiltestingapi.MakeAdmission("tas-main").
+					PodSets(utiltestingapi.MakePodSetAssignment("one").
+						Assignment(corev1.ResourceCPU, "tas-default", "2000m").
+						TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+							Obj()).
+						Obj()).
+					Obj(),
+			},
+		},
 		"workload with unhealthyNode annotation; second pass; required rack; fit": {
 			nodes:           defaultNodes,
 			admissionChecks: []kueue.AdmissionCheck{defaultProvCheck},

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -52,6 +52,7 @@ import (
 	testingnode "sigs.k8s.io/kueue/pkg/util/testingjobs/node"
 	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
 	"sigs.k8s.io/kueue/pkg/workload"
+	workloadevict "sigs.k8s.io/kueue/pkg/workload/evict"
 	workloadpatching "sigs.k8s.io/kueue/pkg/workload/patching"
 	"sigs.k8s.io/kueue/pkg/workloadslicing"
 	"sigs.k8s.io/kueue/test/integration/framework"
@@ -3756,6 +3757,119 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 							},
 						}),
 					))
+				})
+			})
+			ginkgo.It("should defer the fail-fast eviction of a Workload while an in-flight eviction can free a replacement node", framework.SlowSpec, func() {
+				makeRackWorkload := func(name string, count int) *kueue.Workload {
+					return utiltestingapi.MakeWorkload(name, ns.Name).
+						Queue(kueue.LocalQueueName(localQueue.Name)).
+						PodSets(*utiltestingapi.MakePodSet("worker", count).
+							RequiredTopologyRequest(utiltesting.DefaultRackTopologyLevel).
+							Request(corev1.ResourceCPU, "1").
+							Obj()).
+						Obj()
+				}
+				admittedNode := func(g gomega.Gomega, wl *kueue.Workload) string {
+					ginkgo.GinkgoHelper()
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
+					g.Expect(wl.Status.Admission).NotTo(gomega.BeNil())
+					g.Expect(wl.Status.Admission.PodSetAssignments).NotTo(gomega.BeEmpty())
+					for domain := range utiltas.InternalSeqFrom(wl.Status.Admission.PodSetAssignments[0].TopologyAssignment) {
+						return domain.Values[len(domain.Values)-1]
+					}
+					return ""
+				}
+
+				var foo, victim *kueue.Workload
+				ginkgo.By("admitting a workload on a node of the first rack", func() {
+					foo = makeRackWorkload("foo", 1)
+					util.MustCreate(ctx, k8sClient, foo)
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, foo)
+				})
+
+				ginkgo.By("admitting a workload that will be evicted on the remaining node of the same rack", func() {
+					victim = makeRackWorkload("victim", 1)
+					util.MustCreate(ctx, k8sClient, victim)
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, victim)
+				})
+
+				ginkgo.By("occupying the second rack so the only replacement capacity is the victim node", func() {
+					guard := makeRackWorkload("guard", 2)
+					util.MustCreate(ctx, k8sClient, guard)
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, guard)
+				})
+
+				fooNode := admittedNode(gomega.Default, foo)
+				victimNode := admittedNode(gomega.Default, victim)
+				gomega.Expect(fooNode).NotTo(gomega.Equal(victimNode))
+
+				ginkgo.By("marking the victim as evicted by preemption while it keeps its reservation, as when a preemption is in flight", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(victim), victim)).To(gomega.Succeed())
+						g.Expect(workloadpatching.PatchAdmissionStatus(ctx, k8sClient, victim, util.RealClock, func(wl *kueue.Workload) (bool, error) {
+							return workloadevict.SetEvictedCondition(wl, util.RealClock.Now(), kueue.WorkloadEvictedByPreemption, "Preempted to accommodate a workload"), nil
+						})).To(gomega.Succeed())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("making the node running foo NotReady to trigger a failed replacement", func() {
+					nodeToUpdate := &corev1.Node{}
+					gomega.Expect(k8sClient.Get(ctx, apitypes.NamespacedName{Name: fooNode}, nodeToUpdate)).Should(gomega.Succeed())
+					util.SetNodeCondition(ctx, k8sClient, nodeToUpdate, &corev1.NodeCondition{
+						Type:               corev1.NodeReady,
+						Status:             corev1.ConditionFalse,
+						LastTransitionTime: metav1.NewTime(time.Now().Add(-tas.NodeFailureDelay)),
+					})
+				})
+
+				ginkgo.By("verifying foo keeps its reservation and is not evicted while the eviction is in flight", func() {
+					// Wait until foo has been re-processed: it records the unhealthy
+					// node, keeps its quota reservation and is not marked evicted.
+					gomega.Eventually(func(g gomega.Gomega) {
+						var updated kueue.Workload
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(foo), &updated)).To(gomega.Succeed())
+						g.Expect(updated.Status.UnhealthyNodes).To(gomega.ContainElement(kueue.UnhealthyNode{Name: fooNode}))
+						g.Expect(workload.HasQuotaReservation(&updated)).To(gomega.BeTrue())
+						g.Expect(apimeta.FindStatusCondition(updated.Status.Conditions, kueue.WorkloadEvicted)).To(gomega.BeNil())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+					// The deferral must be stable: the workload is re-evaluated each
+					// scheduling cycle until the evicted workload is removed, and no
+					// cycle may fail-fast evict it in the meantime. The evicted
+					// workload must keep holding its reservation (and therefore its
+					// usage) for the whole window, which is what keeps the replacement
+					// from fitting yet.
+					gomega.Consistently(func(g gomega.Gomega) {
+						var updatedFoo, updatedVictim kueue.Workload
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(foo), &updatedFoo)).To(gomega.Succeed())
+						g.Expect(workload.HasQuotaReservation(&updatedFoo)).To(gomega.BeTrue())
+						g.Expect(apimeta.FindStatusCondition(updatedFoo.Status.Conditions, kueue.WorkloadEvicted)).To(gomega.BeNil())
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(victim), &updatedVictim)).To(gomega.Succeed())
+						g.Expect(workload.HasQuotaReservation(&updatedVictim)).To(gomega.BeTrue())
+					}, 3*time.Second, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("removing the evicted workload so it frees the node foo needs", func() {
+					// An evicted workload keeps its usage until it is removed from the
+					// cache. Finishing the eviction would requeue the victim, and with
+					// no higher-priority workload waiting it would simply be re-admitted
+					// onto the same node. Deleting the victim is what frees the capacity
+					// without re-queueing it.
+					gomega.Expect(k8sClient.Delete(ctx, victim)).To(gomega.Succeed())
+				})
+
+				ginkgo.By("verifying foo completes the replacement on the freed node", func() {
+					// foo keeps its quota reservation (and therefore its old admission)
+					// while deferred, so wait for the admission to move to the node
+					// freed by the victim.
+					// Second-pass requeues use exponential backoff (capped at 30s), so
+					// allow enough time for the next retry after the removal.
+					gomega.Eventually(func(g gomega.Gomega) {
+						var updated kueue.Workload
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(foo), &updated)).To(gomega.Succeed())
+						g.Expect(updated.Status.UnhealthyNodes).NotTo(gomega.ContainElement(kueue.UnhealthyNode{Name: fooNode}))
+						g.Expect(admittedNode(g, foo)).To(gomega.Equal(victimNode))
+					}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 				})
 			})
 			ginkgo.It("should update workload UnhealthyNodes immediately when node has NoExecute taint and TASReplaceNodeOnPodTermination is disabled", framework.SlowSpec, func() {


### PR DESCRIPTION
Replaces #15102: that PR was closed by mistake; after the head fork's visibility was toggled, GitHub detached the fork and would not allow reopening the PR. Same branch (`fix-14187-defer-tas-replacement`), opened from the same head as #15102 (`201b08642`); the head has since been rebased onto `main` and updated with review fixes (`e0926c0dd`). All prior review discussion, including the three comments from the previous review round, remains in #15102.

#### What type of PR is this?

/kind bug
/area tas

#### What this PR does / why we need it:

A failed-node replacement workload has no preemption targets, because replacement is only considered when no preemption/reclamation is needed (KEP-2724). As a result, `needsOverlapRecompute` never fires for it and the DeferredFit path is unreachable. With `TASFailedNodeReplacementFailFast` (beta, on by default since 0.14), the fail-fast branch then evicts based only on `mode != Fit`, ignoring in-flight evictions that could free a suitable topology placement shortly; the workload is torn down while the node it needs is about to become free.

This PR adds a check right before that eviction:

1. Collect the workloads already marked `Evicted` but still holding usage in the snapshot; they are exactly the in-flight evictions, since an evicted workload keeps its usage until it is deleted.
2. Simulate their removal with `Snapshot.SimulateWorkloadRemoval`, the same mechanism the overlap recompute in `updateAssignmentIfNeeded` uses, and recompute the assignment.
3. If the replacement then fits, requeue the workload with the same semantics as the DeferredFit branch: requeue reason `PendingPreemption`, quota-reserved reason `WaitingForPreemptedWorkloads`, `LastAssignment` cleared, net usage of the recomputed assignment re-added, instead of evicting it.
4. Otherwise, or when there are no in-flight evictions, the fail-fast behavior is unchanged.

#### Which issue(s) this PR fixes:

Fixes #14187

#### Special notes for your reviewer:

- Reachable on default settings: the deferral only runs inside the existing `TASFailedNodeReplacementFailFast` gate (beta, on by default), so no new feature gate is introduced and disabling the gate keeps the behavior unchanged.
- The deferral is bounded the same way as the existing DeferredFit path (#13863): the workload stays quota-reserved, the check re-runs on subsequent scheduling cycles (the second-pass queue retries with backoff, and the eviction-completion event can trigger a cycle sooner), picks up the freed capacity as soon as the evictions complete, and falls back to the fail-fast eviction if the simulated removal stops yielding a fit. One consequence is specific to this path and worth calling out: while it waits, the workload keeps its admission, so its pods stay on the unhealthy node until the replacement happens. The issue thread already asks whether that wait needs a bound; happy to follow your preference there.
- The recomputed assignment is explicitly marked with the `DeferredFit` mode: a replacement workload has no preemption targets, so it never reaches the overlap recompute that sets that mode on its own; the deferral sets it only after the simulated recompute yields a fit.
- The "capacity is coming" signal is snapshot-derived rather than read from `preemptionExpectations`, so it survives leader switches; it degrades safely on the read side because the fit check bounds any over-counting (e.g. admin evictions count as victims too): if the simulation does not fit, we still fail fast.
- Tests in `TestScheduleForTAS` (`pkg/scheduler/scheduler_tas_test.go`), all sharing the `workload with unhealthyNode annotation; second pass; preferred; no fit` prefix:
  - `FailFast; no in-flight preemption`: fail-fast preserved when there is no in-flight eviction (a healthy admitted workload occupies the only 2-core node). Passes on main as a regression guard.
  - `FailFast; in-flight preemption in a different domain`: the victim sits on a 1-core node, so the simulated removal does not yield a fit and fail-fast is preserved. Passes on main as a regression guard.
  - `in-flight preemption frees capacity; deferred`: the victim occupies the only node the replacement can use; the workload is deferred, keeps its reservation and current assignment, and no eviction or `SecondPassFailed` event is emitted. Fails on main, which evicts the workload.
- Integration test in `test/integration/singlecluster/tas/tas_test.go`: `should defer the fail-fast eviction of a Workload while an in-flight eviction can free a replacement node`; it admits a victim on the only node the replacement can use, marks it as evicted by preemption while it keeps holding its usage, and verifies the replacement is deferred instead of fail-fast evicted and completes the replacement once the victim is removed. Fails on main, which evicts the workload.
- Small side change: no `SecondPassFailed` event is emitted when a workload is requeued with `PendingPreemption`, since that requeue is an intentional wait rather than a failure. Reachable through the new deferral (second-pass workloads requeue through `QueueSecondPassIfNeeded`); happy to split it out if you prefer.

This PR was written in part with the assistance of generative AI.

#### Does this PR introduce a user-facing change?

```release-note
TAS: Fixed a bug where a failed-node replacement workload was evicted immediately even when in-flight preemptions were about to free a suitable topology placement; it is now deferred until the preemptions complete, falling back to the eviction when no placement becomes available.
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## AI summary

- TAS failed-node replacement now defers fail-fast eviction when an in-flight preemption can provide a suitable topology placement.
- The workload keeps its quota reservation until capacity becomes available.
- Fail-fast eviction remains unchanged when no suitable placement is expected.
- Added scheduler and integration tests for both outcomes.
- Suppressed `SecondPassFailed` events for intentional deferrals.

### Suggested release note

TAS: Fixed a bug that caused failed-node replacement workloads to be evicted while suitable capacity was pending preemption. Kueue now preserves their quota reservations until that capacity becomes available. This behavior is gated by `TASFailedNodeReplacementFailFast`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

