### PR TITLE
Implement quota distribution logic and soft validation for DynamicQuotaOrchestrator

### DIFF
--- a/pkg/controller/core/dynamicquotaorchestrator_controller.go
+++ b/pkg/controller/core/dynamicquotaorchestrator_controller.go
@@ -22,8 +22,10 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strings"
 
 	"github.com/go-logr/logr"
+	"gopkg.in/inf.v0"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -37,6 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 
 	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/features"
 	utilresource "sigs.k8s.io/kueue/pkg/util/resource"
@@ -44,7 +47,8 @@ import (
 )
 
 const (
-	dqoControllerName = "dynamicquotaorchestrator-reconciler"
+	dqoControllerName            = "dynamicquotaorchestrator-reconciler"
+	dynamicQuotaOrchestratorKind = "DynamicQuotaOrchestrator"
 )
 
 type DynamicQuotaOrchestratorReconciler struct {
@@ -81,6 +85,10 @@ func (r *DynamicQuotaOrchestratorReconciler) logger() logr.Logger {
 // +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=dynamicquotaorchestrators,verbs=get;list;watch
 // +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=dynamicquotaorchestrators/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=capacityproviders,verbs=get;list;watch
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=clusterqueues,verbs=get;list;watch
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=clusterqueues/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=cohorts,verbs=get;list;watch
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=cohorts/status,verbs=get;update;patch
 
 // SetupWithManager registers the DynamicQuotaOrchestrator controller and its watches with the manager.
 func (r *DynamicQuotaOrchestratorReconciler) SetupWithManager(mgr ctrl.Manager) error {
@@ -115,7 +123,7 @@ func (r *DynamicQuotaOrchestratorReconciler) mapCapacityProviderToDQOs(ctx conte
 	return requests
 }
 
-// Reconcile coordinates capacity discovery for a DynamicQuotaOrchestrator.
+// Reconcile coordinates capacity discovery and quota distribution for a DynamicQuotaOrchestrator.
 func (r *DynamicQuotaOrchestratorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	if !features.Enabled(features.DynamicQuotaOrchestration) {
 		return ctrl.Result{}, nil
@@ -136,9 +144,38 @@ func (r *DynamicQuotaOrchestratorReconciler) Reconcile(ctx context.Context, req 
 	oldStatus := orchestrator.Status.DeepCopy()
 
 	// Phase 1: Capacity Discovery
-	discoveryErr := r.reconcileDiscovery(ctx, &orchestrator)
-	err := r.updateStatus(ctx, &orchestrator, oldStatus)
-	return ctrl.Result{}, errors.Join(discoveryErr, err)
+	if discoveryErr := r.reconcileDiscovery(ctx, &orchestrator); discoveryErr != nil {
+		err := r.updateStatus(ctx, &orchestrator, oldStatus)
+		return ctrl.Result{}, errors.Join(discoveryErr, err)
+	}
+
+	// Phase 2: Quota Distribution
+	var distributionErr error
+	switch {
+	case orchestrator.Spec.CapacityDistribution == nil:
+		apimeta.RemoveStatusCondition(&orchestrator.Status.Conditions, kueuealpha.DynamicQuotaOrchestratorDistributed)
+	case orchestrator.Status.EffectiveCapacity == nil:
+		apimeta.SetStatusCondition(&orchestrator.Status.Conditions, metav1.Condition{
+			Type:               kueuealpha.DynamicQuotaOrchestratorDistributed,
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: orchestrator.Generation,
+			Reason:             kueuealpha.DynamicQuotaOrchestratorReasonEffectiveCapacityNotComputed,
+			Message:            "Capacity discovery not ready",
+		})
+	default:
+		if err := r.reconcileDistribution(ctx, &orchestrator, orchestrator.Status.EffectiveCapacity); err != nil {
+			log.Error(err, "Failed to distribute quotas")
+			distributionErr = err
+		}
+	}
+
+	if err := r.updateStatus(ctx, &orchestrator, oldStatus); err != nil {
+		return ctrl.Result{}, err
+	}
+	if distributionErr != nil {
+		return ctrl.Result{}, distributionErr
+	}
+	return ctrl.Result{}, nil
 }
 
 // reconcileDiscovery performs Phase 1 reconciliation: aggregates normalized capacities across referenced CapacityProviders.
@@ -223,6 +260,544 @@ func aggregateProviderCapacity(
 	}
 }
 
+// reconcileDistribution performs Phase 2 reconciliation: validates subtree conflicts, resolves the target hierarchy, and distributes effective quotas.
+func (r *DynamicQuotaOrchestratorReconciler) reconcileDistribution(ctx context.Context, orchestrator *kueuealpha.DynamicQuotaOrchestrator, effectiveCapacity *kueuealpha.EffectiveCapacity) error {
+	rootRef := orchestrator.Spec.CapacityDistribution.SubtreeRootQuotaRef
+	if rootRef.Kind != kueuealpha.CohortSubtreeRootRefKind && rootRef.Kind != kueuealpha.ClusterQueueSubtreeRootRefKind {
+		r.setDistributionCondition(orchestrator, metav1.ConditionFalse, kueuealpha.DynamicQuotaOrchestratorReasonMisconfigured, fmt.Sprintf("unsupported subtree root kind %q", rootRef.Kind))
+		return nil
+	}
+
+	otherOrchestrators, err := r.listDistributingDQOs(ctx)
+	if err != nil {
+		return err
+	}
+
+	conflictMsg, err := r.findConflictingDistributingDQO(ctx, orchestrator, otherOrchestrators)
+	if err != nil {
+		return err
+	}
+	if conflictMsg != "" {
+		r.setDistributionCondition(orchestrator, metav1.ConditionFalse, kueuealpha.DynamicQuotaOrchestratorReasonConflictingDynamicQuotaOrchestrator, conflictMsg)
+		return nil
+	}
+
+	targetClusterQueues, targetCohorts, err := r.resolveSubtree(ctx, rootRef)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			r.setDistributionCondition(orchestrator, metav1.ConditionFalse, kueuealpha.DynamicQuotaOrchestratorReasonMisconfigured, fmt.Sprintf("%s %q not found", rootRef.Kind, rootRef.Name))
+			return nil
+		}
+		return err
+	}
+
+	if err := r.findOwnershipConflict(ctx, orchestrator, targetClusterQueues, targetCohorts, otherOrchestrators); err != nil {
+		r.setDistributionCondition(orchestrator, metav1.ConditionFalse, kueuealpha.DynamicQuotaOrchestratorReasonEffectiveQuotasConflict, err.Error())
+		return nil
+	}
+
+	allocatedQuantities := calculateAllocations(effectiveCapacity, targetCohorts, targetClusterQueues)
+	if err := r.applyEffectiveQuotas(ctx, orchestrator.Name, targetClusterQueues, targetCohorts, allocatedQuantities); err != nil {
+		return err
+	}
+
+	r.setDistributionCondition(orchestrator, metav1.ConditionTrue, kueuealpha.DynamicQuotaOrchestratorReasonQuotasDistributed, "Quotas successfully distributed")
+	return nil
+}
+
+// listDistributingDQOs returns all DynamicQuotaOrchestrators currently configured for distribution.
+func (r *DynamicQuotaOrchestratorReconciler) listDistributingDQOs(ctx context.Context) ([]kueuealpha.DynamicQuotaOrchestrator, error) {
+	var list kueuealpha.DynamicQuotaOrchestratorList
+	if err := r.client.List(ctx, &list, client.MatchingFields{
+		indexer.DynamicQuotaOrchestratorIsDistributingKey: "true",
+	}); err != nil {
+		return nil, err
+	}
+	return list.Items, nil
+}
+
+// findConflictingDistributingDQO checks if another distributing DQO conflicts by being an ancestor or an older instance on the same root.
+// It returns a non-empty conflict message string if a conflict is found, or an empty string if no conflict exists.
+func (r *DynamicQuotaOrchestratorReconciler) findConflictingDistributingDQO(
+	ctx context.Context,
+	orchestrator *kueuealpha.DynamicQuotaOrchestrator,
+	otherOrchestrators []kueuealpha.DynamicQuotaOrchestrator,
+) (string, error) {
+	currentRoot := orchestrator.Spec.CapacityDistribution.SubtreeRootQuotaRef
+	for _, otherOrchestrator := range otherOrchestrators {
+		if otherOrchestrator.Name == orchestrator.Name || !otherOrchestrator.DeletionTimestamp.IsZero() {
+			continue
+		}
+
+		otherRoot := otherOrchestrator.Spec.CapacityDistribution.SubtreeRootQuotaRef
+		isAncestor, err := r.isStrictAncestor(ctx, otherRoot, currentRoot)
+		if err != nil {
+			return "", err
+		}
+		if isAncestor {
+			return fmt.Sprintf("Conflicts with ancestor DynamicQuotaOrchestrator %q", otherOrchestrator.Name), nil
+		}
+
+		if otherRoot == currentRoot && hasPrecedence(&otherOrchestrator, orchestrator) {
+			return fmt.Sprintf("Conflicts with older DynamicQuotaOrchestrator %q", otherOrchestrator.Name), nil
+		}
+	}
+	return "", nil
+}
+
+// findOwnershipConflict checks whether any target ClusterQueue or Cohort is currently managed by another active distributing orchestrator.
+// If the target object is managed by a descendant orchestrator, the current ancestor orchestrator has higher precedence and is allowed to take over.
+func (r *DynamicQuotaOrchestratorReconciler) findOwnershipConflict(
+	ctx context.Context,
+	orchestrator *kueuealpha.DynamicQuotaOrchestrator,
+	targetClusterQueues []kueue.ClusterQueue,
+	targetCohorts []kueue.Cohort,
+	otherOrchestrators []kueuealpha.DynamicQuotaOrchestrator,
+) error {
+	currentRoot := orchestrator.Spec.CapacityDistribution.SubtreeRootQuotaRef
+	for _, clusterQueue := range targetClusterQueues {
+		if err := r.checkManagedConflict(
+			ctx,
+			orchestrator,
+			currentRoot,
+			kueuealpha.ClusterQueueSubtreeRootRefKind,
+			clusterQueue.Name,
+			clusterQueue.Status.EffectiveQuotas,
+			otherOrchestrators,
+		); err != nil {
+			return err
+		}
+	}
+	for _, cohort := range targetCohorts {
+		if err := r.checkManagedConflict(ctx, orchestrator, currentRoot, kueuealpha.CohortSubtreeRootRefKind, cohort.Name, cohort.Status.EffectiveQuotas, otherOrchestrators); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// checkManagedConflict verifies whether an individual object's EffectiveQuotas is owned by another active distributing orchestrator.
+// It returns an error if owned by another active orchestrator that is not a descendant or older instance on the same root,
+// or nil if no conflict exists or if the reconciling orchestrator has precedence.
+func (r *DynamicQuotaOrchestratorReconciler) checkManagedConflict(
+	ctx context.Context,
+	orchestrator *kueuealpha.DynamicQuotaOrchestrator,
+	currentRoot kueuealpha.CapacityDistributionSubtreeRootRef,
+	kind kueuealpha.SubtreeRootRefKind,
+	name string,
+	quotas *kueue.EffectiveQuotaStatus,
+	otherOrchestrators []kueuealpha.DynamicQuotaOrchestrator,
+) error {
+	if quotas == nil {
+		return nil
+	}
+	ref := quotas.OrchestratorRef
+	if ref.Name == orchestrator.Name {
+		return nil
+	}
+	if ref.Kind != dynamicQuotaOrchestratorKind || (ref.APIGroup != "" && ref.APIGroup != kueuealpha.SchemeGroupVersion.Group) {
+		return fmt.Errorf("%s %q already managed by %s/%s", kind, name, ref.Kind, ref.Name)
+	}
+	idx := slices.IndexFunc(otherOrchestrators, func(o kueuealpha.DynamicQuotaOrchestrator) bool {
+		return o.Name == ref.Name
+	})
+	if idx == -1 {
+		return nil
+	}
+
+	other := &otherOrchestrators[idx]
+	if !other.DeletionTimestamp.IsZero() || other.Spec.CapacityDistribution == nil {
+		return nil
+	}
+
+	distCond := apimeta.FindStatusCondition(other.Status.Conditions, kueuealpha.DynamicQuotaOrchestratorDistributed)
+	if distCond != nil && distCond.Status == metav1.ConditionFalse {
+		// The other orchestrator is deactivated; its effective quota can be taken over.
+		return nil
+	}
+	isAncestor, err := r.isStrictAncestor(ctx, currentRoot, other.Spec.CapacityDistribution.SubtreeRootQuotaRef)
+	if err != nil {
+		return err
+	}
+	if isAncestor {
+		// Current orchestrator is a strict ancestor of the managing orchestrator, so it has precedence.
+		return nil
+	}
+	if other.Spec.CapacityDistribution.SubtreeRootQuotaRef == currentRoot && hasPrecedence(orchestrator, other) {
+		// Current orchestrator has the same root and has precedence (older or UID tie-break).
+		return nil
+	}
+	return fmt.Errorf("%s %q already managed by %s/%s", kind, name, ref.Kind, ref.Name)
+}
+
+// calculateAllocations distributes total capacity across all flavors and resources to participant nodes in the subtree.
+func calculateAllocations(
+	effectiveCapacity *kueuealpha.EffectiveCapacity,
+	cohorts []kueue.Cohort,
+	clusterQueues []kueue.ClusterQueue,
+) map[quotaKey]map[string]resource.Quantity {
+	participantsByKey := indexParticipantsByQuotaKey(cohorts, clusterQueues)
+	allocatedQuantities := make(map[quotaKey]map[string]resource.Quantity)
+	for _, flavor := range effectiveCapacity.Flavors {
+		for resourceName, totalCapacity := range flavor.Resources {
+			key := quotaKey{flavor: flavor.Name, resource: resourceName}
+			allocatedQuantities[key] = distributeCapacityProportionally(resourceName, totalCapacity, participantsByKey[key])
+		}
+	}
+	return allocatedQuantities
+}
+
+// applyEffectiveQuotas updates status.effectiveQuotas on all target ClusterQueues and Cohorts in the subtree.
+func (r *DynamicQuotaOrchestratorReconciler) applyEffectiveQuotas(
+	ctx context.Context,
+	orchestratorName string,
+	targetClusterQueues []kueue.ClusterQueue,
+	targetCohorts []kueue.Cohort,
+	allocatedQuantities map[quotaKey]map[string]resource.Quantity,
+) error {
+	var errs []error
+
+	// Step 1: Apply calculated effective quotas to all target ClusterQueues in the subtree.
+	for i := range targetClusterQueues {
+		clusterQueue := &targetClusterQueues[i]
+		newEffectiveQuotas := buildEffectiveQuotas(
+			orchestratorName,
+			kueuealpha.ClusterQueueSubtreeRootRefKind,
+			clusterQueue.Spec.ResourceGroups,
+			allocatedQuantities,
+			getParticipantID(kueuealpha.ClusterQueueSubtreeRootRefKind, clusterQueue.Name),
+		)
+		if !equality.Semantic.DeepEqual(clusterQueue.Status.EffectiveQuotas, newEffectiveQuotas) {
+			clusterQueue.Status.EffectiveQuotas = newEffectiveQuotas
+			if err := r.client.Status().Update(ctx, clusterQueue); err != nil {
+				errs = append(errs, fmt.Errorf("updating ClusterQueue %q effectiveQuotas: %w", clusterQueue.Name, err))
+			}
+		}
+	}
+
+	// Step 2: Apply calculated effective quotas to all target Cohorts in the subtree.
+	for i := range targetCohorts {
+		cohort := &targetCohorts[i]
+		newEffectiveQuotas := buildEffectiveQuotas(
+			orchestratorName,
+			kueuealpha.CohortSubtreeRootRefKind,
+			cohort.Spec.ResourceGroups,
+			allocatedQuantities,
+			getParticipantID(kueuealpha.CohortSubtreeRootRefKind, cohort.Name),
+		)
+		if !equality.Semantic.DeepEqual(cohort.Status.EffectiveQuotas, newEffectiveQuotas) {
+			cohort.Status.EffectiveQuotas = newEffectiveQuotas
+			if err := r.client.Status().Update(ctx, cohort); err != nil {
+				errs = append(errs, fmt.Errorf("updating Cohort %q effectiveQuotas: %w", cohort.Name, err))
+			}
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+type quotaKey struct {
+	flavor   kueuealpha.ResourceFlavorReference
+	resource corev1.ResourceName
+}
+
+type quotaParticipant struct {
+	kind             kueuealpha.SubtreeRootRefKind
+	name             string
+	uid              types.UID
+	specNominalQuota resource.Quantity
+}
+
+// getParticipantID returns a canonical identifier string for a participant Cohort or ClusterQueue.
+func getParticipantID(kind kueuealpha.SubtreeRootRefKind, name string) string {
+	return string(kind) + "/" + name
+}
+
+// indexParticipantsByQuotaKey indexes Cohorts and ClusterQueues by the (flavor, resource) pairs they declare in spec.resourceGroups.
+func indexParticipantsByQuotaKey(cohorts []kueue.Cohort, clusterQueues []kueue.ClusterQueue) map[quotaKey][]quotaParticipant {
+	index := make(map[quotaKey][]quotaParticipant)
+
+	addParticipants := func(kind kueuealpha.SubtreeRootRefKind, name string, uid types.UID, rgs []kueue.ResourceGroup) {
+		for _, rg := range rgs {
+			for _, f := range rg.Flavors {
+				for _, r := range f.Resources {
+					key := quotaKey{flavor: kueuealpha.ResourceFlavorReference(f.Name), resource: r.Name}
+					index[key] = append(index[key], quotaParticipant{
+						kind:             kind,
+						name:             name,
+						uid:              uid,
+						specNominalQuota: r.NominalQuota,
+					})
+				}
+			}
+		}
+	}
+
+	for _, cohort := range cohorts {
+		addParticipants(kueuealpha.CohortSubtreeRootRefKind, cohort.Name, cohort.UID, cohort.Spec.ResourceGroups)
+	}
+	for _, cq := range clusterQueues {
+		addParticipants(kueuealpha.ClusterQueueSubtreeRootRefKind, cq.Name, cq.UID, cq.Spec.ResourceGroups)
+	}
+
+	return index
+}
+
+type remainderEntry struct {
+	participant quotaParticipant
+	floor       *inf.Dec
+	remainder   *inf.Dec
+}
+
+// distributeCapacityProportionally distributes total capacity among participants using the largest-remainder method
+// for deterministic proportional allocation per KEP-12382:
+//  1. Determines the resource scale and unit: milliCPU (1m, scale 3) for CPU; integer (scale 0) for other resources.
+//  2. Calculates each participant's floor_i and exact remainder_i = (capacity * specNominal_i) - (floor_i * sumSpecNominal).
+//  3. Calculates the unallocated surplus capacity: diff = capacity - sum(floor_i).
+//  4. Sorts participants by remainder descending. Ties are broken deterministically by object UID (lexicographical).
+//  5. Assigns final allocations, adding +1 capacity unit to each of the top N participants (where N = diff / unit), and records the result.
+func distributeCapacityProportionally(
+	resourceName corev1.ResourceName,
+	capacity resource.Quantity,
+	participants []quotaParticipant,
+) map[string]resource.Quantity {
+	result := make(map[string]resource.Quantity, len(participants))
+	if len(participants) == 0 {
+		return result
+	}
+
+	sumSpecNominalQuota := new(inf.Dec)
+	for _, p := range participants {
+		sumSpecNominalQuota.Add(sumSpecNominalQuota, p.specNominalQuota.AsDec())
+	}
+
+	if sumSpecNominalQuota.Sign() <= 0 {
+		for _, p := range participants {
+			result[getParticipantID(p.kind, p.name)] = *resource.NewQuantity(0, capacity.Format)
+		}
+		return result
+	}
+
+	// Step 1: Determine the resource scale and unit.
+	// Per KEP-12382, CPU is distributed in milliCPUs (1m, scale 3) because container CPU requests in Kubernetes
+	// are fractional down to millicores. Other resources (e.g. memory in bytes, GPUs, or scalar items) use integer units (scale 0).
+	var scale inf.Scale
+	if resourceName == corev1.ResourceCPU {
+		scale = 3
+	}
+	unitDec := inf.NewDec(1, scale)
+
+	capacityAtScale := new(inf.Dec).Round(capacity.AsDec(), scale, inf.RoundDown)
+
+	// Step 2: Calculate floor_i and exact remainder_i = (capacity * specNominal_i) - (floor_i * sumSpecNominal).
+	entries := make([]remainderEntry, len(participants))
+	sumFloors := new(inf.Dec)
+
+	for i, p := range participants {
+		idealNumerator := new(inf.Dec).Mul(capacityAtScale, p.specNominalQuota.AsDec())
+		floor := new(inf.Dec).QuoRound(idealNumerator, sumSpecNominalQuota, scale, inf.RoundDown)
+
+		floorTimesSum := new(inf.Dec).Mul(floor, sumSpecNominalQuota)
+		remainder := new(inf.Dec).Sub(idealNumerator, floorTimesSum)
+
+		entries[i] = remainderEntry{participant: p, floor: floor, remainder: remainder}
+		sumFloors.Add(sumFloors, floor)
+	}
+
+	// Step 3: Calculate unallocated surplus capacity (diff) and number of surplus units (surplusUnits).
+	// Mathematically, 0 <= surplusUnits < len(entries) is guaranteed by the largest-remainder method.
+	diff := new(inf.Dec).Sub(capacityAtScale, sumFloors)
+	surplusUnits := int(diff.UnscaledBig().Int64())
+
+	// Step 4: Sort participants by remainder descending, breaking ties deterministically by object UID per KEP-12382.
+	slices.SortFunc(entries, func(a, b remainderEntry) int {
+		if cmp := b.remainder.Cmp(a.remainder); cmp != 0 {
+			return cmp
+		}
+		return strings.Compare(string(a.participant.uid), string(b.participant.uid))
+	})
+
+	// Step 5: Assign final allocations, adding +1 capacity unit to each of the top N (surplusUnits) participants, and record them in result.
+	for i, entry := range entries {
+		allocated := entry.floor
+		if i < surplusUnits {
+			allocated = new(inf.Dec).Add(allocated, unitDec)
+		}
+		result[getParticipantID(entry.participant.kind, entry.participant.name)] = *resource.NewDecimalQuantity(*allocated, capacity.Format)
+	}
+
+	return result
+}
+
+// buildEffectiveQuotas creates an EffectiveQuotaStatus for a participant with its allocated nominal quotas.
+// For ClusterQueues, any non-null lendingLimit is capped at the effective nominalQuota per KEP-12382.
+func buildEffectiveQuotas(
+	orchestratorName string,
+	kind kueuealpha.SubtreeRootRefKind,
+	specResourceGroups []kueue.ResourceGroup,
+	allocatedQuantities map[quotaKey]map[string]resource.Quantity,
+	participantID string,
+) *kueue.EffectiveQuotaStatus {
+	if len(specResourceGroups) == 0 {
+		return &kueue.EffectiveQuotaStatus{
+			OrchestratorRef: kueue.EffectiveQuotaStatusOrchestratorRef{
+				APIGroup: kueuealpha.SchemeGroupVersion.Group,
+				Kind:     dynamicQuotaOrchestratorKind,
+				Name:     orchestratorName,
+			},
+			ResourceGroups: []kueue.ResourceGroup{},
+		}
+	}
+	effectiveResourceGroups := make([]kueue.ResourceGroup, len(specResourceGroups))
+	for i, resourceGroup := range specResourceGroups {
+		effectiveResourceGroups[i] = *resourceGroup.DeepCopy()
+		for j, flavorQuotas := range effectiveResourceGroups[i].Flavors {
+			for k, resourceQuota := range flavorQuotas.Resources {
+				key := quotaKey{
+					flavor:   kueuealpha.ResourceFlavorReference(flavorQuotas.Name),
+					resource: resourceQuota.Name,
+				}
+				if participantAllocations, found := allocatedQuantities[key]; found {
+					if allocated, ok := participantAllocations[participantID]; ok {
+						effectiveResourceGroups[i].Flavors[j].Resources[k].NominalQuota = allocated
+						if kind == kueuealpha.ClusterQueueSubtreeRootRefKind && resourceQuota.LendingLimit != nil {
+							if resourceQuota.LendingLimit.Cmp(allocated) > 0 {
+								cappedLimit := allocated.DeepCopy()
+								effectiveResourceGroups[i].Flavors[j].Resources[k].LendingLimit = &cappedLimit
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return &kueue.EffectiveQuotaStatus{
+		OrchestratorRef: kueue.EffectiveQuotaStatusOrchestratorRef{
+			APIGroup: kueuealpha.SchemeGroupVersion.Group,
+			Kind:     dynamicQuotaOrchestratorKind,
+			Name:     orchestratorName,
+		},
+		ResourceGroups: effectiveResourceGroups,
+	}
+}
+
+// resolveSubtree traverses the quota hierarchy downwards from the specified root reference to find all member ClusterQueues and Cohorts.
+func (r *DynamicQuotaOrchestratorReconciler) resolveSubtree(
+	ctx context.Context,
+	rootRef kueuealpha.CapacityDistributionSubtreeRootRef,
+) ([]kueue.ClusterQueue, []kueue.Cohort, error) {
+	if rootRef.Kind == kueuealpha.ClusterQueueSubtreeRootRefKind {
+		var clusterQueue kueue.ClusterQueue
+		if err := r.client.Get(ctx, types.NamespacedName{Name: rootRef.Name}, &clusterQueue); err != nil {
+			return nil, nil, err
+		}
+		return []kueue.ClusterQueue{clusterQueue}, nil, nil
+	}
+
+	if rootRef.Kind == kueuealpha.CohortSubtreeRootRefKind {
+		var rootCohort kueue.Cohort
+		if err := r.client.Get(ctx, types.NamespacedName{Name: rootRef.Name}, &rootCohort); err != nil {
+			return nil, nil, err
+		}
+
+		targetCohorts := []kueue.Cohort{rootCohort}
+		var targetClusterQueues []kueue.ClusterQueue
+		cohortQueue := []string{rootCohort.Name}
+		visitedCohorts := sets.New(rootCohort.Name)
+
+		for len(cohortQueue) > 0 {
+			currentCohortName := cohortQueue[0]
+			cohortQueue = cohortQueue[1:]
+
+			// Find direct ClusterQueues under this cohort using indexer
+			var cqList kueue.ClusterQueueList
+			if err := r.client.List(ctx, &cqList, client.MatchingFields{
+				indexer.ClusterQueueCohortKey: currentCohortName,
+			}); err != nil {
+				return nil, nil, err
+			}
+			targetClusterQueues = append(targetClusterQueues, cqList.Items...)
+
+			// Find direct child Cohorts under this cohort using indexer
+			var childCohortList kueue.CohortList
+			if err := r.client.List(ctx, &childCohortList, client.MatchingFields{
+				indexer.CohortParentKey: currentCohortName,
+			}); err != nil {
+				return nil, nil, err
+			}
+			for _, child := range childCohortList.Items {
+				if !visitedCohorts.Has(child.Name) {
+					visitedCohorts.Insert(child.Name)
+					targetCohorts = append(targetCohorts, child)
+					cohortQueue = append(cohortQueue, child.Name)
+				}
+			}
+		}
+
+		return targetClusterQueues, targetCohorts, nil
+	}
+
+	return nil, nil, fmt.Errorf("unsupported subtree root kind %q", rootRef.Kind)
+}
+
+// isStrictAncestor returns true if candidate is a strict ancestor of target in the cohort hierarchy.
+func (r *DynamicQuotaOrchestratorReconciler) isStrictAncestor(
+	ctx context.Context,
+	candidate kueuealpha.CapacityDistributionSubtreeRootRef,
+	target kueuealpha.CapacityDistributionSubtreeRootRef,
+) (bool, error) {
+	if candidate.Kind != kueuealpha.CohortSubtreeRootRefKind || candidate == target {
+		return false, nil
+	}
+
+	currentName := target.Name
+	if target.Kind == kueuealpha.ClusterQueueSubtreeRootRefKind {
+		var cq kueue.ClusterQueue
+		if err := r.client.Get(ctx, types.NamespacedName{Name: target.Name}, &cq); err != nil {
+			return false, client.IgnoreNotFound(err)
+		}
+		if cq.Spec.CohortName == "" {
+			return false, nil
+		}
+		if string(cq.Spec.CohortName) == candidate.Name {
+			return true, nil
+		}
+		currentName = string(cq.Spec.CohortName)
+	}
+
+	visited := sets.New(currentName)
+	for currentName != "" {
+		var cohort kueue.Cohort
+		if err := r.client.Get(ctx, types.NamespacedName{Name: currentName}, &cohort); err != nil {
+			return false, client.IgnoreNotFound(err)
+		}
+		parentName := string(cohort.Spec.ParentName)
+		if parentName == "" || visited.Has(parentName) {
+			return false, nil
+		}
+		if parentName == candidate.Name {
+			return true, nil
+		}
+		visited.Insert(parentName)
+		currentName = parentName
+	}
+
+	return false, nil
+}
+
+// hasPrecedence returns true if a has precedence over b (i.e. created earlier, breaking ties with UID).
+func hasPrecedence(a, b *kueuealpha.DynamicQuotaOrchestrator) bool {
+	if a.CreationTimestamp.Before(&b.CreationTimestamp) {
+		return true
+	}
+	if b.CreationTimestamp.Before(&a.CreationTimestamp) {
+		return false
+	}
+	return a.UID < b.UID
+}
+
+// setDiscoveryCondition sets the EffectiveCapacityComputed condition on the orchestrator status.
 func (r *DynamicQuotaOrchestratorReconciler) setDiscoveryCondition(orchestrator *kueuealpha.DynamicQuotaOrchestrator, status metav1.ConditionStatus, reason, message string) {
 	apimeta.SetStatusCondition(&orchestrator.Status.Conditions, metav1.Condition{
 		Type:               kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
@@ -233,6 +808,16 @@ func (r *DynamicQuotaOrchestratorReconciler) setDiscoveryCondition(orchestrator 
 	})
 }
 
+// setDistributionCondition sets the Distributed condition on the orchestrator status.
+func (r *DynamicQuotaOrchestratorReconciler) setDistributionCondition(orchestrator *kueuealpha.DynamicQuotaOrchestrator, status metav1.ConditionStatus, reason, message string) {
+	apimeta.SetStatusCondition(&orchestrator.Status.Conditions, metav1.Condition{
+		Type:               kueuealpha.DynamicQuotaOrchestratorDistributed,
+		Status:             status,
+		ObservedGeneration: orchestrator.Generation,
+		Reason:             reason,
+		Message:            message,
+	})
+}
 func (r *DynamicQuotaOrchestratorReconciler) updateStatus(ctx context.Context, orchestrator *kueuealpha.DynamicQuotaOrchestrator, oldStatus *kueuealpha.DynamicQuotaOrchestratorStatus) error {
 	if equality.Semantic.DeepEqual(oldStatus, &orchestrator.Status) {
 		return nil

--- a/pkg/controller/core/dynamicquotaorchestrator_controller_test.go
+++ b/pkg/controller/core/dynamicquotaorchestrator_controller_test.go
@@ -18,6 +18,7 @@ package core
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -29,20 +30,30 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingalpha "sigs.k8s.io/kueue/pkg/util/testing/v1alpha1"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 )
 
 func TestDynamicQuotaOrchestratorReconcile(t *testing.T) {
 	features.SetFeatureGateDuringTest(t, features.DynamicQuotaOrchestration, true)
 	halfMultiplier := resource.MustParse("0.5")
 
+	timeNow := time.Now()
+	timeEarlier := timeNow.Add(-10 * time.Minute)
+
 	cases := map[string]struct {
 		enableFeatureGate *bool
 		dqo               *kueuealpha.DynamicQuotaOrchestrator
 		capacityProviders []*kueuealpha.CapacityProvider
+		cohorts           []*kueue.Cohort
+		clusterQueues     []*kueue.ClusterQueue
+		otherDQOs         []*kueuealpha.DynamicQuotaOrchestrator
 		wantDQO           *kueuealpha.DynamicQuotaOrchestrator
+		wantCohorts       []*kueue.Cohort
+		wantClusterQueues []*kueue.ClusterQueue
 		wantErr           bool
 	}{
 		"discovery-only: provider not found": {
@@ -315,6 +326,815 @@ func TestDynamicQuotaOrchestratorReconcile(t *testing.T) {
 				}).
 				Obj(),
 		},
+		"distribution: discovery not ready sets EffectiveCapacityNotComputed condition": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-dist-not-ready").
+				DiscoveryProvider("non-existent-provider", nil).
+				SubtreeRoot(kueuealpha.ClusterQueueSubtreeRootRefKind, "cq-1").
+				Obj(),
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq-1").Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-dist-not-ready").
+				DiscoveryProvider("non-existent-provider", nil).
+				SubtreeRoot(kueuealpha.ClusterQueueSubtreeRootRefKind, "cq-1").
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonMisconfigured,
+					Message: "CapacityProvider \"non-existent-provider\" not found",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorDistributed,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonEffectiveCapacityNotComputed,
+					Message: "Capacity discovery not ready",
+				}).
+				Obj(),
+			wantClusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq-1").Obj(),
+			},
+			wantErr: false,
+		},
+		"distribution: to single ClusterQueue": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-cq").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.ClusterQueueSubtreeRootRefKind, "cq-1").
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
+								Resource(corev1.ResourceCPU, "200").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq-1").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50", "20").Obj(),
+					).
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-cq").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.ClusterQueueSubtreeRootRefKind, "cq-1").
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("default-flavor").
+							Resource(corev1.ResourceCPU, "200").
+							Obj(),
+					).
+					Obj()).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorDistributed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonQuotasDistributed,
+					Message: "Quotas successfully distributed",
+				}).
+				Obj(),
+			wantClusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq-1").
+					EffectiveQuotaStatus(
+						utiltestingapi.MakeEffectiveQuotaStatus().
+							Name("dqo-cq").
+							ResourceGroups(utiltestingapi.ResourceGroup(
+								*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "200", "20").Obj(),
+							)).
+							Obj(),
+					).
+					Obj(),
+			},
+		},
+		"distribution: caps lendingLimit on ClusterQueue at effective nominalQuota, but preserves lendingLimit on Cohort": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-lending").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "root-cohort").
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
+								Resource(corev1.ResourceCPU, "80").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("root-cohort").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "100", "", "80").Obj(),
+					).
+					Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq-1").
+					Cohort("root-cohort").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "100", "", "80").Obj(),
+					).
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-lending").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "root-cohort").
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("default-flavor").
+							Resource(corev1.ResourceCPU, "80").
+							Obj(),
+					).
+					Obj()).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorDistributed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonQuotasDistributed,
+					Message: "Quotas successfully distributed",
+				}).
+				Obj(),
+			wantCohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("root-cohort").
+					EffectiveQuotaStatus(
+						// For Cohort, non-null lendingLimit is preserved unchanged (80) even when nominalQuota is 40.
+						utiltestingapi.MakeEffectiveQuotaStatus().
+							Name("dqo-lending").
+							ResourceGroups(utiltestingapi.ResourceGroup(
+								*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "40", "", "80").Obj(),
+							)).
+							Obj(),
+					).
+					Obj(),
+			},
+			wantClusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq-1").
+					Cohort("root-cohort").
+					EffectiveQuotaStatus(
+						// For ClusterQueue, non-null lendingLimit is capped at effective nominalQuota (40).
+						utiltestingapi.MakeEffectiveQuotaStatus().
+							Name("dqo-lending").
+							ResourceGroups(utiltestingapi.ResourceGroup(
+								*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "40", "", "40").Obj(),
+							)).
+							Obj(),
+					).
+					Obj(),
+			},
+		},
+		"distribution: empty spec.resourceGroups sets empty resourceGroups in effectiveQuotas": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-empty").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.ClusterQueueSubtreeRootRefKind, "cq-empty").
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
+								Resource(corev1.ResourceCPU, "100").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq-empty").Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-empty").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.ClusterQueueSubtreeRootRefKind, "cq-empty").
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("default-flavor").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj()).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorDistributed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonQuotasDistributed,
+					Message: "Quotas successfully distributed",
+				}).
+				Obj(),
+			wantClusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq-empty").
+					EffectiveQuotaStatus(utiltestingapi.MakeEffectiveQuotaStatus().Name("dqo-empty").Obj()).
+					Obj(),
+			},
+		},
+		"distribution: previously managed CQ removed from cohort retains effective quotas as stale": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-1").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "root-cohort").
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
+								Resource(corev1.ResourceCPU, "100").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("root-cohort").Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq-1").
+					Cohort("root-cohort").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj(),
+				utiltestingapi.MakeClusterQueue("cq-removed").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					EffectiveQuotaStatus(utiltestingapi.MakeEffectiveQuotaStatus().Name("dqo-1").Obj()).
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-1").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "root-cohort").
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorDistributed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonQuotasDistributed,
+					Message: "Quotas successfully distributed",
+				}).
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("default-flavor").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj()).
+				Obj(),
+			wantClusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq-1").
+					EffectiveQuotaStatus(
+						utiltestingapi.MakeEffectiveQuotaStatus().
+							Name("dqo-1").
+							ResourceGroups(utiltestingapi.ResourceGroup(
+								*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "100").Obj(),
+							)).
+							Obj(),
+					).
+					Obj(),
+				utiltestingapi.MakeClusterQueue("cq-removed").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					EffectiveQuotaStatus(utiltestingapi.MakeEffectiveQuotaStatus().Name("dqo-1").Obj()).
+					Obj(),
+			},
+			wantErr: false,
+		},
+		"soft validation: child DQO deactivated when ancestor DQO is distributing": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-child").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "child-cohort").
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
+								Resource(corev1.ResourceCPU, "100").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("root-cohort").Obj(),
+				utiltestingapi.MakeCohort("child-cohort").Parent("root-cohort").Obj(),
+			},
+			otherDQOs: []*kueuealpha.DynamicQuotaOrchestrator{
+				utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-ancestor").
+					DiscoveryProvider("cp-1", nil).
+					SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "root-cohort").
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-child").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "child-cohort").
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("default-flavor").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj()).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorDistributed,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonConflictingDynamicQuotaOrchestrator,
+					Message: "Conflicts with ancestor DynamicQuotaOrchestrator \"dqo-ancestor\"",
+				}).
+				Obj(),
+		},
+		"soft validation: ancestor DQO takes precedence and overwrites quotas set by descendant DQO": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("parent-dqo").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "parent-cohort").
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
+								Resource(corev1.ResourceCPU, "100").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("parent-cohort").Obj(),
+				utiltestingapi.MakeCohort("child-cohort").Parent("parent-cohort").Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("child-cq").
+					Cohort("child-cohort").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "100").Obj(),
+					).
+					EffectiveQuotaStatus(
+						utiltestingapi.MakeEffectiveQuotaStatus().
+							Name("child-dqo").
+							ResourceGroups(utiltestingapi.ResourceGroup(
+								*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+							)).
+							Obj(),
+					).
+					Obj(),
+			},
+			otherDQOs: []*kueuealpha.DynamicQuotaOrchestrator{
+				utiltestingalpha.MakeDynamicQuotaOrchestrator("child-dqo").
+					DiscoveryProvider("cp-1", nil).
+					SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "child-cohort").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.DynamicQuotaOrchestratorDistributed,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.DynamicQuotaOrchestratorReasonQuotasDistributed,
+					}).
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("parent-dqo").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "parent-cohort").
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("default-flavor").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj()).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorDistributed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonQuotasDistributed,
+					Message: "Quotas successfully distributed",
+				}).
+				Obj(),
+			wantClusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("child-cq").
+					Cohort("child-cohort").
+					EffectiveQuotaStatus(
+						utiltestingapi.MakeEffectiveQuotaStatus().
+							Name("parent-dqo").
+							ResourceGroups(utiltestingapi.ResourceGroup(
+								*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "100").Obj(),
+							)).
+							Obj(),
+					).
+					Obj(),
+			},
+		},
+		"soft validation: duplicate root DQO deactivated by creation timestamp tie-break": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-newer").
+				Creation(timeNow).
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.ClusterQueueSubtreeRootRefKind, "cq-1").
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
+								Resource(corev1.ResourceCPU, "100").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq-1").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					Obj(),
+			},
+			otherDQOs: []*kueuealpha.DynamicQuotaOrchestrator{
+				utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-older").
+					Creation(timeEarlier).
+					DiscoveryProvider("cp-1", nil).
+					SubtreeRoot(kueuealpha.ClusterQueueSubtreeRootRefKind, "cq-1").
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-newer").
+				Creation(timeNow).
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.ClusterQueueSubtreeRootRefKind, "cq-1").
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("default-flavor").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj()).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorDistributed,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonConflictingDynamicQuotaOrchestrator,
+					Message: "Conflicts with older DynamicQuotaOrchestrator \"dqo-older\"",
+				}).
+				Obj(),
+		},
+		"soft validation: older DQO takes over effective quotas on same root from younger DQO": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-older").
+				Creation(timeEarlier).
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.ClusterQueueSubtreeRootRefKind, "cq-1").
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
+								Resource(corev1.ResourceCPU, "100").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq-1").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					EffectiveQuotaStatus(
+						utiltestingapi.MakeEffectiveQuotaStatus().
+							Name("dqo-younger").
+							ResourceGroups(utiltestingapi.ResourceGroup(
+								*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+							)).
+							Obj(),
+					).
+					Obj(),
+			},
+			otherDQOs: []*kueuealpha.DynamicQuotaOrchestrator{
+				utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-younger").
+					Creation(timeNow).
+					DiscoveryProvider("cp-1", nil).
+					SubtreeRoot(kueuealpha.ClusterQueueSubtreeRootRefKind, "cq-1").
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-older").
+				Creation(timeEarlier).
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.ClusterQueueSubtreeRootRefKind, "cq-1").
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("default-flavor").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj()).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorDistributed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonQuotasDistributed,
+					Message: "Quotas successfully distributed",
+				}).
+				Obj(),
+			wantClusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq-1").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					EffectiveQuotaStatus(
+						utiltestingapi.MakeEffectiveQuotaStatus().
+							Name("dqo-older").
+							ResourceGroups(utiltestingapi.ResourceGroup(
+								*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "100").Obj(),
+							)).
+							Obj(),
+					).
+					Obj(),
+			},
+			wantErr: false,
+		},
+		"soft validation: child DQO deactivates and retains previously managed effective quotas when ancestor DQO distributes": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("child-dqo").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "child-cohort").
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
+								Resource(corev1.ResourceCPU, "100").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("parent-cohort").Obj(),
+				utiltestingapi.MakeCohort("child-cohort").Parent("parent-cohort").Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("child-cq").
+					Cohort("child-cohort").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					EffectiveQuotaStatus(utiltestingapi.MakeEffectiveQuotaStatus().Name("child-dqo").Obj()).
+					Obj(),
+			},
+			otherDQOs: []*kueuealpha.DynamicQuotaOrchestrator{
+				utiltestingalpha.MakeDynamicQuotaOrchestrator("parent-dqo").
+					DiscoveryProvider("cp-1", nil).
+					SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "parent-cohort").
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("child-dqo").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "child-cohort").
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("default-flavor").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj()).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorDistributed,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonConflictingDynamicQuotaOrchestrator,
+					Message: "Conflicts with ancestor DynamicQuotaOrchestrator \"parent-dqo\"",
+				}).
+				Obj(),
+			wantClusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("child-cq").
+					Cohort("child-cohort").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					EffectiveQuotaStatus(utiltestingapi.MakeEffectiveQuotaStatus().Name("child-dqo").Obj()).
+					Obj(),
+			},
+			wantErr: false,
+		},
+		"soft validation: effective quotas conflict when managed by another DynamicQuotaOrchestrator": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-1").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.ClusterQueueSubtreeRootRefKind, "cq-1").
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
+								Resource(corev1.ResourceCPU, "100").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq-1").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					EffectiveQuotaStatus(utiltestingapi.MakeEffectiveQuotaStatus().Name("other-dqo").Obj()).
+					Obj(),
+			},
+			otherDQOs: []*kueuealpha.DynamicQuotaOrchestrator{
+				utiltestingalpha.MakeDynamicQuotaOrchestrator("other-dqo").
+					DiscoveryProvider("cp-1", nil).
+					SubtreeRoot(kueuealpha.ClusterQueueSubtreeRootRefKind, "cq-other").
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-1").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.ClusterQueueSubtreeRootRefKind, "cq-1").
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("default-flavor").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj()).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorDistributed,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonEffectiveQuotasConflict,
+					Message: "ClusterQueue \"cq-1\" already managed by DynamicQuotaOrchestrator/other-dqo",
+				}).
+				Obj(),
+		},
+		"transition: switch to discovery-only preserves stale effective quotas and removes Distributed condition": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-discovery-only").
+				DiscoveryProvider("cp-1", nil).
+				Condition(metav1.Condition{
+					Type:   kueuealpha.DynamicQuotaOrchestratorDistributed,
+					Status: metav1.ConditionTrue,
+					Reason: kueuealpha.DynamicQuotaOrchestratorReasonQuotasDistributed,
+				}).
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
+								Resource(corev1.ResourceCPU, "100").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq-1").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					EffectiveQuotaStatus(utiltestingapi.MakeEffectiveQuotaStatus().Name("dqo-discovery-only").Obj()).
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-discovery-only").
+				DiscoveryProvider("cp-1", nil).
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("default-flavor").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj()).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Obj(),
+			wantClusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq-1").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					EffectiveQuotaStatus(utiltestingapi.MakeEffectiveQuotaStatus().Name("dqo-discovery-only").Obj()).
+					Obj(),
+			},
+			wantErr: false,
+		},
 		"feature gate disabled": {
 			enableFeatureGate: new(bool),
 			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-disabled").
@@ -336,6 +1156,15 @@ func TestDynamicQuotaOrchestratorReconcile(t *testing.T) {
 			objs := []client.Object{tc.dqo}
 			for _, cp := range tc.capacityProviders {
 				objs = append(objs, cp)
+			}
+			for _, co := range tc.cohorts {
+				objs = append(objs, co)
+			}
+			for _, cq := range tc.clusterQueues {
+				objs = append(objs, cq)
+			}
+			for _, other := range tc.otherDQOs {
+				objs = append(objs, other)
 			}
 
 			cl := builder.WithObjects(objs...).WithStatusSubresource(objs...).Build()
@@ -361,6 +1190,107 @@ func TestDynamicQuotaOrchestratorReconcile(t *testing.T) {
 				cmpopts.EquateEmpty(),
 			); diff != "" {
 				t.Errorf("Unexpected DQO (-want +got):\n%s", diff)
+			}
+
+			for _, wantCQ := range tc.wantClusterQueues {
+				var gotCQ kueue.ClusterQueue
+				if err := cl.Get(ctx, types.NamespacedName{Name: wantCQ.Name}, &gotCQ); err != nil {
+					t.Errorf("Failed to get ClusterQueue %s: %v", wantCQ.Name, err)
+					continue
+				}
+				if diff := cmp.Diff(wantCQ.Status.EffectiveQuotas, gotCQ.Status.EffectiveQuotas, cmpopts.EquateEmpty()); diff != "" {
+					t.Errorf("Unexpected EffectiveQuotas for ClusterQueue %s (-want +got):\n%s", wantCQ.Name, diff)
+				}
+			}
+
+			for _, wantCohort := range tc.wantCohorts {
+				var gotCohort kueue.Cohort
+				if err := cl.Get(ctx, types.NamespacedName{Name: wantCohort.Name}, &gotCohort); err != nil {
+					t.Errorf("Failed to get Cohort %s: %v", wantCohort.Name, err)
+					continue
+				}
+				if diff := cmp.Diff(wantCohort.Status.EffectiveQuotas, gotCohort.Status.EffectiveQuotas, cmpopts.EquateEmpty()); diff != "" {
+					t.Errorf("Unexpected EffectiveQuotas for Cohort %s (-want +got):\n%s", wantCohort.Name, diff)
+				}
+			}
+		})
+	}
+}
+
+func TestDistributeCapacityProportionally(t *testing.T) {
+	cases := map[string]struct {
+		resource     corev1.ResourceName
+		capacity     resource.Quantity
+		participants []quotaParticipant
+		want         map[string]resource.Quantity
+	}{
+		"empty participants": {
+			resource:     corev1.ResourceCPU,
+			capacity:     resource.MustParse("100"),
+			participants: nil,
+			want:         map[string]resource.Quantity{},
+		},
+		"zero sum spec nominal quota": {
+			resource: corev1.ResourceCPU,
+			capacity: resource.MustParse("100"),
+			participants: []quotaParticipant{
+				{kind: kueuealpha.ClusterQueueSubtreeRootRefKind, name: "cq-1", specNominalQuota: resource.MustParse("0")},
+				{kind: kueuealpha.CohortSubtreeRootRefKind, name: "cohort-1", specNominalQuota: resource.MustParse("0")},
+			},
+			want: map[string]resource.Quantity{
+				"ClusterQueue/cq-1": resource.MustParse("0"),
+				"Cohort/cohort-1":   resource.MustParse("0"),
+			},
+		},
+		"remainder tie-breaker: UUID ordering per KEP-12382": {
+			resource: corev1.ResourceCPU,
+			capacity: resource.MustParse("10"),
+			participants: []quotaParticipant{
+				{kind: kueuealpha.ClusterQueueSubtreeRootRefKind, name: "cq-1", uid: "uid-c", specNominalQuota: resource.MustParse("1")},
+				{kind: kueuealpha.ClusterQueueSubtreeRootRefKind, name: "cq-2", uid: "uid-a", specNominalQuota: resource.MustParse("1")},
+				{kind: kueuealpha.CohortSubtreeRootRefKind, name: "cohort-1", uid: "uid-b", specNominalQuota: resource.MustParse("1")},
+			},
+			want: map[string]resource.Quantity{
+				"ClusterQueue/cq-1": resource.MustParse("3333m"),
+				"ClusterQueue/cq-2": resource.MustParse("3334m"),
+				"Cohort/cohort-1":   resource.MustParse("3333m"),
+			},
+		},
+		"scalar resource distribution uses integer unit (scale 0)": {
+			resource: corev1.ResourceMemory,
+			capacity: resource.MustParse("10"),
+			participants: []quotaParticipant{
+				{kind: kueuealpha.ClusterQueueSubtreeRootRefKind, name: "cq-1", uid: "uid-c", specNominalQuota: resource.MustParse("1")},
+				{kind: kueuealpha.ClusterQueueSubtreeRootRefKind, name: "cq-2", uid: "uid-a", specNominalQuota: resource.MustParse("1")},
+				{kind: kueuealpha.CohortSubtreeRootRefKind, name: "cohort-1", uid: "uid-b", specNominalQuota: resource.MustParse("1")},
+			},
+			want: map[string]resource.Quantity{
+				"ClusterQueue/cq-1": resource.MustParse("3"),
+				"ClusterQueue/cq-2": resource.MustParse("4"),
+				"Cohort/cohort-1":   resource.MustParse("3"),
+			},
+		},
+		"proportional allocation without remainders across cohorts and clusterqueues": {
+			resource: corev1.ResourceCPU,
+			capacity: resource.MustParse("50"),
+			participants: []quotaParticipant{
+				{kind: kueuealpha.CohortSubtreeRootRefKind, name: "parent-cohort", uid: "uid-1", specNominalQuota: resource.MustParse("20")},
+				{kind: kueuealpha.ClusterQueueSubtreeRootRefKind, name: "cq-1", uid: "uid-2", specNominalQuota: resource.MustParse("10")},
+				{kind: kueuealpha.ClusterQueueSubtreeRootRefKind, name: "cq-2", uid: "uid-3", specNominalQuota: resource.MustParse("10")},
+			},
+			want: map[string]resource.Quantity{
+				"Cohort/parent-cohort": resource.MustParse("25"),
+				"ClusterQueue/cq-1":    resource.MustParse("12500m"),
+				"ClusterQueue/cq-2":    resource.MustParse("12500m"),
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := distributeCapacityProportionally(tc.resource, tc.capacity, tc.participants)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Unexpected distribution (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/util/testing/v1alpha1/wrappers.go
+++ b/pkg/util/testing/v1alpha1/wrappers.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -78,6 +80,12 @@ func (w *DynamicQuotaOrchestratorWrapper) EffectiveCapacity(capacity *kueuealpha
 // Condition adds a condition to the DynamicQuotaOrchestrator.
 func (w *DynamicQuotaOrchestratorWrapper) Condition(condition metav1.Condition) *DynamicQuotaOrchestratorWrapper {
 	w.Status.Conditions = append(w.Status.Conditions, condition)
+	return w
+}
+
+// Creation sets the creation timestamp of the DynamicQuotaOrchestrator.
+func (w *DynamicQuotaOrchestratorWrapper) Creation(t time.Time) *DynamicQuotaOrchestratorWrapper {
+	w.CreationTimestamp = metav1.NewTime(t)
 	return w
 }
 

--- a/pkg/util/testing/v1beta2/wrappers.go
+++ b/pkg/util/testing/v1beta2/wrappers.go
@@ -944,6 +944,12 @@ func (c *CohortWrapper) EffectiveQuotas(flavors ...kueue.FlavorQuotas) *CohortWr
 	return c
 }
 
+// EffectiveQuotaStatus sets status.effectiveQuotas.
+func (c *CohortWrapper) EffectiveQuotaStatus(eq *kueue.EffectiveQuotaStatus) *CohortWrapper {
+	c.Status.EffectiveQuotas = eq
+	return c
+}
+
 func (c *CohortWrapper) FairWeight(w resource.Quantity) *CohortWrapper {
 	if c.Spec.FairSharing == nil {
 		c.Spec.FairSharing = &kueue.FairSharing{}
@@ -1102,6 +1108,12 @@ func (c *ClusterQueueWrapper) EffectiveQuotas(flavors ...kueue.FlavorQuotas) *Cl
 		c.Status.EffectiveQuotas = &kueue.EffectiveQuotaStatus{}
 	}
 	c.Status.EffectiveQuotas.ResourceGroups = append(c.Status.EffectiveQuotas.ResourceGroups, ResourceGroup(flavors...))
+	return c
+}
+
+// EffectiveQuotaStatus sets status.effectiveQuotas.
+func (c *ClusterQueueWrapper) EffectiveQuotaStatus(eq *kueue.EffectiveQuotaStatus) *ClusterQueueWrapper {
+	c.Status.EffectiveQuotas = eq
 	return c
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it?

Part of #12382

This PR implements Phase 2 (Capacity Distribution) logic and soft validation for the `DynamicQuotaOrchestrator` controller. It builds on the field indexers added in #15260 (Part 1).

Key capabilities implemented in this PR:
1. **Subtree Resolution & Inverted Indexing**:
   - Traverses the quota hierarchy downward from `spec.capacityDistribution.subtreeRootQuotaRef` (Cohort or ClusterQueue) with cycle protection.
   - Builds an inverted index of participants (`Cohort` and `ClusterQueue`) mapped by `(flavor, resource)` pair in a single pass to enable efficient proportional distribution.
2. **Deterministic Proportional Allocation (Largest-Remainder Method)**:
   - Distributes discovered capacity among subtree participants using the largest-remainder (Hamilton-Hare) method per KEP-12382.
   - Resource scale-aware: uses milliCPU (scale 3, 1m) for CPU, and integer units (scale 0) for other resources.
   - Exact integer remainder arithmetic using `inf.Dec` to avoid floating-point imprecision and 64-bit overflow.
   - Resolves equal remainder ties deterministically using object UIDs.
3. **Quota Construction & Capping**:
   - Constructs `status.effectiveQuotas.resourceGroups` by overlaying nominal quotas for distributed flavors/resources while preserving unmanaged resources from `spec.resourceGroups`.
   - Caps non-null `lendingLimit` at effective nominal quota on `ClusterQueue`, while preserving `Cohort.lendingLimit` unchanged.
4. **Soft Validation & Multi-DQO Conflict Rules**:
   - Detects conflicts with ancestor DQOs and older instances on the same root; deactivates conflicting DQO with condition `Distributed=False` (`Reason: ConflictingDynamicQuotaOrchestrator`).
   - Detects ownership conflicts on target objects (`Reason: EffectiveQuotasConflict`), while permitting takeover when the prior manager is deactivated or no longer distributing.
   - Retains previously written `status.effectiveQuotas` as stale when a participant leaves the subtree or a DQO stops distributing.
5. **Testing**:
   - Adds 22 table-driven unit tests in `dynamicquotaorchestrator_controller_test.go` covering distribution to single/multiple CQs, cohort hierarchies, lendingLimit capping, discovery-only transitions, and soft validation conflict paths.

This is part 2 of the 3-part DQO Phase 2 stack:
- [x] **Part 1**: Indexers and test client builder (#15260 - merged)
- [x] **Part 2**: Distribution logic, inverted index, largest-remainder math, soft validation, and unit tests (this PR)
- [ ] **Part 3**: Reconciler watches, event mappers, and integration tests

#### Useful notes for your reviewer

- Proportional distribution logic is isolated in `distributeCapacityProportionally` and thoroughly tested in unit tests with scale 3 (CPU) and scale 0 (Memory) test cases.
- Reconciler watches and Ginkgo integration tests are intentionally deferred to Part 3 to keep review sizes manageable.

#### Release note

```release-note
DynamicQuotaOrchestration: Implemented proportional capacity distribution and soft validation for DynamicQuotaOrchestrator.
```

---
*AI usage disclosure: Assisted by AI agent (Antigravity) in refactoring, math verification, documentation, and unit tests per the Kubernetes AI Tool Usage Policy.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds Phase 2 capacity distribution for `DynamicQuotaOrchestrator`.
- Traverses quota subtrees with cycle protection and indexes participants by flavor and resource.
- Uses deterministic largest-remainder allocation with exact integer arithmetic.
- Builds effective quotas and applies `ClusterQueue` lending-limit caps.
- Adds conflict detection, takeover rules, and stale quota retention.
- Adds 22 table-driven tests and testing helpers.

## Release note assessment

No `release-note` block was provided for review. Suggested release note:

> DynamicQuotaOrchestrator: Add proportional capacity distribution and soft validation for Cohorts and ClusterQueues.

Please verify this note and update the canonical `release-note` block in the PR description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->