### PR TITLE
Decompose DynamicQuotaOrchestrator reconciler into dedicated dqo subpackage

### DIFF
--- a/pkg/controller/core/core.go
+++ b/pkg/controller/core/core.go
@@ -28,6 +28,7 @@ import (
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	"sigs.k8s.io/kueue/pkg/constants"
+	"sigs.k8s.io/kueue/pkg/controller/core/dqo"
 	"sigs.k8s.io/kueue/pkg/dra"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/metrics"
@@ -135,7 +136,7 @@ func SetupControllers(mgr ctrl.Manager, qManager *qcache.Manager, cc *schdcache.
 	}
 
 	if features.Enabled(features.DynamicQuotaOrchestration) {
-		dqoRec := NewDynamicQuotaOrchestratorReconciler(mgr.GetClient(), WithDynamicQuotaOrchestratorRoleTracker(opts.RoleTracker))
+		dqoRec := dqo.NewReconciler(mgr.GetClient(), dqo.WithRoleTracker(opts.RoleTracker))
 		if err := dqoRec.SetupWithManager(mgr); err != nil {
 			return "DynamicQuotaOrchestrator", err
 		}

--- a/pkg/controller/core/dqo/discovery.go
+++ b/pkg/controller/core/dqo/discovery.go
@@ -1,0 +1,128 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dqo
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
+	utilresource "sigs.k8s.io/kueue/pkg/util/resource"
+)
+
+// reconcileDiscovery performs Phase 1 reconciliation: aggregates normalized capacities across referenced CapacityProviders.
+func (r *Reconciler) reconcileDiscovery(ctx context.Context, orchestrator *kueuealpha.DynamicQuotaOrchestrator) error {
+	aggregatedCapacity := make(map[kueuealpha.ResourceFlavorReference]corev1.ResourceList)
+
+	for _, providerContribution := range orchestrator.Spec.CapacityDiscovery.Providers {
+		var capacityProvider kueuealpha.CapacityProvider
+		if err := r.client.Get(ctx, types.NamespacedName{Name: string(providerContribution.Name)}, &capacityProvider); err != nil {
+			if apierrors.IsNotFound(err) {
+				r.setDiscoveryCondition(
+					orchestrator,
+					metav1.ConditionFalse,
+					kueuealpha.DynamicQuotaOrchestratorReasonMisconfigured,
+					fmt.Sprintf("CapacityProvider %q not found", providerContribution.Name),
+				)
+				orchestrator.Status.EffectiveCapacity = nil
+				return nil
+			}
+			return err
+		}
+
+		if !apimeta.IsStatusConditionTrue(capacityProvider.Status.Conditions, kueuealpha.CapacityProviderCapacitySynchronized) {
+			r.setDiscoveryCondition(
+				orchestrator,
+				metav1.ConditionFalse,
+				kueuealpha.DynamicQuotaOrchestratorReasonProviderNotReady,
+				fmt.Sprintf("CapacityProvider %q is not synchronized", providerContribution.Name),
+			)
+			orchestrator.Status.EffectiveCapacity = nil
+			return nil
+		}
+
+		aggregateProviderCapacity(capacityProvider.Status.Capacity, capacityProvider.Spec.OrchestratedFlavors, providerContribution.EffectiveCapacityMultiplier, aggregatedCapacity)
+	}
+
+	effectiveCapacityFlavors := make([]kueuealpha.EffectiveCapacityFlavor, 0, len(aggregatedCapacity))
+	for _, flavorName := range slices.Sorted(maps.Keys(aggregatedCapacity)) {
+		effectiveCapacityFlavors = append(effectiveCapacityFlavors, kueuealpha.EffectiveCapacityFlavor{
+			Name:      flavorName,
+			Resources: aggregatedCapacity[flavorName],
+		})
+	}
+
+	orchestrator.Status.EffectiveCapacity = &kueuealpha.EffectiveCapacity{
+		Flavors: effectiveCapacityFlavors,
+	}
+	r.setDiscoveryCondition(orchestrator, metav1.ConditionTrue, kueuealpha.DynamicQuotaOrchestratorReasonComputed, "Aggregated capacity successfully computed")
+	return nil
+}
+
+// aggregateProviderCapacity scales and adds flavor resource quantities from a single CapacityProvider into the running aggregated total,
+// filtering exclusively by the flavors declared in the CapacityProvider's spec.orchestratedFlavors.
+func aggregateProviderCapacity(
+	capacity *kueuealpha.CapacityProviderNormalizedCapacity,
+	orchestratedFlavors []kueuealpha.CapacityProviderOrchestratedFlavor,
+	multiplier *resource.Quantity,
+	aggregatedCapacity map[kueuealpha.ResourceFlavorReference]corev1.ResourceList,
+) {
+	if capacity == nil {
+		return
+	}
+	allowedFlavors := sets.New[kueuealpha.ResourceFlavorReference]()
+	for _, f := range orchestratedFlavors {
+		allowedFlavors.Insert(f.Name)
+	}
+	for _, flavor := range capacity.Flavors {
+		if !allowedFlavors.Has(flavor.Name) {
+			continue
+		}
+		res := flavor.Resources
+		if len(res) == 0 {
+			continue
+		}
+		if multiplier != nil {
+			res = make(corev1.ResourceList, len(flavor.Resources))
+			for k, v := range flavor.Resources {
+				res[k] = utilresource.MultiplyQuantity(v, *multiplier)
+			}
+		}
+		aggregatedCapacity[flavor.Name] = utilresource.MergeResourceListKeepSum(aggregatedCapacity[flavor.Name], res)
+	}
+}
+
+// setDiscoveryCondition sets the EffectiveCapacityComputed condition on the orchestrator status.
+func (r *Reconciler) setDiscoveryCondition(orchestrator *kueuealpha.DynamicQuotaOrchestrator, status metav1.ConditionStatus, reason, message string) {
+	apimeta.SetStatusCondition(&orchestrator.Status.Conditions, metav1.Condition{
+		Type:               kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+		Status:             status,
+		ObservedGeneration: orchestrator.Generation,
+		Reason:             reason,
+		Message:            message,
+	})
+}

--- a/pkg/controller/core/dqo/distribution.go
+++ b/pkg/controller/core/dqo/distribution.go
@@ -14,17 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package core
+package dqo
 
 import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"slices"
 	"strings"
 
-	"github.com/go-logr/logr"
 	"gopkg.in/inf.v0"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -34,306 +32,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
-	"sigs.k8s.io/kueue/pkg/features"
-	utilresource "sigs.k8s.io/kueue/pkg/util/resource"
-	"sigs.k8s.io/kueue/pkg/util/roletracker"
 )
