### PR TITLE
test(dqo): add comprehensive reconciler distribution unit test coverage

### DIFF
--- a/pkg/controller/core/dqo/distribution_test.go
+++ b/pkg/controller/core/dqo/distribution_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -864,6 +863,1312 @@ func TestDynamicQuotaOrchestratorDistribution(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		"soft validation: grandchild CQ DQO deactivated when ancestor DQO distributes to grandparent cohort": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("child-dqo").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.ClusterQueueSubtreeRootRefKind, "child-cq").
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
+								Resource(corev1.ResourceCPU, "100").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("grandparent-cohort").Obj(),
+				utiltestingapi.MakeCohort("parent-cohort").Parent("grandparent-cohort").Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("child-cq").
+					Cohort("parent-cohort").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					Obj(),
+			},
+			otherDQOs: []*kueuealpha.DynamicQuotaOrchestrator{
+				utiltestingalpha.MakeDynamicQuotaOrchestrator("grandparent-dqo").
+					DiscoveryProvider("cp-1", nil).
+					SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "grandparent-cohort").
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("child-dqo").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.ClusterQueueSubtreeRootRefKind, "child-cq").
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("default-flavor").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj()).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorDistributed,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonConflictingDynamicQuotaOrchestrator,
+					Message: "Conflicts with ancestor DynamicQuotaOrchestrator \"grandparent-dqo\"",
+				}).
+				Obj(),
+			wantClusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("child-cq").
+					Cohort("parent-cohort").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					Obj(),
+			},
+			wantErr: false,
+		},
+		"soft validation: ancestor DQO takes over effective quotas on multi-level descendant CQ": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("grandparent-dqo").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "grandparent-cohort").
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
+								Resource(corev1.ResourceCPU, "100").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("grandparent-cohort").Obj(),
+				utiltestingapi.MakeCohort("parent-cohort").Parent("grandparent-cohort").Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("child-cq").
+					Cohort("parent-cohort").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					EffectiveQuotaStatus(
+						utiltestingapi.MakeEffectiveQuotaStatus().
+							Name("child-dqo").
+							ResourceGroups(utiltestingapi.ResourceGroup(
+								*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+							)).
+							Obj(),
+					).
+					Obj(),
+			},
+			otherDQOs: []*kueuealpha.DynamicQuotaOrchestrator{
+				utiltestingalpha.MakeDynamicQuotaOrchestrator("child-dqo").
+					DiscoveryProvider("cp-1", nil).
+					SubtreeRoot(kueuealpha.ClusterQueueSubtreeRootRefKind, "child-cq").
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("grandparent-dqo").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "grandparent-cohort").
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("default-flavor").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj()).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorDistributed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonQuotasDistributed,
+					Message: "Quotas successfully distributed",
+				}).
+				Obj(),
+			wantClusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("child-cq").
+					Cohort("parent-cohort").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					EffectiveQuotaStatus(
+						utiltestingapi.MakeEffectiveQuotaStatus().
+							Name("grandparent-dqo").
+							ResourceGroups(utiltestingapi.ResourceGroup(
+								*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "100").Obj(),
+							)).
+							Obj(),
+					).
+					Obj(),
+			},
+			wantErr: false,
+		},
+		"soft validation: sibling cohorts do not conflict and both distribute successfully": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-a").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "cohort-a").
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
+								Resource(corev1.ResourceCPU, "100").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("root-cohort").Obj(),
+				utiltestingapi.MakeCohort("cohort-a").Parent("root-cohort").Obj(),
+				utiltestingapi.MakeCohort("cohort-b").Parent("root-cohort").Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq-a").
+					Cohort("cohort-a").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					Obj(),
+				utiltestingapi.MakeClusterQueue("cq-b").
+					Cohort("cohort-b").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					Obj(),
+			},
+			otherDQOs: []*kueuealpha.DynamicQuotaOrchestrator{
+				utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-b").
+					DiscoveryProvider("cp-1", nil).
+					SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "cohort-b").
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-a").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "cohort-a").
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("default-flavor").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj()).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorDistributed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonQuotasDistributed,
+					Message: "Quotas successfully distributed",
+				}).
+				Obj(),
+			wantClusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq-a").
+					Cohort("cohort-a").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					EffectiveQuotaStatus(
+						utiltestingapi.MakeEffectiveQuotaStatus().
+							Name("dqo-a").
+							ResourceGroups(utiltestingapi.ResourceGroup(
+								*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "100").Obj(),
+							)).
+							Obj(),
+					).
+					Obj(),
+			},
+			wantErr: false,
+		},
+		"soft validation: separate ClusterQueues do not conflict (ClusterQueue cannot be ancestor)": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-1").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.ClusterQueueSubtreeRootRefKind, "cq-1").
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
+								Resource(corev1.ResourceCPU, "100").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq-1").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					Obj(),
+				utiltestingapi.MakeClusterQueue("cq-2").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					Obj(),
+			},
+			otherDQOs: []*kueuealpha.DynamicQuotaOrchestrator{
+				utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-2").
+					DiscoveryProvider("cp-1", nil).
+					SubtreeRoot(kueuealpha.ClusterQueueSubtreeRootRefKind, "cq-2").
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-1").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.ClusterQueueSubtreeRootRefKind, "cq-1").
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("default-flavor").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj()).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorDistributed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonQuotasDistributed,
+					Message: "Quotas successfully distributed",
+				}).
+				Obj(),
+			wantClusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq-1").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					EffectiveQuotaStatus(
+						utiltestingapi.MakeEffectiveQuotaStatus().
+							Name("dqo-1").
+							ResourceGroups(utiltestingapi.ResourceGroup(
+								*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "100").Obj(),
+							)).
+							Obj(),
+					).
+					Obj(),
+			},
+			wantErr: false,
+		},
+		"soft validation: cyclic cohort hierarchy terminates safely without hanging": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-a").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "cycle-a").
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
+								Resource(corev1.ResourceCPU, "100").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("cycle-a").Parent("cycle-b").Obj(),
+				utiltestingapi.MakeCohort("cycle-b").Parent("cycle-a").Obj(),
+				utiltestingapi.MakeCohort("other-cohort").Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq-a").
+					Cohort("cycle-a").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					Obj(),
+			},
+			otherDQOs: []*kueuealpha.DynamicQuotaOrchestrator{
+				utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-other").
+					DiscoveryProvider("cp-1", nil).
+					SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "other-cohort").
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-a").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "cycle-a").
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("default-flavor").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj()).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorDistributed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonQuotasDistributed,
+					Message: "Quotas successfully distributed",
+				}).
+				Obj(),
+			wantClusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq-a").
+					Cohort("cycle-a").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					EffectiveQuotaStatus(
+						utiltestingapi.MakeEffectiveQuotaStatus().
+							Name("dqo-a").
+							ResourceGroups(utiltestingapi.ResourceGroup(
+								*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "100").Obj(),
+							)).
+							Obj(),
+					).
+					Obj(),
+			},
+			wantErr: false,
+		},
+		"soft validation: managed conflict where other DQO root is non-existent returns conflict error": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-1").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.ClusterQueueSubtreeRootRefKind, "cq-1").
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
+								Resource(corev1.ResourceCPU, "100").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq-1").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					EffectiveQuotaStatus(utiltestingapi.MakeEffectiveQuotaStatus().Name("other-dqo").Obj()).
+					Obj(),
+			},
+			otherDQOs: []*kueuealpha.DynamicQuotaOrchestrator{
+				utiltestingalpha.MakeDynamicQuotaOrchestrator("other-dqo").
+					DiscoveryProvider("cp-1", nil).
+					SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "non-existent-cohort").
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-1").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.ClusterQueueSubtreeRootRefKind, "cq-1").
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("default-flavor").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj()).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorDistributed,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonEffectiveQuotasConflict,
+					Message: "ClusterQueue \"cq-1\" already managed by DynamicQuotaOrchestrator/other-dqo",
+				}).
+				Obj(),
+			wantErr: false,
+		},
+		"distribution: root ClusterQueue not found sets Misconfigured condition": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-cq-not-found").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.ClusterQueueSubtreeRootRefKind, "missing-cq").
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
+								Resource(corev1.ResourceCPU, "100").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-cq-not-found").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.ClusterQueueSubtreeRootRefKind, "missing-cq").
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("default-flavor").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj()).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorDistributed,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonMisconfigured,
+					Message: "ClusterQueue \"missing-cq\" not found",
+				}).
+				Obj(),
+			wantErr: false,
+		},
+		"distribution: root Cohort not found sets Misconfigured condition": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-cohort-not-found").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "missing-cohort").
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
+								Resource(corev1.ResourceCPU, "100").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-cohort-not-found").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "missing-cohort").
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("default-flavor").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj()).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorDistributed,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonMisconfigured,
+					Message: "Cohort \"missing-cohort\" not found",
+				}).
+				Obj(),
+			wantErr: false,
+		},
+		"distribution: unsupported subtree root kind sets Misconfigured condition": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-unsupported-kind").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot("UnknownKind", "foo").
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
+								Resource(corev1.ResourceCPU, "100").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-unsupported-kind").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot("UnknownKind", "foo").
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("default-flavor").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj()).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorDistributed,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonMisconfigured,
+					Message: "unsupported subtree root kind \"UnknownKind\"",
+				}).
+				Obj(),
+			wantErr: false,
+		},
+		"distribution: to standalone Cohort with no child queues or cohorts": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-standalone-cohort").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "root-cohort").
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
+								Resource(corev1.ResourceCPU, "100").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("root-cohort").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-standalone-cohort").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "root-cohort").
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("default-flavor").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj()).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorDistributed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonQuotasDistributed,
+					Message: "Quotas successfully distributed",
+				}).
+				Obj(),
+			wantCohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("root-cohort").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					EffectiveQuotaStatus(
+						utiltestingapi.MakeEffectiveQuotaStatus().
+							Name("dqo-standalone-cohort").
+							ResourceGroups(utiltestingapi.ResourceGroup(
+								*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "100").Obj(),
+							)).
+							Obj(),
+					).
+					Obj(),
+			},
+			wantErr: false,
+		},
+		"distribution: multi-level hierarchy excludes disjoint cohort trees": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-multi-level").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "root-cohort").
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
+								Resource(corev1.ResourceCPU, "100").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("root-cohort").Obj(),
+				utiltestingapi.MakeCohort("child-cohort").Parent("root-cohort").Obj(),
+				utiltestingapi.MakeCohort("other-root").Obj(),
+				utiltestingapi.MakeCohort("disjoint-child").Parent("other-root").Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("root-cq").
+					Cohort("root-cohort").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					Obj(),
+				utiltestingapi.MakeClusterQueue("child-cq").
+					Cohort("child-cohort").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					Obj(),
+				utiltestingapi.MakeClusterQueue("disjoint-cq").
+					Cohort("disjoint-child").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-multi-level").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "root-cohort").
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("default-flavor").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj()).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorDistributed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonQuotasDistributed,
+					Message: "Quotas successfully distributed",
+				}).
+				Obj(),
+			wantClusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("root-cq").
+					Cohort("root-cohort").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					EffectiveQuotaStatus(
+						utiltestingapi.MakeEffectiveQuotaStatus().
+							Name("dqo-multi-level").
+							ResourceGroups(utiltestingapi.ResourceGroup(
+								*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+							)).
+							Obj(),
+					).
+					Obj(),
+				utiltestingapi.MakeClusterQueue("child-cq").
+					Cohort("child-cohort").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					EffectiveQuotaStatus(
+						utiltestingapi.MakeEffectiveQuotaStatus().
+							Name("dqo-multi-level").
+							ResourceGroups(utiltestingapi.ResourceGroup(
+								*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+							)).
+							Obj(),
+					).
+					Obj(),
+				utiltestingapi.MakeClusterQueue("disjoint-cq").
+					Cohort("disjoint-child").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					Obj(),
+			},
+			wantErr: false,
+		},
+		"distribution: intermediate cohort only distributes to descendants, excludes ancestors and siblings": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-mid").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "mid-cohort").
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
+								Resource(corev1.ResourceCPU, "100").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("top-root").Obj(),
+				utiltestingapi.MakeCohort("mid-cohort").Parent("top-root").Obj(),
+				utiltestingapi.MakeCohort("sibling-cohort").Parent("top-root").Obj(),
+				utiltestingapi.MakeCohort("leaf-cohort").Parent("mid-cohort").Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("top-cq").
+					Cohort("top-root").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					Obj(),
+				utiltestingapi.MakeClusterQueue("mid-cq").
+					Cohort("mid-cohort").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					Obj(),
+				utiltestingapi.MakeClusterQueue("sibling-cq").
+					Cohort("sibling-cohort").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					Obj(),
+				utiltestingapi.MakeClusterQueue("leaf-cq").
+					Cohort("leaf-cohort").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-mid").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "mid-cohort").
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("default-flavor").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj()).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorDistributed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonQuotasDistributed,
+					Message: "Quotas successfully distributed",
+				}).
+				Obj(),
+			wantClusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("top-cq").
+					Cohort("top-root").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					Obj(),
+				utiltestingapi.MakeClusterQueue("mid-cq").
+					Cohort("mid-cohort").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					EffectiveQuotaStatus(
+						utiltestingapi.MakeEffectiveQuotaStatus().
+							Name("dqo-mid").
+							ResourceGroups(utiltestingapi.ResourceGroup(
+								*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+							)).
+							Obj(),
+					).
+					Obj(),
+				utiltestingapi.MakeClusterQueue("sibling-cq").
+					Cohort("sibling-cohort").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					Obj(),
+				utiltestingapi.MakeClusterQueue("leaf-cq").
+					Cohort("leaf-cohort").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					EffectiveQuotaStatus(
+						utiltestingapi.MakeEffectiveQuotaStatus().
+							Name("dqo-mid").
+							ResourceGroups(utiltestingapi.ResourceGroup(
+								*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+							)).
+							Obj(),
+					).
+					Obj(),
+			},
+			wantErr: false,
+		},
+		"distribution: cyclic cohort hierarchy in subtree resolution terminates safely": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-cycle").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "root-cohort").
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
+								Resource(corev1.ResourceCPU, "100").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("root-cohort").Parent("child-cohort").Obj(),
+				utiltestingapi.MakeCohort("child-cohort").Parent("root-cohort").Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq-1").
+					Cohort("root-cohort").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					Obj(),
+				utiltestingapi.MakeClusterQueue("cq-2").
+					Cohort("child-cohort").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-cycle").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "root-cohort").
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("default-flavor").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj()).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorDistributed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonQuotasDistributed,
+					Message: "Quotas successfully distributed",
+				}).
+				Obj(),
+			wantClusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq-1").
+					Cohort("root-cohort").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					EffectiveQuotaStatus(
+						utiltestingapi.MakeEffectiveQuotaStatus().
+							Name("dqo-cycle").
+							ResourceGroups(utiltestingapi.ResourceGroup(
+								*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+							)).
+							Obj(),
+					).
+					Obj(),
+				utiltestingapi.MakeClusterQueue("cq-2").
+					Cohort("child-cohort").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					EffectiveQuotaStatus(
+						utiltestingapi.MakeEffectiveQuotaStatus().
+							Name("dqo-cycle").
+							ResourceGroups(utiltestingapi.ResourceGroup(
+								*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+							)).
+							Obj(),
+					).
+					Obj(),
+			},
+			wantErr: false,
+		},
+		"proportional distribution: zero sum spec nominal quota allocates zero effective quota": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-zero-sum").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "cohort-1").
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
+								Resource(corev1.ResourceCPU, "100").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("cohort-1").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "0").Obj(),
+					).
+					Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq-1").
+					Cohort("cohort-1").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "0").Obj(),
+					).
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-zero-sum").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "cohort-1").
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("default-flavor").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj()).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorDistributed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonQuotasDistributed,
+					Message: "Quotas successfully distributed",
+				}).
+				Obj(),
+			wantCohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("cohort-1").
+					EffectiveQuotaStatus(
+						utiltestingapi.MakeEffectiveQuotaStatus().
+							Name("dqo-zero-sum").
+							ResourceGroups(utiltestingapi.ResourceGroup(
+								*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "0").Obj(),
+							)).
+							Obj(),
+					).
+					Obj(),
+			},
+			wantClusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq-1").
+					Cohort("cohort-1").
+					EffectiveQuotaStatus(
+						utiltestingapi.MakeEffectiveQuotaStatus().
+							Name("dqo-zero-sum").
+							ResourceGroups(utiltestingapi.ResourceGroup(
+								*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "0").Obj(),
+							)).
+							Obj(),
+					).
+					Obj(),
+			},
+		},
+		"proportional distribution: remainder tie-breaker uses UUID ordering per KEP-12382": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-tie-breaker").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "cohort-1").
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
+								Resource(corev1.ResourceCPU, "10").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("cohort-1").
+					UID("uid-b").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "1").Obj(),
+					).
+					Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq-1").
+					UID("uid-c").
+					Cohort("cohort-1").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "1").Obj(),
+					).
+					Obj(),
+				utiltestingapi.MakeClusterQueue("cq-2").
+					UID("uid-a").
+					Cohort("cohort-1").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "1").Obj(),
+					).
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-tie-breaker").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "cohort-1").
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("default-flavor").
+							Resource(corev1.ResourceCPU, "10").
+							Obj(),
+					).
+					Obj()).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorDistributed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonQuotasDistributed,
+					Message: "Quotas successfully distributed",
+				}).
+				Obj(),
+			wantCohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("cohort-1").
+					EffectiveQuotaStatus(
+						utiltestingapi.MakeEffectiveQuotaStatus().
+							Name("dqo-tie-breaker").
+							ResourceGroups(utiltestingapi.ResourceGroup(
+								*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "3333m").Obj(),
+							)).
+							Obj(),
+					).
+					Obj(),
+			},
+			wantClusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq-1").
+					Cohort("cohort-1").
+					EffectiveQuotaStatus(
+						utiltestingapi.MakeEffectiveQuotaStatus().
+							Name("dqo-tie-breaker").
+							ResourceGroups(utiltestingapi.ResourceGroup(
+								*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "3333m").Obj(),
+							)).
+							Obj(),
+					).
+					Obj(),
+				utiltestingapi.MakeClusterQueue("cq-2").
+					Cohort("cohort-1").
+					EffectiveQuotaStatus(
+						utiltestingapi.MakeEffectiveQuotaStatus().
+							Name("dqo-tie-breaker").
+							ResourceGroups(utiltestingapi.ResourceGroup(
+								*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "3334m").Obj(),
+							)).
+							Obj(),
+					).
+					Obj(),
+			},
+		},
+		"proportional distribution: scalar resource distribution uses integer unit (scale 0)": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-scalar-scale").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "cohort-1").
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
+								Resource(corev1.ResourceMemory, "10").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("cohort-1").
+					UID("uid-b").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceMemory, "1").Obj(),
+					).
+					Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq-1").
+					UID("uid-c").
+					Cohort("cohort-1").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceMemory, "1").Obj(),
+					).
+					Obj(),
+				utiltestingapi.MakeClusterQueue("cq-2").
+					UID("uid-a").
+					Cohort("cohort-1").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceMemory, "1").Obj(),
+					).
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-scalar-scale").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.CohortSubtreeRootRefKind, "cohort-1").
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("default-flavor").
+							Resource(corev1.ResourceMemory, "10").
+							Obj(),
+					).
+					Obj()).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorDistributed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonQuotasDistributed,
+					Message: "Quotas successfully distributed",
+				}).
+				Obj(),
+			wantCohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("cohort-1").
+					EffectiveQuotaStatus(
+						utiltestingapi.MakeEffectiveQuotaStatus().
+							Name("dqo-scalar-scale").
+							ResourceGroups(utiltestingapi.ResourceGroup(
+								*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceMemory, "3").Obj(),
+							)).
+							Obj(),
+					).
+					Obj(),
+			},
+			wantClusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq-1").
+					Cohort("cohort-1").
+					EffectiveQuotaStatus(
+						utiltestingapi.MakeEffectiveQuotaStatus().
+							Name("dqo-scalar-scale").
+							ResourceGroups(utiltestingapi.ResourceGroup(
+								*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceMemory, "3").Obj(),
+							)).
+							Obj(),
+					).
+					Obj(),
+				utiltestingapi.MakeClusterQueue("cq-2").
+					Cohort("cohort-1").
+					EffectiveQuotaStatus(
+						utiltestingapi.MakeEffectiveQuotaStatus().
+							Name("dqo-scalar-scale").
+							ResourceGroups(utiltestingapi.ResourceGroup(
+								*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceMemory, "4").Obj(),
+							)).
+							Obj(),
+					).
+					Obj(),
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -931,85 +2236,6 @@ func TestDynamicQuotaOrchestratorDistribution(t *testing.T) {
 				if diff := cmp.Diff(wantCohort.Status.EffectiveQuotas, gotCohort.Status.EffectiveQuotas, cmpopts.EquateEmpty()); diff != "" {
 					t.Errorf("Unexpected EffectiveQuotas for Cohort %s (-want +got):\n%s", wantCohort.Name, diff)
 				}
-			}
-		})
-	}
-}
-
-func TestDistributeCapacityProportionally(t *testing.T) {
-	cases := map[string]struct {
-		resource     corev1.ResourceName
-		capacity     resource.Quantity
-		participants []quotaParticipant
-		want         map[string]resource.Quantity
-	}{
-		"empty participants": {
-			resource:     corev1.ResourceCPU,
-			capacity:     resource.MustParse("100"),
-			participants: nil,
-			want:         map[string]resource.Quantity{},
-		},
-		"zero sum spec nominal quota": {
-			resource: corev1.ResourceCPU,
-			capacity: resource.MustParse("100"),
-			participants: []quotaParticipant{
-				{kind: kueuealpha.ClusterQueueSubtreeRootRefKind, name: "cq-1", specNominalQuota: resource.MustParse("0")},
-				{kind: kueuealpha.CohortSubtreeRootRefKind, name: "cohort-1", specNominalQuota: resource.MustParse("0")},
-			},
-			want: map[string]resource.Quantity{
-				"ClusterQueue/cq-1": resource.MustParse("0"),
-				"Cohort/cohort-1":   resource.MustParse("0"),
-			},
-		},
-		"remainder tie-breaker: UUID ordering per KEP-12382": {
-			resource: corev1.ResourceCPU,
-			capacity: resource.MustParse("10"),
-			participants: []quotaParticipant{
-				{kind: kueuealpha.ClusterQueueSubtreeRootRefKind, name: "cq-1", uid: "uid-c", specNominalQuota: resource.MustParse("1")},
-				{kind: kueuealpha.ClusterQueueSubtreeRootRefKind, name: "cq-2", uid: "uid-a", specNominalQuota: resource.MustParse("1")},
-				{kind: kueuealpha.CohortSubtreeRootRefKind, name: "cohort-1", uid: "uid-b", specNominalQuota: resource.MustParse("1")},
-			},
-			want: map[string]resource.Quantity{
-				"ClusterQueue/cq-1": resource.MustParse("3333m"),
-				"ClusterQueue/cq-2": resource.MustParse("3334m"),
-				"Cohort/cohort-1":   resource.MustParse("3333m"),
-			},
-		},
-		"scalar resource distribution uses integer unit (scale 0)": {
-			resource: corev1.ResourceMemory,
-			capacity: resource.MustParse("10"),
-			participants: []quotaParticipant{
-				{kind: kueuealpha.ClusterQueueSubtreeRootRefKind, name: "cq-1", uid: "uid-c", specNominalQuota: resource.MustParse("1")},
-				{kind: kueuealpha.ClusterQueueSubtreeRootRefKind, name: "cq-2", uid: "uid-a", specNominalQuota: resource.MustParse("1")},
-				{kind: kueuealpha.CohortSubtreeRootRefKind, name: "cohort-1", uid: "uid-b", specNominalQuota: resource.MustParse("1")},
-			},
-			want: map[string]resource.Quantity{
-				"ClusterQueue/cq-1": resource.MustParse("3"),
-				"ClusterQueue/cq-2": resource.MustParse("4"),
-				"Cohort/cohort-1":   resource.MustParse("3"),
-			},
-		},
-		"proportional allocation without remainders across cohorts and clusterqueues": {
-			resource: corev1.ResourceCPU,
-			capacity: resource.MustParse("50"),
-			participants: []quotaParticipant{
-				{kind: kueuealpha.CohortSubtreeRootRefKind, name: "parent-cohort", uid: "uid-1", specNominalQuota: resource.MustParse("20")},
-				{kind: kueuealpha.ClusterQueueSubtreeRootRefKind, name: "cq-1", uid: "uid-2", specNominalQuota: resource.MustParse("10")},
-				{kind: kueuealpha.ClusterQueueSubtreeRootRefKind, name: "cq-2", uid: "uid-3", specNominalQuota: resource.MustParse("10")},
-			},
-			want: map[string]resource.Quantity{
-				"Cohort/parent-cohort": resource.MustParse("25"),
-				"ClusterQueue/cq-1":    resource.MustParse("12500m"),
-				"ClusterQueue/cq-2":    resource.MustParse("12500m"),
-			},
-		},
-	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			got := distributeCapacityProportionally(tc.resource, tc.capacity, tc.participants)
-			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("Unexpected distribution (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/controller/core/dqo/reconciler_test.go
+++ b/pkg/controller/core/dqo/reconciler_test.go
@@ -321,6 +321,38 @@ func TestDynamicQuotaOrchestratorReconcile(t *testing.T) {
 				}).
 				Obj(),
 		},
+		"discovery-only: provider reports flavor with empty resources": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-empty-res").
+				DiscoveryProvider("cp-1", nil).
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("empty-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(utiltestingalpha.MakeNormalizedCapacityFlavor("empty-flavor").Obj()).
+						Obj(),
+					).
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-empty-res").
+				DiscoveryProvider("cp-1", nil).
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors().
+					Obj(),
+				).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Obj(),
+		},
 		"feature gate disabled": {
 			enableFeatureGate: new(bool),
 			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-disabled").

--- a/pkg/util/testing/v1alpha1/wrappers.go
+++ b/pkg/util/testing/v1alpha1/wrappers.go
@@ -22,6 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
 )
