### PR TITLE
Tidy the new PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,31 +1,21 @@
-<!--  Thanks for sending a pull request!  Here are some tips for you:
-
-1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
-2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
-https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
-3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
-4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
--->
+<!-- Thank you for contributing! Check CONTRIBUTING.md for details. -->
 
 #### What type of PR is this?
-
-<!--
-Add one of the following kinds:
+<!-- Choose one of the following kinds:
 /kind bug
 /kind cleanup
 /kind documentation
 /kind feature
 /kind kep
 
-Optionally add one or more of the following kinds if applicable:
+Optionally choose one or more of the following kinds:
 /kind api-change
 /kind deprecation
 /kind failing-test
 /kind flake
 /kind regression
 
-Please also consider setting the area:
+Consider setting the area:
 /area tas
 /area was
 /area integrations
@@ -36,19 +26,16 @@ Please also consider setting the area:
 /area website
 -->
 
-#### What this PR does / why we need it:
-
-#### Which issue(s) this PR fixes:
+#### What this PR does / why we need it?
 <!--
-*Automatically closes linked issue when PR is merged.
-Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
+Use `Fixes #123` for an issue addressed by this PR; it will be closed when the PR merges.
+Use `Related:` or `Part of:` to reference an issue without closing it.
 -->
 Fixes #
 
-#### Special notes for your reviewer:
+#### Useful notes for your reviewer
 
-#### Does this PR introduce a user-facing change?
+#### Release note
 <!-- Describe the behavior change accurately from the user's perspective. Hints:
 - Do not leave this block blank.
 - Use "NONE" when there is no user-facing change.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- to make the template less verbose -  the contributor guide already has all links
- the /kind and /area label choices are taking many lines
- replace "Special" with "Useful" to make the purpose more clear
- make it clear that PR with "Fixes" will close the "Issue", skip info that flake fixes should not link issues
- replace the "Special notes for your reviewer" section with "Useful notes for your reviewer" tag

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Streamlined the pull request template with shorter contributor messaging and condensed kind/area guidance.
  * Added clearly visible reviewer-notes and release-note sections with guidance for documenting user-facing changes.
  * Clarified issue references by distinguishing closing links from related or part-of references.
  * Removed the previous contributor-guidelines comment and separate issue, reviewer-notes, and user-facing-change sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->