### PR TITLE
Add reconciler watches and integration tests for DynamicQuotaOrchestrator distribution

### DIFF
--- a/pkg/controller/core/dynamicquotaorchestrator_controller.go
+++ b/pkg/controller/core/dynamicquotaorchestrator_controller.go
@@ -35,8 +35,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -98,7 +101,34 @@ func (r *DynamicQuotaOrchestratorReconciler) SetupWithManager(mgr ctrl.Manager) 
 			&kueuealpha.CapacityProvider{},
 			handler.EnqueueRequestsFromMapFunc(r.mapCapacityProviderToDQOs),
 		).
+		Watches(
+			&kueue.Cohort{},
+			handler.EnqueueRequestsFromMapFunc(r.mapDistributingDQOs),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+		).
+		Watches(
+			&kueue.ClusterQueue{},
+			handler.EnqueueRequestsFromMapFunc(r.mapDistributingDQOs),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+		).
+		Watches(
+			&kueuealpha.DynamicQuotaOrchestrator{},
+			handler.EnqueueRequestsFromMapFunc(r.mapOtherDistributingDQOs),
+			builder.WithPredicates(dqoSpecOrDeletionChangedPredicate),
+		).
 		Complete(r)
+}
+
+var dqoSpecOrDeletionChangedPredicate = predicate.Funcs{
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		if e.ObjectOld == nil || e.ObjectNew == nil {
+			return false
+		}
+		if e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() {
+			return true
+		}
+		return e.ObjectOld.GetDeletionTimestamp().IsZero() != e.ObjectNew.GetDeletionTimestamp().IsZero()
+	},
 }
 
 // mapCapacityProviderToDQOs maps a CapacityProvider event to reconcile requests for all DynamicQuotaOrchestrators referencing it.
@@ -118,6 +148,48 @@ func (r *DynamicQuotaOrchestratorReconciler) mapCapacityProviderToDQOs(ctx conte
 	for _, orchestrator := range orchestratorList.Items {
 		requests = append(requests, ctrl.Request{
 			NamespacedName: types.NamespacedName{Name: orchestrator.Name},
+		})
+	}
+	return requests
+}
+
+// mapDistributingDQOs maps Cohort or ClusterQueue events to reconcile requests for all distributing DynamicQuotaOrchestrators.
+func (r *DynamicQuotaOrchestratorReconciler) mapDistributingDQOs(ctx context.Context, _ client.Object) []ctrl.Request {
+	distributingDQOs, err := r.listDistributingDQOs(ctx)
+	if err != nil {
+		r.logger().Error(err, "Failed to list distributing DynamicQuotaOrchestrators")
+		return nil
+	}
+	requests := make([]ctrl.Request, 0, len(distributingDQOs))
+	for _, orchestrator := range distributingDQOs {
+		requests = append(requests, ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: orchestrator.Name},
+		})
+	}
+	return requests
+}
+
+// mapOtherDistributingDQOs maps a DynamicQuotaOrchestrator event to reconcile requests for other distributing DynamicQuotaOrchestrators.
+func (r *DynamicQuotaOrchestratorReconciler) mapOtherDistributingDQOs(ctx context.Context, obj client.Object) []ctrl.Request {
+	if obj == nil {
+		return nil
+	}
+	orchestrator, ok := obj.(*kueuealpha.DynamicQuotaOrchestrator)
+	if !ok || orchestrator == nil {
+		return nil
+	}
+	distributingDQOs, err := r.listDistributingDQOs(ctx)
+	if err != nil {
+		r.logger().Error(err, "Failed to list distributing DynamicQuotaOrchestrators")
+		return nil
+	}
+	requests := make([]ctrl.Request, 0, len(distributingDQOs))
+	for _, item := range distributingDQOs {
+		if item.Name == orchestrator.Name {
+			continue
+		}
+		requests = append(requests, ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: item.Name},
 		})
 	}
 	return requests

