### PR TITLE
Fix: share one rate limiter across per-worker MultiKueue REST clients

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -47,6 +47,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/events"
+	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
@@ -132,11 +133,31 @@ func (c *clientConfig) toRESTConfig() (*rest.Config, error) {
 	}
 
 	if c.ClientConnection != nil && features.Enabled(features.MultiKueueReuseClientConnectionConfigForWorkers) {
-		if c.ClientConnection.QPS != nil {
+		hasQPS := c.ClientConnection.QPS != nil
+		hasBurst := c.ClientConnection.Burst != nil
+		if hasQPS {
 			restConfig.QPS = *c.ClientConnection.QPS
 		}
-		if c.ClientConnection.Burst != nil {
+		if hasBurst {
 			restConfig.Burst = int(*c.ClientConnection.Burst)
+		}
+		if hasQPS || hasBurst {
+			// The direct client and remote cache are built from this config, so setting
+			// the limiter here makes both consume the same per-cluster request budget.
+			// It must replace an existing limiter because rest.Config ignores QPS and
+			// Burst when RateLimiter is already set.
+			restConfig.RateLimiter = nil
+			if restConfig.QPS >= 0 {
+				qps := restConfig.QPS
+				if qps == 0 {
+					qps = rest.DefaultQPS
+				}
+				burst := restConfig.Burst
+				if burst == 0 {
+					burst = rest.DefaultBurst
+				}
+				restConfig.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(qps, burst)
+			}
 		}
 	}
 	return restConfig, nil

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/utils/clock"
 	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
@@ -1838,11 +1839,14 @@ func TestStopWatchersJoinsParkedWatcher(t *testing.T) {
 
 func TestClientConfigToRESTConfig(t *testing.T) {
 	testKubeconfigData := []byte(testKubeconfig("worker1"))
+	existingRateLimiter := flowcontrol.NewFakeNeverRateLimiter()
 	cases := map[string]struct {
-		config            *clientConfig
-		enableFeatureGate bool
-		wantQPS           float32
-		wantBurst         int
+		config                  *clientConfig
+		enableFeatureGate       bool
+		wantQPS                 float32
+		wantBurst               int
+		wantRateLimiter         bool
+		wantRateLimiterReplaced bool
 	}{
 		"feature disabled with Kubeconfig": {
 			config: &clientConfig{
@@ -1883,7 +1887,7 @@ func TestClientConfigToRESTConfig(t *testing.T) {
 				Kubeconfig:       testKubeconfigData,
 				ClientConnection: &configapi.ClientConnection{QPS: ptr.To[float32](100), Burst: ptr.To[int32](200)},
 			},
-			wantQPS: 100, wantBurst: 200,
+			wantQPS: 100, wantBurst: 200, wantRateLimiter: true,
 		},
 		"feature enabled with custom QPS and Burst and RestConfig": {
 			enableFeatureGate: true,
@@ -1891,7 +1895,7 @@ func TestClientConfigToRESTConfig(t *testing.T) {
 				RestConfig:       &rest.Config{QPS: 5, Burst: 10},
 				ClientConnection: &configapi.ClientConnection{QPS: ptr.To[float32](100), Burst: ptr.To[int32](200)},
 			},
-			wantQPS: 100, wantBurst: 200,
+			wantQPS: 100, wantBurst: 200, wantRateLimiter: true,
 		},
 		"feature enabled with QPS-only and Kubeconfig": {
 			enableFeatureGate: true,
@@ -1899,7 +1903,7 @@ func TestClientConfigToRESTConfig(t *testing.T) {
 				Kubeconfig:       testKubeconfigData,
 				ClientConnection: &configapi.ClientConnection{QPS: ptr.To[float32](100)},
 			},
-			wantQPS: 100, wantBurst: 0,
+			wantQPS: 100, wantBurst: 0, wantRateLimiter: true,
 		},
 		"feature enabled with QPS-only and RestConfig": {
 			enableFeatureGate: true,
@@ -1907,7 +1911,7 @@ func TestClientConfigToRESTConfig(t *testing.T) {
 				RestConfig:       &rest.Config{Burst: 10},
 				ClientConnection: &configapi.ClientConnection{QPS: ptr.To[float32](100)},
 			},
-			wantQPS: 100, wantBurst: 10,
+			wantQPS: 100, wantBurst: 10, wantRateLimiter: true,
 		},
 		"feature enabled with Burst-only and Kubeconfig": {
 			enableFeatureGate: true,
@@ -1915,7 +1919,7 @@ func TestClientConfigToRESTConfig(t *testing.T) {
 				Kubeconfig:       testKubeconfigData,
 				ClientConnection: &configapi.ClientConnection{Burst: ptr.To[int32](200)},
 			},
-			wantQPS: 0, wantBurst: 200,
+			wantQPS: 0, wantBurst: 200, wantRateLimiter: true,
 		},
 		"feature enabled with Burst-only and RestConfig": {
 			enableFeatureGate: true,
@@ -1923,7 +1927,23 @@ func TestClientConfigToRESTConfig(t *testing.T) {
 				RestConfig:       &rest.Config{QPS: 5},
 				ClientConnection: &configapi.ClientConnection{Burst: ptr.To[int32](200)},
 			},
-			wantQPS: 5, wantBurst: 200,
+			wantQPS: 5, wantBurst: 200, wantRateLimiter: true,
+		},
+		"feature enabled replaces existing RateLimiter": {
+			enableFeatureGate: true,
+			config: &clientConfig{
+				RestConfig:       &rest.Config{QPS: 5, Burst: 10, RateLimiter: existingRateLimiter},
+				ClientConnection: &configapi.ClientConnection{Burst: ptr.To[int32](200)},
+			},
+			wantQPS: 5, wantBurst: 200, wantRateLimiter: true, wantRateLimiterReplaced: true,
+		},
+		"feature enabled with negative QPS disables rate limiting": {
+			enableFeatureGate: true,
+			config: &clientConfig{
+				Kubeconfig:       testKubeconfigData,
+				ClientConnection: &configapi.ClientConnection{QPS: ptr.To[float32](-1), Burst: ptr.To[int32](200)},
+			},
+			wantQPS: -1, wantBurst: 200,
 		},
 	}
 
@@ -1937,7 +1957,41 @@ func TestClientConfigToRESTConfig(t *testing.T) {
 			if restConfig.QPS != tc.wantQPS || restConfig.Burst != tc.wantBurst {
 				t.Errorf("unexpected QPS/Burst: want %v/%v, got %v/%v", tc.wantQPS, tc.wantBurst, restConfig.QPS, restConfig.Burst)
 			}
+			if got := restConfig.RateLimiter != nil; got != tc.wantRateLimiter {
+				t.Errorf("unexpected RateLimiter presence: want %t, got %t", tc.wantRateLimiter, got)
+			}
+			if tc.wantRateLimiterReplaced && restConfig.RateLimiter == tc.config.RestConfig.RateLimiter {
+				t.Error("expected configured QPS/Burst to replace the existing RateLimiter")
+			}
 		})
+	}
+}
+
+func TestClientConfigRateLimiterSharedAcrossRESTConfigCopies(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.MultiKueueReuseClientConnectionConfigForWorkers, true)
+	config := &clientConfig{
+		Kubeconfig: []byte(testKubeconfig("worker1")),
+		ClientConnection: &configapi.ClientConnection{
+			QPS:   ptr.To[float32](0.0001),
+			Burst: ptr.To[int32](1),
+		},
+	}
+
+	restConfig, err := config.toRESTConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	directClientConfig := rest.CopyConfig(restConfig)
+	cacheConfig := rest.CopyConfig(restConfig)
+
+	if directClientConfig.RateLimiter != cacheConfig.RateLimiter {
+		t.Fatal("expected direct client and remote cache configs to share the same RateLimiter")
+	}
+	if !directClientConfig.RateLimiter.TryAccept() {
+		t.Fatal("expected the shared RateLimiter to allow its initial request")
+	}
+	if cacheConfig.RateLimiter.TryAccept() {
+		t.Fatal("expected the remote cache to observe the token consumed by the direct client")
 	}
 }
 
@@ -1947,12 +2001,14 @@ func TestClustersReconcilerWorkerClientConstruction(t *testing.T) {
 		clientConn        *configapi.ClientConnection
 		wantQPS           float32
 		wantBurst         int
+		wantRateLimiter   bool
 	}{
 		"feature enabled propagates configured QPS and Burst": {
 			enableFeatureGate: true,
 			clientConn:        &configapi.ClientConnection{QPS: ptr.To[float32](120), Burst: ptr.To[int32](240)},
 			wantQPS:           120,
 			wantBurst:         240,
+			wantRateLimiter:   true,
 		},
 		"feature disabled preserves default behavior": {
 			clientConn: &configapi.ClientConnection{QPS: ptr.To[float32](120), Burst: ptr.To[int32](240)},
@@ -2005,6 +2061,9 @@ func TestClustersReconcilerWorkerClientConstruction(t *testing.T) {
 			}
 			if constructedRESTConfig.QPS != tc.wantQPS || constructedRESTConfig.Burst != tc.wantBurst {
 				t.Errorf("unexpected constructed client QPS/Burst: want %v/%v, got %v/%v", tc.wantQPS, tc.wantBurst, constructedRESTConfig.QPS, constructedRESTConfig.Burst)
+			}
+			if got := constructedRESTConfig.RateLimiter != nil; got != tc.wantRateLimiter {
+				t.Errorf("unexpected constructed client RateLimiter presence: want %t, got %t", tc.wantRateLimiter, got)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- Thank you for contributing! Check CONTRIBUTING.md for details. -->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it?

Previously, `toRESTConfig` only propagated the configured QPS and Burst values:

```
restConfig.QPS = qps
restConfig.Burst = burst
```

It did not initialize  restConfig.RateLimiter

The resulting configuration was then used by multiple client construction paths, including:

1. Direct MultiKueue client
```
// pkg/controller/admissionchecks/multikueue/multikueuecluster.go:279
client.NewWithWatch(restConfig, options)
```

2. Remote cache used by quota automation
```
// pkg/controller/admissionchecks/multikueue/remote_client.go:128
cache.New(restConfig, cache.Options{Scheme: scheme})
```

When `RateLimiter` is nil, the downstream client-go and controller-runtime code can create independent token-bucket rate limiters for their derived REST clients. 

Although every limiter uses the same QPS and Burst values, each maintains a separate request budget.


For example, an administrator could configure the Kueue controller through Helm with:

```
apiVersion: config.kueue.x-k8s.io/v1beta2
kind: Configuration
clientConnection:
  qps: 50
  burst: 100
```

This configuration is expected to limit MultiKueue traffic to a worker cluster to one shared budget of 50 QPS with a burst of 100. Instead, multiple independently constructed REST clients can each receive that budget, allowing aggregate traffic to exceed the configured limit.

A single rate limiter should be created per worker cluster and shared by all clients derived from that worker’s REST configuration.


#### Useful notes for your reviewer

#### Release note
<!-- Describe the behavior change accurately from the user's perspective. Hints:
- Do not leave this block blank.
- Use "NONE" when there is no user-facing change.
- When feasible use a prefix for the sub-component or feature, e.g. "FairSharing:" or "MultiKueue:".
- If upgrade steps are required, include an "ACTION REQUIRED:" section.
You may consider AI assistance using the skill: cmd/experimental/skills/kueue-release-notes/SKILL.md.
-->
```release-note
MultiKueue: share one rate limiter across per-worker MultiKueue REST clients.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## AI summary

MultiKueue now shares one rate limiter across REST clients for each worker cluster. This prevents clients from exceeding configured QPS and burst limits.

### Release note assessment

No contributor-supplied `release-note` block was found.

Alternative:

```release-note
MultiKueue: Share one rate limiter across worker-cluster REST clients to enforce configured request limits.
```

This states the user-visible bug fix and uses the narrowest applicable prefix. Please verify this wording and update the canonical `release-note` block in the PR description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->