### PR TITLE
Retry the dra-example-driver clone and image build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,12 +70,14 @@ CGO_ENABLED ?= 0
 
 YAML_PROCESSOR_LOG_LEVEL ?= info
 
+IMAGE_BUILD_RETRIABLE_ERRORS := context deadline exceeded|unexpected status from HEAD request to .*: 401 Unauthorized|unexpected status from POST request to .*: 502 Bad Gateway|connection reset by peer|too ?many ?requests|ref .* locked for .*: unavailable|tls handshake timeout|stream error: stream ID [0-9]+; INTERNAL_ERROR|http2: server sent GOAWAY|500 Internal Server Error|i/o timeout
+
 IMAGE_BUILD_RETRY = $(PROJECT_DIR)/hack/testing/retry.sh \
 	--attempts 7 \
 	--delay 2 \
 	--exponential \
 	--stream \
-	--continue-if "grep -qiE '(context deadline exceeded|unexpected status from HEAD request to .*: 401 Unauthorized|unexpected status from POST request to .*: 502 Bad Gateway|connection reset by peer|too ?many ?requests|ref .* locked for .*: unavailable|tls handshake timeout)' {output}" \
+	--continue-if "grep -qiE '($(IMAGE_BUILD_RETRIABLE_ERRORS))' {output}" \
 	-- env
 
 MAKE_TIMING ?= $(if $(filter 1 true TRUE yes YES on ON,$(CI)),1,0)

--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -56,6 +56,14 @@ export KIND_VERSION="${E2E_KIND_VERSION#kindest/node:v}"
 # Shared by `e2e_docker_pull_if_needed` and `e2e_docker_manifest_available` below.
 export E2E_NON_RETRIABLE_IMAGE_ERRORS="no such manifest|manifest (unknown|for .* not found)|repository does not exist|not found|pull access denied|unauthorized|denied: requested access|no space left on device"
 
