### PR TITLE
Attempt to intruct agents to fit into the templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,11 @@ Kueue follows the [Kubernetes AI Tool Usage Policy](https://www.kubernetes.dev/d
 - **Disclose AI usage** when commenting or filing issues.
 - **No AI authorship markers.** Do not add AI co-author lines, `assisted-by`, `co-developed`, or similar commit trailers.
 - **No auto-close keywords or `#` mentions in commit messages.** [Keywords which can automatically close issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) (for example `Fixes #123`) and `#` mentions are not allowed in commit messages — Prow flags them with the `do-not-merge/invalid-commit-message` label. Put issue references in the PR description instead.
-- Always use `PULL_REQUEST_TEMPLATE.md` or `ISSUE_TEMPLATE`, in the .github directory, before creating pull requests or issues.
+- For opening PRs always use the template in `.github/PULL_REQUEST_TEMPLATE.md`. Fit the content into the predefined sections.
+  Do not add, remove or rename any sections. 
+  The list of accepted AI agents that can inject new sections into the PR description: CodeRabbit AI (@coderabbitai).
+- For opening issues select a template from `.github/ISSUE_TEMPLATE` corresponding best to the issue type.
+  Fit the content into the predefined sections. Do not add, remove or rename any sections.
 
 ## Skills
 


### PR DESCRIPTION
<!-- Thank you for contributing! Check CONTRIBUTING.md for details. -->

#### What type of PR is this?
/kind cleanup
#### What this PR does / why we need it?
<!--
Use `Fixes #123` for an issue addressed by this PR; it will be closed when the PR merges.
Use `Related:` or `Part of:` to reference an issue without closing it.
-->
This is an attempt to make the agents using our templates when opening PRs or Issues.

#### Useful notes for your reviewer

#### Release note
<!-- Describe the behavior change accurately from the user's perspective. Hints:
- Do not leave this block blank.
- Use "NONE" when there is no user-facing change.
- When feasible use a prefix for the sub-component or feature, e.g. "FairSharing:" or "MultiKueue:".
- If upgrade steps are required, include an "ACTION REQUIRED:" section.
You may consider AI assistance using the skill: cmd/experimental/skills/kueue-release-notes/SKILL.md.
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated `AGENTS.md` with separate instructions for pull request and issue templates. Agents must use the correct template and preserve its predefined sections.

### Release note assessment

Ready. `NONE` accurately describes this documentation-only change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->