### PR TITLE
kueuectl: Do not list all Workloads when the --for object is not found

### DIFF
--- a/cmd/kueuectl/app/list/list_workload.go
+++ b/cmd/kueuectl/app/list/list_workload.go
@@ -110,6 +110,9 @@ func NewWorkloadCmd(clientGetter clientgetter.ClientGetter, streams genericioopt
 			if err != nil {
 				return err
 			}
+			if o.UserSpecifiedForObject != "" && o.forObject == nil {
+				return nil
+			}
 			return o.Run(cmd.Context())
 		},
 	}

--- a/cmd/kueuectl/app/list/list_workload_test.go
+++ b/cmd/kueuectl/app/list/list_workload_test.go
@@ -866,6 +866,40 @@ wl2               j2         lq2          cq2            PENDING   22           
 		"should print not found error": {
 			wantOutErr: fmt.Sprintf("No resources found in %s namespace.\n", metav1.NamespaceDefault),
 		},
+		"should not print workloads when the --for object is not found": {
+			args: []string{"--for", "job.batch/job-test"},
+			apiResourceLists: []*metav1.APIResourceList{
+				{
+					GroupVersion: "batch/v1",
+					APIResources: []metav1.APIResource{
+						{
+							SingularName: "job",
+							Kind:         "Job",
+							Group:        "batch",
+						},
+					},
+				},
+			},
+			objs: []runtime.Object{
+				utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).
+					Queue("lq1").
+					Active(true).
+					Creation(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)).
+					Obj(),
+				utiltestingapi.MakeWorkload("wl2", metav1.NamespaceDefault).
+					Queue("lq2").
+					Active(true).
+					Creation(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
+					Obj(),
+			},
+			mapperKinds: []schema.GroupVersionKind{
+				batchv1.SchemeGroupVersion.WithKind("Job"),
+			},
+			job: []runtime.Object{
+				&batchv1.JobList{},
+			},
+			wantOutErr: fmt.Sprintf("No resources found in %s namespace.\n", metav1.NamespaceDefault),
+		},
 		"should print not found error with all-namespaces filter": {
 			args:       []string{"-A"},
 			wantOutErr: "No resources found\n",


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When `kueuectl list workload --for TYPE/NAME` targets an object that does not exist, the command prints `No resources found` to stderr and then lists every Workload in the namespace anyway. `Complete` returns `nil` with `forObject` unset, and `Run` treats a nil `forObject` as "no filter requested".

This PR skips `Run` when `--for` was given but the object was not resolved, so only the not-found message is printed. This matches the existing guard in `kueuectl list pods`.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

- The guard checks both `UserSpecifiedForObject != ""` and `forObject == nil`, because `--for` is optional for `list workload` and a nil `forObject` alone also means "no `--for` given".
- The new unit test feeds an empty `JobList` through the fake REST client to simulate a missing Job; without the fix it prints both Workloads.

#### Does this PR introduce a user-facing change?

```release-note
kueuectl: Fixed a bug where `kueuectl list workload --for TYPE/NAME` could list all Workloads in the namespace when the referenced object did not exist. The command now prints only the not-found message.
```