### PR TITLE
kueuectl: Document quotareserved in the list workload --status flag

### DIFF
--- a/cmd/kueuectl/app/list/list_workload.go
+++ b/cmd/kueuectl/app/list/list_workload.go
@@ -126,7 +126,7 @@ func NewWorkloadCmd(clientGetter clientgetter.ClientGetter, streams genericioopt
 	cobra.CheckErr(cmd.RegisterFlagCompletionFunc("clusterqueue", completion.ClusterQueueNameFunc(clientGetter, nil)))
 	cobra.CheckErr(cmd.RegisterFlagCompletionFunc("localqueue", completion.LocalQueueNameFunc(clientGetter, nil)))
 
-	cmd.Flags().StringArray("status", nil, `Filter workloads by status. Must be "all", "pending", "admitted" or "finished"`)
+	cmd.Flags().StringArray("status", nil, `Filter workloads by status. Must be "all", "pending", "quotareserved", "admitted" or "finished"`)
 
 	return cmd
 }
@@ -152,7 +152,7 @@ func getWorkloadStatuses(cmd *cobra.Command) (sets.Set[int], error) {
 		case "finished":
 			statuses.Insert(workloadStatusFinished)
 		default:
-			return nil, fmt.Errorf(`invalid status value (%v). Must be "all", "pending", "admitted" or "finished"`, status)
+			return nil, fmt.Errorf(`invalid status value (%v). Must be "all", "pending", "quotareserved", "admitted" or "finished"`, status)
 		}
 	}
 

--- a/cmd/kueuectl/app/list/list_workload_test.go
+++ b/cmd/kueuectl/app/list/list_workload_test.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	kftraining "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -70,7 +69,7 @@ func TestWorkloadCmd(t *testing.T) {
 		listPages            []runtime.Object
 		wantOut              string
 		wantOutErr           string
-		wantErr              error
+		wantErr              string
 	}{
 		"should print workload list with namespace filter": {
 			ns: "ns1",
@@ -958,6 +957,10 @@ kind: WorkloadList
 metadata: {}
 `,
 		},
+		"should fail with invalid status value": {
+			args:    []string{"--status", "unknown"},
+			wantErr: `invalid status value (unknown). Must be "all", "pending", "quotareserved", "admitted" or "finished"`,
+		},
 		"should print not found error": {
 			wantOutErr: fmt.Sprintf("No resources found in %s namespace.\n", metav1.NamespaceDefault),
 		},
@@ -1036,7 +1039,11 @@ metadata: {}
 			cmd.SetArgs(tc.args)
 
 			gotErr := cmd.Execute()
-			if diff := cmp.Diff(tc.wantErr, gotErr, cmpopts.EquateErrors()); diff != "" {
+			var gotErrStr string
+			if gotErr != nil {
+				gotErrStr = gotErr.Error()
+			}
+			if diff := cmp.Diff(tc.wantErr, gotErrStr); diff != "" {
 				t.Errorf("Unexpected error (-want/+got)\n%s", diff)
 			}
 

--- a/site/content/en/docs/reference/kubectl-kueue/commands/kueuectl_list/kueuectl_list_workload.md
+++ b/site/content/en/docs/reference/kubectl-kueue/commands/kueuectl_list/kueuectl_list_workload.md
@@ -133,7 +133,7 @@ kueuectl list workload [--clusterqueue CLUSTER_QUEUE_NAME] [--localqueue LOCAL_Q
     <tr>
         <td></td>
         <td style="line-height: 130%; word-wrap: break-word;">
-            <p>Filter workloads by status. Must be &#34;all&#34;, &#34;pending&#34;, &#34;admitted&#34; or &#34;finished&#34;</p>
+            <p>Filter workloads by status. Must be &#34;all&#34;, &#34;pending&#34;, &#34;quotareserved&#34;, &#34;admitted&#34; or &#34;finished&#34;</p>
         </td>
     </tr>
     <tr>


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`kueuectl list workload --status` accepts `quotareserved`, but the flag help text, the generated CLI reference and the invalid-value error message only list `all`, `pending`, `admitted` and `finished`. Users cannot discover the value from `--help` or the docs, and a typo produces an error message that denies the value exists.

This PR adds `quotareserved` to both strings, regenerates the kueuectl reference docs, and adds a test that asserts the invalid-status error message.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

- `TestWorkloadCmd` now compares `wantErr` as a string instead of via `cmpopts.EquateErrors()`, matching `delete_workload_test.go` and `create_resourceflavor_test.go`, so the exact error message can be asserted. No existing case in that table used `wantErr`.

#### Does this PR introduce a user-facing change?

```release-note
CLI: Fixed the `--status` flag help text and error message of `kueuectl list workload` to include the supported `quotareserved` value.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## AI summary

- Added `quotareserved` to the supported `kueuectl list workload --status` values.
- Updated CLI help, validation errors, generated documentation, and tests.

### Suggested release note

Workloads: Added `quotareserved` as a supported value for `kueuectl list workload --status`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->