### PR TITLE
Improve the CodeRabbit instructions wrt release notes

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -13,23 +13,26 @@ reviews:
   high_level_summary_instructions: |
     Keep the PR summary concise. Name the section "AI summary".
 
-    Add the "Release note assessment" sub-section that reviews the author's
-    `release-note` code block. Search it under the "Release note" section.
+    Add a "Suggested release note" sub-section with a release note suggestion describing
+    the user-facing change introduced by this PR.
 
-    If the existing release note accurately describes the user-facing change,
-    say "Ready". This includes `NONE` when there is no user-facing change.
-
-    Otherwise, or if you cannot locate the contributor supplied release note, provide
-    one alternative release note and briefly justify the adjustments.
-
-    Instructions:
-    * If the impact is unclear, ask one focused question instead of guessing.
-    * When feasible, use the narrowest applicable feature or sub-component prefix,
-      e.g. `FairSharing:`, `MultiKueue:`, or `TAS:`.
+    Follow the release-note guidance in cmd/experimental/skills/kueue-release-notes/SKILL.md.
+    In particular:
+    * Describe the user-facing behavior change rather than implementation details.
+    * For bug fixes, prefer wording such as: <ScopingPrefix>: Fixed a bug that caused
+      [<incorrect behavior>] when <scenario>. Now Kueue <correct behavior>.
+    * When feasible, use the corresponding feature or sub-component name as the scoping prefix.
+      Examples: `FairSharing:`, `MultiKueue:`, `Observability:`, `TAS:`, `Workloads:`.
+      For integrations you may use the integration name as prefix, eg. `JobSet:`.
+    * Treat logs, metrics, events, and visibility endpoints as user-facing observability changes.
+    * If the behavior change is controlled by a feature gate, mention that, e.g.
+      This behavior is gated by the <FeatureGate> feature gate.
+      Do not state whether the feature gate is enabled or disabled by default,
+      as this may differ across release branches and cherry-picks.
+    * Use `NONE` when there is no user-facing change.
     * Use `ACTION REQUIRED:` only when users must take action when upgrading.
 
-    Ask the author to verify the alternative and update the canonical
-    `release-note` block in the PR description.
+    If the user-facing impact cannot be determined, state that instead instead of guessing.
 
   path_filters:
     - "!client-go/**"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -32,7 +32,7 @@ reviews:
     * Use `NONE` when there is no user-facing change.
     * Use `ACTION REQUIRED:` only when users must take action when upgrading.
 
-    If the user-facing impact cannot be determined, state that instead instead of guessing.
+    If the user-facing impact cannot be determined, state that instead of guessing.
 
   path_filters:
     - "!client-go/**"


### PR DESCRIPTION
<!-- Thank you for contributing! Check CONTRIBUTING.md for details. -->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it?
<!--
Use `Fixes #123` for an issue addressed by this PR; it will be closed when the PR merges.
Use `Related:` or `Part of:` to reference an issue without closing it.
-->

This is a proposal to fix the issue with CodeRabbit not seeing the release notes proposed by contributors, 
for example

#### Useful notes for your reviewer

Example: https://github.com/kubernetes-sigs/kueue/pull/15293

CodeRabbit just says: "The contributor-supplied release-note block was not located.".

So instead of reviewing the release note I propose to suggest an alternative.

#### Release note
<!-- Describe the behavior change accurately from the user's perspective. Hints:
- Do not leave this block blank.
- Use "NONE" when there is no user-facing change.
- When feasible use a prefix for the sub-component or feature, e.g. "FairSharing:" or "MultiKueue:".
- If upgrade steps are required, include an "ACTION REQUIRED:" section.
You may consider AI assistance using the skill: cmd/experimental/skills/kueue-release-notes/SKILL.md.
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## AI summary

Updated `.coderabbit.yaml` to request a suggested release note based on the PR's user-facing impact.

### Release note assessment

The contributor-provided `release-note` block was not located. Suggested release note:

```text
NONE
```

This change updates review instructions only. Please verify this alternative and update the canonical `release-note` block in the PR description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->