### PR TITLE
Added options struct for newClustersReconciler

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/clusterqueue_test.go
+++ b/pkg/controller/admissionchecks/multikueue/clusterqueue_test.go
@@ -457,7 +457,7 @@ func TestCQReconcile(t *testing.T) {
 
 			adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("batch/job"))
 			recorder := &utiltesting.EventRecorder{}
-			cRec := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, nil, nil, recorder, nil)
+			cRec := newClustersReconciler(c, TestNamespace, withAdapters(adapters), withEventRecorder(recorder))
 			cRec.rootContext = ctx
 			for worker, wState := range tc.workers {
 				workerClient := NewNeverCachingClient(utiltesting.NewClientBuilder().

--- a/pkg/controller/admissionchecks/multikueue/controllers.go
+++ b/pkg/controller/admissionchecks/multikueue/controllers.go
@@ -160,10 +160,16 @@ func SetupControllers(mgr ctrl.Manager, namespace string, opts ...SetupOption) e
 	}
 
 	cRec := newClustersReconciler(
-		mgr.GetClient(), namespace, options.gcInterval, options.origin, fsWatcher,
-		options.adapters, cpAccessProvider, options.roleTracker,
-		mgr.GetEventRecorder("multikueue-cluster"),
-		options.clientConnection,
+		mgr.GetClient(),
+		namespace,
+		withGCInterval(options.gcInterval),
+		withOrigin(options.origin),
+		withFSWatcher(fsWatcher),
+		withAdapters(options.adapters),
+		withClusterProfileAccessProvider(cpAccessProvider),
+		withRoleTracker(options.roleTracker),
+		withEventRecorder(mgr.GetEventRecorder("multikueue-cluster")),
+		withClientConnection(options.clientConnection),
 	)
 	err = cRec.setupWithManager(mgr)
 	if err != nil {

--- a/pkg/controller/admissionchecks/multikueue/metrics_test.go
+++ b/pkg/controller/admissionchecks/multikueue/metrics_test.go
@@ -81,7 +81,7 @@ func TestCQReconcilerReportsClusterStatusMetric(t *testing.T) {
 		Build()
 	helper, _ := admissioncheck.NewMultiKueueStoreHelper(c)
 	adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("batch/job"))
-	cRec := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, nil, nil, &utiltesting.EventRecorder{}, nil)
+	cRec := newClustersReconciler(c, TestNamespace, withAdapters(adapters), withEventRecorder(&utiltesting.EventRecorder{}))
 	reconciler := newCQReconciler(c, helper, cRec, nil, 100*time.Millisecond)
 
 	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cq1"}}
@@ -209,7 +209,7 @@ func TestCQReconcilerKeepsClusterStatusMetricOnReadError(t *testing.T) {
 				Build()
 			helper, _ := admissioncheck.NewMultiKueueStoreHelper(c)
 			adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("batch/job"))
-			cRec := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, nil, nil, &utiltesting.EventRecorder{}, nil)
+			cRec := newClustersReconciler(c, TestNamespace, withAdapters(adapters), withEventRecorder(&utiltesting.EventRecorder{}))
 			reconciler := newCQReconciler(c, helper, cRec, nil, 100*time.Millisecond)
 
 			req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cq1"}}
@@ -261,7 +261,7 @@ func TestCQReconcilerClearsClusterStatusMetricPerClusterQueue(t *testing.T) {
 		Build()
 	helper, _ := admissioncheck.NewMultiKueueStoreHelper(c)
 	adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("batch/job"))