--- a/test/integration/singlecluster/controller/dynamicquotaorchestrator/dynamicquotaorchestrator_test.go
+++ b/test/integration/singlecluster/controller/dynamicquotaorchestrator/dynamicquotaorchestrator_test.go
@@ -18,6 +18,7 @@ package dynamicquotaorchestrator
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -31,16 +32,27 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingalpha "sigs.k8s.io/kueue/pkg/util/testing/v1alpha1"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	"sigs.k8s.io/kueue/test/util"
 )
 
 var _ = ginkgo.Describe("DynamicQuotaOrchestrator controller", ginkgo.Label("controller:dynamicquotaorchestrator", "area:dynamicquotaorchestration"), func() {
 	var (
-		cps []*kueuealpha.CapacityProvider
-		dqo *kueuealpha.DynamicQuotaOrchestrator
+		cps              []*kueuealpha.CapacityProvider
+		dqo              *kueuealpha.DynamicQuotaOrchestrator
+		ancestorDQO      *kueuealpha.DynamicQuotaOrchestrator
+		childDQO         *kueuealpha.DynamicQuotaOrchestrator
+		cq               *kueue.ClusterQueue
+		cq1              *kueue.ClusterQueue
+		cq2              *kueue.ClusterQueue
+		cq3              *kueue.ClusterQueue
+		rootCohort       *kueue.Cohort
+		childCohort      *kueue.Cohort
+		grandchildCohort *kueue.Cohort
 	)
 
 	ginkgo.BeforeEach(func() {
@@ -48,11 +60,22 @@ var _ = ginkgo.Describe("DynamicQuotaOrchestrator controller", ginkgo.Label("con
 	})
 
 	ginkgo.AfterEach(func() {
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, childDQO, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, ancestorDQO, true)
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, dqo, true)
 		for _, cp := range cps {
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, cp, true)
 		}
-		dqo = nil
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, cq1, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, cq2, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, cq3, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, grandchildCohort, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, childCohort, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, rootCohort, true)
+		childDQO, ancestorDQO, dqo = nil, nil, nil
+		cq, cq1, cq2, cq3 = nil, nil, nil, nil
+		childCohort, grandchildCohort, rootCohort = nil, nil, nil
 		cps = nil
 	})
 