@@ -49,6 +50,12 @@ func MakeDynamicQuotaOrchestrator(name string) *DynamicQuotaOrchestratorWrapper 
 // Obj returns the DynamicQuotaOrchestrator.
 func (w *DynamicQuotaOrchestratorWrapper) Obj() *kueuealpha.DynamicQuotaOrchestrator {
 	return &w.DynamicQuotaOrchestrator
+}
+
+// UID sets the UID of the DynamicQuotaOrchestrator.
+func (w *DynamicQuotaOrchestratorWrapper) UID(uid types.UID) *DynamicQuotaOrchestratorWrapper {
+	w.DynamicQuotaOrchestrator.UID = uid
+	return w
 }
 
 // DiscoveryProvider adds a CapacityDiscoveryProviderContribution to the DynamicQuotaOrchestrator.

--- a/pkg/util/testing/v1beta2/wrappers.go
+++ b/pkg/util/testing/v1beta2/wrappers.go
@@ -924,6 +924,11 @@ func (c *CohortWrapper) Obj() *kueue.Cohort {
 	return &c.Cohort
 }
 
+func (c *CohortWrapper) UID(uid types.UID) *CohortWrapper {
+	c.Cohort.UID = uid
+	return c
+}
+
 func (c *CohortWrapper) Parent(parentName kueue.CohortReference) *CohortWrapper {
 	c.Spec.ParentName = parentName
 	return c
@@ -1008,6 +1013,11 @@ func (c *ClusterQueueWrapper) Clone() *ClusterQueueWrapper {
 // Obj returns the inner ClusterQueue.
 func (c *ClusterQueueWrapper) Obj() *kueue.ClusterQueue {
 	return &c.ClusterQueue
+}
+
+func (c *ClusterQueueWrapper) UID(uid types.UID) *ClusterQueueWrapper {
+	c.ClusterQueue.UID = uid
+	return c
 }
 
 // Cohort sets the borrowing cohort.


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/area testing

#### What this PR does / why we need it?
Part of #14207

Add comprehensive table-driven reconciler unit test coverage for the `dqo` package:
- Reconciler distribution, soft validation & hierarchy resolution: Added table-driven scenarios to `TestDynamicQuotaOrchestratorDistribution` covering:
  - Multi-level ancestor conflict (grandparent/child) and multi-level ancestor takeover
  - Sibling cohorts and separate ClusterQueues (no conflict)
  - Subtree resolution: ClusterQueue root, Cohort root, multi-level hierarchy (excluding disjoint trees), intermediate cohort (scoped descendant resolution), standalone Cohort, missing root objects, and unsupported subtree root kinds
  - Cyclic cohort hierarchy safe termination in both conflict checking and subtree resolution
  - Proportional capacity distribution mathematical edge cases: zero-sum nominal quotas, remainder tie-breaking by UID ascending (per KEP-12382), and scalar integer units (scale 0)
- Capacity discovery edge case: Added test case for capacity provider reporting a flavor with empty resources in `TestDynamicQuotaOrchestratorReconcile`.
- Testing wrappers: Added fluent `.UID(types.UID)` helper methods to `CohortWrapper`, `ClusterQueueWrapper`, and `DynamicQuotaOrchestratorWrapper` matching existing wrapper conventions.

Overall package statement coverage increased from **73.3%** to **76.9%** (+3.6%), with 100% of the unit tests exercising the controller through its top-level `Reconcile` entry point.

#### Useful notes for your reviewer
This addresses review feedback by @mimowo on [PR #15283 (comment)](https://github.com/kubernetes-sigs/kueue/pull/15283#discussion_r3957548954) regarding unit test coverage for code paths in the DQO reconciler, and incorporates the suggestion on [PR #15325 (comment)](https://github.com/kubernetes-sigs/kueue/pull/15325#discussion_r3967993074) by testing hierarchy resolution, soft validation, and proportional capacity distribution strictly through higher-level `Reconcile` in `TestDynamicQuotaOrchestratorDistribution` rather than testing low-level unexported helpers directly.

*Disclosure: In accordance with the Kubernetes AI policy, AI tools were used in formulating test cases and validating coverage.*

#### Release note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## AI summary

Added comprehensive table-driven tests for `dqo` reconciliation, including hierarchy conflicts, subtree resolution, proportional capacity distribution, cycles, missing objects, and unsupported roots. Added coverage for empty-resource flavors and UID builder helpers for test wrappers.

## Suggested release note

NONE

<!-- end of auto-generated comment: release notes by coderabbit.ai -->