-	cRec := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, nil, nil, &utiltesting.EventRecorder{}, nil)
+	cRec := newClustersReconciler(c, TestNamespace, withAdapters(adapters), withEventRecorder(&utiltesting.EventRecorder{}))
 	reconciler := newCQReconciler(c, helper, cRec, nil, 100*time.Millisecond)
 
 	req1 := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cq1"}}

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -1257,35 +1257,98 @@ func (c *clustersReconciler) getRemoteClients() []*remoteClient {
 // +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=multikueueclusters,verbs=get;list;watch
 // +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=multikueueclusters/status,verbs=get;update;patch
 
+type clustersReconcilerOptions struct {
+	gcInterval                   time.Duration
+	origin                       string
+	fsWatcher                    *KubeConfigFSWatcher
+	adapters                     map[string]jobframework.MultiKueueAdapter
+	clusterProfileAccessProvider clusterProfileAccessProvider
+	roleTracker                  *roletracker.RoleTracker
+	recorder                     events.EventRecorder
+	clientConnection             *configapi.ClientConnection
+}
+
+type clustersReconcilerOption func(*clustersReconcilerOptions)
+
+func withGCInterval(gcInterval time.Duration) clustersReconcilerOption {
+	return func(o *clustersReconcilerOptions) {
+		o.gcInterval = gcInterval
+	}
+}
+
+func withOrigin(origin string) clustersReconcilerOption {
+	return func(o *clustersReconcilerOptions) {
+		o.origin = origin
+	}
+}
+
+func withFSWatcher(fsWatcher *KubeConfigFSWatcher) clustersReconcilerOption {
+	return func(o *clustersReconcilerOptions) {
+		o.fsWatcher = fsWatcher
+	}
+}
+
+func withAdapters(adapters map[string]jobframework.MultiKueueAdapter) clustersReconcilerOption {
+	return func(o *clustersReconcilerOptions) {
+		o.adapters = adapters
+	}
+}
+
+func withClusterProfileAccessProvider(cpAccessProvider clusterProfileAccessProvider) clustersReconcilerOption {
+	return func(o *clustersReconcilerOptions) {
+		o.clusterProfileAccessProvider = cpAccessProvider
+	}
+}
+
+func withRoleTracker(roleTracker *roletracker.RoleTracker) clustersReconcilerOption {
+	return func(o *clustersReconcilerOptions) {
+		o.roleTracker = roleTracker
+	}
+}
+
+func withEventRecorder(recorder events.EventRecorder) clustersReconcilerOption {
+	return func(o *clustersReconcilerOptions) {
+		o.recorder = recorder
+	}
+}
+
+func withClientConnection(clientConnection *configapi.ClientConnection) clustersReconcilerOption {
+	return func(o *clustersReconcilerOptions) {
+		o.clientConnection = clientConnection
+	}
+}
+
 func newClustersReconciler(
 	c client.Client,
 	namespace string,
-	gcInterval time.Duration,
-	origin string,
-	fsWatcher *KubeConfigFSWatcher,
-	adapters map[string]jobframework.MultiKueueAdapter,
-	cpAccessProvider clusterProfileAccessProvider,
-	roleTracker *roletracker.RoleTracker,
-	recorder events.EventRecorder,
-	clientConnection *configapi.ClientConnection,
+	opts ...clustersReconcilerOption,
 ) *clustersReconciler {
+	options := clustersReconcilerOptions{
+		origin: defaultOrigin,
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
+	if options.clusterProfileAccessProvider == nil {
+		options.clusterProfileAccessProvider = &NoOpClusterProfileAccessProvider{}
+	}
 	return &clustersReconciler{
 		localClient:                  c,
 		configNamespace:              namespace,
 		kubeConfigPathPrefix:         defaultKubeConfigPathPrefix,
-		recorder:                     recorder,
+		recorder:                     options.recorder,
 		remoteClients:                make(map[string]*remoteClient),
 		wlUpdateCh:                   make(chan event.GenericEvent, eventChBufferSize),
 		watchEndedCh:                 make(chan event.GenericEvent, eventChBufferSize),
 		cqUpdateCh:                   make(chan event.TypedGenericEvent[kueue.ClusterQueueReference], eventChBufferSize),
-		gcInterval:                   gcInterval,
-		origin:                       origin,
-		fsWatcher:                    fsWatcher,
-		adapters:                     adapters,
-		clusterProfileAccessProvider: cpAccessProvider,
+		gcInterval:                   options.gcInterval,
+		origin:                       options.origin,
+		fsWatcher:                    options.fsWatcher,
+		adapters:                     options.adapters,
+		clusterProfileAccessProvider: options.clusterProfileAccessProvider,
 		logName:                      "multikueue-multikueuecluster-reconciler",
-		roleTracker:                  roleTracker,
-		clientConnection:             clientConnection,
+		roleTracker:                  options.roleTracker,
+		clientConnection:             options.clientConnection,
 	}
 }
 

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -692,7 +692,11 @@ func TestUpdateConfig(t *testing.T) {
 
 			adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("batch/job"))
 			recorder := &utiltesting.EventRecorder{}
-			reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, tc.cpAccessProvider, nil, recorder, nil)
+			reconciler := newClustersReconciler(c, TestNamespace,
+				withAdapters(adapters),
+				withClusterProfileAccessProvider(tc.cpAccessProvider),
+				withEventRecorder(recorder),
+			)
 
 			reconciler.rootContext = ctx
 
@@ -868,7 +872,11 @@ func TestReconnectBackoff(t *testing.T) {
 
 			adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("batch/job"))
 			recorder := &utiltesting.EventRecorder{}
-			reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, &testClusterProfileAccessProvider{}, nil, recorder, nil)
+			reconciler := newClustersReconciler(c, TestNamespace,
+				withAdapters(adapters),
+				withClusterProfileAccessProvider(&testClusterProfileAccessProvider{}),
+				withEventRecorder(recorder),
+			)
 			reconciler.rootContext = ctx
 
 			var buildCalls int
