### PR TITLE
Attempt to fix release note instructions for Coderabbit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -11,15 +11,18 @@ reviews:
   request_changes_workflow: false
 
   high_level_summary_instructions: |
-    Keep the PR summary concise. Add a "Release note assessment" section that
-    reviews the author's `release-note` block.
+    Keep the PR summary concise. Name the section "AI summary".
+
+    Add the "Release note assessment" sub-section that reviews the author's
+    `release-note` code block. Search it under the "Release note" section.
 
     If the existing release note accurately describes the user-facing change,
     say "Ready". This includes `NONE` when there is no user-facing change.
 
-    Otherwise, provide one alternative release note and briefly justify the
-    adjustments. Instructions:
+    Otherwise, or if you cannot locate the contributor supplied release note, provide
+    one alternative release note and briefly justify the adjustments.
 
+    Instructions:
     * If the impact is unclear, ask one focused question instead of guessing.
     * When feasible, use the narrowest applicable feature or sub-component prefix,
       e.g. `FairSharing:`, `MultiKueue:`, or `TAS:`.


### PR DESCRIPTION
<!-- Thank you for contributing! Check CONTRIBUTING.md for details. -->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it?
<!--
Use `Fixes #123` for an issue addressed by this PR; it will be closed when the PR merges.
Use `Related:` or `Part of:` to reference an issue without closing it.
-->

#### Useful notes for your reviewer

Follow up to https://github.com/kubernetes-sigs/kueue/pull/15275
This is attempt to fix code rabbit not being able to find the release note supplied by a contributor.

Examples:
- https://github.com/kubernetes-sigs/kueue/pull/15280
- https://github.com/kubernetes-sigs/kueue/pull/15279

#### Release note
<!-- Describe the behavior change accurately from the user's perspective. Hints:
- Do not leave this block blank.
- Use "NONE" when there is no user-facing change.
- When feasible use a prefix for the sub-component or feature, e.g. "FairSharing:" or "MultiKueue:".
- If upgrade steps are required, include an "ACTION REQUIRED:" section.
You may consider AI assistance using the skill: cmd/experimental/skills/kueue-release-notes/SKILL.md.
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Update CodeRabbit release note instructions.
- Require an “AI summary” section and a “Release note assessment” section.
- Add guidance for missing or inaccurate release notes.

## Release note assessment

Ready. The `release-note` block uses `NONE`, which accurately indicates no user-facing change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->