### PR TITLE
Integrate Giveback algorithm into PodSetReducer and rename Search

### DIFF
--- a/pkg/scheduler/flavorassigner/podset_reducer.go
+++ b/pkg/scheduler/flavorassigner/podset_reducer.go
@@ -29,18 +29,25 @@ import (
 // fullCounts, writing the resulting per-PodSet counts into out; deltas caps
 // how much each PodSet can individually give up. Every out[i] must be
 // monotonically non-increasing as amount grows, or the binary search in
-// Search breaks.
+// Reduce breaks.
 type distributeFunc func(out, fullCounts, deltas []int32, amount, totalDelta int64)
 
-// PodSetReducer helper structure used to gradually walk down
-// from PodSets[*].Count to *PodSets[*].MinimumCount.
+// PodSetReducer helper structure used to find the largest counts between
+// PodSets[*].MinCount and PodSets[*].Count that fit.
 type PodSetReducer[R any] struct {
 	podSets    []kueue.PodSet
 	fullCounts []int32
 	deltas     []int32
 	totalDelta int64
+	// fits reports whether the given counts can be admitted. The slice is scratch that is
+	// overwritten on every probe, including long after a successful one, so an implementation
+	// must not retain it - copy anything it needs to keep.
 	fits       func([]int32) (R, bool)
 	distribute distributeFunc
+	// refine optionally improves the counts the shrink settled on, for a shrink that can give
+	// up more than the constraints required. Only the ordered strategy sets it today; a
+	// strategy whose shrink is already exact leaves it nil.
+	refine func(counts []int32, best R) (R, bool)
 }
 
 func newPodSetReducer[R any](podSets []kueue.PodSet, fits func([]int32) (R, bool), distribute distributeFunc) *PodSetReducer[R] {
@@ -65,9 +72,17 @@ func newPodSetReducer[R any](podSets []kueue.PodSet, fits func([]int32) (R, bool
 
 // NewOrderedPodSetReducer shrinks PodSets sequentially, starting from the
 // last one in podSets and moving towards the first only once the current one
-// has been shrunk down to its minimum count.
+// has been shrunk down to its minimum count. A second pass then grows back
+// whatever that order cut beyond what the constraints required, so the counts
+// Reduce returns are not simply the result of one ordered shrink.
 func NewOrderedPodSetReducer[R any](podSets []kueue.PodSet, fits func([]int32) (R, bool)) *PodSetReducer[R] {
-	return newPodSetReducer(podSets, fits, distributeOrderBased)
+	psr := newPodSetReducer(podSets, fits, distributeOrderBased)
+	// The budget is a single number, but PodSets can draw on separate capacity - different node
+	// selectors tied to different node groups, and so different flavors. Spending strictly from
+	// the back can therefore drain a PodSet whose own capacity was never the constraint, which
+	// the second pass gives back.
+	psr.refine = psr.giveBack
+	return psr
 }
 
 func distributeOrderBased(out, fullCounts, deltas []int32, amount, _ int64) {
@@ -79,8 +94,10 @@ func distributeOrderBased(out, fullCounts, deltas []int32, amount, _ int64) {
 	}
 }
 
-// Reduce returns the fits() result for the largest counts that fit, giving up as little of
-// PodSets[*].Count as the constraints allow, and false when no combination fits.
+// Reduce returns the fits() result for the largest counts that fit, and false when no
+// combination does. It gives up as little of PodSets[*].Count as the reduction strategy allows
+// - which is not necessarily the smallest possible total, since a strategy may deliberately
+// favour some PodSets over others.
 func (psr *PodSetReducer[R]) Reduce() (R, bool) {
 	var best R
 
@@ -92,11 +109,16 @@ func (psr *PodSetReducer[R]) Reduce() (R, bool) {
 	// to its minimum count is a candidate like any other, and is the only one left when nothing
 	// smaller fits. sort.Search takes a half-open range, hence the +1.
 	current := make([]int32, len(psr.podSets))
+	// current is scratch for the budget being probed, and the binary search usually probes a
+	// failing budget last. bestCounts is copied only on success, so it always describes the
+	// same attempt as best - which refine needs as its starting point.
+	bestCounts := make([]int32, len(psr.podSets))
 	idx := sort.Search(int(psr.totalDelta)+1, func(i int) bool {
 		psr.distribute(current, psr.fullCounts, psr.deltas, int64(i), psr.totalDelta)
 		r, f := psr.fits(current)
 		if f {
 			best = r
+			copy(bestCounts, current)
 		}
 		return f
 	})
@@ -104,6 +126,72 @@ func (psr *PodSetReducer[R]) Reduce() (R, bool) {
 	// Not even the full reduction fit.
 	if idx > int(psr.totalDelta) {
 		return best, false
+	}
+	if psr.refine != nil {
+		return psr.refine(bestCounts, best)
+	}
+	return best, true
+}
+
+// giveBack grows back the PodSets that the ordered shrink cut further than the constraints
+// required. It walks the PodSets from the first to the last, since those are the ones the
+// order-based policy protects, and commits each grown count before moving on so that later
+// PodSets are measured against the quota the earlier ones just took.
+//
+// It grows counts in place and returns the fits() result matching them.
+//
+// Two preconditions: counts must be a combination that fits, with best its fits() result; and a
+// count that fits must imply every smaller count fits, holding the other PodSets steady, since
+// the binary search below relies on it. The latter holds for a workload slice because it is
+// pinned to the assignment of the slice it replaces, so a PodSet's assignment cannot change
+// underneath the search. Were it ever violated the result would be a smaller admission, never
+// an invalid one, because every count committed here came back from a successful fits().
+func (psr *PodSetReducer[R]) giveBack(counts []int32, best R) (R, bool) {
+	reduced := 0
+	for i := range counts {
+		if counts[i] < psr.fullCounts[i] {
+			reduced++
+		}
+	}
+	// A single reduced PodSet has nothing to redistribute: the shrink already found the
+	// smallest budget that fits, and giving any of it back means a budget it has rejected.
+	// This also keeps the second pass away from classic partial admission, where a Workload
+	// may carry at most one minCount PodSet, so it only ever runs where the PodSets can draw
+	// on separate capacity.
+	if reduced < 2 {
+		return best, true
+	}
+
+	trial := make([]int32, len(counts))
+	copy(trial, counts)
+
+	for i := range counts {
+		if counts[i] == psr.fullCounts[i] {
+			continue
+		}
+
+		// Restoring the full count is the common case, and one call settles it.
+		trial[i] = psr.fullCounts[i]
+		if r, f := psr.fits(trial); f {
+			counts[i], best = psr.fullCounts[i], r
+			continue
+		}
+
+		// Otherwise look for the largest count that still fits, between the count the shrink
+		// settled on (exclusive) and the full count (exclusive, having just failed).
+		lo, hi := counts[i]+1, psr.fullCounts[i]-1
+		grownTo, grownBest := counts[i], best
+		sort.Search(int(hi-lo+1), func(k int) bool {
+			trial[i] = lo + int32(k)
+			r, f := psr.fits(trial)
+			if f {
+				// sort.Search only raises its lower bound past a count that fits, so the
+				// last one seen to fit is the largest one that does.
+				grownTo, grownBest = trial[i], r
+			}
+			return !f
+		})
+		counts[i], trial[i], best = grownTo, grownTo, grownBest
 	}
 	return best, true
 }

--- a/pkg/scheduler/flavorassigner/podset_reducer.go
+++ b/pkg/scheduler/flavorassigner/podset_reducer.go
@@ -83,27 +83,28 @@ func distributeOrderBased(out, fullCounts, deltas []int32, amount, _ int64) {
 // binary Search so the last call to fits() might not be a successful one
 // Returns nil if no solution was found
 func (psr *PodSetReducer[R]) Search() (R, bool) {
-	var lastR R
+	var best R
 
 	if psr.totalDelta == 0 {
-		return lastR, false
+		return best, false
 	}
 
+	// The searched range is [0, totalDelta], inclusive of totalDelta: cutting every PodSet down
+	// to its minimum count is a candidate like any other, and is the only one left when nothing
+	// smaller fits. sort.Search takes a half-open range, hence the +1.
 	current := make([]int32, len(psr.podSets))
-	idx := sort.Search(int(psr.totalDelta), func(i int) bool {
+	idx := sort.Search(int(psr.totalDelta)+1, func(i int) bool {
 		psr.distribute(current, psr.fullCounts, psr.deltas, int64(i), psr.totalDelta)
 		r, f := psr.fits(current)
 		if f {
-			lastR = r
+			best = r
 		}
 		return f
 	})
 
-	if idx < int(psr.totalDelta) {
-		return lastR, true
+	// Not even the full reduction fit.
+	if idx > int(psr.totalDelta) {
+		return best, false
 	}
-
-	// sort.Search searches [0, totalDelta), so check totalDelta separately.
-	psr.distribute(current, psr.fullCounts, psr.deltas, psr.totalDelta, psr.totalDelta)
-	return psr.fits(current)
+	return best, true
 }

--- a/pkg/scheduler/flavorassigner/podset_reducer.go
+++ b/pkg/scheduler/flavorassigner/podset_reducer.go
@@ -79,10 +79,9 @@ func distributeOrderBased(out, fullCounts, deltas []int32, amount, _ int64) {
 	}
 }
 
-// Search find the first biggest set of counts that pass fits(), it's using
-// binary Search so the last call to fits() might not be a successful one
-// Returns nil if no solution was found
-func (psr *PodSetReducer[R]) Search() (R, bool) {
+// Reduce returns the fits() result for the largest counts that fit, giving up as little of
+// PodSets[*].Count as the constraints allow, and false when no combination fits.
+func (psr *PodSetReducer[R]) Reduce() (R, bool) {
 	var best R
 
 	if psr.totalDelta == 0 {

--- a/pkg/scheduler/flavorassigner/podset_reducer.go
+++ b/pkg/scheduler/flavorassigner/podset_reducer.go
@@ -39,14 +39,12 @@ type PodSetReducer[R any] struct {
 	fullCounts []int32
 	deltas     []int32
 	totalDelta int64
-	// fits reports whether the given counts can be admitted. The slice is scratch that is
-	// overwritten on every probe, including long after a successful one, so an implementation
-	// must not retain it - copy anything it needs to keep.
+	// fits reports whether the given counts can be admitted. The slice is scratch,
+	// overwritten on every probe, so an implementation must copy anything it keeps.
 	fits       func([]int32) (R, bool)
 	distribute distributeFunc
-	// refine optionally improves the counts the shrink settled on, for a shrink that can give
-	// up more than the constraints required. Only the ordered strategy sets it today; a
-	// strategy whose shrink is already exact leaves it nil.
+	// refine optionally grows back counts the shrink gave up needlessly. Nil for a
+	// strategy whose shrink is already exact.
 	refine func(counts []int32, best R) (R, bool)
 }
 
@@ -70,17 +68,13 @@ func newPodSetReducer[R any](podSets []kueue.PodSet, fits func([]int32) (R, bool
 	return psr
 }
 
-// NewOrderedPodSetReducer shrinks PodSets sequentially, starting from the
-// last one in podSets and moving towards the first only once the current one
-// has been shrunk down to its minimum count. A second pass then grows back
-// whatever that order cut beyond what the constraints required, so the counts
-// Reduce returns are not simply the result of one ordered shrink.
+// NewOrderedPodSetReducer shrinks PodSets from the last towards the first, moving on only
+// once the current one is at its minimum count, then gives back what that order cut
+// needlessly. The budget is a single number, but PodSets tied to different node groups draw
+// on separate capacity, so spending from the back can drain a PodSet whose own capacity was
+// never the constraint.
 func NewOrderedPodSetReducer[R any](podSets []kueue.PodSet, fits func([]int32) (R, bool)) *PodSetReducer[R] {
 	psr := newPodSetReducer(podSets, fits, distributeOrderBased)
-	// The budget is a single number, but PodSets can draw on separate capacity - different node
-	// selectors tied to different node groups, and so different flavors. Spending strictly from
-	// the back can therefore drain a PodSet whose own capacity was never the constraint, which
-	// the second pass gives back.
 	psr.refine = psr.giveBack
 	return psr
 }
@@ -94,10 +88,9 @@ func distributeOrderBased(out, fullCounts, deltas []int32, amount, _ int64) {
 	}
 }
 
-// Reduce returns the fits() result for the largest counts that fit, and false when no
-// combination does. It gives up as little of PodSets[*].Count as the reduction strategy allows
-// - which is not necessarily the smallest possible total, since a strategy may deliberately
-// favour some PodSets over others.
+// Reduce returns the fits() result for the largest counts the reduction strategy can admit,
+// and false when no combination fits. A strategy may favour some PodSets over others, so the
+// total is not necessarily the largest one possible.
 func (psr *PodSetReducer[R]) Reduce() (R, bool) {
 	var best R
 
@@ -105,13 +98,9 @@ func (psr *PodSetReducer[R]) Reduce() (R, bool) {
 		return best, false
 	}
 
-	// The searched range is [0, totalDelta], inclusive of totalDelta: cutting every PodSet down
-	// to its minimum count is a candidate like any other, and is the only one left when nothing
-	// smaller fits. sort.Search takes a half-open range, hence the +1.
 	current := make([]int32, len(psr.podSets))
-	// current is scratch for the budget being probed, and the binary search usually probes a
-	// failing budget last. bestCounts is copied only on success, so it always describes the
-	// same attempt as best - which refine needs as its starting point.
+	// current holds the budget probed last, usually a failing one, so the winning counts are
+	// kept separately for refine to start from.
 	bestCounts := make([]int32, len(psr.podSets))
 	idx := sort.Search(int(psr.totalDelta)+1, func(i int) bool {
 		psr.distribute(current, psr.fullCounts, psr.deltas, int64(i), psr.totalDelta)
@@ -133,19 +122,10 @@ func (psr *PodSetReducer[R]) Reduce() (R, bool) {
 	return best, true
 }
 
-// giveBack grows back the PodSets that the ordered shrink cut further than the constraints
-// required. It walks the PodSets from the first to the last, since those are the ones the
-// order-based policy protects, and commits each grown count before moving on so that later
-// PodSets are measured against the quota the earlier ones just took.
-//
-// It grows counts in place and returns the fits() result matching them.
-//
-// Two preconditions: counts must be a combination that fits, with best its fits() result; and a
-// count that fits must imply every smaller count fits, holding the other PodSets steady, since
-// the binary search below relies on it. The latter holds for a workload slice because it is
-// pinned to the assignment of the slice it replaces, so a PodSet's assignment cannot change
-// underneath the search. Were it ever violated the result would be a smaller admission, never
-// an invalid one, because every count committed here came back from a successful fits().
+// giveBack grows back the counts that the shrink cut more than it had to.
+// It goes through the PodSets from first to last and grows each one as far as
+// still fits before moving on - so a later PodSet only sees the capacity the earlier ones
+// left. It grows counts in place and returns what fits() gave for the final counts.
 func (psr *PodSetReducer[R]) giveBack(counts []int32, best R) (R, bool) {
 	reduced := 0
 	for i := range counts {
@@ -153,11 +133,9 @@ func (psr *PodSetReducer[R]) giveBack(counts []int32, best R) (R, bool) {
 			reduced++
 		}
 	}
-	// A single reduced PodSet has nothing to redistribute: the shrink already found the
-	// smallest budget that fits, and giving any of it back means a budget it has rejected.
-	// This also keeps the second pass away from classic partial admission, where a Workload
-	// may carry at most one minCount PodSet, so it only ever runs where the PodSets can draw
-	// on separate capacity.
+	// With one reduced PodSet there is nothing to redistribute: growing it means a budget the
+	// shrink already rejected. This also keeps the pass away from classic partial admission,
+	// which allows at most one minCount PodSet per Workload.
 	if reduced < 2 {
 		return best, true
 	}
@@ -177,8 +155,8 @@ func (psr *PodSetReducer[R]) giveBack(counts []int32, best R) (R, bool) {
 			continue
 		}
 
-		// Otherwise look for the largest count that still fits, between the count the shrink
-		// settled on (exclusive) and the full count (exclusive, having just failed).
+		// Otherwise find the largest count that still fits, between the count the shrink
+		// settled on and the full count, both exclusive.
 		lo, hi := counts[i]+1, psr.fullCounts[i]-1
 		grownTo, grownBest := counts[i], best
 		sort.Search(int(hi-lo+1), func(k int) bool {

--- a/pkg/scheduler/flavorassigner/podset_reducer_test.go
+++ b/pkg/scheduler/flavorassigner/podset_reducer_test.go
@@ -142,7 +142,7 @@ func TestOrderedSearch(t *testing.T) {
 				return out, true
 			}
 			red := NewOrderedPodSetReducer(tc.podSets, fits)
-			count, found := red.Search()
+			count, found := red.Reduce()
 			if found != tc.wantFound {
 				t.Errorf("Unexpected found:%v, want: %v", found, tc.wantFound)
 			}
@@ -179,7 +179,7 @@ func TestSearchTotalDeltaLarge(t *testing.T) {
 		t.Fatalf("Unexpected totalDelta: %d, want %d", got, want)
 	}
 
-	count, found := red.Search()
+	count, found := red.Reduce()
 	if !found {
 		t.Fatal("Expected a solution")
 	}

--- a/pkg/scheduler/flavorassigner/podset_reducer_test.go
+++ b/pkg/scheduler/flavorassigner/podset_reducer_test.go
@@ -18,6 +18,7 @@ package flavorassigner
 
 import (
 	"math"
+	"slices"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -79,7 +80,7 @@ func TestDistributeOrderBased(t *testing.T) {
 	}
 }
 
-func TestOrderedSearch(t *testing.T) {
+func TestOrderedReduce(t *testing.T) {
 	cases := map[string]struct {
 		podSets   []kueue.PodSet
 		ok        func(counts []int32) bool
@@ -108,17 +109,67 @@ func TestOrderedSearch(t *testing.T) {
 			},
 			wantFound: false,
 		},
-		"KEP scenario D phase 1: independent flavors force draining a podset with its own slack": {
+		// The PodSets below draw on separate capacity, which is what lets a count be given back.
+		// In practice that separation comes from PodSets carrying different node selectors tied
+		// to different node groups, and so being assigned different resource flavors; here it is
+		// just a per-PodSet bound in the fake.
+		"KEP scenario A: only the last podset is cut, and only as far as needed": {
 			podSets: []kueue.PodSet{
 				*utiltestingapi.MakePodSet("ps0", 1).Obj(),
 				*utiltestingapi.MakePodSet("ps1", 4).SetMinimumCount(2).Obj(),
 				*utiltestingapi.MakePodSet("ps2", 20).SetMinimumCount(10).Obj(),
 			},
-			// ps1 tied to rf1 (quota 2), ps2 tied to rf2 (quota 20, never the bottleneck).
+			// One shared pool of 19 against the 25 requested, so 6 pods have to go.
 			ok: func(counts []int32) bool {
-				return counts[1] <= 2
+				return counts[0]+counts[1]+counts[2] <= 19
+			},
+			// ps2 alone absorbs the cut, so only one podset is reduced and there is nothing for
+			// the give-back phase to redistribute.
+			wantCount: []int32{1, 4, 14},
+			wantFound: true,
+		},
+		"KEP scenario B: the cut spills into the previous podset, and cannot be given back": {
+			podSets: []kueue.PodSet{
+				*utiltestingapi.MakePodSet("ps0", 1).Obj(),
+				*utiltestingapi.MakePodSet("ps1", 4).SetMinimumCount(2).Obj(),
+				*utiltestingapi.MakePodSet("ps2", 20).SetMinimumCount(10).Obj(),
+			},
+			// One shared pool of 13, so every count competes with every other.
+			ok: func(counts []int32) bool {
+				return counts[0]+counts[1]+counts[2] <= 13
 			},
 			wantCount: []int32{1, 2, 10},
+			wantFound: true,
+		},
+		"KEP scenario D: a podset drained for another's sake is restored in full": {
+			podSets: []kueue.PodSet{
+				*utiltestingapi.MakePodSet("ps0", 1).Obj(),
+				*utiltestingapi.MakePodSet("ps1", 4).SetMinimumCount(2).Obj(),
+				*utiltestingapi.MakePodSet("ps2", 20).SetMinimumCount(10).Obj(),
+			},
+			// ps1 capped at 2, ps2 at its full 20. Both bounds are modelled: with only the ps1
+			// bound, a give-back that restored ps2 without limit would pass just as happily as
+			// a correct one.
+			ok: func(counts []int32) bool {
+				return counts[1] <= 2 && counts[2] <= 20
+			},
+			// The ordered shrink drains ps2 to its minimum before it can touch ps1, even though
+			// ps2's own capacity was never the constraint, so ps2 is given back afterwards.
+			wantCount: []int32{1, 2, 20},
+			wantFound: true,
+		},
+		"a podset whose own capacity is partly exhausted is given back only as far as it fits": {
+			podSets: []kueue.PodSet{
+				*utiltestingapi.MakePodSet("ps0", 1).Obj(),
+				*utiltestingapi.MakePodSet("ps1", 4).SetMinimumCount(2).Obj(),
+				*utiltestingapi.MakePodSet("ps2", 20).SetMinimumCount(10).Obj(),
+			},
+			// ps2 has room for 15 of its 20, so the give-back lands strictly between the count
+			// the shrink settled on and the full count.
+			ok: func(counts []int32) bool {
+				return counts[1] <= 2 && counts[2] <= 15
+			},
+			wantCount: []int32{1, 2, 15},
 			wantFound: true,
 		},
 		"no podset has room to shrink": {
@@ -135,7 +186,7 @@ func TestOrderedSearch(t *testing.T) {
 				if !tc.ok(counts) {
 					return nil, false
 				}
-				// counts is reused across calls by Search, so it must be
+				// counts is reused across calls by Reduce, so it must be
 				// cloned to be safely returned as the winning result.
 				out := make([]int32, len(counts))
 				copy(out, counts)
@@ -155,7 +206,7 @@ func TestOrderedSearch(t *testing.T) {
 	}
 }
 
-func TestSearchTotalDeltaLarge(t *testing.T) {
+func TestReduceTotalDeltaLarge(t *testing.T) {
 	podSets := []kueue.PodSet{
 		*utiltestingapi.MakePodSet("ps1", math.MaxInt32).SetMinimumCount(0).Obj(),
 		*utiltestingapi.MakePodSet("ps2", math.MaxInt32).SetMinimumCount(0).Obj(),
@@ -187,5 +238,60 @@ func TestSearchTotalDeltaLarge(t *testing.T) {
 	wantCount := []int32{1, 0, 0}
 	if diff := cmp.Diff(wantCount, count); diff != "" {
 		t.Errorf("Unexpected counts (-want,+got):\n%s", diff)
+	}
+}
+
+// TestGiveBack covers the guard that decides whether the second pass runs at all. It calls
+// giveBack directly with a fits() that accepts anything, so a pass that runs is visible in both
+// the counts it returns and the number of probes it makes - which a test going through Reduce
+// could not show, since with one reduced PodSet the pass provably cannot change the counts.
+func TestGiveBack(t *testing.T) {
+	podSets := []kueue.PodSet{
+		*utiltestingapi.MakePodSet("ps1", 4).SetMinimumCount(2).Obj(),
+		*utiltestingapi.MakePodSet("ps2", 20).SetMinimumCount(10).Obj(),
+	}
+
+	cases := map[string]struct {
+		// counts stands in for what the ordered shrink settled on.
+		counts     []int32
+		wantCounts []int32
+		wantProbes int
+	}{
+		"one reduced podset: the pass is skipped": {
+			counts:     []int32{4, 15},
+			wantCounts: []int32{4, 15},
+			wantProbes: 0,
+		},
+		"two reduced podsets: both are restored": {
+			counts:     []int32{3, 15},
+			wantCounts: []int32{4, 20},
+			wantProbes: 2,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			probes := 0
+			fits := func(counts []int32) ([]int32, bool) {
+				probes++
+				return slices.Clone(counts), true
+			}
+			psr := NewOrderedPodSetReducer(podSets, fits)
+
+			counts := slices.Clone(tc.counts)
+			best, found := psr.giveBack(counts, slices.Clone(tc.counts))
+			if !found {
+				t.Fatal("Expected giveBack to keep the solution it was given")
+			}
+			if diff := cmp.Diff(tc.wantCounts, counts); diff != "" {
+				t.Errorf("Unexpected counts (-want,+got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantCounts, best); diff != "" {
+				t.Errorf("Unexpected result, out of step with counts (-want,+got):\n%s", diff)
+			}
+			if probes != tc.wantProbes {
+				t.Errorf("Unexpected fits() probes: %d, want %d", probes, tc.wantProbes)
+			}
+		})
 	}
 }

--- a/pkg/scheduler/flavorassigner/podset_reducer_test.go
+++ b/pkg/scheduler/flavorassigner/podset_reducer_test.go
@@ -158,6 +158,21 @@ func TestOrderedReduce(t *testing.T) {
 			wantCount: []int32{1, 2, 20},
 			wantFound: true,
 		},
+		"spare capacity goes to whichever competing podset comes first in podSets": {
+			podSets: []kueue.PodSet{
+				*utiltestingapi.MakePodSet("ps0", 20).SetMinimumCount(10).Obj(),
+				*utiltestingapi.MakePodSet("ps1", 20).SetMinimumCount(10).Obj(),
+				*utiltestingapi.MakePodSet("ps2", 20).SetMinimumCount(10).Obj(),
+			},
+			// ps0 capped at its minimum costs the shrink its whole budget, so all three land
+			// at 10 and the pool of 32 leaves 2 to give back.
+			ok: func(counts []int32) bool {
+				return counts[0] <= 10 && counts[0]+counts[1]+counts[2] <= 32
+			},
+			// ps1 and ps2 both have room for those 2, ps1 takes them, being ahead in podSets.
+			wantCount: []int32{10, 12, 10},
+			wantFound: true,
+		},
 		"a podset whose own capacity is partly exhausted is given back only as far as it fits": {
 			podSets: []kueue.PodSet{
 				*utiltestingapi.MakePodSet("ps0", 1).Obj(),
@@ -203,6 +218,38 @@ func TestOrderedReduce(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestReduceWithoutRefine covers a reducer that leaves refine nil, which a strategy whose
+// shrink is already exact would do. It uses the inputs of the KEP scenario D case above, so
+// the counts it asserts are what that scenario would be admitted at without the give-back.
+func TestReduceWithoutRefine(t *testing.T) {
+	podSets := []kueue.PodSet{
+		*utiltestingapi.MakePodSet("ps0", 1).Obj(),
+		*utiltestingapi.MakePodSet("ps1", 4).SetMinimumCount(2).Obj(),
+		*utiltestingapi.MakePodSet("ps2", 20).SetMinimumCount(10).Obj(),
+	}
+
+	fits := func(counts []int32) ([]int32, bool) {
+		if counts[1] > 2 || counts[2] > 20 {
+			return nil, false
+		}
+		return slices.Clone(counts), true
+	}
+
+	red := newPodSetReducer(podSets, fits, distributeOrderBased)
+	if red.refine != nil {
+		t.Fatal("Expected newPodSetReducer to leave refine unset")
+	}
+
+	count, found := red.Reduce()
+	if !found {
+		t.Fatal("Expected a solution")
+	}
+	// ps2 stays drained, since only the give-back pass would restore it to 20.
+	if diff := cmp.Diff([]int32{1, 2, 10}, count); diff != "" {
+		t.Errorf("Unexpected counts (-want,+got):\n%s", diff)
 	}
 }
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -954,7 +954,7 @@ func (s *Scheduler) getInitialAssignments(ctx context.Context, wl *workload.Info
 			}
 			return nil, false
 		})
-		if pa, found := reducer.Search(); found {
+		if pa, found := reducer.Reduce(); found {
 			return pa.assignment, append(preemptionTargets, pa.preemptionTargets...)
 		}
 	}

--- a/pkg/util/testingjobs/raycluster/wrappers.go
+++ b/pkg/util/testingjobs/raycluster/wrappers.go
@@ -38,6 +38,65 @@ func MakeWorkerGroups(count int) []rayv1.WorkerGroupSpec {
 	return groups
 }
 
+// WorkerGroupWrapper wraps a RayCluster worker group spec, for tests that need more than
+// the single default group the ClusterWrapper and ServiceWrapper setters address.
+type WorkerGroupWrapper struct{ rayv1.WorkerGroupSpec }
+
+// MakeWorkerGroup creates a wrapper for a worker group with the given name and replicas.
+func MakeWorkerGroup(name string, replicas int32) *WorkerGroupWrapper {
+	return &WorkerGroupWrapper{rayv1.WorkerGroupSpec{
+		GroupName:      name,
+		Replicas:       new(replicas),
+		MinReplicas:    new(int32(0)),
+		MaxReplicas:    new(int32(10)),
+		RayStartParams: map[string]string{},
+		Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				NodeSelector: map[string]string{},
+				Containers: []corev1.Container{
+					{
+						Name:    "worker-container",
+						Command: []string{},
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{},
+							Limits:   corev1.ResourceList{},
+						},
+					},
+				},
+			},
+		},
+	}}
+}
+
+// Obj returns the inner WorkerGroupSpec.
+func (w *WorkerGroupWrapper) Obj() *rayv1.WorkerGroupSpec {
+	return &w.WorkerGroupSpec
+}
+
+// MinReplicas sets the group's minReplicas.
+func (w *WorkerGroupWrapper) MinReplicas(replicas int32) *WorkerGroupWrapper {
+	w.WorkerGroupSpec.MinReplicas = new(replicas)
+	return w
+}
+
+// MaxReplicas sets the group's maxReplicas.
+func (w *WorkerGroupWrapper) MaxReplicas(replicas int32) *WorkerGroupWrapper {
+	w.WorkerGroupSpec.MaxReplicas = new(replicas)
+	return w
+}
+
+// Request adds a resource request to the group's default container.
+func (w *WorkerGroupWrapper) Request(r corev1.ResourceName, v string) *WorkerGroupWrapper {
+	w.Template.Spec.Containers[0].Resources.Requests[r] = resource.MustParse(v)
+	return w
+}
+
+// NodeSelector adds a node selector to the group's pod template.
+func (w *WorkerGroupWrapper) NodeSelector(key, value string) *WorkerGroupWrapper {
+	w.Template.Spec.NodeSelector[key] = value
+	return w
+}
+
 // ClusterWrapper wraps a RayCluster.
 type ClusterWrapper struct{ rayv1.RayCluster }
 

--- a/test/integration/singlecluster/controller/jobs/raycluster/raycluster_controller_partial_scaleup_test.go
+++ b/test/integration/singlecluster/controller/jobs/raycluster/raycluster_controller_partial_scaleup_test.go
@@ -37,7 +37,10 @@ import (
 
 // The RayCluster workload has two PodSets: the head, which cannot be shrunk, and the single
 // worker group, which is the one partial scale-up reduces.
-const workersPodSetIdx = 1
+const (
+	workersPodSetIdx = 1
+	workersGroupName = "workers-group-0"
+)
 
 // KEP-12100: Partial Replica ScaleUp for ElasticJob.
 var _ = ginkgo.Describe("RayCluster with partial replica scale-up for elastic jobs", ginkgo.Label("job:ray", "area:jobs"), ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
@@ -63,16 +66,6 @@ var _ = ginkgo.Describe("RayCluster with partial replica scale-up for elastic jo
 			})
 			g.Expect(idx).ShouldNot(gomega.Equal(-1), "ClusterQueue reports no pods usage, only %v", resources)
 			g.Expect(resources[idx].Total.Value()).Should(gomega.Equal(pods))
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-	}
-
-	// expectAdmittedWorkers asserts how many pods of the worker group the slice was admitted with.
-	expectAdmittedWorkers := func(wl *kueue.Workload, count int32) {
-		ginkgo.GinkgoHelper()
-		util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
-		gomega.Eventually(func(g gomega.Gomega) {
-			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).Should(gomega.Succeed())
-			g.Expect(wl.Status.Admission.PodSetAssignments[workersPodSetIdx].Count).Should(gomega.Equal(new(count)))
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	}
 	// scaleFirstWorkerGroup emulates the KubeRay controller, which is what updates .replicas in
@@ -149,7 +142,7 @@ var _ = ginkgo.Describe("RayCluster with partial replica scale-up for elastic jo
 		initialSlice := &util.ExpectWorkloadsInNamespace(ctx, k8sClient, ns.Name, 1)[0]
 		gomega.Expect(initialSlice.Spec.PodSets).Should(gomega.HaveLen(2))
 		gomega.Expect(initialSlice.Spec.PodSets[workersPodSetIdx].Count).Should(gomega.Equal(int32(5)))
-		expectAdmittedWorkers(initialSlice, 5)
+		util.ExpectPodSetAdmittedCount(ctx, k8sClient, initialSlice, workersGroupName, 5)
 
 		ginkgo.By("quota usage reflects the full 6 pods (1 head + 5 workers)")
 		expectPodsUsage(6)
@@ -170,7 +163,7 @@ var _ = ginkgo.Describe("RayCluster with partial replica scale-up for elastic jo
 		gomega.Expect(partialSlice.Spec.PodSets[workersPodSetIdx].MinCount).Should(gomega.Equal(new(int32(6))))
 
 		ginkgo.By("only 6 of the 10 requested workers fit: 1 head + 6 workers = the whole quota")
-		expectAdmittedWorkers(partialSlice, 6)
+		util.ExpectPodSetAdmittedCount(ctx, k8sClient, partialSlice, workersGroupName, 6)
 		expectPodsUsage(7)
 
 		ginkgo.By("the old (pre-scale-up) slice is finished")
@@ -215,7 +208,7 @@ var _ = ginkgo.Describe("RayCluster with partial replica scale-up for elastic jo
 		}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 
 		ginkgo.By("the partially-admitted slice still holds its 6 admitted workers")
-		expectAdmittedWorkers(partialSlice, 6)
+		util.ExpectPodSetAdmittedCount(ctx, k8sClient, partialSlice, workersGroupName, 6)
 
 		ginkgo.By("the probe workload is still pending")
 		util.ExpectWorkloadsToBePendingByKeys(ctx, k8sClient, probeKey)
@@ -234,7 +227,7 @@ var _ = ginkgo.Describe("RayCluster with partial replica scale-up for elastic jo
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 		ginkgo.By("the probe workload is admitted with the full 12 workers")
-		expectAdmittedWorkers(probe, 12)
+		util.ExpectPodSetAdmittedCount(ctx, k8sClient, probe, workersGroupName, 12)
 
 		ginkgo.By("the partially-admitted slice is finished, having been replaced by the probe")
 		util.ExpectWorkloadToFinish(ctx, k8sClient, client.ObjectKeyFromObject(partialSlice))
@@ -278,7 +271,7 @@ var _ = ginkgo.Describe("RayCluster with partial replica scale-up for elastic jo
 		})
 		gomega.Expect(initialSliceIdx).ShouldNot(gomega.Equal(-1), "no RayCluster slice alongside the victim")
 		initialSlice := &workloads[initialSliceIdx]
-		expectAdmittedWorkers(initialSlice, 2)
+		util.ExpectPodSetAdmittedCount(ctx, k8sClient, initialSlice, workersGroupName, 2)
 		expectPodsUsage(7)
 
 		// The scale-up wants 1 + 10 = 11 pods, which does not fit in the 7-pod quota even after
@@ -305,7 +298,7 @@ var _ = ginkgo.Describe("RayCluster with partial replica scale-up for elastic jo
 
 		// The whole 7-pod quota is now the RayCluster's: 1 head + 6 workers. MinCount is asserted
 		// in the spec above; this one is about the preemption interaction.
-		expectAdmittedWorkers(partialSlice, 6)
+		util.ExpectPodSetAdmittedCount(ctx, k8sClient, partialSlice, workersGroupName, 6)
 		expectPodsUsage(7)
 	})
 })

--- a/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_partial_scaleup_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_partial_scaleup_test.go
@@ -39,7 +39,10 @@ import (
 var _ = ginkgo.Describe("RayJob with partial replica scale-up for elastic jobs", ginkgo.Label("job:ray", "area:jobs"), ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	// The RayJob workload has the head PodSet at index 0 and the single worker group at index 1;
 	// the submitter PodSet is only added in K8sJobMode, which these specs avoid.
-	const workersPodSet = 1
+	const (
+		workersPodSet    = 1
+		workersGroupName = "workers-group-0"
+	)
 
 	var (
 		ns             *corev1.Namespace
@@ -53,15 +56,6 @@ var _ = ginkgo.Describe("RayJob with partial replica scale-up for elastic jobs",
 			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), job)).Should(gomega.Succeed())
 			job.Spec.RayClusterSpec.WorkerGroupSpecs[0].Replicas = new(replicas)
 			g.Expect(k8sClient.Update(ctx, job)).Should(gomega.Succeed())
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-	}
-
-	expectAdmittedWorkers := func(wl *kueue.Workload, count int32) {
-		ginkgo.GinkgoHelper()
-		util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
-		gomega.Eventually(func(g gomega.Gomega) {
-			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).Should(gomega.Succeed())
-			g.Expect(wl.Status.Admission.PodSetAssignments[workersPodSet].Count).Should(gomega.Equal(new(count)))
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	}
 
@@ -122,7 +116,7 @@ var _ = ginkgo.Describe("RayJob with partial replica scale-up for elastic jobs",
 		initialSlice := &util.ExpectWorkloadsInNamespace(ctx, k8sClient, ns.Name, 1)[0]
 		gomega.Expect(initialSlice.Spec.PodSets).Should(gomega.HaveLen(2))
 		gomega.Expect(initialSlice.Spec.PodSets[workersPodSet].Count).Should(gomega.Equal(int32(2)))
-		expectAdmittedWorkers(initialSlice, 2)
+		util.ExpectPodSetAdmittedCount(ctx, k8sClient, initialSlice, workersGroupName, 2)
 
 		// The full request is 1 + 5 = 6 pods against a 4-pod quota, so only 3 workers fit.
 		ginkgo.By("scaling the worker group to 5 replicas")
@@ -134,7 +128,7 @@ var _ = ginkgo.Describe("RayJob with partial replica scale-up for elastic jobs",
 		gomega.Expect(partialSlice.Spec.PodSets[workersPodSet].MinCount).Should(gomega.Equal(new(int32(3))))
 
 		ginkgo.By("only 3 of the 5 requested workers fit: 1 head + 3 workers = the whole quota")
-		expectAdmittedWorkers(partialSlice, 3)
+		util.ExpectPodSetAdmittedCount(ctx, k8sClient, partialSlice, workersGroupName, 3)
 
 		// This is what the RayCluster suite verifies too. RayJob overrides the workload slice name
 		// extra part with its own generation-derived value, so if that discards the probe's extra

--- a/test/integration/singlecluster/controller/jobs/rayservice/rayservice_controller_partial_scaleup_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayservice/rayservice_controller_partial_scaleup_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rayservice
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/component-base/featuregate"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/constants"
+	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/util/podset"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	testingraycluster "sigs.k8s.io/kueue/pkg/util/testingjobs/raycluster"
+	testingrayservice "sigs.k8s.io/kueue/pkg/util/testingjobs/rayservice"
+	"sigs.k8s.io/kueue/pkg/workloadslicing"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+// KEP-12100, Scenario D: two worker groups pinned to separate resource flavors by their node
+// selectors. The order-based shrink spends its whole budget from the last group before it can
+// touch the first, draining a group whose own flavor was never the constraint - so the give-back
+// phase has to restore it.
+var _ = ginkgo.Describe("RayService with partial replica scale-up across resource flavors", ginkgo.Label("job:ray", "area:jobs"), ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+	const (
+		instanceTypeLabel = "instance-type"
+		reservationGroup  = "workers-reservation"
+		spotGroup         = "workers-spot"
+	)
+
+	var (
+		ns           *corev1.Namespace
+		reservation  *kueue.ResourceFlavor
+		spot         *kueue.ResourceFlavor
+		clusterQueue *kueue.ClusterQueue
+		localQueue   *kueue.LocalQueue
+	)
+
+	scaleWorkerGroups := func(service *rayv1.RayService, reservationReplicas, spotReplicas int32) {
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(service), service)).Should(gomega.Succeed())
+			g.Expect(service.Spec.RayClusterSpec.WorkerGroupSpecs).Should(gomega.HaveLen(2))
+			service.Spec.RayClusterSpec.WorkerGroupSpecs[0].Replicas = new(reservationReplicas)
+			service.Spec.RayClusterSpec.WorkerGroupSpecs[1].Replicas = new(spotReplicas)
+			g.Expect(k8sClient.Update(ctx, service)).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+	}
+
+	ginkgo.BeforeAll(func() {
+		features.SetFeatureGatesDuringTest(ginkgo.GinkgoTB(), map[featuregate.Feature]bool{
+			features.ElasticJobsViaWorkloadSlices:                          true,
+			features.ElasticJobsViaWorkloadSlicesWithPartialReplicaScaleUp: true,
+		})
+		fwk.StartManager(ctx, cfg, managerAndSchedulerSetup())
+	})
+	ginkgo.AfterAll(func() {
+		fwk.StopManager(ctx)
+	})
+
+	ginkgo.BeforeEach(func() {
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "rayservice-partial-")
+
+		reservation = utiltestingapi.MakeResourceFlavor("reservation").
+			NodeLabel(instanceTypeLabel, "reservation").Obj()
+		util.MustCreate(ctx, k8sClient, reservation)
+		spot = utiltestingapi.MakeResourceFlavor("spot").
+			NodeLabel(instanceTypeLabel, "spot").Obj()
+		util.MustCreate(ctx, k8sClient, spot)
+
+		// The reservation flavor is the scarce one: it can hold 2 workers, so a scale-up of the
+		// reservation group has to be cut. The spot flavor has room for every spot worker, so
+		// anything the shrink takes from the spot group has to be given back.
+		clusterQueue = utiltestingapi.MakeClusterQueue("cq").
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas("reservation").Resource(corev1.ResourceCPU, "2").Obj(),
+				*utiltestingapi.MakeFlavorQuotas("spot").Resource(corev1.ResourceCPU, "20").Obj(),
+			).
+			Obj()
+		util.MustCreate(ctx, k8sClient, clusterQueue)
+
+		localQueue = utiltestingapi.MakeLocalQueue("lq", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+		util.MustCreate(ctx, k8sClient, localQueue)
+	})
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, localQueue, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, reservation, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, spot, true)
+	})
+
+	ginkgo.It("Should give back a worker group drained for another group's flavor", func() {
+		// Each worker asks for 1 CPU, so a group's replica count is its CPU usage in the flavor
+		// its node selector pins it to. minReplicas opts a group into partial scale-up; only its
+		// presence is checked, not its value. The head asks for no CPU, which keeps it out of the
+		// quota arithmetic entirely.
+		testRayService := testingrayservice.MakeService("foo", ns.Name).
+			Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			Annotation(constants.ElasticJobScaleUpStrategyAnnotationKey, constants.ElasticJobScaleUpStrategyPartial).
+			Queue(localQueue.Name).
+			WithWorkerGroups(
+				*testingraycluster.MakeWorkerGroup(reservationGroup, 1).
+					MaxReplicas(50).
+					Request(corev1.ResourceCPU, "1").
+					NodeSelector(instanceTypeLabel, "reservation").
+					Obj(),
+				*testingraycluster.MakeWorkerGroup(spotGroup, 9).
+					MaxReplicas(50).
+					Request(corev1.ResourceCPU, "1").
+					NodeSelector(instanceTypeLabel, "spot").
+					Obj(),
+			).
+			Obj()
+
+		ginkgo.By("admitting the rayservice at 1 reservation and 9 spot workers")
+		util.MustCreate(ctx, k8sClient, testRayService)
+		initialSlice := &util.ExpectWorkloadsInNamespace(ctx, k8sClient, ns.Name, 1)[0]
+		util.ExpectPodSetAdmittedCount(ctx, k8sClient, initialSlice, reservationGroup, 1)
+		util.ExpectPodSetAdmittedCount(ctx, k8sClient, initialSlice, spotGroup, 9)
+
+		// Scaling both groups makes minCount = admitted + 1 for each: 2 for the reservation
+		// group and 10 for the spot one, matching the KEP's Scenario D shape.
+		ginkgo.By("scaling to 4 reservation and 20 spot workers")
+		scaleWorkerGroups(testRayService, 4, 20)
+
+		ginkgo.By("a new slice requests the full scale-up, with a floor under each worker group")
+		scaleUpSlice := util.ExpectNewWorkloadSlice(ctx, k8sClient, initialSlice)
+		gomega.Expect(podset.FindPodSetByName(scaleUpSlice.Spec.PodSets, kueue.NewPodSetReference(reservationGroup)).Count).
+			Should(gomega.Equal(int32(4)))
+		gomega.Expect(podset.FindPodSetByName(scaleUpSlice.Spec.PodSets, kueue.NewPodSetReference(spotGroup)).Count).
+			Should(gomega.Equal(int32(20)))
+
+		// The reservation flavor holds 2, so the reservation group is cut from 4 to its floor of
+		// 2. Reaching that floor costs the shrink its whole budget, which means draining the spot
+		// group to its own floor of 10 first - even though the spot flavor had room for all 20.
+		// Give-back restores it; without that phase the spot group would stay at 10.
+		ginkgo.By("admitting the reservation group at its floor and the spot group in full")
+		util.ExpectPodSetAdmittedCount(ctx, k8sClient, scaleUpSlice, reservationGroup, 2)
+		util.ExpectPodSetAdmittedCount(ctx, k8sClient, scaleUpSlice, spotGroup, 20)
+
+		ginkgo.By("the pre-scale-up slice is finished")
+		util.ExpectWorkloadToFinish(ctx, k8sClient, client.ObjectKeyFromObject(initialSlice))
+	})
+})

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -442,6 +442,25 @@ func FinishWorkloads(ctx context.Context, k8sClient client.Client, workloads ...
 	}
 }
 
+// ExpectPodSetAdmittedCount waits until wl is admitted with count pods assigned to the named
+// PodSet, refreshing wl. A partially admitted workload - an elastic job whose scale-up was
+// reduced to fit the available quota - is admitted with fewer pods than it requested, so the
+// assigned count is what says how far the scale-up actually got.
+func ExpectPodSetAdmittedCount(ctx context.Context, k8sClient client.Client, wl *kueue.Workload, podSetName kueue.PodSetReference, count int32) {
+	ginkgo.GinkgoHelper()
+	ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).Should(gomega.Succeed())
+		g.Expect(wl.Status.Admission).ShouldNot(gomega.BeNil())
+		assignments := wl.Status.Admission.PodSetAssignments
+		idx := slices.IndexFunc(assignments, func(psa kueue.PodSetAssignment) bool {
+			return psa.Name == podSetName
+		})
+		g.Expect(idx).ShouldNot(gomega.Equal(-1), AssertMsg(fmt.Sprintf("No admitted podSet %q", podSetName), wl))
+		g.Expect(assignments[idx].Count).Should(gomega.Equal(new(count)))
+	}, Timeout, Interval).Should(gomega.Succeed())
+}
+
 func ExpectWorkloadsToHaveQuotaReservation(ctx context.Context, k8sClient client.Client, cqName string, wls ...*kueue.Workload) {
 	ginkgo.GinkgoHelper()
 	wlKeys := workloadKeys(wls)


### PR DESCRIPTION
<!-- Thank you for contributing! Check CONTRIBUTING.md for details. -->

#### What type of PR is this?
/kind feature
<!-- Choose one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally choose one or more of the following kinds:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it?

Implements the give-back phase of the order-based PodSet reduction from KEP-12100, which the KEP specifies but which was never built.

The ordered shrink searches over a single number — a total count budget spent from the last PodSet backwards. 
But PodSets can draw on separate capacity, since different node selectors tie them to different node groups and so different flavors. 
So the shrink can drain a PodSet whose own capacity was never the constraint, simply because it has to walk past it to reach the one that is. 
KEP Scenario D: ps1 is capped at 2 by its flavor while ps2 has room for all 20, so ps2 gets drained to 10 as a side effect and the job is admitted at {1,2,10} instead of {1,2,20} — smaller than the quota allowed.

Give-back repairs that: walk PodSets first to last, restore each reduced one as far as still fits, committing each count before the next.

Two preparatory commits come first. 
Fold the full-reduction probe into PodSetReducer.Search collapses two success paths into one — Scenario D exits through the second, so a hook on only the first would have missed the KEP's own example. 
Rename Search to Reduce names the outcome rather than the mechanism.

<!--
Use `Fixes #123` for an issue addressed by this PR; it will be closed when the PR merges.
Use `Related:` or `Part of:` to reference an issue without closing it.
-->
Part of #12100

#### Useful notes for your reviewer

The binary search assumes a count that fits implies every smaller count fits. 
That holds because a PodSet's assignment doesn't move while give-back runs — flavorassigner pins a slice to the assignment of the slice it replaces.

Give-back is skipped unless at least two PodSets were reduced, since with one, restoring any budget means a total the shrink already rejected. That keeps the common head-plus-one-worker-group shape at zero added cost. 
It is deliberately not gated on spanning multiple flavors: such a gate would need to see everything fits sees, and skipping a legitimate give-back under-admits, which is worse than wasted probes.

The unit table now names all four KEP scenarios (A and B were missing or unlabelled), plus a mid-range restore and a shared-pool case where give-back correctly declines. The new RayService spec is Scenario D end to end. 
I verified it fails with the refinement disabled (Expected <int32>: 10 to equal <int32>: 20), and it gives RayService its first partial scale-up coverage.

Prepared with the assistance of Claude Code.

#### Release note
<!-- Describe the behavior change accurately from the user's perspective. Hints:
- Do not leave this block blank.
- Use "NONE" when there is no user-facing change.
- When feasible use a prefix for the sub-component or feature, e.g. "FairSharing:" or "MultiKueue:".
- If upgrade steps are required, include an "ACTION REQUIRED:" section.
You may consider AI assistance using the skill: cmd/experimental/skills/kueue-release-notes/SKILL.md.
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## AI summary

- Improved partial admission by restoring eligible PodSet counts when capacity allows.
- Renamed `Search` to `Reduce` and integrated the full-reduction probe.
- Added unit and RayService integration coverage.
- Added a shared helper for validating admitted PodSet counts.

### Suggested release note

`Scheduling: Fixed partial admission that could unnecessarily reduce eligible PodSet counts when capacity was available.`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->