+# Retriable: transport-level failures reaching a git remote.
+# Composed from git's transport error strings; extend it as CI hits new ones.
+export E2E_RETRIABLE_GIT_ERRORS="could not resolve host|connection refused|connection reset by peer|connection timed out|operation timed out|rpc failed|early eof|remote end hung up unexpectedly|gnutls_handshake|ssl_error|tls handshake timeout|500 internal server error|502 bad gateway|503 service unavailable"
+
+# Retriable: registry and module proxy failures during an image build.
+# Duplicates IMAGE_BUILD_RETRIABLE_ERRORS, which Make does not export to this script.
+export E2E_RETRIABLE_IMAGE_BUILD_ERRORS="context deadline exceeded|unexpected status from HEAD request to .*: 401 Unauthorized|unexpected status from POST request to .*: 502 Bad Gateway|connection reset by peer|too ?many ?requests|ref .* locked for .*: unavailable|tls handshake timeout|stream error: stream ID [0-9]+; INTERNAL_ERROR|http2: server sent GOAWAY|500 Internal Server Error|i/o timeout"
+
 function build_kind_node_image {
     if [[ "$E2E_KIND_VERSION" != kindest/node:v* ]]; then
         echo "Skipping kind node image build for non-standard image: $E2E_KIND_VERSION"
@@ -1457,7 +1465,10 @@ function install_dra_example_driver {
     dra_driver_temp_dir=$(mktemp -d)
     # shellcheck disable=SC2064 # Intentionally expand now to capture the temp dir path
     trap "rm -rf '$dra_driver_temp_dir'" RETURN
-    git clone --depth 1 --branch "${DRA_EXAMPLE_DRIVER_VERSION}" "${DRA_EXAMPLE_DRIVER_REPO}" "$dra_driver_temp_dir"
+    "${ROOT_DIR}/hack/testing/retry.sh" --attempts 7 --delay 2 --exponential --stream \
+        --continue-if "grep -qiE '${E2E_RETRIABLE_GIT_ERRORS}' {output}" \
+        --cleanup "rm -rf -- '${dra_driver_temp_dir}'" \
+        -- git clone --depth 1 --branch "${DRA_EXAMPLE_DRIVER_VERSION}" "${DRA_EXAMPLE_DRIVER_REPO}" "$dra_driver_temp_dir"
 
     local dra_image_repo="dra-example-driver"
     local dra_image_tag="${expected_version#v}"
@@ -1473,7 +1484,9 @@ function install_dra_example_driver {
     # Patch Makefile to ensure static build with CGO_ENABLED=0
     sed 's/CGO_LDFLAGS_ALLOW/CGO_ENABLED=0 CGO_LDFLAGS_ALLOW/' "$dra_driver_temp_dir/Makefile" > "$dra_driver_temp_dir/Makefile.tmp" \
         && mv "$dra_driver_temp_dir/Makefile.tmp" "$dra_driver_temp_dir/Makefile"
-    docker build -t "${dra_image_repo}:${dra_image_tag}" \
+    "${ROOT_DIR}/hack/testing/retry.sh" --attempts 7 --delay 2 --exponential --stream \
+        --continue-if "grep -qiE '${E2E_RETRIABLE_IMAGE_BUILD_ERRORS}' {output}" \
+        -- docker build -t "${dra_image_repo}:${dra_image_tag}" \
         --build-arg GO_VERSION="${go_version}" \
         --build-arg BASE_IMAGE=gcr.io/distroless/static:latest \
         -f "$dra_driver_temp_dir/deployments/container/Dockerfile" \


### PR DESCRIPTION
<!-- Thank you for contributing! Check CONTRIBUTING.md for details. -->

#### What type of PR is this?
<!-- Choose one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally choose one or more of the following kinds:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

/kind flake
/area testing

#### What this PR does / why we need it?
<!--
Use `Fixes #123` for an issue addressed by this PR; it will be closed when the PR merges.
Use `Related:` or `Part of:` to reference an issue without closing it.
-->
`install_dra_example_driver` in `hack/testing/e2e-common.sh` clones the upstream dra-example-driver repo and then runs `docker build` on it, and neither call is retried. The upstream Dockerfile resolves Go modules during `go build`, against a module cache that is cold on every Prow run. In #15258 one proxy.golang.org stream reset was enough to fail `run-test-e2e-dra-counter-1.36.4`.

Both calls now go through `retry.sh` with `--attempts 7 --delay 2 --exponential --stream`, the settings `build_kind_node_image` already uses. Each one carries its own `--continue-if` allowlist, so only the listed errors are retried and everything else fails on the first attempt. The clone also gets `--cleanup`, since a clone that fails midway leaves a partial checkout and git refuses to clone into a destination that is no longer empty.

The `Makefile` change is separate. `IMAGE_BUILD_RETRY` retries only the errors on its allowlist, and the go module proxy errors from #15258 were not on it. The list moves into `IMAGE_BUILD_RETRIABLE_ERRORS` and picks up the http2 stream reset, `GOAWAY`, `500 Internal Server Error` and `i/o timeout` patterns.

Fixes #15258

#### Useful notes for your reviewer
- Why an allowlist instead of retrying everything: the module proxy failure from #15258 has the same shape as a compile error, so listing what is retriable is the only way to fail fast on a real build failure.
- `E2E_RETRIABLE_IMAGE_BUILD_ERRORS` is evidence-based, every pattern traces to a reported flake. It repeats `IMAGE_BUILD_RETRIABLE_ERRORS`, which Make does not export to `e2e-common.sh`.
- `E2E_RETRIABLE_GIT_ERRORS` is not. No clone failure has been reported for this step, so it is composed from git's own transport error strings. A missing repository, a 404 and an auth failure still fail on the first attempt.
- Verified with `make shell-lint`, `make e2e-common-test`, and a stub clone that fails midway to check `--cleanup`.
- This PR was written in part with the assistance of generative AI.

#### Release note
<!-- Describe the behavior change accurately from the user's perspective. Hints:
- Do not leave this block blank.
- Use "NONE" when there is no user-facing change.
- When feasible use a prefix for the sub-component or feature, e.g. "FairSharing:" or "MultiKueue:".
- If upgrade steps are required, include an "ACTION REQUIRED:" section.
You may consider AI assistance using the skill: cmd/experimental/skills/kueue-release-notes/SKILL.md.
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## AI summary

- Added retries for DRA example driver cloning and Docker image builds.
- Retries use seven attempts, exponential two-second backoff, streamed output, and operation-specific error patterns.
- Partial clone directories are cleaned up before retrying.
- Expanded image-build matching for transient HTTP/2, HTTP 500, timeout, registry, and Go module proxy errors.
- Verified with `make shell-lint`, `make e2e-common-test`, and a clone cleanup test.

### Suggested release note

NONE

<!-- end of auto-generated comment: release notes by coderabbit.ai -->