-
-const (
-	dqoControllerName            = "dynamicquotaorchestrator-reconciler"
-	dynamicQuotaOrchestratorKind = "DynamicQuotaOrchestrator"
-)
-
-type DynamicQuotaOrchestratorReconciler struct {
-	client      client.Client
-	roleTracker *roletracker.RoleTracker
-	logName     string
-}
-
-type DynamicQuotaOrchestratorReconcilerOption func(*DynamicQuotaOrchestratorReconciler)
-
-// WithDynamicQuotaOrchestratorRoleTracker configures the RoleTracker for the reconciler.
-func WithDynamicQuotaOrchestratorRoleTracker(rt *roletracker.RoleTracker) DynamicQuotaOrchestratorReconcilerOption {
-	return func(r *DynamicQuotaOrchestratorReconciler) {
-		r.roleTracker = rt
-	}
-}
-
-// NewDynamicQuotaOrchestratorReconciler instantiates a new DynamicQuotaOrchestrator reconciler.
-func NewDynamicQuotaOrchestratorReconciler(client client.Client, opts ...DynamicQuotaOrchestratorReconcilerOption) *DynamicQuotaOrchestratorReconciler {
-	r := &DynamicQuotaOrchestratorReconciler{
-		client:  client,
-		logName: dqoControllerName,
-	}
-	for _, opt := range opts {
-		opt(r)
-	}
-	return r
-}
-
-func (r *DynamicQuotaOrchestratorReconciler) logger() logr.Logger {
-	return roletracker.WithReplicaRole(ctrl.Log.WithName(r.logName), r.roleTracker)
-}
-
-// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=dynamicquotaorchestrators,verbs=get;list;watch
-// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=dynamicquotaorchestrators/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=capacityproviders,verbs=get;list;watch
-// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=clusterqueues,verbs=get;list;watch
-// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=clusterqueues/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=cohorts,verbs=get;list;watch
-// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=cohorts/status,verbs=get;update;patch
-
-// SetupWithManager registers the DynamicQuotaOrchestrator controller and its watches with the manager.
-func (r *DynamicQuotaOrchestratorReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&kueuealpha.DynamicQuotaOrchestrator{}).
-		Watches(
-			&kueuealpha.CapacityProvider{},
-			handler.EnqueueRequestsFromMapFunc(r.mapCapacityProviderToDQOs),
-		).
-		Watches(
-			&kueue.Cohort{},
-			handler.EnqueueRequestsFromMapFunc(r.mapDistributingDQOs),
-			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
-		).
-		Watches(
-			&kueue.ClusterQueue{},
-			handler.EnqueueRequestsFromMapFunc(r.mapDistributingDQOs),
-			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
-		).
-		Watches(
-			&kueuealpha.DynamicQuotaOrchestrator{},
-			handler.EnqueueRequestsFromMapFunc(r.mapOtherDistributingDQOs),
-			builder.WithPredicates(dqoSpecOrDeletionChangedPredicate),
-		).
-		Complete(r)
-}
-
-var dqoSpecOrDeletionChangedPredicate = predicate.Funcs{
-	UpdateFunc: func(e event.UpdateEvent) bool {
-		if e.ObjectOld == nil || e.ObjectNew == nil {
-			return false
-		}
-		if e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() {
-			return true
-		}
-		return e.ObjectOld.GetDeletionTimestamp().IsZero() != e.ObjectNew.GetDeletionTimestamp().IsZero()
-	},
-}
-
-// mapCapacityProviderToDQOs maps a CapacityProvider event to reconcile requests for all DynamicQuotaOrchestrators referencing it.
-func (r *DynamicQuotaOrchestratorReconciler) mapCapacityProviderToDQOs(ctx context.Context, obj client.Object) []ctrl.Request {
-	capacityProvider, ok := obj.(*kueuealpha.CapacityProvider)
-	if !ok || capacityProvider == nil {
-		return nil
-	}
-	var orchestratorList kueuealpha.DynamicQuotaOrchestratorList
-	if err := r.client.List(ctx, &orchestratorList, client.MatchingFields{
-		indexer.DynamicQuotaOrchestratorCapacityProviderKey: capacityProvider.Name,
-	}); err != nil {
-		r.logger().Error(err, "Failed to list DynamicQuotaOrchestrators for CapacityProvider", "capacityProvider", capacityProvider.Name)
-		return nil
-	}
-	requests := make([]ctrl.Request, 0, len(orchestratorList.Items))
-	for _, orchestrator := range orchestratorList.Items {
-		requests = append(requests, ctrl.Request{
-			NamespacedName: types.NamespacedName{Name: orchestrator.Name},
-		})
-	}
-	return requests
-}
-
-// mapDistributingDQOs maps Cohort or ClusterQueue events to reconcile requests for all distributing DynamicQuotaOrchestrators.
-func (r *DynamicQuotaOrchestratorReconciler) mapDistributingDQOs(ctx context.Context, _ client.Object) []ctrl.Request {
-	distributingDQOs, err := r.listDistributingDQOs(ctx)
-	if err != nil {
-		r.logger().Error(err, "Failed to list distributing DynamicQuotaOrchestrators")
-		return nil
-	}
-	requests := make([]ctrl.Request, 0, len(distributingDQOs))
-	for _, orchestrator := range distributingDQOs {
-		requests = append(requests, ctrl.Request{
-			NamespacedName: types.NamespacedName{Name: orchestrator.Name},
-		})
-	}
-	return requests
-}
-
-// mapOtherDistributingDQOs maps a DynamicQuotaOrchestrator event to reconcile requests for other distributing DynamicQuotaOrchestrators.
-func (r *DynamicQuotaOrchestratorReconciler) mapOtherDistributingDQOs(ctx context.Context, obj client.Object) []ctrl.Request {
-	if obj == nil {
-		return nil
-	}
-	orchestrator, ok := obj.(*kueuealpha.DynamicQuotaOrchestrator)
-	if !ok || orchestrator == nil {
-		return nil
-	}
-	distributingDQOs, err := r.listDistributingDQOs(ctx)
-	if err != nil {
-		r.logger().Error(err, "Failed to list distributing DynamicQuotaOrchestrators")
-		return nil
-	}
-	requests := make([]ctrl.Request, 0, len(distributingDQOs))
-	for _, item := range distributingDQOs {
-		if item.Name == orchestrator.Name {
-			continue
-		}
-		requests = append(requests, ctrl.Request{
-			NamespacedName: types.NamespacedName{Name: item.Name},
-		})
-	}
-	return requests
-}
-
-// Reconcile coordinates capacity discovery and quota distribution for a DynamicQuotaOrchestrator.
-func (r *DynamicQuotaOrchestratorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	if !features.Enabled(features.DynamicQuotaOrchestration) {
-		return ctrl.Result{}, nil
-	}
-
-	log := ctrl.LoggerFrom(ctx)
-	log.V(2).Info("Reconcile DynamicQuotaOrchestrator")
-
-	var orchestrator kueuealpha.DynamicQuotaOrchestrator
-	if err := r.client.Get(ctx, req.NamespacedName, &orchestrator); err != nil {
-		return ctrl.Result{}, client.IgnoreNotFound(err)
-	}
-
-	if !orchestrator.DeletionTimestamp.IsZero() {
-		return ctrl.Result{}, nil
-	}
-
-	oldStatus := orchestrator.Status.DeepCopy()
-
-	// Phase 1: Capacity Discovery
-	if discoveryErr := r.reconcileDiscovery(ctx, &orchestrator); discoveryErr != nil {
-		err := r.updateStatus(ctx, &orchestrator, oldStatus)
-		return ctrl.Result{}, errors.Join(discoveryErr, err)
-	}
-
-	// Phase 2: Quota Distribution
-	var distributionErr error
-	switch {
-	case orchestrator.Spec.CapacityDistribution == nil:
-		apimeta.RemoveStatusCondition(&orchestrator.Status.Conditions, kueuealpha.DynamicQuotaOrchestratorDistributed)
-	case orchestrator.Status.EffectiveCapacity == nil:
-		apimeta.SetStatusCondition(&orchestrator.Status.Conditions, metav1.Condition{
-			Type:               kueuealpha.DynamicQuotaOrchestratorDistributed,
-			Status:             metav1.ConditionFalse,
-			ObservedGeneration: orchestrator.Generation,
-			Reason:             kueuealpha.DynamicQuotaOrchestratorReasonEffectiveCapacityNotComputed,
-			Message:            "Capacity discovery not ready",
-		})
-	default:
-		if err := r.reconcileDistribution(ctx, &orchestrator, orchestrator.Status.EffectiveCapacity); err != nil {
-			log.Error(err, "Failed to distribute quotas")
-			distributionErr = err
-		}
-	}
-
-	if err := r.updateStatus(ctx, &orchestrator, oldStatus); err != nil {
-		return ctrl.Result{}, err
-	}
-	if distributionErr != nil {
-		return ctrl.Result{}, distributionErr
-	}
-	return ctrl.Result{}, nil
-}
-
-// reconcileDiscovery performs Phase 1 reconciliation: aggregates normalized capacities across referenced CapacityProviders.
-func (r *DynamicQuotaOrchestratorReconciler) reconcileDiscovery(ctx context.Context, orchestrator *kueuealpha.DynamicQuotaOrchestrator) error {
-	aggregatedCapacity := make(map[kueuealpha.ResourceFlavorReference]corev1.ResourceList)
-
-	for _, providerContribution := range orchestrator.Spec.CapacityDiscovery.Providers {
-		var capacityProvider kueuealpha.CapacityProvider
-		if err := r.client.Get(ctx, types.NamespacedName{Name: string(providerContribution.Name)}, &capacityProvider); err != nil {
-			if apierrors.IsNotFound(err) {
-				r.setDiscoveryCondition(
-					orchestrator,
-					metav1.ConditionFalse,
-					kueuealpha.DynamicQuotaOrchestratorReasonMisconfigured,
-					fmt.Sprintf("CapacityProvider %q not found", providerContribution.Name),
-				)
-				orchestrator.Status.EffectiveCapacity = nil
-				return nil
-			}
-			return err
-		}
-
-		if !apimeta.IsStatusConditionTrue(capacityProvider.Status.Conditions, kueuealpha.CapacityProviderCapacitySynchronized) {
-			r.setDiscoveryCondition(
-				orchestrator,
-				metav1.ConditionFalse,
-				kueuealpha.DynamicQuotaOrchestratorReasonProviderNotReady,
-				fmt.Sprintf("CapacityProvider %q is not synchronized", providerContribution.Name),
-			)
-			orchestrator.Status.EffectiveCapacity = nil
-			return nil
-		}
-
-		aggregateProviderCapacity(capacityProvider.Status.Capacity, capacityProvider.Spec.OrchestratedFlavors, providerContribution.EffectiveCapacityMultiplier, aggregatedCapacity)
-	}
-
-	effectiveCapacityFlavors := make([]kueuealpha.EffectiveCapacityFlavor, 0, len(aggregatedCapacity))
-	for _, flavorName := range slices.Sorted(maps.Keys(aggregatedCapacity)) {
-		effectiveCapacityFlavors = append(effectiveCapacityFlavors, kueuealpha.EffectiveCapacityFlavor{
-			Name:      flavorName,
-			Resources: aggregatedCapacity[flavorName],
-		})
-	}
-
-	orchestrator.Status.EffectiveCapacity = &kueuealpha.EffectiveCapacity{
-		Flavors: effectiveCapacityFlavors,
-	}
-	r.setDiscoveryCondition(orchestrator, metav1.ConditionTrue, kueuealpha.DynamicQuotaOrchestratorReasonComputed, "Aggregated capacity successfully computed")
-	return nil
-}
-
-// aggregateProviderCapacity scales and adds flavor resource quantities from a single CapacityProvider into the running aggregated total,
-// filtering exclusively by the flavors declared in the CapacityProvider's spec.orchestratedFlavors.
-func aggregateProviderCapacity(
-	capacity *kueuealpha.CapacityProviderNormalizedCapacity,
-	orchestratedFlavors []kueuealpha.CapacityProviderOrchestratedFlavor,
-	multiplier *resource.Quantity,
-	aggregatedCapacity map[kueuealpha.ResourceFlavorReference]corev1.ResourceList,
-) {
-	if capacity == nil {
-		return
-	}
-	allowedFlavors := sets.New[kueuealpha.ResourceFlavorReference]()
-	for _, f := range orchestratedFlavors {
-		allowedFlavors.Insert(f.Name)
-	}
-	for _, flavor := range capacity.Flavors {
-		if !allowedFlavors.Has(flavor.Name) {
-			continue
-		}
-		res := flavor.Resources
-		if len(res) == 0 {
-			continue
-		}
-		if multiplier != nil {
-			res = make(corev1.ResourceList, len(flavor.Resources))
-			for k, v := range flavor.Resources {
-				res[k] = utilresource.MultiplyQuantity(v, *multiplier)
-			}
-		}
-		aggregatedCapacity[flavor.Name] = utilresource.MergeResourceListKeepSum(aggregatedCapacity[flavor.Name], res)
-	}
-}
 
 // reconcileDistribution performs Phase 2 reconciliation: validates subtree conflicts, resolves the target hierarchy, and distributes effective quotas.