@@ -925,7 +933,11 @@ func TestDisconnectedClientReconnectsWithSameConfig(t *testing.T) {
 
 	adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("batch/job"))
 	recorder := &utiltesting.EventRecorder{}
-	reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, &testClusterProfileAccessProvider{}, nil, recorder, nil)
+	reconciler := newClustersReconciler(c, TestNamespace,
+		withAdapters(adapters),
+		withClusterProfileAccessProvider(&testClusterProfileAccessProvider{}),
+		withEventRecorder(recorder),
+	)
 	reconciler.rootContext = ctx
 
 	var buildCalls int
@@ -1004,7 +1016,7 @@ func TestActiveConditionSurfacesBackoff(t *testing.T) {
 	managerClient := getClientBuilder(ctx).WithObjects(cluster).WithStatusSubresource(cluster).Build()
 	adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("batch/job"))
 	recorder := &utiltesting.EventRecorder{}
-	cRec := newClustersReconciler(managerClient, TestNamespace, 0, defaultOrigin, nil, adapters, &NoOpClusterProfileAccessProvider{}, nil, recorder, nil)
+	cRec := newClustersReconciler(managerClient, TestNamespace, withAdapters(adapters), withEventRecorder(recorder))
 
 	nextRetry := time.Now().Truncate(time.Second).Add(20 * time.Second)
 	rc := newRemoteClient(managerClient, nil, nil, nil, defaultOrigin, "", adapters)