@@ -435,6 +458,374 @@ var _ = ginkgo.Describe("DynamicQuotaOrchestrator controller", ginkgo.Label("con
 					).
 					Obj()
 				g.Expect(cmp.Diff(wantCapacity, latestDQO.Status.EffectiveCapacity, cmpopts.EquateEmpty())).Should(gomega.BeEmpty())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+
+	ginkgo.It("Should distribute capacity to a single ClusterQueue and update dynamically", func() {
+		cp := utiltestingalpha.MakeCapacityProvider("dist-cq-cp").
+			ControllerName("example.com/test-provider").
+			OrchestratedFlavors("f1").
+			Capacity(
+				utiltestingalpha.MakeNormalizedCapacity().
+					Flavors(
+						utiltestingalpha.MakeNormalizedCapacityFlavor("f1").
+							Resource(corev1.ResourceCPU, "100").
+							Resource(corev1.ResourceMemory, "50Gi").
+							Obj(),
+					).
+					Obj(),
+			).
+			Condition(metav1.Condition{
+				Type:    kueuealpha.CapacityProviderCapacitySynchronized,
+				Status:  metav1.ConditionTrue,
+				Reason:  kueuealpha.CapacityProviderReasonSynchronized,
+				Message: "Capacity synchronized successfully",
+			}).
+			Obj()
+		cps = append(cps, cp)
+		createCapacityProvider(ctx, k8sClient, cp)
+
+		cq = utiltestingapi.MakeClusterQueue("dist-cq").
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas("f1").
+					Resource(corev1.ResourceCPU, "10").
+					Resource(corev1.ResourceMemory, "20Gi").
+					Obj(),
+			).
+			Obj()
+		util.MustCreate(ctx, k8sClient, cq)
+
+		dqo = utiltestingalpha.MakeDynamicQuotaOrchestrator("dist-dqo").
+			DiscoveryProvider("dist-cq-cp", nil).
+			SubtreeRoot(kueuealpha.ClusterQueueSubtreeRootRefKind, "dist-cq").
+			Obj()
+		util.MustCreate(ctx, k8sClient, dqo)
+
+		cqKey := types.NamespacedName{Name: cq.Name}
+		latestCQ := &kueue.ClusterQueue{}
+
+		ginkgo.By("Verifying initial effective quota distribution", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, cqKey, latestCQ)).Should(gomega.Succeed())
+				g.Expect(latestCQ.Status.EffectiveQuotas).ShouldNot(gomega.BeNil())
+				g.Expect(latestCQ.Status.EffectiveQuotas.OrchestratorRef).Should(gomega.Equal(kueue.EffectiveQuotaStatusOrchestratorRef{
+					APIGroup: "kueue.x-k8s.io",
+					Kind:     "DynamicQuotaOrchestrator",
+					Name:     "dist-dqo",
+				}))
+
+				wantResourceGroups := []kueue.ResourceGroup{
+					utiltestingapi.ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("f1").
+							Resource(corev1.ResourceCPU, "100").
+							Resource(corev1.ResourceMemory, "50Gi").
+							Obj(),
+					),
+				}
+				g.Expect(cmp.Diff(wantResourceGroups, latestCQ.Status.EffectiveQuotas.ResourceGroups, cmpopts.EquateEmpty())).Should(gomega.BeEmpty())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("Updating capacity and verifying ClusterQueue effective quota updates", func() {
+			updatedCapacity := utiltestingalpha.MakeNormalizedCapacity().
+				Flavors(
+					utiltestingalpha.MakeNormalizedCapacityFlavor("f1").
+						Resource(corev1.ResourceCPU, "200").
+						Resource(corev1.ResourceMemory, "80Gi").
+						Obj(),
+				).
+				Obj()
+			setCapacityProviderCapacity(ctx, k8sClient, cp, updatedCapacity)
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, cqKey, latestCQ)).Should(gomega.Succeed())
+				wantUpdatedResourceGroups := []kueue.ResourceGroup{
+					utiltestingapi.ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("f1").
+							Resource(corev1.ResourceCPU, "200").
+							Resource(corev1.ResourceMemory, "80Gi").
+							Obj(),
+					),
+				}
+				g.Expect(cmp.Diff(wantUpdatedResourceGroups, latestCQ.Status.EffectiveQuotas.ResourceGroups, cmpopts.EquateEmpty())).Should(gomega.BeEmpty())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+
+	// Cohort tree hierarchy (3 levels):
+	//
+	//              root-cohort (Level 1)
+	//             /           \
+	//           cq-1       child-cohort (Level 2, 20 CPU)
+	//          (10 CPU)   /            \
+	//                   cq-2     grandchild-cohort (Level 3)
+	//                  (10 CPU)         |
+	//                                  cq-3
+	//                                 (30 CPU)
+	ginkgo.It("Should distribute capacity proportionally across 3-level Cohort tree with Cohort and CQ participants", func() {
+		cp := utiltestingalpha.MakeCapacityProvider("cohort-tree-cp").
+			ControllerName("example.com/test-provider").
+			OrchestratedFlavors("f1").
+			Capacity(
+				utiltestingalpha.MakeNormalizedCapacity().
+					Flavors(
+						utiltestingalpha.MakeNormalizedCapacityFlavor("f1").
+							Resource(corev1.ResourceCPU, "70").
+							Obj(),
+					).
+					Obj(),
+			).
+			Condition(metav1.Condition{
+				Type:    kueuealpha.CapacityProviderCapacitySynchronized,
+				Status:  metav1.ConditionTrue,
+				Reason:  kueuealpha.CapacityProviderReasonSynchronized,
+				Message: "Capacity synchronized successfully",
+			}).
+			Obj()
+		cps = append(cps, cp)
+		createCapacityProvider(ctx, k8sClient, cp)
+
+		rootCohort = utiltestingapi.MakeCohort("root-cohort").Obj()
+		util.MustCreate(ctx, k8sClient, rootCohort)
+
+		childCohort = utiltestingapi.MakeCohort("child-cohort").
+			Parent("root-cohort").
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas("f1").Resource(corev1.ResourceCPU, "20").Obj(),
+			).
+			Obj()
+		util.MustCreate(ctx, k8sClient, childCohort)
+
+		grandchildCohort = utiltestingapi.MakeCohort("grandchild-cohort").Parent("child-cohort").Obj()
+		util.MustCreate(ctx, k8sClient, grandchildCohort)
+
+		cq1 = utiltestingapi.MakeClusterQueue("cq-1").
+			Cohort("root-cohort").
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas("f1").Resource(corev1.ResourceCPU, "10").Obj(),
+			).
+			Obj()
+		util.MustCreate(ctx, k8sClient, cq1)
+
+		cq2 = utiltestingapi.MakeClusterQueue("cq-2").
+			Cohort("child-cohort").
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas("f1").Resource(corev1.ResourceCPU, "10").Obj(),
+			).
+			Obj()
+		util.MustCreate(ctx, k8sClient, cq2)
+
+		cq3 = utiltestingapi.MakeClusterQueue("cq-3").
+			Cohort("grandchild-cohort").
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas("f1").Resource(corev1.ResourceCPU, "30").Obj(),
+			).
+			Obj()
+		util.MustCreate(ctx, k8sClient, cq3)
+
+		dqo = utiltestingalpha.MakeDynamicQuotaOrchestrator("cohort-dqo").
+			DiscoveryProvider("cohort-tree-cp", nil).
+			SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "root-cohort").
+			Obj()
+		util.MustCreate(ctx, k8sClient, dqo)
+
+		childCohortKey := types.NamespacedName{Name: childCohort.Name}
+		cq1Key := types.NamespacedName{Name: cq1.Name}
+		cq2Key := types.NamespacedName{Name: cq2.Name}
+		cq3Key := types.NamespacedName{Name: cq3.Name}
+
+		ginkgo.By("Verifying proportional distribution to Cohorts and CQs across all 3 levels of the cohort tree", func() {
+			var gotChildCohort kueue.Cohort
+			var gotCQ1, gotCQ2, gotCQ3 kueue.ClusterQueue
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, childCohortKey, &gotChildCohort)).Should(gomega.Succeed())
+				g.Expect(gotChildCohort.Status.EffectiveQuotas).ShouldNot(gomega.BeNil())
+				g.Expect(gotChildCohort.Status.EffectiveQuotas.ResourceGroups[0].Flavors[0].Resources[0].NominalQuota).
+					Should(gomega.Equal(resource.MustParse("20")))
+
+				g.Expect(k8sClient.Get(ctx, cq1Key, &gotCQ1)).Should(gomega.Succeed())
+				g.Expect(gotCQ1.Status.EffectiveQuotas).ShouldNot(gomega.BeNil())
+				g.Expect(gotCQ1.Status.EffectiveQuotas.ResourceGroups[0].Flavors[0].Resources[0].NominalQuota).
+					Should(gomega.Equal(resource.MustParse("10")))
+
+				g.Expect(k8sClient.Get(ctx, cq2Key, &gotCQ2)).Should(gomega.Succeed())
+				g.Expect(gotCQ2.Status.EffectiveQuotas).ShouldNot(gomega.BeNil())
+				g.Expect(gotCQ2.Status.EffectiveQuotas.ResourceGroups[0].Flavors[0].Resources[0].NominalQuota).
+					Should(gomega.Equal(resource.MustParse("10")))
+
+				g.Expect(k8sClient.Get(ctx, cq3Key, &gotCQ3)).Should(gomega.Succeed())
+				g.Expect(gotCQ3.Status.EffectiveQuotas).ShouldNot(gomega.BeNil())
+				g.Expect(gotCQ3.Status.EffectiveQuotas.ResourceGroups[0].Flavors[0].Resources[0].NominalQuota).
+					Should(gomega.Equal(resource.MustParse("30")))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+
+	ginkgo.It("Should soft-validate overlapping DQOs and activate once conflict is removed", func() {
+		cp := utiltestingalpha.MakeCapacityProvider("overlap-cp").
+			ControllerName("example.com/test-provider").
+			OrchestratedFlavors("f1").
+			Capacity(
+				utiltestingalpha.MakeNormalizedCapacity().
+					Flavors(
+						utiltestingalpha.MakeNormalizedCapacityFlavor("f1").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj(),
+			).
+			Condition(metav1.Condition{
+				Type:    kueuealpha.CapacityProviderCapacitySynchronized,
+				Status:  metav1.ConditionTrue,
+				Reason:  kueuealpha.CapacityProviderReasonSynchronized,
+				Message: "Capacity synchronized successfully",
+			}).
+			Obj()
+		cps = append(cps, cp)
+		createCapacityProvider(ctx, k8sClient, cp)
+
+		rootCohort = utiltestingapi.MakeCohort("overlap-root").Obj()
+		util.MustCreate(ctx, k8sClient, rootCohort)
+
+		childCohort = utiltestingapi.MakeCohort("overlap-child").Parent("overlap-root").Obj()
+		util.MustCreate(ctx, k8sClient, childCohort)
+
+		cq = utiltestingapi.MakeClusterQueue("overlap-cq").
+			Cohort("overlap-child").
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas("f1").Resource(corev1.ResourceCPU, "50").Obj(),
+			).
+			Obj()
+		util.MustCreate(ctx, k8sClient, cq)
+
+		ancestorDQO = utiltestingalpha.MakeDynamicQuotaOrchestrator("ancestor-dqo").
+			DiscoveryProvider("overlap-cp", nil).
+			SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "overlap-root").
+			Obj()
+		util.MustCreate(ctx, k8sClient, ancestorDQO)
+
+		childDQO = utiltestingalpha.MakeDynamicQuotaOrchestrator("child-dqo").
+			DiscoveryProvider("overlap-cp", nil).
+			SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "overlap-child").
+			Obj()
+		util.MustCreate(ctx, k8sClient, childDQO)
+
+		childDQOKey := types.NamespacedName{Name: childDQO.Name}
+		latestChildDQO := &kueuealpha.DynamicQuotaOrchestrator{}
+
+		ginkgo.By("Verifying child DQO is deactivated due to ancestor conflict", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, childDQOKey, latestChildDQO)).Should(gomega.Succeed())
+				g.Expect(latestChildDQO.Status.Conditions).Should(utiltesting.HaveConditionStatusFalseAndReason(
+					kueuealpha.DynamicQuotaOrchestratorDistributed,
+					kueuealpha.DynamicQuotaOrchestratorReasonConflictingDynamicQuotaOrchestrator,
+				))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("Deleting ancestor DQO and verifying child DQO becomes active", func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, ancestorDQO, true)
+			ancestorDQO = nil
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, childDQOKey, latestChildDQO)).Should(gomega.Succeed())
+				g.Expect(latestChildDQO.Status.Conditions).Should(utiltesting.HaveConditionStatusTrueAndReason(
+					kueuealpha.DynamicQuotaOrchestratorDistributed,
+					kueuealpha.DynamicQuotaOrchestratorReasonQuotasDistributed,
+				))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+
+	ginkgo.It("Should soft-validate DQOs targeting the same subtree root and assign deterministic owner", func() {
+		cp := utiltestingalpha.MakeCapacityProvider("identical-cp").
+			ControllerName("example.com/test-provider").
+			OrchestratedFlavors("f1").
+			Capacity(
+				utiltestingalpha.MakeNormalizedCapacity().
+					Flavors(
+						utiltestingalpha.MakeNormalizedCapacityFlavor("f1").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj(),
+			).
+			Condition(metav1.Condition{
+				Type:    kueuealpha.CapacityProviderCapacitySynchronized,
+				Status:  metav1.ConditionTrue,
+				Reason:  kueuealpha.CapacityProviderReasonSynchronized,
+				Message: "Capacity synchronized successfully",
+			}).
+			Obj()
+		cps = append(cps, cp)
+		createCapacityProvider(ctx, k8sClient, cp)
+
+		rootCohort = utiltestingapi.MakeCohort("identical-root").Obj()
+		util.MustCreate(ctx, k8sClient, rootCohort)
+
+		cq = utiltestingapi.MakeClusterQueue("identical-cq").
+			Cohort("identical-root").
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas("f1").Resource(corev1.ResourceCPU, "50").Obj(),
+			).
+			Obj()
+		util.MustCreate(ctx, k8sClient, cq)
+
+		ancestorDQO = utiltestingalpha.MakeDynamicQuotaOrchestrator("older-dqo").
+			DiscoveryProvider("identical-cp", nil).
+			SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "identical-root").
+			Obj()
+		util.MustCreate(ctx, k8sClient, ancestorDQO)
+
+		olderDQOKey := types.NamespacedName{Name: ancestorDQO.Name}
+		latestOlderDQO := &kueuealpha.DynamicQuotaOrchestrator{}
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, olderDQOKey, latestOlderDQO)).Should(gomega.Succeed())
+			g.Expect(latestOlderDQO.Status.Conditions).Should(utiltesting.HaveConditionStatusTrueAndReason(
+				kueuealpha.DynamicQuotaOrchestratorDistributed,
+				kueuealpha.DynamicQuotaOrchestratorReasonQuotasDistributed,
+			))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		// Ensure newer-dqo gets a strictly later CreationTimestamp.
+		time.Sleep(1 * time.Second)
+
+		childDQO = utiltestingalpha.MakeDynamicQuotaOrchestrator("newer-dqo").
+			DiscoveryProvider("identical-cp", nil).
+			SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "identical-root").
+			Obj()
+		util.MustCreate(ctx, k8sClient, childDQO)
+
+		newerDQOKey := types.NamespacedName{Name: childDQO.Name}
+		latestNewerDQO := &kueuealpha.DynamicQuotaOrchestrator{}
+
+		ginkgo.By("Verifying newer DQO is deactivated due to identical root conflict", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, newerDQOKey, latestNewerDQO)).Should(gomega.Succeed())
+				g.Expect(latestNewerDQO.Status.Conditions).Should(utiltesting.HaveConditionStatusFalseAndReason(
+					kueuealpha.DynamicQuotaOrchestratorDistributed,
+					kueuealpha.DynamicQuotaOrchestratorReasonConflictingDynamicQuotaOrchestrator,
+				))
+
+				g.Expect(k8sClient.Get(ctx, olderDQOKey, latestOlderDQO)).Should(gomega.Succeed())
+				g.Expect(latestOlderDQO.Status.Conditions).Should(utiltesting.HaveConditionStatusTrueAndReason(
+					kueuealpha.DynamicQuotaOrchestratorDistributed,
+					kueuealpha.DynamicQuotaOrchestratorReasonQuotasDistributed,
+				))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("Deleting older DQO and verifying newer DQO becomes active", func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, ancestorDQO, true)
+			ancestorDQO = nil
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, newerDQOKey, latestNewerDQO)).Should(gomega.Succeed())
+				g.Expect(latestNewerDQO.Status.Conditions).Should(utiltesting.HaveConditionStatusTrueAndReason(
+					kueuealpha.DynamicQuotaOrchestratorDistributed,
+					kueuealpha.DynamicQuotaOrchestratorReasonQuotasDistributed,
+				))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it?