-func (r *DynamicQuotaOrchestratorReconciler) reconcileDistribution(ctx context.Context, orchestrator *kueuealpha.DynamicQuotaOrchestrator, effectiveCapacity *kueuealpha.EffectiveCapacity) error {
+func (r *Reconciler) reconcileDistribution(ctx context.Context, orchestrator *kueuealpha.DynamicQuotaOrchestrator, effectiveCapacity *kueuealpha.EffectiveCapacity) error {
 	rootRef := orchestrator.Spec.CapacityDistribution.SubtreeRootQuotaRef
 	if rootRef.Kind != kueuealpha.CohortSubtreeRootRefKind && rootRef.Kind != kueuealpha.ClusterQueueSubtreeRootRefKind {
 		r.setDistributionCondition(orchestrator, metav1.ConditionFalse, kueuealpha.DynamicQuotaOrchestratorReasonMisconfigured, fmt.Sprintf("unsupported subtree root kind %q", rootRef.Kind))
@@ -378,7 +85,7 @@ func (r *DynamicQuotaOrchestratorReconciler) reconcileDistribution(ctx context.C
 }
 
 // listDistributingDQOs returns all DynamicQuotaOrchestrators currently configured for distribution.
-func (r *DynamicQuotaOrchestratorReconciler) listDistributingDQOs(ctx context.Context) ([]kueuealpha.DynamicQuotaOrchestrator, error) {
+func (r *Reconciler) listDistributingDQOs(ctx context.Context) ([]kueuealpha.DynamicQuotaOrchestrator, error) {
 	var list kueuealpha.DynamicQuotaOrchestratorList
 	if err := r.client.List(ctx, &list, client.MatchingFields{
 		indexer.DynamicQuotaOrchestratorIsDistributingKey: "true",
@@ -390,7 +97,7 @@ func (r *DynamicQuotaOrchestratorReconciler) listDistributingDQOs(ctx context.Co
 
 // findConflictingDistributingDQO checks if another distributing DQO conflicts by being an ancestor or an older instance on the same root.
 // It returns a non-empty conflict message string if a conflict is found, or an empty string if no conflict exists.
-func (r *DynamicQuotaOrchestratorReconciler) findConflictingDistributingDQO(
+func (r *Reconciler) findConflictingDistributingDQO(
 	ctx context.Context,
 	orchestrator *kueuealpha.DynamicQuotaOrchestrator,
 	otherOrchestrators []kueuealpha.DynamicQuotaOrchestrator,
@@ -419,7 +126,7 @@ func (r *DynamicQuotaOrchestratorReconciler) findConflictingDistributingDQO(
 
 // findOwnershipConflict checks whether any target ClusterQueue or Cohort is currently managed by another active distributing orchestrator.
 // If the target object is managed by a descendant orchestrator, the current ancestor orchestrator has higher precedence and is allowed to take over.
-func (r *DynamicQuotaOrchestratorReconciler) findOwnershipConflict(
+func (r *Reconciler) findOwnershipConflict(
 	ctx context.Context,
 	orchestrator *kueuealpha.DynamicQuotaOrchestrator,
 	targetClusterQueues []kueue.ClusterQueue,
@@ -451,7 +158,7 @@ func (r *DynamicQuotaOrchestratorReconciler) findOwnershipConflict(
 // checkManagedConflict verifies whether an individual object's EffectiveQuotas is owned by another active distributing orchestrator.
 // It returns an error if owned by another active orchestrator that is not a descendant or older instance on the same root,
 // or nil if no conflict exists or if the reconciling orchestrator has precedence.
-func (r *DynamicQuotaOrchestratorReconciler) checkManagedConflict(
+func (r *Reconciler) checkManagedConflict(
 	ctx context.Context,
 	orchestrator *kueuealpha.DynamicQuotaOrchestrator,
 	currentRoot kueuealpha.CapacityDistributionSubtreeRootRef,
@@ -520,7 +227,7 @@ func calculateAllocations(
 }
 
 // applyEffectiveQuotas updates status.effectiveQuotas on all target ClusterQueues and Cohorts in the subtree.
-func (r *DynamicQuotaOrchestratorReconciler) applyEffectiveQuotas(
+func (r *Reconciler) applyEffectiveQuotas(
 	ctx context.Context,
 	orchestratorName string,
 	targetClusterQueues []kueue.ClusterQueue,
@@ -755,7 +462,7 @@ func buildEffectiveQuotas(
 }
 
 // resolveSubtree traverses the quota hierarchy downwards from the specified root reference to find all member ClusterQueues and Cohorts.
-func (r *DynamicQuotaOrchestratorReconciler) resolveSubtree(
+func (r *Reconciler) resolveSubtree(
 	ctx context.Context,
 	rootRef kueuealpha.CapacityDistributionSubtreeRootRef,
 ) ([]kueue.ClusterQueue, []kueue.Cohort, error) {
@@ -814,7 +521,7 @@ func (r *DynamicQuotaOrchestratorReconciler) resolveSubtree(
 }
 
 // isStrictAncestor returns true if candidate is a strict ancestor of target in the cohort hierarchy.
-func (r *DynamicQuotaOrchestratorReconciler) isStrictAncestor(
+func (r *Reconciler) isStrictAncestor(
 	ctx context.Context,
 	candidate kueuealpha.CapacityDistributionSubtreeRootRef,
 	target kueuealpha.CapacityDistributionSubtreeRootRef,
@@ -869,19 +576,8 @@ func hasPrecedence(a, b *kueuealpha.DynamicQuotaOrchestrator) bool {
 	return a.UID < b.UID
 }
 
-// setDiscoveryCondition sets the EffectiveCapacityComputed condition on the orchestrator status.
-func (r *DynamicQuotaOrchestratorReconciler) setDiscoveryCondition(orchestrator *kueuealpha.DynamicQuotaOrchestrator, status metav1.ConditionStatus, reason, message string) {
-	apimeta.SetStatusCondition(&orchestrator.Status.Conditions, metav1.Condition{
-		Type:               kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
-		Status:             status,
-		ObservedGeneration: orchestrator.Generation,
-		Reason:             reason,
-		Message:            message,
-	})
-}
-
 // setDistributionCondition sets the Distributed condition on the orchestrator status.
-func (r *DynamicQuotaOrchestratorReconciler) setDistributionCondition(orchestrator *kueuealpha.DynamicQuotaOrchestrator, status metav1.ConditionStatus, reason, message string) {
+func (r *Reconciler) setDistributionCondition(orchestrator *kueuealpha.DynamicQuotaOrchestrator, status metav1.ConditionStatus, reason, message string) {
 	apimeta.SetStatusCondition(&orchestrator.Status.Conditions, metav1.Condition{
 		Type:               kueuealpha.DynamicQuotaOrchestratorDistributed,
 		Status:             status,
@@ -889,10 +585,4 @@ func (r *DynamicQuotaOrchestratorReconciler) setDistributionCondition(orchestrat
 		Reason:             reason,
 		Message:            message,
 	})
-}
-func (r *DynamicQuotaOrchestratorReconciler) updateStatus(ctx context.Context, orchestrator *kueuealpha.DynamicQuotaOrchestrator, oldStatus *kueuealpha.DynamicQuotaOrchestratorStatus) error {
-	if equality.Semantic.DeepEqual(oldStatus, &orchestrator.Status) {
-		return nil
-	}
-	return r.client.Status().Update(ctx, orchestrator)
 }

--- a/pkg/controller/core/dqo/distribution_test.go
+++ b/pkg/controller/core/dqo/distribution_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package core
+package dqo
 
 import (
 	"testing"
@@ -37,9 +37,8 @@ import (
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 )
 
-func TestDynamicQuotaOrchestratorReconcile(t *testing.T) {
+func TestDynamicQuotaOrchestratorDistribution(t *testing.T) {
 	features.SetFeatureGateDuringTest(t, features.DynamicQuotaOrchestration, true)
-	halfMultiplier := resource.MustParse("0.5")
 
 	timeNow := time.Now()
 	timeEarlier := timeNow.Add(-10 * time.Minute)
@@ -56,276 +55,6 @@ func TestDynamicQuotaOrchestratorReconcile(t *testing.T) {
 		wantClusterQueues []*kueue.ClusterQueue
 		wantErr           bool
 	}{
-		"discovery-only: provider not found": {
-			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-1").
-				DiscoveryProvider("non-existent-provider", nil).
-				Obj(),
-			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-1").
-				DiscoveryProvider("non-existent-provider", nil).
-				Condition(metav1.Condition{
-					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
-					Status:  metav1.ConditionFalse,
-					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonMisconfigured,
-					Message: "CapacityProvider \"non-existent-provider\" not found",
-				}).
-				Obj(),
-			wantErr: false,
-		},
-		"discovery-only: provider not ready (no condition)": {
-			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-1").
-				DiscoveryProvider("cp-1", nil).
-				Obj(),
-			capacityProviders: []*kueuealpha.CapacityProvider{
-				utiltestingalpha.MakeCapacityProvider("cp-1").Obj(),
-			},
-			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-1").
-				DiscoveryProvider("cp-1", nil).
-				Condition(metav1.Condition{
-					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
-					Status:  metav1.ConditionFalse,
-					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonProviderNotReady,
-					Message: "CapacityProvider \"cp-1\" is not synchronized",
-				}).
-				Obj(),
-			wantErr: false,
-		},
-		"discovery-only: single provider aggregated successfully": {
-			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-1").
-				DiscoveryProvider("cp-1", nil).
-				Obj(),
-			capacityProviders: []*kueuealpha.CapacityProvider{
-				utiltestingalpha.MakeCapacityProvider("cp-1").
-					OrchestratedFlavors("default-flavor").
-					Condition(metav1.Condition{
-						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
-						Status: metav1.ConditionTrue,
-						Reason: kueuealpha.CapacityProviderReasonSynchronized,
-					}).
-					Capacity(utiltestingalpha.MakeNormalizedCapacity().
-						Flavors(
-							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
-								Resource(corev1.ResourceCPU, "100").
-								Resource(corev1.ResourceMemory, "50Gi").
-								Obj(),
-						).
-						Obj()).
-					Obj(),
-			},
-			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-1").
-				DiscoveryProvider("cp-1", nil).
-				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
-					Flavors(
-						*utiltestingalpha.MakeEffectiveCapacityFlavor("default-flavor").
-							Resource(corev1.ResourceCPU, "100").
-							Resource(corev1.ResourceMemory, "50Gi").
-							Obj(),
-					).
-					Obj(),
-				).
-				Condition(metav1.Condition{
-					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
-					Status:  metav1.ConditionTrue,
-					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
-					Message: "Aggregated capacity successfully computed",
-				}).
-				Obj(),
-		},
-		"discovery-only: multiple providers with multipliers": {
-			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-1").
-				DiscoveryProvider("cp-1", &halfMultiplier).
-				DiscoveryProvider("cp-2", &halfMultiplier).
-				Obj(),
-			capacityProviders: []*kueuealpha.CapacityProvider{
-				utiltestingalpha.MakeCapacityProvider("cp-1").
-					OrchestratedFlavors("default-flavor").
-					Condition(metav1.Condition{
-						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
-						Status: metav1.ConditionTrue,
-						Reason: kueuealpha.CapacityProviderReasonSynchronized,
-					}).
-					Capacity(utiltestingalpha.MakeNormalizedCapacity().
-						Flavors(
-							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
-								Resource(corev1.ResourceCPU, "100").
-								Obj(),
-						).
-						Obj()).
-					Obj(),
-				utiltestingalpha.MakeCapacityProvider("cp-2").
-					OrchestratedFlavors("default-flavor", "gpu-flavor").
-					Condition(metav1.Condition{
-						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
-						Status: metav1.ConditionTrue,
-						Reason: kueuealpha.CapacityProviderReasonSynchronized,
-					}).
-					Capacity(utiltestingalpha.MakeNormalizedCapacity().
-						Flavors(
-							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
-								Resource(corev1.ResourceCPU, "200").
-								Obj(),
-							utiltestingalpha.MakeNormalizedCapacityFlavor("gpu-flavor").
-								Resource("nvidia.com/gpu", "8").
-								Obj(),
-						).
-						Obj()).
-					Obj(),
-			},
-			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-1").
-				DiscoveryProvider("cp-1", &halfMultiplier).
-				DiscoveryProvider("cp-2", &halfMultiplier).
-				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
-					Flavors(
-						*utiltestingalpha.MakeEffectiveCapacityFlavor("default-flavor").
-							Resource(corev1.ResourceCPU, "150").
-							Obj(),
-						*utiltestingalpha.MakeEffectiveCapacityFlavor("gpu-flavor").
-							Resource("nvidia.com/gpu", "4").
-							Obj(),
-					).
-					Obj(),
-				).
-				Condition(metav1.Condition{
-					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
-					Status:  metav1.ConditionTrue,
-					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
-					Message: "Aggregated capacity successfully computed",
-				}).
-				Obj(),
-		},
-		"discovery-only: filters flavors not declared in spec.orchestratedFlavors": {
-			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-filter").
-				DiscoveryProvider("cp-1", nil).
-				Obj(),
-			capacityProviders: []*kueuealpha.CapacityProvider{
-				utiltestingalpha.MakeCapacityProvider("cp-1").
-					OrchestratedFlavors("allowed-flavor").
-					Condition(metav1.Condition{
-						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
-						Status: metav1.ConditionTrue,
-						Reason: kueuealpha.CapacityProviderReasonSynchronized,
-					}).
-					Capacity(utiltestingalpha.MakeNormalizedCapacity().
-						Flavors(
-							utiltestingalpha.MakeNormalizedCapacityFlavor("allowed-flavor").
-								Resource(corev1.ResourceCPU, "50").
-								Obj(),
-							utiltestingalpha.MakeNormalizedCapacityFlavor("unorchestrated-flavor").
-								Resource(corev1.ResourceCPU, "50").
-								Obj(),
-						).
-						Obj()).
-					Obj(),
-			},
-			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-filter").
-				DiscoveryProvider("cp-1", nil).
-				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
-					Flavors(
-						*utiltestingalpha.MakeEffectiveCapacityFlavor("allowed-flavor").
-							Resource(corev1.ResourceCPU, "50").
-							Obj(),
-					).
-					Obj(),
-				).
-				Condition(metav1.Condition{
-					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
-					Status:  metav1.ConditionTrue,
-					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
-					Message: "Aggregated capacity successfully computed",
-				}).
-				Obj(),
-		},
-		"discovery-only: no matching orchestrated flavors": {
-			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-no-match").
-				DiscoveryProvider("cp-1", nil).
-				Obj(),
-			capacityProviders: []*kueuealpha.CapacityProvider{
-				utiltestingalpha.MakeCapacityProvider("cp-1").
-					OrchestratedFlavors("other-flavor").
-					Condition(metav1.Condition{
-						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
-						Status: metav1.ConditionTrue,
-						Reason: kueuealpha.CapacityProviderReasonSynchronized,
-					}).
-					Capacity(utiltestingalpha.MakeNormalizedCapacity().
-						Flavors(
-							utiltestingalpha.MakeNormalizedCapacityFlavor("provider-flavor").
-								Resource(corev1.ResourceCPU, "10").
-								Obj(),
-						).
-						Obj()).
-					Obj(),
-			},
-			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-no-match").
-				DiscoveryProvider("cp-1", nil).
-				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
-					Flavors().
-					Obj(),
-				).
-				Condition(metav1.Condition{
-					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
-					Status:  metav1.ConditionTrue,
-					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
-					Message: "Aggregated capacity successfully computed",
-				}).
-				Obj(),
-		},
-		"discovery-only: provider reports empty capacity": {
-			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-empty").
-				DiscoveryProvider("cp-1", nil).
-				Obj(),
-			capacityProviders: []*kueuealpha.CapacityProvider{
-				utiltestingalpha.MakeCapacityProvider("cp-1").
-					OrchestratedFlavors("default-flavor").
-					Condition(metav1.Condition{
-						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
-						Status: metav1.ConditionTrue,
-						Reason: kueuealpha.CapacityProviderReasonSynchronized,
-					}).
-					Capacity(utiltestingalpha.MakeNormalizedCapacity().Obj()).
-					Obj(),
-			},
-			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-empty").
-				DiscoveryProvider("cp-1", nil).
-				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
-					Flavors().
-					Obj(),
-				).
-				Condition(metav1.Condition{
-					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
-					Status:  metav1.ConditionTrue,
-					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
-					Message: "Aggregated capacity successfully computed",
-				}).
-				Obj(),
-		},
-		"discovery-only: provider reports nil capacity with synchronized condition": {
-			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-nil-capacity").
-				DiscoveryProvider("cp-1", nil).
-				Obj(),
-			capacityProviders: []*kueuealpha.CapacityProvider{
-				utiltestingalpha.MakeCapacityProvider("cp-1").
-					OrchestratedFlavors("default-flavor").
-					Condition(metav1.Condition{
-						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
-						Status: metav1.ConditionTrue,
-						Reason: kueuealpha.CapacityProviderReasonSynchronized,
-					}).
-					Obj(),
-			},
-			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-nil-capacity").
-				DiscoveryProvider("cp-1", nil).
-				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
-					Flavors().
-					Obj(),
-				).
-				Condition(metav1.Condition{
-					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
-					Status:  metav1.ConditionTrue,
-					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
-					Message: "Aggregated capacity successfully computed",
-				}).
-				Obj(),
-		},
 		"distribution: discovery not ready sets EffectiveCapacityNotComputed condition": {
 			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-dist-not-ready").
 				DiscoveryProvider("non-existent-provider", nil).
@@ -1135,17 +864,7 @@ func TestDynamicQuotaOrchestratorReconcile(t *testing.T) {
 			},
 			wantErr: false,
 		},
-		"feature gate disabled": {
-			enableFeatureGate: new(bool),
-			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-disabled").
-				DiscoveryProvider("cp-1", nil).
-				Obj(),
-			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-disabled").
-				DiscoveryProvider("cp-1", nil).
-				Obj(),
-		},
 	}
-
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			if tc.enableFeatureGate != nil {
@@ -1168,7 +887,7 @@ func TestDynamicQuotaOrchestratorReconcile(t *testing.T) {
 			}
 
 			cl := builder.WithObjects(objs...).WithStatusSubresource(objs...).Build()
-			r := NewDynamicQuotaOrchestratorReconciler(cl)
+			r := NewReconciler(cl)
 
 			ctx, _ := utiltesting.ContextWithLog(t)
 			_, err := r.Reconcile(ctx, reconcile.Request{

--- a/pkg/controller/core/dqo/reconciler.go
+++ b/pkg/controller/core/dqo/reconciler.go
@@ -1,0 +1,248 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dqo
+
+import (
+	"context"
+	"errors"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
+	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/util/roletracker"
+)
+
+const (
+	dqoControllerName            = "dynamicquotaorchestrator-reconciler"
+	dynamicQuotaOrchestratorKind = "DynamicQuotaOrchestrator"
+)
+
+type Reconciler struct {
+	client      client.Client
+	roleTracker *roletracker.RoleTracker
+	logName     string
+}
+
+type Option func(*Reconciler)
+
+// WithRoleTracker configures the RoleTracker for the reconciler.
+func WithRoleTracker(rt *roletracker.RoleTracker) Option {
+	return func(r *Reconciler) {
+		r.roleTracker = rt
+	}
+}
+
+// NewReconciler instantiates a new DynamicQuotaOrchestrator reconciler.
+func NewReconciler(client client.Client, opts ...Option) *Reconciler {
+	r := &Reconciler{
+		client:  client,
+		logName: dqoControllerName,
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
+}
+
+func (r *Reconciler) logger() logr.Logger {
+	return roletracker.WithReplicaRole(ctrl.Log.WithName(r.logName), r.roleTracker)
+}
+
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=dynamicquotaorchestrators,verbs=get;list;watch
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=dynamicquotaorchestrators/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=capacityproviders,verbs=get;list;watch
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=clusterqueues,verbs=get;list;watch
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=clusterqueues/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=cohorts,verbs=get;list;watch
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=cohorts/status,verbs=get;update;patch
+
+// SetupWithManager registers the DynamicQuotaOrchestrator controller and its watches with the manager.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&kueuealpha.DynamicQuotaOrchestrator{}).
+		Watches(
+			&kueuealpha.CapacityProvider{},
+			handler.EnqueueRequestsFromMapFunc(r.mapCapacityProviderToDQOs),
+		).
+		Watches(
+			&kueue.Cohort{},
+			handler.EnqueueRequestsFromMapFunc(r.mapDistributingDQOs),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+		).
+		Watches(
+			&kueue.ClusterQueue{},
+			handler.EnqueueRequestsFromMapFunc(r.mapDistributingDQOs),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+		).
+		Watches(
+			&kueuealpha.DynamicQuotaOrchestrator{},
+			handler.EnqueueRequestsFromMapFunc(r.mapOtherDistributingDQOs),
+			builder.WithPredicates(dqoSpecOrDeletionChangedPredicate),
+		).
+		Complete(r)
+}
+
+var dqoSpecOrDeletionChangedPredicate = predicate.Funcs{
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		if e.ObjectOld == nil || e.ObjectNew == nil {
+			return false
+		}
+		if e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() {
+			return true
+		}
+		return e.ObjectOld.GetDeletionTimestamp().IsZero() != e.ObjectNew.GetDeletionTimestamp().IsZero()
+	},
+}
+
+// mapCapacityProviderToDQOs maps a CapacityProvider event to reconcile requests for all DynamicQuotaOrchestrators referencing it.
+func (r *Reconciler) mapCapacityProviderToDQOs(ctx context.Context, obj client.Object) []ctrl.Request {
+	capacityProvider, ok := obj.(*kueuealpha.CapacityProvider)
+	if !ok || capacityProvider == nil {
+		return nil
+	}
+	var orchestratorList kueuealpha.DynamicQuotaOrchestratorList
+	if err := r.client.List(ctx, &orchestratorList, client.MatchingFields{
+		indexer.DynamicQuotaOrchestratorCapacityProviderKey: capacityProvider.Name,
+	}); err != nil {
+		r.logger().Error(err, "Failed to list DynamicQuotaOrchestrators for CapacityProvider", "capacityProvider", capacityProvider.Name)
+		return nil
+	}
+	requests := make([]ctrl.Request, 0, len(orchestratorList.Items))
+	for _, orchestrator := range orchestratorList.Items {
+		requests = append(requests, ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: orchestrator.Name},
+		})
+	}
+	return requests
+}
+
+// mapDistributingDQOs maps Cohort or ClusterQueue events to reconcile requests for all distributing DynamicQuotaOrchestrators.
+func (r *Reconciler) mapDistributingDQOs(ctx context.Context, _ client.Object) []ctrl.Request {
+	distributingDQOs, err := r.listDistributingDQOs(ctx)
+	if err != nil {
+		r.logger().Error(err, "Failed to list distributing DynamicQuotaOrchestrators")
+		return nil
+	}
+	requests := make([]ctrl.Request, 0, len(distributingDQOs))
+	for _, orchestrator := range distributingDQOs {
+		requests = append(requests, ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: orchestrator.Name},
+		})
+	}
+	return requests
+}
+
+// mapOtherDistributingDQOs maps a DynamicQuotaOrchestrator event to reconcile requests for other distributing DynamicQuotaOrchestrators.
+func (r *Reconciler) mapOtherDistributingDQOs(ctx context.Context, obj client.Object) []ctrl.Request {
+	if obj == nil {
+		return nil
+	}
+	orchestrator, ok := obj.(*kueuealpha.DynamicQuotaOrchestrator)
+	if !ok || orchestrator == nil {
+		return nil
+	}
+	distributingDQOs, err := r.listDistributingDQOs(ctx)
+	if err != nil {
+		r.logger().Error(err, "Failed to list distributing DynamicQuotaOrchestrators")
+		return nil
+	}
+	requests := make([]ctrl.Request, 0, len(distributingDQOs))
+	for _, item := range distributingDQOs {
+		if item.Name == orchestrator.Name {
+			continue
+		}
+		requests = append(requests, ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: item.Name},
+		})
+	}
+	return requests
+}
+
+// Reconcile coordinates capacity discovery and quota distribution for a DynamicQuotaOrchestrator.
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	if !features.Enabled(features.DynamicQuotaOrchestration) {
+		return ctrl.Result{}, nil
+	}
+
+	log := ctrl.LoggerFrom(ctx)
+	log.V(2).Info("Reconcile DynamicQuotaOrchestrator")
+
+	var orchestrator kueuealpha.DynamicQuotaOrchestrator
+	if err := r.client.Get(ctx, req.NamespacedName, &orchestrator); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if !orchestrator.DeletionTimestamp.IsZero() {
+		return ctrl.Result{}, nil
+	}
+
+	oldStatus := orchestrator.Status.DeepCopy()
+
+	// Phase 1: Capacity Discovery
+	if discoveryErr := r.reconcileDiscovery(ctx, &orchestrator); discoveryErr != nil {
+		err := r.updateStatus(ctx, &orchestrator, oldStatus)
+		return ctrl.Result{}, errors.Join(discoveryErr, err)
+	}
+
+	// Phase 2: Quota Distribution
+	var distributionErr error
+	switch {
+	case orchestrator.Spec.CapacityDistribution == nil:
+		apimeta.RemoveStatusCondition(&orchestrator.Status.Conditions, kueuealpha.DynamicQuotaOrchestratorDistributed)
+	case orchestrator.Status.EffectiveCapacity == nil:
+		apimeta.SetStatusCondition(&orchestrator.Status.Conditions, metav1.Condition{
+			Type:               kueuealpha.DynamicQuotaOrchestratorDistributed,
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: orchestrator.Generation,
+			Reason:             kueuealpha.DynamicQuotaOrchestratorReasonEffectiveCapacityNotComputed,
+			Message:            "Capacity discovery not ready",
+		})
+	default:
+		if err := r.reconcileDistribution(ctx, &orchestrator, orchestrator.Status.EffectiveCapacity); err != nil {
+			log.Error(err, "Failed to distribute quotas")
+			distributionErr = err
+		}
+	}
+
+	if err := r.updateStatus(ctx, &orchestrator, oldStatus); err != nil {
+		return ctrl.Result{}, err
+	}
+	if distributionErr != nil {
+		return ctrl.Result{}, distributionErr
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *Reconciler) updateStatus(ctx context.Context, orchestrator *kueuealpha.DynamicQuotaOrchestrator, oldStatus *kueuealpha.DynamicQuotaOrchestratorStatus) error {
+	if equality.Semantic.DeepEqual(oldStatus, &orchestrator.Status) {
+		return nil
+	}
+	return r.client.Status().Update(ctx, orchestrator)
+}

--- a/pkg/controller/core/dqo/reconciler_test.go
+++ b/pkg/controller/core/dqo/reconciler_test.go
@@ -1,0 +1,404 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dqo
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingalpha "sigs.k8s.io/kueue/pkg/util/testing/v1alpha1"
+)
+
+func TestDynamicQuotaOrchestratorReconcile(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.DynamicQuotaOrchestration, true)
+	halfMultiplier := resource.MustParse("0.5")
+
+	cases := map[string]struct {
+		enableFeatureGate *bool
+		dqo               *kueuealpha.DynamicQuotaOrchestrator
+		capacityProviders []*kueuealpha.CapacityProvider
+		cohorts           []*kueue.Cohort
+		clusterQueues     []*kueue.ClusterQueue
+		otherDQOs         []*kueuealpha.DynamicQuotaOrchestrator
+		wantDQO           *kueuealpha.DynamicQuotaOrchestrator
+		wantCohorts       []*kueue.Cohort
+		wantClusterQueues []*kueue.ClusterQueue
+		wantErr           bool
+	}{
+		"discovery-only: provider not found": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-1").
+				DiscoveryProvider("non-existent-provider", nil).
+				Obj(),
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-1").
+				DiscoveryProvider("non-existent-provider", nil).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonMisconfigured,
+					Message: "CapacityProvider \"non-existent-provider\" not found",
+				}).
+				Obj(),
+			wantErr: false,
+		},
+		"discovery-only: provider not ready (no condition)": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-1").
+				DiscoveryProvider("cp-1", nil).
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-1").
+				DiscoveryProvider("cp-1", nil).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonProviderNotReady,
+					Message: "CapacityProvider \"cp-1\" is not synchronized",
+				}).
+				Obj(),
+			wantErr: false,
+		},
+		"discovery-only: single provider aggregated successfully": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-1").
+				DiscoveryProvider("cp-1", nil).
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
+								Resource(corev1.ResourceCPU, "100").
+								Resource(corev1.ResourceMemory, "50Gi").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-1").
+				DiscoveryProvider("cp-1", nil).
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("default-flavor").
+							Resource(corev1.ResourceCPU, "100").
+							Resource(corev1.ResourceMemory, "50Gi").
+							Obj(),
+					).
+					Obj(),
+				).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Obj(),
+		},
+		"discovery-only: multiple providers with multipliers": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-1").
+				DiscoveryProvider("cp-1", &halfMultiplier).
+				DiscoveryProvider("cp-2", &halfMultiplier).
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
+								Resource(corev1.ResourceCPU, "100").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+				utiltestingalpha.MakeCapacityProvider("cp-2").
+					OrchestratedFlavors("default-flavor", "gpu-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
+								Resource(corev1.ResourceCPU, "200").
+								Obj(),
+							utiltestingalpha.MakeNormalizedCapacityFlavor("gpu-flavor").
+								Resource("nvidia.com/gpu", "8").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-1").
+				DiscoveryProvider("cp-1", &halfMultiplier).
+				DiscoveryProvider("cp-2", &halfMultiplier).
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("default-flavor").
+							Resource(corev1.ResourceCPU, "150").
+							Obj(),
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("gpu-flavor").
+							Resource("nvidia.com/gpu", "4").
+							Obj(),
+					).
+					Obj(),
+				).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Obj(),
+		},
+		"discovery-only: filters flavors not declared in spec.orchestratedFlavors": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-filter").
+				DiscoveryProvider("cp-1", nil).
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("allowed-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("allowed-flavor").
+								Resource(corev1.ResourceCPU, "50").
+								Obj(),
+							utiltestingalpha.MakeNormalizedCapacityFlavor("unorchestrated-flavor").
+								Resource(corev1.ResourceCPU, "50").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-filter").
+				DiscoveryProvider("cp-1", nil).
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("allowed-flavor").
+							Resource(corev1.ResourceCPU, "50").
+							Obj(),
+					).
+					Obj(),
+				).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Obj(),
+		},
+		"discovery-only: no matching orchestrated flavors": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-no-match").
+				DiscoveryProvider("cp-1", nil).
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("other-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("provider-flavor").
+								Resource(corev1.ResourceCPU, "10").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-no-match").
+				DiscoveryProvider("cp-1", nil).
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors().
+					Obj(),
+				).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Obj(),
+		},
+		"discovery-only: provider reports empty capacity": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-empty").
+				DiscoveryProvider("cp-1", nil).
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().Obj()).
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-empty").
+				DiscoveryProvider("cp-1", nil).
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors().
+					Obj(),
+				).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Obj(),
+		},
+		"discovery-only: provider reports nil capacity with synchronized condition": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-nil-capacity").
+				DiscoveryProvider("cp-1", nil).
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-nil-capacity").
+				DiscoveryProvider("cp-1", nil).
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors().
+					Obj(),
+				).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Obj(),
+		},
+		"feature gate disabled": {
+			enableFeatureGate: new(bool),
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-disabled").
+				DiscoveryProvider("cp-1", nil).
+				Obj(),
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-disabled").
+				DiscoveryProvider("cp-1", nil).
+				Obj(),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if tc.enableFeatureGate != nil {
+				features.SetFeatureGateDuringTest(t, features.DynamicQuotaOrchestration, *tc.enableFeatureGate)
+			}
+			builder := utiltesting.NewClientBuilder()
+
+			objs := []client.Object{tc.dqo}
+			for _, cp := range tc.capacityProviders {
+				objs = append(objs, cp)
+			}
+			for _, co := range tc.cohorts {
+				objs = append(objs, co)
+			}
+			for _, cq := range tc.clusterQueues {
+				objs = append(objs, cq)
+			}
+			for _, other := range tc.otherDQOs {
+				objs = append(objs, other)
+			}
+
+			cl := builder.WithObjects(objs...).WithStatusSubresource(objs...).Build()
+			r := NewReconciler(cl)
+
+			ctx, _ := utiltesting.ContextWithLog(t)
+			_, err := r.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: tc.dqo.Name},
+			})
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("Reconcile error = %v, wantErr %v", err, tc.wantErr)
+			}
+
+			var gotDQO kueuealpha.DynamicQuotaOrchestrator
+			if err := cl.Get(ctx, types.NamespacedName{Name: tc.dqo.Name}, &gotDQO); err != nil {
+				t.Fatalf("Failed to get DQO: %v", err)
+			}
+
+			if diff := cmp.Diff(tc.wantDQO, &gotDQO,
+				cmpopts.IgnoreTypes(metav1.TypeMeta{}),
+				cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion", "CreationTimestamp", "Finalizers"),
+				cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime"),
+				cmpopts.EquateEmpty(),
+			); diff != "" {
+				t.Errorf("Unexpected DQO (-want +got):\n%s", diff)
+			}
+
+			for _, wantCQ := range tc.wantClusterQueues {
+				var gotCQ kueue.ClusterQueue
+				if err := cl.Get(ctx, types.NamespacedName{Name: wantCQ.Name}, &gotCQ); err != nil {
+					t.Errorf("Failed to get ClusterQueue %s: %v", wantCQ.Name, err)
+					continue
+				}
+				if diff := cmp.Diff(wantCQ.Status.EffectiveQuotas, gotCQ.Status.EffectiveQuotas, cmpopts.EquateEmpty()); diff != "" {
+					t.Errorf("Unexpected EffectiveQuotas for ClusterQueue %s (-want +got):\n%s", wantCQ.Name, diff)
+				}
+			}
+
+			for _, wantCohort := range tc.wantCohorts {
+				var gotCohort kueue.Cohort
+				if err := cl.Get(ctx, types.NamespacedName{Name: wantCohort.Name}, &gotCohort); err != nil {
+					t.Errorf("Failed to get Cohort %s: %v", wantCohort.Name, err)
+					continue
+				}
+				if diff := cmp.Diff(wantCohort.Status.EffectiveQuotas, gotCohort.Status.EffectiveQuotas, cmpopts.EquateEmpty()); diff != "" {
+					t.Errorf("Unexpected EffectiveQuotas for Cohort %s (-want +got):\n%s", wantCohort.Name, diff)
+				}
+			}
+		})
+	}
+}

