### PR TITLE
kueuectl: Accept decimal quantities in create clusterqueue quota flags

### DIFF
--- a/cmd/kueuectl/app/create/create_clusterqueue.go
+++ b/cmd/kueuectl/app/create/create_clusterqueue.go
@@ -315,7 +315,7 @@ func (o *ClusterQueueOptions) parseResourceGroups() error {
 func parseUserSpecifiedResourceQuotas(resources []string, quotaType string) ([]kueue.ResourceGroup, error) {
 	var resourceGroups []kueue.ResourceGroup
 
-	regex := regexp.MustCompile(`^([a-z0-9][a-z0-9\-\.]{0,252}):((\w+[\.-]?)*\/?\w+=\w+;)*(\w+[\.-]?)*\/?\w+=\w+;?$`)
+	regex := regexp.MustCompile(`^([a-z0-9][a-z0-9\-\.]{0,252}):((\w+[\.-]?)*\/?\w+=[\w.]+;)*(\w+[\.-]?)*\/?\w+=[\w.]+;?$`)
 	for _, r := range resources {
 		if !regex.MatchString(r) {
 			return resourceGroups, errInvalidResourcesSpec

--- a/cmd/kueuectl/app/create/create_clusterqueue_test.go
+++ b/cmd/kueuectl/app/create/create_clusterqueue_test.go
@@ -325,6 +325,21 @@ func TestParseResourceQuotas(t *testing.T) {
 			borrowingArgs: []string{"alpha:example.com/gpu=2"},
 			wantErr:       errInvalidFlavor,
 		},
+		"should create one resource group with decimal quantities": {
+			quotaArgs:     []string{"alpha:cpu=1.5;memory=1.5Gi"},
+			borrowingArgs: []string{"alpha:cpu=0.5;memory=2Gi"},
+			wantResourceGroups: []kueue.ResourceGroup{
+				{
+					CoveredResources: []corev1.ResourceName{"cpu", "memory"},
+					Flavors: []kueue.FlavorQuotas{
+						*utiltestingapi.MakeFlavorQuotas("alpha").
+							Resource("cpu", "1.5", "0.5").
+							Resource("memory", "1.5Gi", "2Gi").
+							Obj(),
+					},
+				},
+			},
+		},
 		"should fail when invalid resource quotas": {
 			quotaArgs: []string{"alpha:cpu=;memory=1"},
 			wantErr:   errInvalidResourcesSpec,
@@ -343,6 +358,10 @@ func TestParseResourceQuotas(t *testing.T) {
 		},
 		"should fail when invalid quantity": {
 			quotaArgs: []string{"alpha:cpu=a;memory=1"},
+			wantErr:   errInvalidResourceQuota,
+		},
+		"should fail when invalid decimal quantity": {
+			quotaArgs: []string{"alpha:cpu=1.5.5;memory=1"},
 			wantErr:   errInvalidResourceQuota,
 		},
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`kueuectl create clusterqueue` rejects valid decimal quantities such as `--nominal-quota "alpha:cpu=1.5;memory=1.5Gi"` with `invalid resources specification`. The regular expression that pre-validates `--nominal-quota`, `--borrowing-limit` and `--lending-limit` only allows `\w+` for the value, so anything containing a dot never reaches `resource.ParseQuantity`. Users had to rewrite `1.5` as `1500m`, which is inconsistent with `kubectl` and YAML manifests.

This PR allows dots in the value part of the regular expression and leaves the actual quantity validation to `resource.ParseQuantity`.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

- The regex change is intentionally minimal (`\w+` to `[\w.]+`); malformed values like `1.5.5` still fail, now with `invalid resource quota` from `resource.ParseQuantity` instead of the regex.

#### Does this PR introduce a user-facing change?

```release-note
CLI: Fixed a bug where `kueuectl create clusterqueue` rejected valid decimal quantities such as `cpu=1.5` or `memory=1.5Gi` in `--nominal-quota`, `--borrowing-limit` and `--lending-limit` with `invalid resources specification`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## AI summary

`kueuectl create clusterqueue` now accepts decimal quantities in quota flags, such as `cpu=1.5` and `memory=1.5Gi`. Invalid quantities, such as `1.5.5`, remain rejected. Tests cover both cases.

### Release note assessment

The contributor-supplied `release-note` block was not found. Add and verify this release note in the PR description:

```release-note
kueuectl: Allow decimal quantities in clusterqueue quota flags.
```

This note describes the user-facing change. Please update the canonical `release-note` block.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->