### PR TITLE
Instruct CodeRabbit about release note in summary

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -10,6 +10,24 @@ knowledge_base:
 reviews:
   request_changes_workflow: false
 
+  high_level_summary_instructions: |
+    Keep the PR summary concise. Add a "Release note assessment" section that
+    reviews the author's `release-note` block.
+
+    If the existing release note accurately describes the user-facing change,
+    say "Ready". This includes `NONE` when there is no user-facing change.
+
+    Otherwise, provide one alternative release note and briefly justify the
+    adjustments. Instructions:
+
+    * If the impact is unclear, ask one focused question instead of guessing.
+    * When feasible, use the narrowest applicable feature or sub-component prefix,
+      e.g. `FairSharing:`, `MultiKueue:`, or `TAS:`.
+    * Use `ACTION REQUIRED:` only when users must take action when upgrading.
+
+    Ask the author to verify the alternative and update the canonical
+    `release-note` block in the PR description.
+
   path_filters:
     - "!client-go/**"
     - "!**/*_generated*.go"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

Currently it takes a lot of time to adjust release notes before release.

Hopefully CodeRabbit can help to review the contributor's release notes using the summary field.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved automated review guidance for release notes.
  - Release notes are now checked for accuracy, clear user impact, focused questions when needed, and appropriate feature prefixes.
  - Upgrade actions are explicitly highlighted only when user intervention is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->