### PR TITLE
chore: regenerate client-go applyconfigurations and API reference docs

### DIFF
--- a/client-go/applyconfiguration/kueue/v1alpha1/capacitydiscovery.go
+++ b/client-go/applyconfiguration/kueue/v1alpha1/capacitydiscovery.go
@@ -22,6 +22,7 @@ package v1alpha1
 // with apply.
 type CapacityDiscoveryApplyConfiguration struct {
 	// providers lists CapacityProvider objects consumed by this DQO.
+	//
 	Providers []CapacityDiscoveryProviderContributionApplyConfiguration `json:"providers,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1alpha1/capacitydiscoveryprovidercontribution.go
+++ b/client-go/applyconfiguration/kueue/v1alpha1/capacitydiscoveryprovidercontribution.go
@@ -27,9 +27,11 @@ import (
 // with apply.
 type CapacityDiscoveryProviderContributionApplyConfiguration struct {
 	// name identifies a CapacityProvider.
+	//
 	Name *kueuev1alpha1.CapacityProviderName `json:"name,omitempty"`
 	// effectiveCapacityMultiplier specifies the multiplier applied to the
 	// discovered capacity from this provider. It defaults to 1.
+	//
 	EffectiveCapacityMultiplier *resource.Quantity `json:"effectiveCapacityMultiplier,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1alpha1/capacitydistribution.go
+++ b/client-go/applyconfiguration/kueue/v1alpha1/capacitydistribution.go
@@ -22,6 +22,7 @@ package v1alpha1
 // with apply.
 type CapacityDistributionApplyConfiguration struct {
 	// subtreeRootQuotaRef identifies the root of the quota subtree.
+	//
 	SubtreeRootQuotaRef *CapacityDistributionSubtreeRootRefApplyConfiguration `json:"subtreeRootQuotaRef,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1alpha1/capacitydistributionsubtreerootref.go
+++ b/client-go/applyconfiguration/kueue/v1alpha1/capacitydistributionsubtreerootref.go
@@ -26,8 +26,10 @@ import (
 // with apply.
 type CapacityDistributionSubtreeRootRefApplyConfiguration struct {
 	// kind indicates the kind of the quota node, i.e. ClusterQueue or Cohort.
+	//
 	Kind *kueuev1alpha1.SubtreeRootRefKind `json:"kind,omitempty"`
 	// name indicates the name of the quota node, i.e. ClusterQueue or Cohort.
+	//
 	Name *string `json:"name,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1alpha1/capacityprovidernormalizedcapacity.go
+++ b/client-go/applyconfiguration/kueue/v1alpha1/capacityprovidernormalizedcapacity.go
@@ -22,6 +22,7 @@ package v1alpha1
 // with apply.
 type CapacityProviderNormalizedCapacityApplyConfiguration struct {
 	// flavors contains capacity per flavor and resource.
+	//
 	Flavors []CapacityProviderNormalizedCapacityFlavorApplyConfiguration `json:"flavors,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1alpha1/capacityprovidernormalizedcapacityflavor.go
+++ b/client-go/applyconfiguration/kueue/v1alpha1/capacityprovidernormalizedcapacityflavor.go
@@ -27,8 +27,10 @@ import (
 // with apply.
 type CapacityProviderNormalizedCapacityFlavorApplyConfiguration struct {
 	// name identifies the ResourceFlavor whose capacity is reported.
+	//
 	Name *kueuev1alpha1.ResourceFlavorReference `json:"name,omitempty"`
 	// resources contains total capacity by resource name.
+	//
 	Resources *v1.ResourceList `json:"resources,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1alpha1/capacityproviderorchestratedflavor.go
+++ b/client-go/applyconfiguration/kueue/v1alpha1/capacityproviderorchestratedflavor.go
@@ -29,6 +29,7 @@ import (
 // The container allows the mapping to be extended in a future API version.
 type CapacityProviderOrchestratedFlavorApplyConfiguration struct {
 	// name identifies the ResourceFlavor managed by this provider.
+	//
 	Name *kueuev1alpha1.ResourceFlavorReference `json:"name,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1alpha1/capacityproviderspec.go
+++ b/client-go/applyconfiguration/kueue/v1alpha1/capacityproviderspec.go
@@ -28,12 +28,15 @@ type CapacityProviderSpecApplyConfiguration struct {
 	// orchestratedFlavors identifies the ResourceFlavors for which this provider may
 	// publish capacity. DQO ignores entries in status.capacity.flavors whose
 	// names are not listed here.
+	//
 	OrchestratedFlavors []CapacityProviderOrchestratedFlavorApplyConfiguration `json:"orchestratedFlavors,omitempty"`
 	// controllerName identifies the controller publishing capacity.
 	// This field is immutable.
+	//
 	ControllerName *kueuev1alpha1.CapacityProviderControllerName `json:"controllerName,omitempty"`
 	// parameters optionally references implementation-specific configuration.
 	// DQO does not read or validate the referenced object.
+	//
 	Parameters *CapacityProviderParametersReferenceApplyConfiguration `json:"parameters,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1alpha1/capacityproviderstatus.go
+++ b/client-go/applyconfiguration/kueue/v1alpha1/capacityproviderstatus.go
@@ -26,8 +26,10 @@ import (
 // with apply.
 type CapacityProviderStatusApplyConfiguration struct {
 	// capacity is the normalized capacity published by the provider.
+	//
 	Capacity *CapacityProviderNormalizedCapacityApplyConfiguration `json:"capacity,omitempty"`
 	// conditions represents the current state of this provider.
+	//
 	Conditions []v1.ConditionApplyConfiguration `json:"conditions,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1alpha1/dynamicquotaorchestratorspec.go
+++ b/client-go/applyconfiguration/kueue/v1alpha1/dynamicquotaorchestratorspec.go
@@ -22,10 +22,12 @@ package v1alpha1
 // with apply.
 type DynamicQuotaOrchestratorSpecApplyConfiguration struct {
 	// capacityDiscovery specifies capacity aggregation.
+	//
 	CapacityDiscovery *CapacityDiscoveryApplyConfiguration `json:"capacityDiscovery,omitempty"`
 	// capacityDistribution specifies how aggregated capacity is distributed.
 	// When omitted, the DQO is discovery-only: it reports aggregated capacity
 	// but does not write effectiveQuotas status.
+	//
 	CapacityDistribution *CapacityDistributionApplyConfiguration `json:"capacityDistribution,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1alpha1/dynamicquotaorchestratorstatus.go
+++ b/client-go/applyconfiguration/kueue/v1alpha1/dynamicquotaorchestratorstatus.go
@@ -26,8 +26,10 @@ import (
 // with apply.
 type DynamicQuotaOrchestratorStatusApplyConfiguration struct {
 	// effectiveCapacity is the capacity aggregated from the referenced providers.
+	//
 	EffectiveCapacity *EffectiveCapacityApplyConfiguration `json:"effectiveCapacity,omitempty"`
 	// conditions represents the current state of the DQO.
+	//
 	Conditions []v1.ConditionApplyConfiguration `json:"conditions,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1alpha1/effectivecapacity.go
+++ b/client-go/applyconfiguration/kueue/v1alpha1/effectivecapacity.go
@@ -22,6 +22,7 @@ package v1alpha1
 // with apply.
 type EffectiveCapacityApplyConfiguration struct {
 	// flavors contains capacity per flavor and resource.
+	//
 	Flavors []EffectiveCapacityFlavorApplyConfiguration `json:"flavors,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1alpha1/effectivecapacityflavor.go
+++ b/client-go/applyconfiguration/kueue/v1alpha1/effectivecapacityflavor.go
@@ -27,8 +27,10 @@ import (
 // with apply.
 type EffectiveCapacityFlavorApplyConfiguration struct {
 	// name identifies the ResourceFlavor whose capacity is reported.
+	//
 	Name *kueuev1alpha1.ResourceFlavorReference `json:"name,omitempty"`
 	// resources contains total capacity by resource name.
+	//
 	Resources *v1.ResourceList `json:"resources,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta1/admissioncheckstate.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/admissioncheckstate.go
@@ -44,6 +44,7 @@ type AdmissionCheckStateApplyConfiguration struct {
 	// If nil when State=Retry, Kueue will retry immediately.
 	// If set, Kueue will add the workload back to the queue after
 	// lastTransitionTime + RequeueAfterSeconds is over.
+	//
 	RequeueAfterSeconds *int32 `json:"requeueAfterSeconds,omitempty"`
 	// retryCount tracks retry attempts for this admission check.
 	// Kueue automatically increments the counter whenever the

--- a/client-go/applyconfiguration/kueue/v1beta1/admissionscope.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/admissionscope.go
@@ -29,6 +29,7 @@ type AdmissionScopeApplyConfiguration struct {
 	// in the AdmissionScope. Possible values are:
 	// - UsageBasedAdmissionFairSharing
 	// - NoAdmissionFairSharing
+	//
 	AdmissionMode *kueuev1beta1.AdmissionMode `json:"admissionMode,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta1/borrowwithincohort.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/borrowwithincohort.go
@@ -36,12 +36,14 @@ type BorrowWithinCohortApplyConfiguration struct {
 	// - `LowerPriority`: allow preemption, in other ClusterQueues
 	// within the cohort, for a borrowing workload, but only if
 	// the preempted workloads are of lower priority.
+	//
 	Policy *kueuev1beta1.BorrowWithinCohortPolicy `json:"policy,omitempty"`
 	// maxPriorityThreshold allows to restrict the set of workloads which
 	// might be preempted by a borrowing workload, to only workloads with
 	// priority less than or equal to the specified threshold priority.
 	// When the threshold is not specified, then any workload satisfying the
 	// policy can be preempted by the borrowing workload.
+	//
 	MaxPriorityThreshold *int32 `json:"maxPriorityThreshold,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta1/clusterqueuepreemption.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/clusterqueuepreemption.go
@@ -61,6 +61,7 @@ type ClusterQueuePreemptionApplyConfiguration struct {
 	// the nominal quota of its ClusterQueue, preempt any Workload in the
 	// cohort, irrespective of priority. **Fair Sharing** preempt Workloads
 	// in the cohort that satisfy the Fair Sharing preemptionStrategies.
+	//
 	ReclaimWithinCohort *kueuev1beta1.PreemptionPolicy `json:"reclaimWithinCohort,omitempty"`
 	// borrowWithinCohort determines whether a pending Workload can preempt
 	// Workloads from other ClusterQueues in the cohort if the workload requires borrowing.
@@ -76,6 +77,7 @@ type ClusterQueuePreemptionApplyConfiguration struct {
 	// - `LowerOrNewerEqualPriority`: only preempt Workloads in the ClusterQueue that
 	// either have a lower priority than the pending workload or equal priority
 	// and are newer than the pending workload.
+	//
 	WithinClusterQueue *kueuev1beta1.PreemptionPolicy `json:"withinClusterQueue,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta1/clusterqueuespec.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/clusterqueuespec.go
@@ -57,6 +57,7 @@ type ClusterQueueSpecApplyConfiguration struct {
 	// - BestEffortFIFO: workloads are ordered by creation time,
 	// however older workloads that can't be admitted will not block
 	// admitting newer workloads that fit existing quota.
+	//
 	QueueingStrategy *kueuev1beta1.QueueingStrategy `json:"queueingStrategy,omitempty"`
 	// namespaceSelector defines which namespaces are allowed to submit workloads to
 	// this clusterQueue. Beyond this basic support for policy, a policy agent like
@@ -83,6 +84,7 @@ type ClusterQueueSpecApplyConfiguration struct {
 	// - None - Workloads are admitted
 	// - HoldAndDrain - Admitted workloads are evicted and Reserving workloads will cancel the reservation.
 	// - Hold - Admitted workloads will run to completion and Reserving workloads will cancel the reservation.
+	//
 	StopPolicy *kueuev1beta1.StopPolicy `json:"stopPolicy,omitempty"`
 	// fairSharing defines the properties of the ClusterQueue when
 	// participating in FairSharing.  The values are only relevant

--- a/client-go/applyconfiguration/kueue/v1beta1/cohortspec.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/cohortspec.go
@@ -61,6 +61,7 @@ type CohortSpecApplyConfiguration struct {
 	// Borrowing and Lending limits must only be set when the
 	// Cohort has a parent.  Otherwise, the Cohort create/update
 	// will be rejected by the webhook.
+	//
 	ResourceGroups []ResourceGroupApplyConfiguration `json:"resourceGroups,omitempty"`
 	// fairSharing defines the properties of the Cohort when
 	// participating in FairSharing. The values are only relevant

--- a/client-go/applyconfiguration/kueue/v1beta1/flavorfungibility.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/flavorfungibility.go
@@ -35,6 +35,7 @@ type FlavorFungibilityApplyConfiguration struct {
 	// fits or requires borrowing to fit.
 	// - `TryNextFlavor`: try next flavor if workload requires borrowing to fit.
 	// - `Borrow` (deprecated): old name for `MayStopSearch`; please use new name.
+	//
 	WhenCanBorrow *kueuev1beta1.FlavorFungibilityPolicy `json:"whenCanBorrow,omitempty"`
 	// whenCanPreempt determines whether a workload should try the next flavor
 	// before preempting in current flavor. The possible values are:
@@ -44,6 +45,7 @@ type FlavorFungibilityApplyConfiguration struct {
 	// - `TryNextFlavor` (default): try next flavor if workload requires preemption
 	// to fit in current flavor.
 	// - `Preempt` (deprecated): old name for `MayStopSearch`; please use new name.
+	//
 	WhenCanPreempt *kueuev1beta1.FlavorFungibilityPolicy `json:"whenCanPreempt,omitempty"`
 	// preference guides the choosing of the flavor for admission in case all candidate flavors
 	// require either preemption, borrowing, or both. The possible values are:
@@ -55,6 +57,7 @@ type FlavorFungibilityApplyConfiguration struct {
 	// when such a choice is possible.  More technically it optimizes the preemption mode
 	// (reclaim over preemption within ClusterQueue), and solves tie-breaks by minimizing
 	// the borrowing distance in the cohort tree.
+	//
 	Preference *kueuev1beta1.FlavorFungibilityPreference `json:"preference,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta1/kubeconfig.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/kubeconfig.go
@@ -31,6 +31,7 @@ type KubeConfigApplyConfiguration struct {
 	// which the kueue controller manager is running. The config should be stored in the "kubeconfig" key.
 	Location *string `json:"location,omitempty"`
 	// locationType of the KubeConfig.
+	//
 	LocationType *kueuev1beta1.LocationType `json:"locationType,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta1/localqueueflavorstatus.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/localqueueflavorstatus.go
@@ -43,6 +43,7 @@ type LocalQueueFlavorStatusApplyConfiguration struct {
 	//
 	// This is a beta field and requires enabling the TopologyAwareScheduling
 	// feature gate.
+	//
 	Topology *TopologyInfoApplyConfiguration `json:"topology,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta1/localqueuespec.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/localqueuespec.go
@@ -37,6 +37,7 @@ type LocalQueueSpecApplyConfiguration struct {
 	// - None - Workloads are admitted
 	// - HoldAndDrain - Admitted workloads are evicted and Reserving workloads will cancel the reservation.
 	// - Hold - Admitted workloads will run to completion and Reserving workloads will cancel the reservation.
+	//
 	StopPolicy *kueuev1beta1.StopPolicy `json:"stopPolicy,omitempty"`
 	// fairSharing defines the properties of the LocalQueue when
 	// participating in AdmissionFairSharing.  The values are only relevant

--- a/client-go/applyconfiguration/kueue/v1beta1/multikueueconfigspec.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/multikueueconfigspec.go
@@ -24,6 +24,7 @@ package v1beta1
 // MultiKueueConfigSpec defines the desired state of MultiKueueConfig
 type MultiKueueConfigSpecApplyConfiguration struct {
 	// clusters is a list of MultiKueueClusters names where the workloads from the ClusterQueue should be distributed.
+	//
 	Clusters []string `json:"clusters,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta1/podset.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/podset.go
@@ -53,8 +53,10 @@ type PodSetApplyConfiguration struct {
 	// Only one podSet within the workload can use this.
 	//
 	// This is an alpha field and requires enabling PartialAdmission feature gate.
+	//
 	MinCount *int32 `json:"minCount,omitempty"`
 	// topologyRequest defines the topology request for the PodSet.
+	//
 	TopologyRequest *PodSetTopologyRequestApplyConfiguration `json:"topologyRequest,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta1/podsetassignment.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/podsetassignment.go
@@ -40,6 +40,7 @@ type PodSetAssignmentApplyConfiguration struct {
 	// This field will not change in case of quota reclaim.
 	// Value could be missing for Workloads created before this field was added,
 	// in that case spec.podSets[*].count value will be used.
+	//
 	Count *int32 `json:"count,omitempty"`
 	// topologyAssignment indicates the topology assignment divided into
 	// topology domains corresponding to the lowest level of the topology.
@@ -85,6 +86,7 @@ type PodSetAssignmentApplyConfiguration struct {
 	// count: 4
 	// - values: [hostname-2]
 	// count: 2
+	//
 	TopologyAssignment *TopologyAssignmentApplyConfiguration `json:"topologyAssignment,omitempty"`
 	// delayedTopologyRequest indicates the topology assignment is delayed.
 	// Topology assignment might be delayed in case there is ProvisioningRequest
@@ -92,6 +94,7 @@ type PodSetAssignmentApplyConfiguration struct {
 	// Kueue schedules the second pass of scheduling for each workload with at
 	// least one PodSet which has delayedTopologyRequest=true and without
 	// topologyAssignment.
+	//
 	DelayedTopologyRequest *kueuev1beta1.DelayedTopologyRequestState `json:"delayedTopologyRequest,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta1/podsettopologyrequest.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/podsettopologyrequest.go
@@ -26,14 +26,17 @@ type PodSetTopologyRequestApplyConfiguration struct {
 	// required indicates the topology level required by the PodSet, as
 	// indicated by the `kueue.x-k8s.io/podset-required-topology` PodSet
 	// annotation.
+	//
 	Required *string `json:"required,omitempty"`
 	// preferred indicates the topology level preferred by the PodSet, as
 	// indicated by the `kueue.x-k8s.io/podset-preferred-topology` PodSet
 	// annotation.
+	//
 	Preferred *string `json:"preferred,omitempty"`
 	// unconstrained indicates that Kueue has the freedom to schedule the PodSet within
 	// the entire available capacity, without constraints on the compactness of the placement.
 	// This is indicated by the `kueue.x-k8s.io/podset-unconstrained-topology` PodSet annotation.
+	//
 	Unconstrained *bool `json:"unconstrained,omitempty"`
 	// podIndexLabel indicates the name of the label indexing the pods.
 	// For example, in the context of
@@ -49,13 +52,16 @@ type PodSetTopologyRequestApplyConfiguration struct {
 	SubGroupCount *int32 `json:"subGroupCount,omitempty"`
 	// podSetGroupName indicates the name of the group of PodSets to which this PodSet belongs to.
 	// PodSets with the same `PodSetGroupName` should be assigned the same ResourceFlavor
+	//
 	PodSetGroupName *string `json:"podSetGroupName,omitempty"`
 	// podSetSliceRequiredTopology indicates the topology level required by the PodSet slice, as
 	// indicated by the `kueue.x-k8s.io/podset-slice-required-topology` annotation.
+	//
 	PodSetSliceRequiredTopology *string `json:"podSetSliceRequiredTopology,omitempty"`
 	// podSetSliceSize indicates the size of a subgroup of pods in a PodSet for which
 	// Kueue finds a requested topology domain on a level defined
 	// in `kueue.x-k8s.io/podset-slice-required-topology` annotation.
+	//
 	PodSetSliceSize *int32 `json:"podSetSliceSize,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta1/provisioningrequestconfigspec.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/provisioningrequestconfigspec.go
@@ -30,8 +30,10 @@ import (
 type ProvisioningRequestConfigSpecApplyConfiguration struct {
 	// provisioningClassName describes the different modes of provisioning the resources.
 	// Check autoscaling.x-k8s.io ProvisioningRequestSpec.ProvisioningClassName for details.
+	//
 	ProvisioningClassName *string `json:"provisioningClassName,omitempty"`
 	// parameters contains all other parameters classes may require.
+	//
 	Parameters map[string]kueuev1beta1.Parameter `json:"parameters,omitempty"`
 	// managedResources contains the list of resources managed by the autoscaling.
 	//
@@ -42,6 +44,7 @@ type ProvisioningRequestConfigSpecApplyConfiguration struct {
 	//
 	// If none of the workloads podsets is requesting at least a managed resource,
 	// the workload is considered ready.
+	//
 	ManagedResources []v1.ResourceName `json:"managedResources,omitempty"`
 	// retryStrategy defines strategy for retrying ProvisioningRequest.
 	// If null, then the default configuration is applied with the following parameter values:
@@ -51,9 +54,11 @@ type ProvisioningRequestConfigSpecApplyConfiguration struct {
 	//
 	// To switch off retry mechanism
 	// set retryStrategy.backoffLimitCount to 0.
+	//
 	RetryStrategy *ProvisioningRequestRetryStrategyApplyConfiguration `json:"retryStrategy,omitempty"`
 	// podSetUpdates specifies the update of the workload's PodSetUpdates which
 	// are used to target the provisioned nodes.
+	//
 	PodSetUpdates *ProvisioningRequestPodSetUpdatesApplyConfiguration `json:"podSetUpdates,omitempty"`
 	// podSetMergePolicy specifies the policy for merging PodSets before being passed
 	// to the cluster autoscaler.
@@ -61,6 +66,7 @@ type ProvisioningRequestConfigSpecApplyConfiguration struct {
 	// The possible policies are:
 	// - `IdenticalPodTemplates`: Merges only identical PodTemplates.
 	// - `IdenticalWorkloadSchedulingRequirements`: Merges PodTemplates with identical fields that are considered when defining the workload scheduling requirements.
+	//
 	PodSetMergePolicy *kueuev1beta1.ProvisioningRequestConfigPodSetMergePolicy `json:"podSetMergePolicy,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta1/provisioningrequestpodsetupdates.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/provisioningrequestpodsetupdates.go
@@ -22,6 +22,7 @@ package v1beta1
 // with apply.
 type ProvisioningRequestPodSetUpdatesApplyConfiguration struct {
 	// nodeSelector specifies the list of updates for the NodeSelector.
+	//
 	NodeSelector []ProvisioningRequestPodSetUpdatesNodeSelectorApplyConfiguration `json:"nodeSelector,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta1/provisioningrequestpodsetupdatesnodeselector.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/provisioningrequestpodsetupdatesnodeselector.go
@@ -22,10 +22,12 @@ package v1beta1
 // with apply.
 type ProvisioningRequestPodSetUpdatesNodeSelectorApplyConfiguration struct {
 	// key specifies the key for the NodeSelector.
+	//
 	Key *string `json:"key,omitempty"`
 	// valueFromProvisioningClassDetail specifies the key of the
 	// ProvisioningRequest.status.provisioningClassDetails from which the value
 	// is used for the update.
+	//
 	ValueFromProvisioningClassDetail *string `json:"valueFromProvisioningClassDetail,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta1/requeuestate.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/requeuestate.go
@@ -28,10 +28,12 @@ type RequeueStateApplyConfiguration struct {
 	// count records the number of times a workload has been re-queued
 	// When a deactivated (`.spec.activate`=`false`) workload is reactivated (`.spec.activate`=`true`),
 	// this count would be reset to null.
+	//
 	Count *int32 `json:"count,omitempty"`
 	// requeueAt records the time when a workload will be re-queued.
 	// When a deactivated (`.spec.activate`=`false`) workload is reactivated (`.spec.activate`=`true`),
 	// this time would be reset to null.
+	//
 	RequeueAt *v1.Time `json:"requeueAt,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta1/resourceflavorspec.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/resourceflavorspec.go
@@ -52,6 +52,7 @@ type ResourceFlavorSpecApplyConfiguration struct {
 	// cloud.provider.com/preemptible="true":NoSchedule
 	//
 	// nodeTaints can be up to 8 elements.
+	//
 	NodeTaints []v1.TaintApplyConfiguration `json:"nodeTaints,omitempty"`
 	// tolerations are extra tolerations that will be added to the pods admitted in
 	// the quota associated with this resource flavor.
@@ -60,10 +61,12 @@ type ResourceFlavorSpecApplyConfiguration struct {
 	// cloud.provider.com/preemptible="true":NoSchedule
 	//
 	// tolerations can be up to 8 elements.
+	//
 	Tolerations []v1.TolerationApplyConfiguration `json:"tolerations,omitempty"`
 	// topologyName indicates topology for the TAS ResourceFlavor.
 	// When specified, it enables scraping of the topology information from the
 	// nodes matching to the Resource Flavor node labels.
+	//
 	TopologyName *kueuev1beta1.TopologyReference `json:"topologyName,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta1/schedulingstats.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/schedulingstats.go
@@ -22,6 +22,7 @@ package v1beta1
 // with apply.
 type SchedulingStatsApplyConfiguration struct {
 	// evictions tracks eviction statistics by reason and underlyingCause.
+	//
 	Evictions []WorkloadSchedulingStatsEvictionApplyConfiguration `json:"evictions,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta1/topologyassignment.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/topologyassignment.go
@@ -24,9 +24,11 @@ type TopologyAssignmentApplyConfiguration struct {
 	// levels is an ordered list of keys denoting the levels of the assigned
 	// topology (i.e. node label keys), from the highest to the lowest level of
 	// the topology.
+	//
 	Levels []string `json:"levels,omitempty"`
 	// domains is a list of topology assignments split by topology domains at
 	// the lowest level of the topology.
+	//
 	Domains []TopologyDomainAssignmentApplyConfiguration `json:"domains,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta1/topologydomainassignment.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/topologydomainassignment.go
@@ -24,9 +24,11 @@ type TopologyDomainAssignmentApplyConfiguration struct {
 	// values is an ordered list of node selector values describing a topology
 	// domain. The values correspond to the consecutive topology levels, from
 	// the highest to the lowest.
+	//
 	Values []string `json:"values,omitempty"`
 	// count indicates the number of Pods to be scheduled in the topology
 	// domain indicated by the values field.
+	//
 	Count *int32 `json:"count,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta1/topologyinfo.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/topologyinfo.go
@@ -26,8 +26,10 @@ import (
 // with apply.
 type TopologyInfoApplyConfiguration struct {
 	// name is the name of the topology.
+	//
 	Name *kueuev1beta1.TopologyReference `json:"name,omitempty"`
 	// levels define the levels of topology.
+	//
 	Levels []string `json:"levels,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta1/topologylevel.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/topologylevel.go
@@ -29,6 +29,7 @@ type TopologyLevelApplyConfiguration struct {
 	// Examples:
 	// - cloud.provider.com/topology-block
 	// - cloud.provider.com/topology-rack
+	//
 	NodeLabel *string `json:"nodeLabel,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta1/topologyspec.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/topologyspec.go
@@ -24,6 +24,7 @@ package v1beta1
 // TopologySpec defines the desired state of Topology
 type TopologySpecApplyConfiguration struct {
 	// levels define the levels of topology.
+	//
 	Levels []TopologyLevelApplyConfiguration `json:"levels,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta1/unhealthynode.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/unhealthynode.go
@@ -22,6 +22,7 @@ package v1beta1
 // with apply.
 type UnhealthyNodeApplyConfiguration struct {
 	// name is the name of the unhealthy node.
+	//
 	Name *string `json:"name,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta1/workloadschedulingstatseviction.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/workloadschedulingstatseviction.go
@@ -26,11 +26,14 @@ import (
 // with apply.
 type WorkloadSchedulingStatsEvictionApplyConfiguration struct {
 	// reason specifies the programmatic identifier for the eviction cause.
+	//
 	Reason *string `json:"reason,omitempty"`
 	// underlyingCause specifies a finer-grained explanation that complements the eviction reason.
 	// This may be an empty string.
+	//
 	UnderlyingCause *kueuev1beta1.EvictionUnderlyingCause `json:"underlyingCause,omitempty"`
 	// count tracks the number of evictions for this reason and detailed reason.
+	//
 	Count *int32 `json:"count,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta1/workloadspec.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/workloadspec.go
@@ -31,6 +31,7 @@ type WorkloadSpecApplyConfiguration struct {
 	// and a count.
 	// There must be at least one element and at most 18.
 	// podSets cannot be changed.
+	//
 	PodSets []PodSetApplyConfiguration `json:"podSets,omitempty"`
 	// queueName is the name of the LocalQueue the Workload is associated with.
 	// queueName cannot be changed while .status.admission is not null.
@@ -66,6 +67,7 @@ type WorkloadSpecApplyConfiguration struct {
 	// the workload can be admitted before it's automatically deactivated.
 	//
 	// If unspecified, no execution time limit is enforced on the Workload.
+	//
 	MaximumExecutionTimeSeconds *int32 `json:"maximumExecutionTimeSeconds,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta1/workloadstatus.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/workloadstatus.go
@@ -36,6 +36,7 @@ type WorkloadStatusApplyConfiguration struct {
 	// - Finished: the associated workload finished running (failed or succeeded).
 	// - PodsReady: at least `.spec.podSets[*].count` Pods are ready or have
 	// succeeded.
+	//
 	Conditions []v1.ConditionApplyConfiguration `json:"conditions,omitempty"`
 	// admission holds the parameters of the admission of the workload by a
 	// ClusterQueue. admission can be set back to null, but its fields cannot be
@@ -43,6 +44,7 @@ type WorkloadStatusApplyConfiguration struct {
 	Admission *AdmissionApplyConfiguration `json:"admission,omitempty"`
 	// requeueState holds the re-queue state
 	// when a workload meets Eviction with PodsReadyTimeout reason.
+	//
 	RequeueState *RequeueStateApplyConfiguration `json:"requeueState,omitempty"`
 	// reclaimablePods keeps track of the number pods within a podset for which
 	// the resource reservation is no longer needed.
@@ -53,16 +55,20 @@ type WorkloadStatusApplyConfiguration struct {
 	// requested by a non-admitted workload when it was considered for admission.
 	// If admission is non-null, resourceRequests will be empty because
 	// admission.resourceUsage contains the detailed information.
+	//
 	ResourceRequests []PodSetRequestApplyConfiguration `json:"resourceRequests,omitempty"`
 	// accumulatedPastExexcutionTimeSeconds holds the total time, in seconds, the workload spent
 	// in Admitted state, in the previous `Admit` - `Evict` cycles.
+	//
 	AccumulatedPastExexcutionTimeSeconds *int32 `json:"accumulatedPastExexcutionTimeSeconds,omitempty"`
 	// schedulingStats tracks scheduling statistics
+	//
 	SchedulingStats *SchedulingStatsApplyConfiguration `json:"schedulingStats,omitempty"`
 	// nominatedClusterNames specifies the list of cluster names that have been nominated for scheduling.
 	// This field is mutually exclusive with the `.status.clusterName` field, and is reset when
 	// `status.clusterName` is set.
 	// This field is optional.
+	//
 	NominatedClusterNames []string `json:"nominatedClusterNames,omitempty"`
 	// clusterName is the name of the cluster where the workload is currently assigned.
 	//
@@ -76,6 +82,7 @@ type WorkloadStatusApplyConfiguration struct {
 	// when Topology-Aware Scheduling is used. This field should not be set by the users.
 	// It indicates Kueue's scheduler is searching for replacements of the failed nodes.
 	// Requires enabling the TASFailedNodeReplacement feature gate.
+	//
 	UnhealthyNodes []UnhealthyNodeApplyConfiguration `json:"unhealthyNodes,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta2/admissioncheckstate.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/admissioncheckstate.go
@@ -44,6 +44,7 @@ type AdmissionCheckStateApplyConfiguration struct {
 	// If nil when State=Retry, Kueue will retry immediately.
 	// If set, Kueue will add the workload back to the queue after
 	// lastTransitionTime + RequeueAfterSeconds is over.
+	//
 	RequeueAfterSeconds *int32 `json:"requeueAfterSeconds,omitempty"`
 	// retryCount tracks retry attempts for this admission check.
 	// Kueue automatically increments the counter whenever the

--- a/client-go/applyconfiguration/kueue/v1beta2/admissionscope.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/admissionscope.go
@@ -29,6 +29,7 @@ type AdmissionScopeApplyConfiguration struct {
 	// in the AdmissionScope. Possible values are:
 	// - UsageBasedAdmissionFairSharing
 	// - NoAdmissionFairSharing
+	//
 	AdmissionMode *kueuev1beta2.AdmissionMode `json:"admissionMode,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta2/borrowwithincohort.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/borrowwithincohort.go
@@ -36,12 +36,14 @@ type BorrowWithinCohortApplyConfiguration struct {
 	// - `LowerPriority`: allow preemption, in other ClusterQueues
 	// within the cohort, for a borrowing workload, but only if
 	// the preempted workloads are of lower priority.
+	//
 	Policy *kueuev1beta2.BorrowWithinCohortPolicy `json:"policy,omitempty"`
 	// maxPriorityThreshold allows to restrict the set of workloads which
 	// might be preempted by a borrowing workload, to only workloads with
 	// priority less than or equal to the specified threshold priority.
 	// When the threshold is not specified, then any workload satisfying the
 	// policy can be preempted by the borrowing workload.
+	//
 	MaxPriorityThreshold *int32 `json:"maxPriorityThreshold,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta2/clusterqueuepreemption.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/clusterqueuepreemption.go
@@ -61,6 +61,7 @@ type ClusterQueuePreemptionApplyConfiguration struct {
 	// the nominal quota of its ClusterQueue, preempt any Workload in the
 	// cohort, irrespective of priority. **Fair Sharing** preempt Workloads
 	// in the cohort that satisfy the Fair Sharing preemptionStrategies.
+	//
 	ReclaimWithinCohort *kueuev1beta2.PreemptionPolicy `json:"reclaimWithinCohort,omitempty"`
 	// borrowWithinCohort determines whether a pending Workload can preempt
 	// Workloads from other ClusterQueues in the cohort if the workload requires borrowing.
@@ -76,6 +77,7 @@ type ClusterQueuePreemptionApplyConfiguration struct {
 	// - `LowerOrNewerEqualPriority`: only preempt Workloads in the ClusterQueue that
 	// either have a lower priority than the pending workload or equal priority
 	// and are newer than the pending workload.
+	//
 	WithinClusterQueue *kueuev1beta2.PreemptionPolicy `json:"withinClusterQueue,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta2/clusterqueuespec.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/clusterqueuespec.go
@@ -57,6 +57,7 @@ type ClusterQueueSpecApplyConfiguration struct {
 	// - BestEffortFIFO: workloads are ordered by creation time,
 	// however older workloads that can't be admitted will not block
 	// admitting newer workloads that fit existing quota.
+	//
 	QueueingStrategy *kueuev1beta2.QueueingStrategy `json:"queueingStrategy,omitempty"`
 	// namespaceSelector defines which namespaces are allowed to submit workloads to
 	// this clusterQueue. Beyond this basic support for policy, a policy agent like
@@ -79,6 +80,7 @@ type ClusterQueueSpecApplyConfiguration struct {
 	// - None - Workloads are admitted
 	// - HoldAndDrain - Admitted workloads are evicted and Reserving workloads will cancel the reservation.
 	// - Hold - Admitted workloads will run to completion and Reserving workloads will cancel the reservation.
+	//
 	StopPolicy *kueuev1beta2.StopPolicy `json:"stopPolicy,omitempty"`
 	// fairSharing defines the properties of the ClusterQueue when
 	// participating in FairSharing.  The values are only relevant
@@ -90,6 +92,7 @@ type ClusterQueueSpecApplyConfiguration struct {
 	// Its main capability is to allow Workloads pursuing multiple flavors at the same time, and starting on the first flavor that led to admission.
 	// Additionally after the admission, Workloads can still try to pursue capacity on the more preferable flavors while running.
 	// It enables them to migrate to more preferable, whenever capacity appears.
+	//
 	ConcurrentAdmissionPolicy *ConcurrentAdmissionPolicyApplyConfiguration `json:"concurrentAdmissionPolicy,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta2/cohortspec.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/cohortspec.go
@@ -61,6 +61,7 @@ type CohortSpecApplyConfiguration struct {
 	// Borrowing and Lending limits must only be set when the
 	// Cohort has a parent.  Otherwise, the Cohort create/update
 	// will be rejected by the webhook.
+	//
 	ResourceGroups []ResourceGroupApplyConfiguration `json:"resourceGroups,omitempty"`
 	// fairSharing defines the properties of the Cohort when
 	// participating in FairSharing. The values are only relevant

--- a/client-go/applyconfiguration/kueue/v1beta2/concurrentadmissionconstraints.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/concurrentadmissionconstraints.go
@@ -30,6 +30,7 @@ type ConcurrentAdmissionConstraintsApplyConfiguration struct {
 	// It can only be used if the Mode is `TryPreferredFlavors`.
 	// If the Mode is `TryPreferredFlavors` and LastAcceptableFlavorName is not specified, then
 	// Workload can migrate to any flavor that is more preferable than the one it was admitted to.
+	//
 	LastAcceptableFlavorName *kueuev1beta2.ResourceFlavorReference `json:"lastAcceptableFlavorName,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta2/concurrentadmissionmigration.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/concurrentadmissionmigration.go
@@ -29,8 +29,10 @@ type ConcurrentAdmissionMigrationApplyConfiguration struct {
 	// The possible values are:
 	// - `TryPreferredFlavors` (default): a Workload will try to migrate to the preferred flavor after it's admitted and running.
 	// - `RetainFirstAdmission`: a Workload, once admitted to a flavor, will stick to a flavor and will not be migrated.
+	//
 	Mode *kueuev1beta2.ConcurrentAdmissionMigrationMode `json:"mode,omitempty"`
 	// constraints defines the constraints of Workload's migration.
+	//
 	Constraints *ConcurrentAdmissionConstraintsApplyConfiguration `json:"constraints,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta2/concurrentadmissionpolicy.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/concurrentadmissionpolicy.go
@@ -28,6 +28,7 @@ type ConcurrentAdmissionPolicyApplyConfiguration struct {
 	// favorable flavors keep trying to get admitted and if they succeed, the Workload migrates to the new flavor.
 	// The Variants that pursue less favorable flavors are deactivated.
 	// Flavor preferences are expressed through the order of flavors in the ClusterQueue.
+	//
 	Migration *ConcurrentAdmissionMigrationApplyConfiguration `json:"migration,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta2/effectivequotastatus.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/effectivequotastatus.go
@@ -29,6 +29,7 @@ type EffectiveQuotaStatusApplyConfiguration struct {
 	// resourceGroups is the effective quota used by the scheduler.
 	// An empty list is a valid complete override and does not cause fallback to
 	// spec.resourceGroups.
+	//
 	ResourceGroups []ResourceGroupApplyConfiguration `json:"resourceGroups,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta2/flavorfungibility.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/flavorfungibility.go
@@ -34,6 +34,7 @@ type FlavorFungibilityApplyConfiguration struct {
 	// - `MayStopSearch` (default): stop the search for candidate flavors if workload
 	// fits or requires borrowing to fit.
 	// - `TryNextFlavor`: try next flavor if workload requires borrowing to fit.
+	//
 	WhenCanBorrow *kueuev1beta2.FlavorFungibilityPolicy `json:"whenCanBorrow,omitempty"`
 	// whenCanPreempt determines whether a workload should try the next flavor
 	// before preempting in current flavor. The possible values are:
@@ -42,6 +43,7 @@ type FlavorFungibilityApplyConfiguration struct {
 	// preemption to fit.
 	// - `TryNextFlavor` (default): try next flavor if workload requires preemption
 	// to fit in current flavor.
+	//
 	WhenCanPreempt *kueuev1beta2.FlavorFungibilityPolicy `json:"whenCanPreempt,omitempty"`
 	// preference guides the choosing of the flavor for admission in case all candidate flavors
 	// require either preemption, borrowing, or both. The possible values are:
@@ -53,6 +55,7 @@ type FlavorFungibilityApplyConfiguration struct {
 	// when such a choice is possible.  More technically it optimizes the preemption mode
 	// (reclaim over preemption within ClusterQueue), and solves tie-breaks by minimizing
 	// the borrowing distance in the cohort tree.
+	//
 	Preference *kueuev1beta2.FlavorFungibilityPreference `json:"preference,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta2/kubeconfig.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/kubeconfig.go
@@ -31,6 +31,7 @@ type KubeConfigApplyConfiguration struct {
 	// which the kueue controller manager is running. The config should be stored in the "kubeconfig" key.
 	Location *string `json:"location,omitempty"`
 	// locationType of the KubeConfig.
+	//
 	LocationType *kueuev1beta2.LocationType `json:"locationType,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta2/localqueuespec.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/localqueuespec.go
@@ -37,6 +37,7 @@ type LocalQueueSpecApplyConfiguration struct {
 	// - None - Workloads are admitted
 	// - HoldAndDrain - Admitted workloads are evicted and Reserving workloads will cancel the reservation.
 	// - Hold - Admitted workloads will run to completion and Reserving workloads will cancel the reservation.
+	//
 	StopPolicy *kueuev1beta2.StopPolicy `json:"stopPolicy,omitempty"`
 	// fairSharing defines the properties of the LocalQueue when
 	// participating in AdmissionFairSharing.  The values are only relevant

--- a/client-go/applyconfiguration/kueue/v1beta2/multikueueconfigspec.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/multikueueconfigspec.go
@@ -30,6 +30,7 @@ type MultiKueueConfigSpecApplyConfiguration struct {
 	// clusters is a list of MultiKueueClusters names where the workloads from the ClusterQueue should be distributed.
 	// The order of the list is significant: the Incremental dispatcher nominates clusters
 	// following this order, so the most preferred clusters should be listed first.
+	//
 	Clusters []string `json:"clusters,omitempty"`
 	// quotaManagement specifies the management of ClusterQueue quotas
 	// in the manager cluster.

--- a/client-go/applyconfiguration/kueue/v1beta2/podset.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/podset.go
@@ -53,8 +53,10 @@ type PodSetApplyConfiguration struct {
 	// Only one podSet within the workload can use this.
 	//
 	// This is an alpha field and requires enabling PartialAdmission feature gate.
+	//
 	MinCount *int32 `json:"minCount,omitempty"`
 	// topologyRequest defines the topology request for the PodSet.
+	//
 	TopologyRequest *PodSetTopologyRequestApplyConfiguration `json:"topologyRequest,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta2/podsetassignment.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/podsetassignment.go
@@ -40,6 +40,7 @@ type PodSetAssignmentApplyConfiguration struct {
 	// This field will not change in case of quota reclaim.
 	// Value could be missing for Workloads created before this field was added,
 	// in that case spec.podSets[*].count value will be used.
+	//
 	Count *int32 `json:"count,omitempty"`
 	// topologyAssignment indicates the topology assignment divided into
 	// topology domains corresponding to the lowest level of the topology.
@@ -152,6 +153,7 @@ type PodSetAssignmentApplyConfiguration struct {
 	// roots: [1, 2]
 	// podCounts:
 	// universal: 1
+	//
 	TopologyAssignment *TopologyAssignmentApplyConfiguration `json:"topologyAssignment,omitempty"`
 	// delayedTopologyRequest indicates the topology assignment is delayed.
 	// Topology assignment might be delayed in case there is ProvisioningRequest
@@ -159,6 +161,7 @@ type PodSetAssignmentApplyConfiguration struct {
 	// Kueue schedules the second pass of scheduling for each workload with at
 	// least one PodSet which has delayedTopologyRequest=true and without
 	// topologyAssignment.
+	//
 	DelayedTopologyRequest *kueuev1beta2.DelayedTopologyRequestState `json:"delayedTopologyRequest,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta2/podsetslicerequiredtopologyconstraint.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/podsetslicerequiredtopologyconstraint.go
@@ -24,8 +24,10 @@ package v1beta2
 // PodsetSliceRequiredTopologyConstraint defines a single slice topology constraint layer.
 type PodsetSliceRequiredTopologyConstraintApplyConfiguration struct {
 	// topology indicates the topology level required for this slice layer.
+	//
 	Topology *string `json:"topology,omitempty"`
 	// size indicates the number of pods in each group at this slice layer.
+	//
 	Size *int32 `json:"size,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta2/podsettopologyrequest.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/podsettopologyrequest.go
@@ -27,15 +27,18 @@ type PodSetTopologyRequestApplyConfiguration struct {
 	// indicated by the `kueue.x-k8s.io/podset-required-topology` PodSet
 	// annotation.
 	// This is limited to 63 characters.
+	//
 	Required *string `json:"required,omitempty"`
 	// preferred indicates the topology level preferred by the PodSet, as
 	// indicated by the `kueue.x-k8s.io/podset-preferred-topology` PodSet
 	// annotation.
 	// This is limited to 63 characters.
+	//
 	Preferred *string `json:"preferred,omitempty"`
 	// unconstrained indicates that Kueue has the freedom to schedule the PodSet within
 	// the entire available capacity, without constraints on the compactness of the placement.
 	// This is indicated by the `kueue.x-k8s.io/podset-unconstrained-topology` PodSet annotation.
+	//
 	Unconstrained *bool `json:"unconstrained,omitempty"`
 	// podIndexLabel indicates the name of the label indexing the pods.
 	// For example, in the context of
@@ -53,6 +56,7 @@ type PodSetTopologyRequestApplyConfiguration struct {
 	SubGroupCount *int32 `json:"subGroupCount,omitempty"`
 	// podSetGroupName indicates the name of the group of PodSets to which this PodSet belongs to.
 	// PodSets with the same `PodSetGroupName` should be assigned the same ResourceFlavor
+	//
 	PodSetGroupName *string `json:"podSetGroupName,omitempty"`
 	// podSetSliceRequiredTopology indicates the topology level required by the PodSet slice, as
 	// indicated by the `kueue.x-k8s.io/podset-slice-required-topology` annotation.
@@ -62,6 +66,7 @@ type PodSetTopologyRequestApplyConfiguration struct {
 	// podSetSliceSize indicates the size of a subgroup of pods in a PodSet for which
 	// Kueue finds a requested topology domain on a level defined
 	// in `kueue.x-k8s.io/podset-slice-required-topology` annotation.
+	//
 	PodSetSliceSize *int32 `json:"podSetSliceSize,omitempty"`
 	// podsetSliceRequiredTopologyConstraints defines all layers of slice
 	// topology constraints. Each entry specifies a topology level and slice
@@ -71,6 +76,7 @@ type PodSetTopologyRequestApplyConfiguration struct {
 	// podSetSliceSize.
 	//
 	// This annotation is alpha-level for the TASMultiLayerTopology feature gate.
+	//
 	PodsetSliceRequiredTopologyConstraints []PodsetSliceRequiredTopologyConstraintApplyConfiguration `json:"podsetSliceRequiredTopologyConstraints,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta2/priorityclassref.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/priorityclassref.go
@@ -30,8 +30,10 @@ type PriorityClassRefApplyConfiguration struct {
 	// group is the API group of the PriorityClass object.
 	// Use "kueue.x-k8s.io" for WorkloadPriorityClass.
 	// Use "scheduling.k8s.io" for Pod PriorityClass.
+	//
 	Group *kueuev1beta2.PriorityClassGroup `json:"group,omitempty"`
 	// kind is the kind of the PriorityClass object.
+	//
 	Kind *kueuev1beta2.PriorityClassKind `json:"kind,omitempty"`
 	// name is the name of the PriorityClass the Workload is associated with.
 	// If specified, indicates the workload's priority.
@@ -40,6 +42,7 @@ type PriorityClassRefApplyConfiguration struct {
 	// the highest priority. Any other name must be defined by creating a
 	// PriorityClass object with that name. If not specified, the workload
 	// priority will be default or zero if there is no default.
+	//
 	Name *string `json:"name,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta2/provisioningrequestconfigspec.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/provisioningrequestconfigspec.go
@@ -30,8 +30,10 @@ import (
 type ProvisioningRequestConfigSpecApplyConfiguration struct {
 	// provisioningClassName describes the different modes of provisioning the resources.
 	// Check autoscaling.x-k8s.io ProvisioningRequestSpec.ProvisioningClassName for details.
+	//
 	ProvisioningClassName *string `json:"provisioningClassName,omitempty"`
 	// parameters contains all other parameters classes may require.
+	//
 	Parameters map[string]kueuev1beta2.Parameter `json:"parameters,omitempty"`
 	// managedResources contains the list of resources managed by the autoscaling.
 	//
@@ -42,6 +44,7 @@ type ProvisioningRequestConfigSpecApplyConfiguration struct {
 	//
 	// If none of the workloads podsets is requesting at least a managed resource,
 	// the workload is considered ready.
+	//
 	ManagedResources []v1.ResourceName `json:"managedResources,omitempty"`
 	// retryStrategy defines strategy for retrying ProvisioningRequest.
 	// If null, then the default configuration is applied with the following parameter values:
@@ -51,9 +54,11 @@ type ProvisioningRequestConfigSpecApplyConfiguration struct {
 	//
 	// To switch off retry mechanism
 	// set retryStrategy.backoffLimitCount to 0.
+	//
 	RetryStrategy *ProvisioningRequestRetryStrategyApplyConfiguration `json:"retryStrategy,omitempty"`
 	// podSetUpdates specifies the update of the workload's PodSetUpdates which
 	// are used to target the provisioned nodes.
+	//
 	PodSetUpdates *ProvisioningRequestPodSetUpdatesApplyConfiguration `json:"podSetUpdates,omitempty"`
 	// podSetMergePolicy specifies the policy for merging PodSets before being passed
 	// to the cluster autoscaler.
@@ -61,6 +66,7 @@ type ProvisioningRequestConfigSpecApplyConfiguration struct {
 	// The possible policies are:
 	// - `IdenticalPodTemplates`: Merges only identical PodTemplates.
 	// - `IdenticalWorkloadSchedulingRequirements`: Merges PodTemplates with identical fields that are considered when defining the workload scheduling requirements.
+	//
 	PodSetMergePolicy *kueuev1beta2.ProvisioningRequestConfigPodSetMergePolicy `json:"podSetMergePolicy,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta2/provisioningrequestpodsetupdates.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/provisioningrequestpodsetupdates.go
@@ -22,6 +22,7 @@ package v1beta2
 // with apply.
 type ProvisioningRequestPodSetUpdatesApplyConfiguration struct {
 	// nodeSelector specifies the list of updates for the NodeSelector.
+	//
 	NodeSelector []ProvisioningRequestPodSetUpdatesNodeSelectorApplyConfiguration `json:"nodeSelector,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta2/provisioningrequestpodsetupdatesnodeselector.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/provisioningrequestpodsetupdatesnodeselector.go
@@ -22,10 +22,12 @@ package v1beta2
 // with apply.
 type ProvisioningRequestPodSetUpdatesNodeSelectorApplyConfiguration struct {
 	// key specifies the key for the NodeSelector.
+	//
 	Key *string `json:"key,omitempty"`
 	// valueFromProvisioningClassDetail specifies the key of the
 	// ProvisioningRequest.status.provisioningClassDetails from which the value
 	// is used for the update.
+	//
 	ValueFromProvisioningClassDetail *string `json:"valueFromProvisioningClassDetail,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta2/requeuestate.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/requeuestate.go
@@ -28,10 +28,12 @@ type RequeueStateApplyConfiguration struct {
 	// count records the number of times a workload has been re-queued
 	// When a deactivated (`.spec.activate`=`false`) workload is reactivated (`.spec.activate`=`true`),
 	// this count would be reset to null.
+	//
 	Count *int32 `json:"count,omitempty"`
 	// requeueAt records the time when a workload will be re-queued.
 	// When a deactivated (`.spec.activate`=`false`) workload is reactivated (`.spec.activate`=`true`),
 	// this time would be reset to null.
+	//
 	RequeueAt *v1.Time `json:"requeueAt,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta2/resourceflavorspec.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/resourceflavorspec.go
@@ -52,6 +52,7 @@ type ResourceFlavorSpecApplyConfiguration struct {
 	// cloud.provider.com/preemptible="true":NoSchedule
 	//
 	// nodeTaints can be up to 8 elements.
+	//
 	NodeTaints []v1.TaintApplyConfiguration `json:"nodeTaints,omitempty"`
 	// tolerations are extra tolerations that will be added to the pods admitted in
 	// the quota associated with this resource flavor.
@@ -60,10 +61,12 @@ type ResourceFlavorSpecApplyConfiguration struct {
 	// cloud.provider.com/preemptible="true":NoSchedule
 	//
 	// tolerations can be up to 8 elements.
+	//
 	Tolerations []v1.TolerationApplyConfiguration `json:"tolerations,omitempty"`
 	// topologyName indicates topology for the TAS ResourceFlavor.
 	// When specified, it enables scraping of the topology information from the
 	// nodes matching to the Resource Flavor node labels.
+	//
 	TopologyName *kueuev1beta2.TopologyReference `json:"topologyName,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta2/schedulingstats.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/schedulingstats.go
@@ -22,6 +22,7 @@ package v1beta2
 // with apply.
 type SchedulingStatsApplyConfiguration struct {
 	// evictions tracks eviction statistics by reason and underlyingCause.
+	//
 	Evictions []WorkloadSchedulingStatsEvictionApplyConfiguration `json:"evictions,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta2/topologyassignment.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/topologyassignment.go
@@ -24,6 +24,7 @@ type TopologyAssignmentApplyConfiguration struct {
 	// levels is an ordered list of keys denoting the levels of the assigned
 	// topology (i.e. node label keys), from the highest to the lowest level of
 	// the topology.
+	//
 	Levels []string `json:"levels,omitempty"`
 	// slices represent topology assignments for subsets of pods of a workload.
 	// The full assignment is obtained as a union of all slices.

--- a/client-go/applyconfiguration/kueue/v1beta2/topologylevel.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/topologylevel.go
@@ -29,6 +29,7 @@ type TopologyLevelApplyConfiguration struct {
 	// Examples:
 	// - cloud.provider.com/topology-block
 	// - cloud.provider.com/topology-rack
+	//
 	NodeLabel *string `json:"nodeLabel,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta2/topologyspec.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/topologyspec.go
@@ -24,6 +24,7 @@ package v1beta2
 // TopologySpec defines the desired state of Topology
 type TopologySpecApplyConfiguration struct {
 	// levels define the levels of topology.
+	//
 	Levels []TopologyLevelApplyConfiguration `json:"levels,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta2/unhealthynode.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/unhealthynode.go
@@ -22,6 +22,7 @@ package v1beta2
 // with apply.
 type UnhealthyNodeApplyConfiguration struct {
 	// name is the name of the unhealthy node.
+	//
 	Name *string `json:"name,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta2/workloadschedulingstatseviction.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/workloadschedulingstatseviction.go
@@ -26,11 +26,14 @@ import (
 // with apply.
 type WorkloadSchedulingStatsEvictionApplyConfiguration struct {
 	// reason specifies the programmatic identifier for the eviction cause.
+	//
 	Reason *string `json:"reason,omitempty"`
 	// underlyingCause specifies a finer-grained explanation that complements the eviction reason.
 	// This may be an empty string.
+	//
 	UnderlyingCause *kueuev1beta2.EvictionUnderlyingCause `json:"underlyingCause,omitempty"`
 	// count tracks the number of evictions for this reason and detailed reason.
+	//
 	Count *int32 `json:"count,omitempty"`
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta2/workloadspec.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/workloadspec.go
@@ -31,11 +31,13 @@ type WorkloadSpecApplyConfiguration struct {
 	// and a count.
 	// There must be at least one element and at most 18.
 	// podSets cannot be changed.
+	//
 	PodSets []PodSetApplyConfiguration `json:"podSets,omitempty"`
 	// queueName is the name of the LocalQueue the Workload is associated with.
 	// queueName cannot be changed while .status.admission is not null.
 	QueueName *kueuev1beta2.LocalQueueName `json:"queueName,omitempty"`
 	// priorityClassRef references a PriorityClass object that defines the workload's priority.
+	//
 	PriorityClassRef *PriorityClassRefApplyConfiguration `json:"priorityClassRef,omitempty"`
 	// priority determines the order of access to the resources managed by the
 	// ClusterQueue where the workload is queued.
@@ -56,6 +58,7 @@ type WorkloadSpecApplyConfiguration struct {
 	// the workload can be admitted before it's automatically deactivated.
 	//
 	// If unspecified, no execution time limit is enforced on the Workload.
+	//
 	MaximumExecutionTimeSeconds *int32 `json:"maximumExecutionTimeSeconds,omitempty"`
 	// preemptionGates is a list of gates governing whether the workload
 	// can trigger preemptions.

--- a/client-go/applyconfiguration/kueue/v1beta2/workloadstatus.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/workloadstatus.go
@@ -37,6 +37,7 @@ type WorkloadStatusApplyConfiguration struct {
 	// - PodsReady: at least `.spec.podSets[*].count` Pods are ready or have
 	// succeeded.
 	// conditions are limited to 16 items.
+	//
 	Conditions []v1.ConditionApplyConfiguration `json:"conditions,omitempty"`
 	// admission holds the parameters of the admission of the workload by a
 	// ClusterQueue. admission can be set back to null, but its fields cannot be
@@ -44,6 +45,7 @@ type WorkloadStatusApplyConfiguration struct {
 	Admission *AdmissionApplyConfiguration `json:"admission,omitempty"`
 	// requeueState holds the re-queue state
 	// when a workload meets Eviction with PodsReadyTimeout reason.
+	//
 	RequeueState *RequeueStateApplyConfiguration `json:"requeueState,omitempty"`
 	// reclaimablePods keeps track of the number pods within a podset for which
 	// the resource reservation is no longer needed.
@@ -54,16 +56,20 @@ type WorkloadStatusApplyConfiguration struct {
 	// requested by a non-admitted workload when it was considered for admission.
 	// If admission is non-null, resourceRequests will be empty because
 	// admission.resourceUsage contains the detailed information.
+	//
 	ResourceRequests []PodSetRequestApplyConfiguration `json:"resourceRequests,omitempty"`
 	// accumulatedPastExecutionTimeSeconds holds the total time, in seconds, the workload spent
 	// in Admitted state, in the previous `Admit` - `Evict` cycles.
+	//
 	AccumulatedPastExecutionTimeSeconds *int32 `json:"accumulatedPastExecutionTimeSeconds,omitempty"`
 	// schedulingStats tracks scheduling statistics
+	//
 	SchedulingStats *SchedulingStatsApplyConfiguration `json:"schedulingStats,omitempty"`
 	// nominatedClusterNames specifies the list of cluster names that have been nominated for scheduling.
 	// This field is mutually exclusive with the `.status.clusterName` field, and is reset when
 	// `status.clusterName` is set.
 	// This field is optional.
+	//
 	NominatedClusterNames []string `json:"nominatedClusterNames,omitempty"`
 	// clusterName is the name of the cluster where the workload is currently assigned.
 	//
@@ -77,6 +83,7 @@ type WorkloadStatusApplyConfiguration struct {
 	// when Topology-Aware Scheduling is used. This field should not be set by the users.
 	// It indicates Kueue's scheduler is searching for replacements of the failed nodes.
 	// Requires enabling the TASFailedNodeReplacement feature gate.
+	//
 	UnhealthyNodes []UnhealthyNodeApplyConfiguration `json:"unhealthyNodes,omitempty"`
 	// preemptionGates is a list of states of gates governing whether the workload
 	// can trigger preemptions.

--- a/site/content/en/docs/reference/kueue-config.v1beta2.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta2.md
@@ -272,7 +272,7 @@ using the ClusterProfile API.</p>
 </td>
 </tr>
 <tr><td><code>credentialsProviders</code><br/>
-<a href="#config-kueue-x-k8s-io-v1beta2-ClusterProfileAccessProvider"><code>[]ClusterProfileAccessProvider</code></a>
+<a href="#config-kueue-x-k8s-io-v1beta2-ClusterProfileCredentialsProvider"><code>[]ClusterProfileCredentialsProvider</code></a>
 </td>
 <td>
    <p>CredentialsProviders defines a list of providers to obtain credentials of worker clusters
@@ -316,6 +316,19 @@ are mutually exclusive.</p>
 </tr>
 </tbody>
 </table>
+
+## `ClusterProfileCredentialsProvider`     {#config-kueue-x-k8s-io-v1beta2-ClusterProfileCredentialsProvider}
+    
+
+**Appears in:**
+
+- [ClusterProfile](#config-kueue-x-k8s-io-v1beta2-ClusterProfile)
+
+
+<p>ClusterProfileAccessProvider defines an access provider in the ClusterProfile API.</p>
+
+
+
 
 ## `ControllerConfigurationSpec`     {#config-kueue-x-k8s-io-v1beta2-ControllerConfigurationSpec}
     


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it?
This PR regenerates `client-go/applyconfiguration/` and `site/content/en/docs/reference/kueue-config.v1beta2.md` to align the repository tree with the updated Kubernetes test-infra Prow runner image (`gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260907-7013e6a654-master`).

##### Background & Root Cause
Between 09:22 UTC and 11:29 UTC on 2026-09-08, Kubernetes test-infra updated the default presubmit test runner image from `kubekins-e2e:v20260831-6ed6668adc-master` to `kubekins-e2e:v20260907-7013e6a654-master`, which runs **Go 1.27.1**.

In `make verify` (`hack/make/verify.mk`), the `verify-checks` target executes `verify-tree-prereqs` (running codegen, API doc gen, etc.) and then enforces a clean git status with:
```bash
git --no-pager diff --exit-code $(PATHS_TO_VERIFY)
```

Under Go 1.27.1:
1. **ApplyConfiguration formatting**: `applyconfiguration-gen` (via `k8s.io/code-generator`) emits paragraph separator comments (`//\n`) above field comments across 74 files in `client-go/applyconfiguration/`.
2. **API reference docs**: `genref` resolves type aliases (`type ClusterProfileCredentialsProvider = ClusterProfileAccessProvider` in `apis/config/v1beta2/deprecated_types.go`) as explicit reference entries under Go 1.27's type system, generating a dedicated section and adjusting link anchors in `site/content/en/docs/reference/kueue-config.v1beta2.md`.

Because `main` did not have these formatting changes checked in, `pull-kueue-verify-main` failed on every incoming PR opened after the runner bump (e.g. #15285, #15286).

##### What was done to fix it
- Regenerated all targets via `make verify-tree-prereqs` inside the matching `kubekins-e2e:v20260907-7013e6a654-master` container.
- Verified that `make fmt` and `make ci-lint` run cleanly with 0 issues.

Merging this PR to `main` will unblock presubmit `make verify` for all current and upcoming PRs.

#### Useful notes for your reviewer
This change only contains machine-generated files (`client-go/applyconfiguration/` and `site/content/en/docs/reference/kueue-config.v1beta2.md`).

AI assistance disclosure: Co-authored with Antigravity following the Kubernetes AI Tool Usage Policy.

#### Release note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Regenerated client-go apply configurations and Kueue API reference documentation.
- Added the `ClusterProfileCredentialsProvider` reference section and corrected the `ClusterProfile.credentialsProviders` link.
- Aligned generated files with the Go 1.27.1 Prow CI runner.

## Release note assessment

Ready. No user-facing behavior changed, so omitting the release note is correct.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->