### PR TITLE
Give users hints about release notes in the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -49,10 +49,12 @@ Fixes #
 #### Special notes for your reviewer:
 
 #### Does this PR introduce a user-facing change?
-<!--
-If no, just write "NONE" in the release-note block below.
-If yes, a release note is required:
-Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
+<!-- Describe the behavior change accurately from the user's perspective. Hints:
+- Do not leave this block blank.
+- Use "NONE" when there is no user-facing change.
+- When feasible use a prefix for the sub-component or feature, e.g. "FairSharing:" or "MultiKueue:".
+- If upgrade steps are required, include an "ACTION REQUIRED:" section.
+You may consider AI assistance using the skill: cmd/experimental/skills/kueue-release-notes/SKILL.md.
 -->
 ```release-note
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

To guide users when creating release notes. 

The higher quality notes produced by users will help:
- understand the user-facing impact easily
- save the maintainers and the release team correcting the notes before the release

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the pull request template with clearer guidance for preparing release notes.
  - Added instructions to accurately describe user-facing behavior changes and avoid leaving the release-note section blank.
  - Clarified when to use “NONE” for changes without user-facing impact.
  - Added guidance to prefix notes with the affected feature or sub-component.
  - Clarified when to include an “ACTION REQUIRED” section for upgrade steps.
  - Included an optional suggestion to use the AI release-notes skill.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->