### PR TITLE
[release-0.18] Wire clientConnection to MultiKueue worker clusters behind FG (#15280)

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -531,6 +531,7 @@ func setupControllers(
 			multikueue.WithDispatcherName(ptr.Deref(cfg.MultiKueue.DispatcherName, configapi.MultiKueueDispatcherModeAllAtOnce)),
 			multikueue.WithClusterProfiles(cfg.MultiKueue.ClusterProfile),
 			multikueue.WithRoleTracker(opts.RoleTracker),
+			multikueue.WithClientConnection(cfg.ClientConnection),
 		); err != nil {
 			return fmt.Errorf("could not setup MultiKueue controller: %w", err)
 		}

--- a/pkg/controller/admissionchecks/multikueue/clusterqueue_test.go
+++ b/pkg/controller/admissionchecks/multikueue/clusterqueue_test.go
@@ -456,7 +456,7 @@ func TestCQReconcile(t *testing.T) {
 				Build()
 
 			adapters, _ := jobframework.GetMultiKueueAdapters(sets.New("batch/job"))
-			cRec := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, nil, nil)
+			cRec := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, nil, nil, nil)
 			cRec.rootContext = ctx
 			for worker, wState := range tc.workers {
 				workerClient := NewNeverCachingClient(utiltesting.NewClientBuilder().

--- a/pkg/controller/admissionchecks/multikueue/controllers.go
+++ b/pkg/controller/admissionchecks/multikueue/controllers.go
@@ -45,6 +45,7 @@ type SetupOptions struct {
 	dispatcherName       string
 	clusterProfileConfig *configapi.ClusterProfile
 	roleTracker          *roletracker.RoleTracker
+	clientConnection     *configapi.ClientConnection
 }
 
 type SetupOption func(o *SetupOptions)
@@ -108,6 +109,12 @@ func WithRoleTracker(tracker *roletracker.RoleTracker) SetupOption {
 	}
 }
 
+func WithClientConnection(c *configapi.ClientConnection) SetupOption {
+	return func(o *SetupOptions) {
+		o.clientConnection = c
+	}
+}
+
 func SetupControllers(mgr ctrl.Manager, namespace string, opts ...SetupOption) error {
 	options := &SetupOptions{
 		gcInterval:        defaultGCInterval,
@@ -148,7 +155,7 @@ func SetupControllers(mgr ctrl.Manager, namespace string, opts ...SetupOption) e
 		cpCreds = &NoOpClusterProfileCreds{}
 	}
 
-	cRec := newClustersReconciler(mgr.GetClient(), namespace, options.gcInterval, options.origin, fsWatcher, options.adapters, cpCreds, options.roleTracker)
+	cRec := newClustersReconciler(mgr.GetClient(), namespace, options.gcInterval, options.origin, fsWatcher, options.adapters, cpCreds, options.roleTracker, options.clientConnection)
 	err = cRec.setupWithManager(mgr)
 	if err != nil {
 		return err

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -62,6 +62,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
@@ -105,15 +106,37 @@ func retryAfter(failedAttempts uint) time.Duration {
 type clientWithWatchBuilder func(ctx context.Context, config *clientConfig, options client.Options) (SelectivelyCachingClient, error)
 
 type clientConfig struct {
-	Kubeconfig []byte
-	RestConfig *rest.Config
+	Kubeconfig       []byte
+	RestConfig       *rest.Config
+	ClientConnection *configapi.ClientConnection
+}
+
+func (c *clientConfig) initialRESTConfig() (*rest.Config, error) {
+	if c.RestConfig != nil {
+		return rest.CopyConfig(c.RestConfig), nil
+	}
+	restConfig, err := clientcmd.RESTConfigFromKubeConfig(c.Kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+	return restConfig, nil
 }
 
 func (c *clientConfig) toRESTConfig() (*rest.Config, error) {
-	if c.RestConfig != nil {
-		return c.RestConfig, nil
+	restConfig, err := c.initialRESTConfig()
+	if err != nil {
+		return nil, err
 	}
-	return clientcmd.RESTConfigFromKubeConfig(c.Kubeconfig)
+
+	if c.ClientConnection != nil && features.Enabled(features.MultiKueueReuseClientConnectionConfigForWorkers) {
+		if c.ClientConnection.QPS != nil {
+			restConfig.QPS = *c.ClientConnection.QPS
+		}
+		if c.ClientConnection.Burst != nil {
+			restConfig.Burst = int(*c.ClientConnection.Burst)
+		}
+	}
+	return restConfig, nil
 }
 
 type remoteClient struct {
@@ -781,6 +804,8 @@ type clustersReconciler struct {
 
 	logName     string
 	roleTracker *roletracker.RoleTracker
+
+	clientConnection *configapi.ClientConnection
 }
 
 type clusterProfileCreds interface {
@@ -933,7 +958,7 @@ func (c *clustersReconciler) loadClientConfig(ctx context.Context, cluster *kueu
 		if err := validateRestConfig(restConfig, opts); err != nil {
 			return nil, "BadRestConfig", err
 		}
-		return &clientConfig{RestConfig: restConfig}, "", nil
+		return &clientConfig{RestConfig: restConfig, ClientConnection: c.clientConnection}, "", nil
 	}
 
 	kubeConfig, err := c.getKubeConfig(ctx, cluster.Spec.ClusterSource.KubeConfig)
@@ -948,7 +973,7 @@ func (c *clustersReconciler) loadClientConfig(ctx context.Context, cluster *kueu
 	if err := validateKubeconfig(kubeConfig); err != nil {
 		return nil, "InsecureKubeConfig", err
 	}
-	return &clientConfig{Kubeconfig: kubeConfig}, "", nil
+	return &clientConfig{Kubeconfig: kubeConfig, ClientConnection: c.clientConnection}, "", nil
 }
 
 // validateKubeconfig checks that the provided kubeconfig content is safe to use
@@ -1143,6 +1168,7 @@ func newClustersReconciler(
 	adapters map[string]jobframework.MultiKueueAdapter,
 	cpCreds clusterProfileCreds,
 	roleTracker *roletracker.RoleTracker,
+	clientConnection *configapi.ClientConnection,
 ) *clustersReconciler {
 	return &clustersReconciler{
 		localClient:         c,
@@ -1158,6 +1184,7 @@ func newClustersReconciler(
 		clusterProfileCreds: cpCreds,
 		logName:             "multikueuecluster-reconciler",
 		roleTracker:         roleTracker,
+		clientConnection:    clientConnection,
 	}
 }
 

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -42,6 +42,7 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/utils/clock"
 	testingclock "k8s.io/utils/clock/testing"
+	"k8s.io/utils/ptr"
 	inventoryv1alpha1 "sigs.k8s.io/cluster-inventory-api/apis/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -49,6 +50,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/features"
@@ -679,7 +681,7 @@ func TestUpdateConfig(t *testing.T) {
 			c := builder.Build()
 
 			adapters, _ := jobframework.GetMultiKueueAdapters(sets.New("batch/job"))
-			reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, tc.cpCreds, nil)
+			reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, tc.cpCreds, nil, nil)
 
 			reconciler.rootContext = ctx
 
@@ -839,7 +841,7 @@ func TestReconnectBackoff(t *testing.T) {
 			c := builder.Build()
 
 			adapters, _ := jobframework.GetMultiKueueAdapters(sets.New("batch/job"))
-			reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, &testClusterProfileCreds{}, nil)
+			reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, &testClusterProfileCreds{}, nil, nil)
 			reconciler.rootContext = ctx
 
 			var buildCalls int
@@ -895,7 +897,7 @@ func TestDisconnectedClientReconnectsWithSameConfig(t *testing.T) {
 	c := builder.Build()
 
 	adapters, _ := jobframework.GetMultiKueueAdapters(sets.New("batch/job"))
-	reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, &testClusterProfileCreds{}, nil)
+	reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, &testClusterProfileCreds{}, nil, nil)
 	reconciler.rootContext = ctx
 
 	var buildCalls int
@@ -1261,7 +1263,7 @@ func TestClustersReconcilerEventFilters(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx, _ := utiltesting.ContextWithLog(t)
 			c := getClientBuilder(ctx).Build()
-			reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, newKubeConfigFSWatcher(), nil, &NoOpClusterProfileCreds{}, nil)
+			reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, newKubeConfigFSWatcher(), nil, &NoOpClusterProfileCreds{}, nil, nil)
 			reconciler.rootContext = ctx
 
 			if got := tc.invoke(reconciler); got != tc.wantReconcile {
@@ -1510,7 +1512,7 @@ func TestSetRemoteClientConfigDoesNotBlockOtherClusters(t *testing.T) {
 		WithStatusSubresource(slowCluster, fastCluster).
 		Build()
 
-	reconciler := newClustersReconciler(localClient, TestNamespace, 0, defaultOrigin, nil, nil, &NoOpClusterProfileCreds{}, nil)
+	reconciler := newClustersReconciler(localClient, TestNamespace, 0, defaultOrigin, nil, nil, &NoOpClusterProfileCreds{}, nil, nil)
 	reconciler.rootContext = ctx
 	reconciler.builderOverride = gatedBuilder
 	t.Cleanup(func() {
@@ -1650,5 +1652,179 @@ func TestStopWatchersJoinsParkedWatcher(t *testing.T) {
 	case <-stopped:
 	case <-time.After(30 * time.Second):
 		t.Fatal("StopWatchers did not return: the watcher goroutine was never joined")
+	}
+}
+
+func TestClientConfigToRESTConfig(t *testing.T) {
+	testKubeconfigData := []byte(testKubeconfig("worker1"))
+	cases := map[string]struct {
+		config            *clientConfig
+		enableFeatureGate bool
+		wantQPS           float32
+		wantBurst         int
+	}{
+		"feature disabled with Kubeconfig": {
+			config: &clientConfig{
+				Kubeconfig:       testKubeconfigData,
+				ClientConnection: &configapi.ClientConnection{QPS: ptr.To[float32](100), Burst: ptr.To[int32](200)},
+			},
+			wantQPS:   0,
+			wantBurst: 0,
+		},
+		"feature disabled with RestConfig": {
+			config: &clientConfig{
+				RestConfig:       &rest.Config{QPS: 5, Burst: 10},
+				ClientConnection: &configapi.ClientConnection{QPS: ptr.To[float32](100), Burst: ptr.To[int32](200)},
+			},
+			wantQPS:   5,
+			wantBurst: 10,
+		},
+		"feature enabled with nil ClientConnection and Kubeconfig": {
+			enableFeatureGate: true,
+			config:            &clientConfig{Kubeconfig: testKubeconfigData},
+			wantQPS:           0,
+			wantBurst:         0,
+		},
+		"feature enabled with nil ClientConnection and RestConfig": {
+			enableFeatureGate: true,
+			config:            &clientConfig{RestConfig: &rest.Config{QPS: 5, Burst: 10}},
+			wantQPS:           5,
+			wantBurst:         10,
+		},
+		"feature enabled with empty ClientConnection": {
+			enableFeatureGate: true,
+			config:            &clientConfig{Kubeconfig: testKubeconfigData, ClientConnection: &configapi.ClientConnection{}},
+			wantQPS:           0, wantBurst: 0,
+		},
+		"feature enabled with custom QPS and Burst and Kubeconfig": {
+			enableFeatureGate: true,
+			config: &clientConfig{
+				Kubeconfig:       testKubeconfigData,
+				ClientConnection: &configapi.ClientConnection{QPS: ptr.To[float32](100), Burst: ptr.To[int32](200)},
+			},
+			wantQPS: 100, wantBurst: 200,
+		},
+		"feature enabled with custom QPS and Burst and RestConfig": {
+			enableFeatureGate: true,
+			config: &clientConfig{
+				RestConfig:       &rest.Config{QPS: 5, Burst: 10},
+				ClientConnection: &configapi.ClientConnection{QPS: ptr.To[float32](100), Burst: ptr.To[int32](200)},
+			},
+			wantQPS: 100, wantBurst: 200,
+		},
+		"feature enabled with QPS-only and Kubeconfig": {
+			enableFeatureGate: true,
+			config: &clientConfig{
+				Kubeconfig:       testKubeconfigData,
+				ClientConnection: &configapi.ClientConnection{QPS: ptr.To[float32](100)},
+			},
+			wantQPS: 100, wantBurst: 0,
+		},
+		"feature enabled with QPS-only and RestConfig": {
+			enableFeatureGate: true,
+			config: &clientConfig{
+				RestConfig:       &rest.Config{Burst: 10},
+				ClientConnection: &configapi.ClientConnection{QPS: ptr.To[float32](100)},
+			},
+			wantQPS: 100, wantBurst: 10,
+		},
+		"feature enabled with Burst-only and Kubeconfig": {
+			enableFeatureGate: true,
+			config: &clientConfig{
+				Kubeconfig:       testKubeconfigData,
+				ClientConnection: &configapi.ClientConnection{Burst: ptr.To[int32](200)},
+			},
+			wantQPS: 0, wantBurst: 200,
+		},
+		"feature enabled with Burst-only and RestConfig": {
+			enableFeatureGate: true,
+			config: &clientConfig{
+				RestConfig:       &rest.Config{QPS: 5},
+				ClientConnection: &configapi.ClientConnection{Burst: ptr.To[int32](200)},
+			},
+			wantQPS: 5, wantBurst: 200,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.MultiKueueReuseClientConnectionConfigForWorkers, tc.enableFeatureGate)
+			restConfig, err := tc.config.toRESTConfig()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if restConfig.QPS != tc.wantQPS || restConfig.Burst != tc.wantBurst {
+				t.Errorf("unexpected QPS/Burst: want %v/%v, got %v/%v", tc.wantQPS, tc.wantBurst, restConfig.QPS, restConfig.Burst)
+			}
+		})
+	}
+}
+
+func TestClustersReconcilerWorkerClientConstruction(t *testing.T) {
+	cases := map[string]struct {
+		enableFeatureGate bool
+		clientConn        *configapi.ClientConnection
+		wantQPS           float32
+		wantBurst         int
+	}{
+		"feature enabled propagates configured QPS and Burst": {
+			enableFeatureGate: true,
+			clientConn:        &configapi.ClientConnection{QPS: ptr.To[float32](120), Burst: ptr.To[int32](240)},
+			wantQPS:           120,
+			wantBurst:         240,
+		},
+		"feature disabled preserves default behavior": {
+			clientConn: &configapi.ClientConnection{QPS: ptr.To[float32](120), Burst: ptr.To[int32](240)},
+			wantQPS:    0,
+			wantBurst:  0,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.MultiKueueReuseClientConnectionConfigForWorkers, tc.enableFeatureGate)
+			ctx, _ := utiltesting.ContextWithLog(t)
+			cluster := utiltestingapi.MakeMultiKueueCluster("worker1").
+				KubeConfig(kueue.SecretLocationType, "worker1").
+				Generation(1).
+				Obj()
+			secret := makeTestSecret("worker1", testKubeconfig("worker1"))
+
+			c := getClientBuilder(ctx).
+				WithObjects(cluster, &secret).
+				WithStatusSubresource(&kueue.MultiKueueCluster{}).
+				Build()
+
+			adapters, _ := jobframework.GetMultiKueueAdapters(sets.New("batch/job"))
+			reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, &NoOpClusterProfileCreds{}, nil, tc.clientConn)
+			reconciler.rootContext = ctx
+
+			var constructedRESTConfig *rest.Config
+			reconciler.builderOverride = func(builderCtx context.Context, cfg *clientConfig, opts client.Options) (SelectivelyCachingClient, error) {
+				var err error
+				constructedRESTConfig, err = cfg.toRESTConfig()
+				if err != nil {
+					return nil, err
+				}
+				return fakeClientBuilder(ctx)(builderCtx, cfg, opts)
+			}
+
+			if _, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "worker1"}}); err != nil {
+				t.Fatalf("unexpected reconcile error: %v", err)
+			}
+
+			rc, found := reconciler.remoteClients["worker1"]
+			if !found {
+				t.Fatalf("expected remote client for worker1 to be registered")
+			}
+			defer rc.StopWatchers()
+
+			if constructedRESTConfig == nil {
+				t.Fatalf("expected worker-client builder to be invoked")
+			}
+			if constructedRESTConfig.QPS != tc.wantQPS || constructedRESTConfig.Burst != tc.wantBurst {
+				t.Errorf("unexpected constructed client QPS/Burst: want %v/%v, got %v/%v", tc.wantQPS, tc.wantBurst, constructedRESTConfig.QPS, constructedRESTConfig.Burst)
+			}
+		})
 	}
 }

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -2116,7 +2116,7 @@ func TestWlReconcile(t *testing.T) {
 
 				managerClient := managerBuilder.Build()
 				adapters, _ := jobframework.GetMultiKueueAdapters(sets.New("batch/job"))
-				cRec := newClustersReconciler(managerClient, TestNamespace, 0, defaultOrigin, nil, adapters, nil, nil)
+				cRec := newClustersReconciler(managerClient, TestNamespace, 0, defaultOrigin, nil, adapters, nil, nil, nil)
 
 				worker1Client := NewNeverCachingClient(getClientBuilder(ctx).
 					WithLists(&kueue.WorkloadList{Items: tc.worker1Workloads}, &batchv1.JobList{Items: tc.worker1Jobs}).
@@ -2298,7 +2298,7 @@ func TestOrphanedRemoteWorkloadCleanedAfterReconnect(t *testing.T) {
 	managerClient := managerBuilder.Build()
 
 	adapters, _ := jobframework.GetMultiKueueAdapters(sets.New("batch/job"))
-	cRec := newClustersReconciler(managerClient, TestNamespace, 0, defaultOrigin, nil, adapters, nil, nil)
+	cRec := newClustersReconciler(managerClient, TestNamespace, 0, defaultOrigin, nil, adapters, nil, nil, nil)
 
 	w1remoteClient := newRemoteClient(managerClient, nil, nil, nil, defaultOrigin, "", adapters)
 	w1remoteClient.client = NewNeverCachingClient(getClientBuilder(ctx).

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -660,6 +660,12 @@ const (
 	// Note: This feature can be promoted to "beta" once https://github.com/kubernetes-sigs/kueue/issues/14543
 	// is fixed because it might boost chances for issue #14543 to appear.
 	FairSharingReevaluatePreemptionCandidates featuregate.Feature = "FairSharingReevaluatePreemptionCandidates"
+
+	// owner: @alien1403
+	// issue: https://github.com/kubernetes-sigs/kueue/issues/14973
+	//
+	// Reuse clientConnection (QPS and Burst) for MultiKueue worker clusters instead of creating a new client for each request.
+	MultiKueueReuseClientConnectionConfigForWorkers featuregate.Feature = "MultiKueueReuseClientConnectionConfigForWorkers"
 )
 
 func init() {
@@ -1004,6 +1010,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 
 	FairSharingReevaluatePreemptionCandidates: {
+		{Version: version.MustParse("0.18"), Default: false, PreRelease: featuregate.Alpha},
+	},
+
+	MultiKueueReuseClientConnectionConfigForWorkers: {
 		{Version: version.MustParse("0.18"), Default: false, PreRelease: featuregate.Alpha},
 	},
 }

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -315,6 +315,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.18"
+- name: MultiKueueReuseClientConnectionConfigForWorkers
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.18"
 - name: MultiKueueWaitForWorkloadAdmitted
   versionedSpecs:
   - default: true

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -315,6 +315,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.18"
+- name: MultiKueueReuseClientConnectionConfigForWorkers
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.18"
 - name: MultiKueueWaitForWorkloadAdmitted
   versionedSpecs:
   - default: true


### PR DESCRIPTION
Cherry-pick of #15280 on `release-0.18`.

#### What type of PR is this?
/kind feature
/area multikueue

#### What this PR does / why we need it?
Cherry-pick of #15280 to reuse `clientConnection` settings for MultiKueue worker clusters.

The feature gate `MultiKueueReuseClientConnectionConfigForWorkers` is configured as Alpha (`Default: false`, `Version: "0.18"`).

#### Which issue(s) this PR fixes:

Related: #14973

#### Useful notes for your reviewer
Feature gate is set to Alpha (disabled by default) for 0.18.

#### Release note
```release-note
MultiKueue: Added support for reusing clientConnection configuration (QPS and Burst) for worker clusters via the `MultiKueueReuseClientConnectionConfigForWorkers` Alpha feature gate.
```