Part of #12382

This PR completes Phase 2 (Capacity Distribution) for the `DynamicQuotaOrchestrator` controller by registering reconciler watches/event handlers and adding end-to-end integration tests. It builds on the field indexers merged in #15260 (Part 1) and the core distribution logic merged in #15283 (Part 2).

Key changes in this PR:
1. **Reconciler Watches & Event Handlers**:
   - Watches `Cohort` and `ClusterQueue` resources to trigger DQO reconciliation when subtree hierarchy relationships or participant specs change.
   - Watches other `DynamicQuotaOrchestrator` instances to react to conflicts, deactivations, or ownership takeovers.
2. **Integration Tests**:
   - Comprehensive suite of EnvTest integration tests in `test/integration/singlecluster/controller/dynamicquotaorchestrator/dynamicquotaorchestrator_test.go`.
   - Verifies end-to-end capacity distribution from discovery through to `status.effectiveQuotas` updates on `ClusterQueue` and `Cohort`.
   - Verifies dynamic reallocation when cluster capacity changes or nodes scale up/down.
   - Verifies soft validation, conflict detection, and deactivation rules under real API server conditions.
   - Verifies stale quota retention when resources leave the subtree.

This is the final part of the 3-part DQO Phase 2 stack:
- [x] **Part 1**: Indexers and test client builder (#15260 - merged)
- [x] **Part 2**: Distribution logic, inverted index, largest-remainder math, soft validation, and unit tests (#15283 - merged)
- [x] **Part 3**: Reconciler watches, event mappers, and integration tests (this PR)

#### Useful notes for your reviewer

- A follow-up PR will decompose the DQO controller helpers into dedicated files (`dqo_discovery.go`, `dqo_distribution.go`) as requested in review comments on #15283.
- All integration specs pass locally via `envtest` (9/9 specs).

#### Release note

```release-note
DynamicQuotaOrchestration: Registered reconciler watches and added integration tests for DynamicQuotaOrchestrator capacity distribution.
```

---
*AI usage disclosure: Assisted by AI agent (Antigravity) in implementing watches, integration test scenarios, and documentation per the Kubernetes AI Tool Usage Policy.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added watches and reconciliation triggers for `Cohort`, `ClusterQueue`, and `DynamicQuotaOrchestrator` changes.
- Added integration tests for quota distribution, dynamic reallocation, conflicts, deactivation, and stale quota retention.

## Release note assessment

The `release-note` block was not provided. Can you confirm whether this user-facing behavior requires a release note? Please update the canonical block after confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->