--- a/test/integration/singlecluster/controller/dynamicquotaorchestrator/suite_test.go
+++ b/test/integration/singlecluster/controller/dynamicquotaorchestrator/suite_test.go
@@ -26,7 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	"sigs.k8s.io/kueue/pkg/controller/core"
+	"sigs.k8s.io/kueue/pkg/controller/core/dqo"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/webhooks"
@@ -64,7 +64,7 @@ func managerSetup(ctx context.Context, mgr manager.Manager) {
 	failedWebhook, err := webhooks.Setup(mgr, nil)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
 
-	dqoRec := core.NewDynamicQuotaOrchestratorReconciler(mgr.GetClient())
+	dqoRec := dqo.NewReconciler(mgr.GetClient())
 	err = dqoRec.SetupWithManager(mgr)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it?

Part of #12382

Follow-up to #15283 and #15286. As suggested during review by @mimowo (https://github.com/kubernetes-sigs/kueue/pull/15283#pullrequestreview-5140319251), this PR decomposes the `DynamicQuotaOrchestrator` controller into a dedicated subpackage `pkg/controller/core/dqo`:

1. `pkg/controller/core/dqo/reconciler.go`:
   - Contains `dqo.Reconciler`, options (`dqo.WithRoleTracker`), manager setup, watches/predicates/event mappers, and the main `Reconcile` coordinating loop.
2. `pkg/controller/core/dqo/discovery.go`:
   - Encapsulates Phase 1 capacity discovery logic (`reconcileDiscovery`, `aggregateProviderCapacity`, `setDiscoveryCondition`).
3. `pkg/controller/core/dqo/distribution.go`:
   - Encapsulates Phase 2 capacity distribution logic (`reconcileDistribution`, conflict detection, subtree traversal, proportional largest-remainder math, and `applyEffectiveQuotas`).
4. Unit tests:
   - `pkg/controller/core/dqo/reconciler_test.go`: Focused on discovery and reconciler lifecycle cases.
   - `pkg/controller/core/dqo/distribution_test.go`: Focused on distribution, proportional allocation, and soft validation conflict cases.
5. Integration tests and core controller wiring:
   - `pkg/controller/core/core.go`: Updated to instantiate `dqo.NewReconciler`.
   - `test/integration/singlecluster/controller/dynamicquotaorchestrator/suite_test.go`: Updated to import `dqo` package.

#### Useful notes for your reviewer

- Pure refactoring / code reorganization with no functional changes.
- All unit and integration test suites pass without regressions.

#### Release note

```release-note
NONE
```

---
*AI usage disclosure: Assisted by AI agent (Antigravity) in subpackage decomposition, refactoring, and test organization per the Kubernetes AI Tool Usage Policy.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## AI summary

- Moved `DynamicQuotaOrchestrator` into the `pkg/controller/core/dqo` package.
- Split reconciliation, discovery, and distribution logic into focused files.
- Updated controller wiring and integration tests to use `dqo.NewReconciler`.
- No functional changes.

### Release note assessment

No contributor-supplied `Release note` block was found. Suggested release note: `NONE`, because this PR is an internal refactoring with no user-facing change. Please verify this assessment and update the canonical `release-note` block in the PR description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->