### PR TITLE
fix(kueueviz): fall back to same-origin when no backend URL is set

### DIFF
--- a/cmd/kueueviz/frontend/src/utils/urlHelper.js
+++ b/cmd/kueueviz/frontend/src/utils/urlHelper.js
@@ -17,18 +17,23 @@ limitations under the License.
 import { env } from "../env";
 
 /**
- * Gets the backend WebSocket URL from environment variables
+ * Gets the backend WebSocket URL from the environment variables. If neither
+ * one is set, it falls back to the origin the page was served from.
  * @returns {string} The WebSocket URL
- * @throws {Error} If no backend URL is configured
  */
 export const getBackendWebSocketUrl = () => {
   const backendUrl = env.REACT_APP_WEBSOCKET_URL || env.VITE_WEBSOCKET_URL;
-  if (!backendUrl) {
-    throw new Error(
-      "Backend URL is not configured. Please set REACT_APP_WEBSOCKET_URL or VITE_WEBSOCKET_URL."
-    );
+  // The Helm chart builds "<scheme>://<host>", so an empty backend ingress
+  // host leaves just "wss://". That string is not empty, but it has no host
+  // to build on, so treat it as if nothing was set.
+  if (backendUrl && !backendUrl.endsWith("://")) {
+    return backendUrl;
   }
-  return backendUrl;
+  // Nothing is set, so use the origin of the page itself. This works if a
+  // proxy in front of both containers sends /ws and /api to the backend. The
+  // chart does not do this: it gives them separate ingress hosts.
+  const { protocol, host } = window.location;
+  return `${protocol === "https:" ? "wss" : "ws"}://${host}`;
 };
 
 /**
@@ -43,7 +48,6 @@ export const convertWebSocketToHttp = (wsUrl) => {
 /**
  * Gets the backend HTTP URL for API calls
  * @returns {string} The HTTP URL
- * @throws {Error} If no backend URL is configured
  */
 export const getBackendHttpUrl = () => {
   const wsUrl = getBackendWebSocketUrl();

--- a/cmd/kueueviz/frontend/src/utils/urlHelper.test.js
+++ b/cmd/kueueviz/frontend/src/utils/urlHelper.test.js
@@ -36,8 +36,15 @@ import {
 // clean slate regardless of what a previous test set.
 const ENV_KEYS = ['REACT_APP_WEBSOCKET_URL', 'VITE_WEBSOCKET_URL'];
 
+// urlHelper uses the origin of the page when no backend URL is set. The
+// "node" test environment has no window, so build a fake one with only the
+// fields urlHelper reads. Keep this file on "node": under jsdom this would
+// replace the real window.
+const stubLocation = (protocol, host) => vi.stubGlobal('window', { location: { protocol, host } });
+
 beforeEach(() => {
   ENV_KEYS.forEach((key) => delete env[key]);
+  stubLocation('http:', 'dashboard.example');
 });
 
 // ---------------------------------------------------------------------------
@@ -60,15 +67,26 @@ describe('getBackendWebSocketUrl', () => {
     expect(getBackendWebSocketUrl()).toBe('ws://react-backend:8080');
   });
 
-  it('throws when neither variable is configured', () => {
-    expect(() => getBackendWebSocketUrl()).toThrow(
-      'Backend URL is not configured. Please set REACT_APP_WEBSOCKET_URL or VITE_WEBSOCKET_URL.'
-    );
+  it('falls back to the page origin when neither variable is configured', () => {
+    expect(getBackendWebSocketUrl()).toBe('ws://dashboard.example');
   });
 
-  it('throws when the configured value is an empty string', () => {
+  it('falls back to the page origin when the configured value is an empty string', () => {
     env.REACT_APP_WEBSOCKET_URL = '';
-    expect(() => getBackendWebSocketUrl()).toThrow(/not configured/);
+    expect(getBackendWebSocketUrl()).toBe('ws://dashboard.example');
+  });
+
+  it('falls back to the page origin when the configured value is a bare scheme', () => {
+    // charts/kueue/templates/kueueviz/frontend-configmap.yaml builds
+    // "<scheme>://<host>" with no default for the host, so an empty backend
+    // ingress host leaves just "wss://": not empty, but not usable either.
+    env.REACT_APP_WEBSOCKET_URL = 'wss://';
+    expect(getBackendWebSocketUrl()).toBe('ws://dashboard.example');
+  });
+
+  it('uses wss when the page is served over https', () => {
+    stubLocation('https:', 'dashboard.example');
+    expect(getBackendWebSocketUrl()).toBe('wss://dashboard.example');
   });
 });
 
@@ -111,8 +129,8 @@ describe('getBackendHttpUrl', () => {
     expect(getBackendHttpUrl()).toBe('https://backend:8080');
   });
 
-  it('propagates the "not configured" error when no backend URL is set', () => {
-    expect(() => getBackendHttpUrl()).toThrow(/not configured/);
+  it('derives an http URL from the page origin when no backend URL is set', () => {
+    expect(getBackendHttpUrl()).toBe('http://dashboard.example');
   });
 });
 
@@ -130,8 +148,8 @@ describe('buildWebSocketUrl', () => {
     expect(buildWebSocketUrl('ws/workloads')).toBe('ws://backend:8080ws/workloads');
   });
 
-  it('throws when no backend URL is configured', () => {
-    expect(() => buildWebSocketUrl('/ws/workloads')).toThrow(/not configured/);
+  it('appends the path to the page origin when no backend URL is configured', () => {
+    expect(buildWebSocketUrl('/ws/workloads')).toBe('ws://dashboard.example/ws/workloads');
   });
 });
 


### PR DESCRIPTION
<!-- Thank you for contributing! Check CONTRIBUTING.md for details. -->

#### What type of PR is this?
/kind bug
/area dashboard

<!-- Choose one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally choose one or more of the following kinds:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it?
<!--
Use `Fixes #123` for an issue addressed by this PR; it will be closed when the PR merges.
Use `Related:` or `Part of:` to reference an issue without closing it.
-->
Part of:  #12141

The KueueViz frontend reads its backend WebSocket URL from `REACT_APP_WEBSOCKET_URL` or
`VITE_WEBSOCKET_URL`. Two configurations break it:

1. `getBackendWebSocketUrl` throws before any component renders,  so the user gets a blank page instead of a dashboard.
2. `charts/kueue/templates/kueueviz/frontend-configmap.yaml` builds the URL as `"<scheme>://<host>"` from `kueueViz.backend.ingress.host`. An empty host leaves a bare `wss://`, which is truthy, so the guard passes it through. The app then connects to `wss:///ws/workloads` — a URL with no host. It fails silently.


#### Useful notes for your reviewer

#### Release note
<!-- Describe the behavior change accurately from the user's perspective. Hints:
- Do not leave this block blank.
- Use "NONE" when there is no user-facing change.
- When feasible use a prefix for the sub-component or feature, e.g. "FairSharing:" or "MultiKueue:".
- If upgrade steps are required, include an "ACTION REQUIRED:" section.
You may consider AI assistance using the skill: cmd/experimental/skills/kueue-release-notes/SKILL.md.
-->
```release-note
KueueViz: Fixed a bug where the dashboard failed to load when no backend WebSocket URL was configured.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## AI summary

KueueViz now falls back to the page origin when no backend WebSocket URL is configured. Tests cover empty and bare-scheme URLs, including `wss` for HTTPS pages.

### Release note assessment

The contributor-supplied `release-note` block was not located. Alternative release note:

> KueueViz: Load the dashboard when no backend WebSocket URL is configured by using the page origin.

Please verify this wording and update the canonical `release-note` block in the PR description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->