### PR TITLE
Fix /sync-release-notes ChatOps command.

### DIFF
--- a/.github/workflows/release-utils.yml
+++ b/.github/workflows/release-utils.yml
@@ -200,15 +200,19 @@ jobs:
           ref: main
           persist-credentials: false
 
-      - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version-file: 'go.mod'
-
       - name: Install release-notes tool
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          go install k8s.io/release/cmd/release-notes@v0.20.1
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+          DOWNLOAD_DIR=$(mktemp -d)
+          gh release download v0.20.1 \
+            --repo kubernetes/release \
+            --pattern 'release-notes-amd64-linux' \
+            --pattern 'checksums.txt' \
+            --dir "$DOWNLOAD_DIR"
+          grep -E '(^|[[:space:]])release-notes-amd64-linux$' "$DOWNLOAD_DIR/checksums.txt" \
+            | (cd "$DOWNLOAD_DIR" && sha256sum -c -)
+          install -m 0755 "$DOWNLOAD_DIR/release-notes-amd64-linux" /usr/local/bin/release-notes
 
       - name: Run Sync Notes
         id: sync


### PR DESCRIPTION
<!-- Thank you for contributing! Check CONTRIBUTING.md for details. -->

#### What type of PR is this?
<!-- Choose one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally choose one or more of the following kinds:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->
/kind bug
/area release

#### What this PR does / why we need it?
Fix sync-release-notes ChatOps command.

<!--
Use `Fixes #123` for an issue addressed by this PR; it will be closed when the PR merges.
Use `Related:` or `Part of:` to reference an issue without closing it.
-->
Fixes #

#### Useful notes for your reviewer
Currently /sync-release-notes ChatOps command failing https://github.com/kubernetes-sigs/kueue/actions/runs/34349804460/job/102460208270.

#### Release note
<!-- Describe the behavior change accurately from the user's perspective. Hints:
- Do not leave this block blank.
- Use "NONE" when there is no user-facing change.
- When feasible use a prefix for the sub-component or feature, e.g. "FairSharing:" or "MultiKueue:".
- If upgrade steps are required, include an "ACTION REQUIRED:" section.
You may consider AI assistance using the skill: cmd/experimental/skills/kueue-release-notes/SKILL.md.
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## AI summary

Fixed the `sync-release-notes` ChatOps command by installing the required `release-notes` binary correctly.

### Suggested release note

NONE
<!-- end of auto-generated comment: release notes by coderabbit.ai -->