@@ -1339,7 +1351,7 @@ func TestClustersReconcilerEventFilters(t *testing.T) {
 			ctx, _ := utiltesting.ContextWithLog(t)
 			c := getClientBuilder(ctx).Build()
 			recorder := &utiltesting.EventRecorder{}
-			reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, newKubeConfigFSWatcher(), nil, &NoOpClusterProfileAccessProvider{}, nil, recorder, nil)
+			reconciler := newClustersReconciler(c, TestNamespace, withFSWatcher(newKubeConfigFSWatcher()), withEventRecorder(recorder))
 			reconciler.rootContext = ctx
 
 			if got := tc.invoke(reconciler); got != tc.wantReconcile {
@@ -1589,7 +1601,7 @@ func TestSetRemoteClientConfigDoesNotBlockOtherClusters(t *testing.T) {
 		Build()
 
 	recorder := &utiltesting.EventRecorder{}
-	reconciler := newClustersReconciler(localClient, TestNamespace, 0, defaultOrigin, nil, nil, &NoOpClusterProfileAccessProvider{}, nil, recorder, nil)
+	reconciler := newClustersReconciler(localClient, TestNamespace, withEventRecorder(recorder))
 	reconciler.rootContext = ctx
 	reconciler.builderOverride = gatedBuilder
 	t.Cleanup(func() {
@@ -2033,7 +2045,11 @@ func TestClustersReconcilerWorkerClientConstruction(t *testing.T) {
 				Build()
 
 			adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("batch/job"))
-			reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, &NoOpClusterProfileAccessProvider{}, nil, &utiltesting.EventRecorder{}, tc.clientConn)
+			reconciler := newClustersReconciler(c, TestNamespace,
+				withAdapters(adapters),
+				withEventRecorder(&utiltesting.EventRecorder{}),
+				withClientConnection(tc.clientConn),
+			)
 			reconciler.rootContext = ctx
 
 			var constructedRESTConfig *rest.Config
@@ -2075,7 +2091,10 @@ func TestStopAndRemoveClusterClearsStatusMetric(t *testing.T) {
 
 	ctx, _ := utiltesting.ContextWithLog(t)
 	adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("batch/job"))
-	reconciler := newClustersReconciler(getClientBuilder(ctx).Build(), TestNamespace, 0, defaultOrigin, nil, adapters, nil, nil, &utiltesting.EventRecorder{}, nil)
+	reconciler := newClustersReconciler(getClientBuilder(ctx).Build(), TestNamespace,
+		withAdapters(adapters),
+		withEventRecorder(&utiltesting.EventRecorder{}),
+	)
 
 	// The same ClusterQueue references both workers.
 	metrics.ReportMultiKueueClusterStatus("cq1", "worker1", metav1.ConditionTrue, nil)

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -2119,7 +2119,7 @@ func TestWlReconcile(t *testing.T) {
 				managerClient := managerBuilder.Build()
 				adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("batch/job"))
 				recorder := &utiltesting.EventRecorder{}
-				cRec := newClustersReconciler(managerClient, TestNamespace, 0, defaultOrigin, nil, adapters, nil, nil, recorder, nil)
+				cRec := newClustersReconciler(managerClient, TestNamespace, withAdapters(adapters), withEventRecorder(recorder))
 
 				worker1Client := NewNeverCachingClient(getClientBuilder(ctx).
 					WithLists(&kueue.WorkloadList{Items: tc.worker1Workloads}, &batchv1.JobList{Items: tc.worker1Jobs}).
@@ -2300,7 +2300,7 @@ func TestOrphanedRemoteWorkloadCleanedAfterReconnect(t *testing.T) {
 	managerClient := managerBuilder.Build()
 
 	adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("batch/job"))
-	cRec := newClustersReconciler(managerClient, TestNamespace, 0, defaultOrigin, nil, adapters, nil, nil, nil, nil)
+	cRec := newClustersReconciler(managerClient, TestNamespace, withAdapters(adapters))
 
 	w1remoteClient := newRemoteClient(managerClient, nil, nil, nil, defaultOrigin, "", adapters)
 	w1remoteClient.client = NewNeverCachingClient(getClientBuilder(ctx).
@@ -2411,7 +2411,7 @@ func setupAdmittedMetricTest(ctx context.Context, t *testing.T, acState kueue.Ch
 		Build()
 
 	adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("batch/job"))
-	cRec := newClustersReconciler(managerClient, TestNamespace, 0, defaultOrigin, nil, adapters, nil, nil, nil, nil)
+	cRec := newClustersReconciler(managerClient, TestNamespace, withAdapters(adapters))
 
 	w1remoteClient := newRemoteClient(managerClient, nil, nil, nil, defaultOrigin, "", adapters)
 	w1remoteClient.client = NewNeverCachingClient(getClientBuilder(ctx).


### PR DESCRIPTION
<!-- Thank you for contributing! Check CONTRIBUTING.md for details. -->

#### What type of PR is this?
<!-- Choose one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally choose one or more of the following kinds:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

/kind cleanup
/area multikueue

#### What this PR does / why we need it?

Refactors `newClustersReconciler` to use functional options (`clustersReconcilerOption`) instead of a long positional argument list. This avoids having to pass multiple `nil` values across unit and integration tests and makes constructor calls cleaner and easier to extend.
<!--
Use `Fixes #123` for an issue addressed by this PR; it will be closed when the PR merges.
Use `Related:` or `Part of:` to reference an issue without closing it.
-->
Fixes #15287 

#### Useful notes for your reviewer

#### Release note
<!-- Describe the behavior change accurately from the user's perspective. Hints:
- Do not leave this block blank.
- Use "NONE" when there is no user-facing change.
- When feasible use a prefix for the sub-component or feature, e.g. "FairSharing:" or "MultiKueue:".
- If upgrade steps are required, include an "ACTION REQUIRED:" section.
You may consider AI assistance using the skill: cmd/experimental/skills/kueue-release-notes/SKILL.md.
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## AI summary

Refactors `newClustersReconciler` to use functional options. Updates production code and tests to remove long positional argument lists and repeated `nil` values. No user-facing behavior changes.

### Suggested release note

NONE
<!-- end of auto-generated comment: release notes by coderabbit.ai -->