### PR TITLE
Fix TAS balanced placement to respect preferred node affinity

### DIFF
--- a/pkg/cache/scheduler/tas_balanced_placement.go
+++ b/pkg/cache/scheduler/tas_balanced_placement.go
@@ -17,9 +17,12 @@ limitations under the License.
 package scheduler
 
 import (
+	"cmp"
 	"maps"
 	"math"
 	"slices"
+
+	"sigs.k8s.io/kueue/pkg/features"
 )
 
 // evaluateGreedyAssignment simulates placement of a (leaderCount, sliceCount) request on the given domains.
@@ -86,7 +89,7 @@ func selectOptimalDomainSetToFit(s *TASFlavorSnapshot, domains []*domain, sliceC
 	if prioritizeByEntropy {
 		slices.SortFunc(orderedDomains, s.compareDomainCapacityAndEntropy)
 	} else {
-		slices.SortFunc(orderedDomains, compareDomainLevelValues)
+		slices.SortFunc(orderedDomains, s.compareDomainsForBalancedPlacement)
 	}
 
 	// domain_placements[i][j][k] stores a list of domains that uses 'i' domains with
@@ -225,6 +228,20 @@ func (s *TASFlavorSnapshot) compareDomainCapacityAndEntropy(a, b *domain) int {
 	}
 	if bEntropy < aEntropy {
 		return -1
+	}
+	return compareDomainLevelValues(a, b)
+}
+
+// compareDomainsForBalancedPlacement orders domains for balanced placement.
+// When the TASRespectNodeAffinityPreferred feature gate is enabled, it prefers
+// domains with a higher preferred node affinity score before falling back to
+// level values as a stable tiebreaker. This ensures balanced placement honors
+// preferred node affinity when selecting between otherwise equivalent domains.
+func (s *TASFlavorSnapshot) compareDomainsForBalancedPlacement(a, b *domain) int {
+	if features.Enabled(features.TASRespectNodeAffinityPreferred) {
+		if r := cmp.Compare(s.domainStateOf(b).affinityScore, s.domainStateOf(a).affinityScore); r != 0 {
+			return r
+		}
 	}
 	return compareDomainLevelValues(a, b)
 }

--- a/pkg/cache/scheduler/tas_balanced_placement.go
+++ b/pkg/cache/scheduler/tas_balanced_placement.go
@@ -214,6 +214,10 @@ func (s *TASFlavorSnapshot) calculateDomainsEntropy(domains []*domain) float64 {
 	return entropy
 }
 
+// compareDomainCapacityAndEntropy orders domains for entropy-prioritized
+// selection. Remaining ties go through compareDomainsForBalancedPlacement so
+// preferred node affinity can change which domains are chosen, not only how
+// slices are later packed onto an already selected set.
 func (s *TASFlavorSnapshot) compareDomainCapacityAndEntropy(a, b *domain) int {
 	if r := s.domainStateOf(b).leaderCount - s.domainStateOf(a).leaderCount; r != 0 {
 		return int(r)
@@ -229,7 +233,7 @@ func (s *TASFlavorSnapshot) compareDomainCapacityAndEntropy(a, b *domain) int {
 	if bEntropy < aEntropy {
 		return -1
 	}
-	return compareDomainLevelValues(a, b)
+	return s.compareDomainsForBalancedPlacement(a, b)
 }
 
 // compareDomainsForBalancedPlacement orders domains for balanced placement.

--- a/pkg/cache/scheduler/tas_balanced_placement_test.go
+++ b/pkg/cache/scheduler/tas_balanced_placement_test.go
@@ -171,16 +171,27 @@ func TestSelectOptimalDomainSetToFitStableTieBreak(t *testing.T) {
 
 func TestSelectOptimalDomainSetToFitRespectsAffinity(t *testing.T) {
 	testCases := map[string]struct {
-		enableAffinity bool
-		want           []string
+		enableAffinity      bool
+		prioritizeByEntropy bool
+		want                []string
 	}{
 		"prefers higher-affinity domain when feature gate is enabled": {
 			enableAffinity: true,
 			want:           []string{"rack-high"},
 		},
+		"prefers higher-affinity domain when selecting by entropy": {
+			enableAffinity:      true,
+			prioritizeByEntropy: true,
+			want:                []string{"rack-high"},
+		},
 		"falls back to level values when feature gate is disabled": {
 			enableAffinity: false,
 			want:           []string{"rack-low"},
+		},
+		"falls back to level values when selecting by entropy and feature gate is disabled": {
+			enableAffinity:      false,
+			prioritizeByEntropy: true,
+			want:                []string{"rack-low"},
 		},
 	}
 
@@ -198,7 +209,7 @@ func TestSelectOptimalDomainSetToFitRespectsAffinity(t *testing.T) {
 				}),
 			}
 
-			got := selectOptimalDomainSetToFit(s, domains, 1, 0, 1, false)
+			got := selectOptimalDomainSetToFit(s, domains, 1, 0, 1, tc.prioritizeByEntropy)
 
 			if diff := cmp.Diff(tc.want, domainIDs(got)); diff != "" {
 				t.Errorf("unexpected optimal domain set (-want,+got): %s", diff)
@@ -209,8 +220,9 @@ func TestSelectOptimalDomainSetToFitRespectsAffinity(t *testing.T) {
 
 func TestCompareDomainCapacityAndEntropy(t *testing.T) {
 	testCases := map[string]struct {
-		domains func(s *TASFlavorSnapshot) []*domain
-		want    []string
+		enableAffinity bool
+		domains        func(s *TASFlavorSnapshot) []*domain
+		want           []string
 	}{
 		"tie-breaking on level values when capacity and entropy are equal": {
 			domains: func(s *TASFlavorSnapshot) []*domain {
@@ -249,10 +261,44 @@ func TestCompareDomainCapacityAndEntropy(t *testing.T) {
 			},
 			want: []string{"high-entropy", "low-entropy", "lower-capacity", "lower-leader"},
 		},
+		"prefers higher affinity score when capacity and entropy are equal": {
+			enableAffinity: true,
+			domains: func(s *TASFlavorSnapshot) []*domain {
+				leaderStateLow := domainState{leaderCount: 1, sliceCountWithLeader: 5, affinityScore: 10}
+				leaderStateHigh := domainState{leaderCount: 1, sliceCountWithLeader: 5, affinityScore: 100}
+				childState := domainState{podCount: 2}
+				return []*domain{
+					addDomainWithState(s, &domain{id: "rack-low", levelValues: []string{"a"}, children: []*domain{
+						addDomainWithState(s, &domain{}, childState), addDomainWithState(s, &domain{}, childState),
+					}}, leaderStateLow),
+					addDomainWithState(s, &domain{id: "rack-high", levelValues: []string{"b"}, children: []*domain{
+						addDomainWithState(s, &domain{}, childState), addDomainWithState(s, &domain{}, childState),
+					}}, leaderStateHigh),
+				}
+			},
+			want: []string{"rack-high", "rack-low"},
+		},
+		"ignores affinity score when feature gate is disabled": {
+			domains: func(s *TASFlavorSnapshot) []*domain {
+				leaderStateLow := domainState{leaderCount: 1, sliceCountWithLeader: 5, affinityScore: 10}
+				leaderStateHigh := domainState{leaderCount: 1, sliceCountWithLeader: 5, affinityScore: 100}
+				childState := domainState{podCount: 2}
+				return []*domain{
+					addDomainWithState(s, &domain{id: "rack-low", levelValues: []string{"a"}, children: []*domain{
+						addDomainWithState(s, &domain{}, childState), addDomainWithState(s, &domain{}, childState),
+					}}, leaderStateLow),
+					addDomainWithState(s, &domain{id: "rack-high", levelValues: []string{"b"}, children: []*domain{
+						addDomainWithState(s, &domain{}, childState), addDomainWithState(s, &domain{}, childState),
+					}}, leaderStateHigh),
+				}
+			},
+			want: []string{"rack-low", "rack-high"},
+		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.TASRespectNodeAffinityPreferred, tc.enableAffinity)
 			_, log := utiltesting.ContextWithLog(t)
 			s := newTASFlavorSnapshot(log, "dummy", newTopologyTree([]string{}, nil, 0), nil, newDefaultSimulatorSnapshot())
 			got := tc.domains(s)

--- a/pkg/cache/scheduler/tas_balanced_placement_test.go
+++ b/pkg/cache/scheduler/tas_balanced_placement_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
+	"sigs.k8s.io/kueue/pkg/features"
 	utilslices "sigs.k8s.io/kueue/pkg/util/slices"
 	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -162,6 +163,44 @@ func TestSelectOptimalDomainSetToFitStableTieBreak(t *testing.T) {
 			got := selectOptimalDomainSetToFit(s, domains, 1, 0, 1, tc.prioritizeByEntropy)
 
 			if diff := cmp.Diff([]string{"leaf-z"}, domainIDs(got)); diff != "" {
+				t.Errorf("unexpected optimal domain set (-want,+got): %s", diff)
+			}
+		})
+	}
+}
+
+func TestSelectOptimalDomainSetToFitRespectsAffinity(t *testing.T) {
+	testCases := map[string]struct {
+		enableAffinity bool
+		want           []string
+	}{
+		"prefers higher-affinity domain when feature gate is enabled": {
+			enableAffinity: true,
+			want:           []string{"rack-high"},
+		},
+		"falls back to level values when feature gate is disabled": {
+			enableAffinity: false,
+			want:           []string{"rack-low"},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.TASRespectNodeAffinityPreferred, tc.enableAffinity)
+			_, log := utiltesting.ContextWithLog(t)
+			s := newTASFlavorSnapshot(log, "dummy", newTopologyTree([]string{}, nil, 0), nil, newDefaultSimulatorSnapshot())
+			domains := []*domain{
+				addDomainWithState(s, &domain{id: "rack-low", levelValues: []string{"a"}}, domainState{
+					podCount: 3, sliceCount: 3, podCountWithLeader: 3, sliceCountWithLeader: 3, affinityScore: 10,
+				}),
+				addDomainWithState(s, &domain{id: "rack-high", levelValues: []string{"b"}}, domainState{
+					podCount: 3, sliceCount: 3, podCountWithLeader: 3, sliceCountWithLeader: 3, affinityScore: 100,
+				}),
+			}
+
+			got := selectOptimalDomainSetToFit(s, domains, 1, 0, 1, false)
+
+			if diff := cmp.Diff(tc.want, domainIDs(got)); diff != "" {
 				t.Errorf("unexpected optimal domain set (-want,+got): %s", diff)
 			}
 		})

--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -4548,6 +4548,128 @@ func TestFindTopologyAssignments(t *testing.T) {
 				},
 			},
 		},
+		// Two equal-capacity racks; only r2 matches preferred node affinity.
+		// Topology declares kubernetes.io/hostname, so requested rack is above
+		// the slice level and domain selection uses compareDomainCapacityAndEntropy.
+		// Without balanced placement both Pods land on r2; with balanced placement
+		// the entropy path must keep that affinity ranking instead of falling back
+		// to level values (r1).
+		//
+		//          b1
+		//        /    \
+		//      r1      r2
+		//       |       |
+		//     x1:2    x2:2     x2 has region=us-west (preferred)
+		// request: 2
+		// expected outcome: x2:2
+		"balanced placement; equal-capacity racks; prefer affinity-matching rack": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TASBalancedPlacement:            true,
+				features.TASRespectNodeAffinityPreferred: true,
+			},
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("b1-r1-x1").
+					Label(tasBlockLabel, "b1").
+					Label(tasRackLabel, "r1").
+					Label(corev1.LabelHostname, "x1").
+					Label("region", "us-east").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("b1-r2-x2").
+					Label(tasBlockLabel, "b1").
+					Label(tasRackLabel, "r2").
+					Label(corev1.LabelHostname, "x2").
+					Label("region", "us-west").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			levels: defaultThreeLevels,
+			podSets: []PodSetTestCase{{
+				topologyRequest: &kueue.PodSetTopologyRequest{
+					Preferred: new(tasRackLabel),
+				},
+				nodeAffinity: &corev1.NodeAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: utiltesting.MakePreferredSchedulingTerms().
+						Term(10, "region", corev1.NodeSelectorOpIn, "us-west").
+						Obj(),
+				},
+				requests: map[corev1.ResourceName]int64{
+					corev1.ResourceCPU: 1000,
+				},
+				count: 2,
+				wantAssignment: &tas.TopologyAssignment{
+					Levels: defaultOneLevel,
+					Domains: []tas.TopologyDomainAssignment{
+						{
+							Count:  2,
+							Values: []string{"x2"},
+						},
+					},
+				},
+			}},
+		},
+		"balanced placement; equal-capacity racks; ignore affinity when feature gate is disabled": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TASBalancedPlacement:            true,
+				features.TASRespectNodeAffinityPreferred: false,
+			},
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("b1-r1-x1").
+					Label(tasBlockLabel, "b1").
+					Label(tasRackLabel, "r1").
+					Label(corev1.LabelHostname, "x1").
+					Label("region", "us-east").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("b1-r2-x2").
+					Label(tasBlockLabel, "b1").
+					Label(tasRackLabel, "r2").
+					Label(corev1.LabelHostname, "x2").
+					Label("region", "us-west").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			levels: defaultThreeLevels,
+			podSets: []PodSetTestCase{{
+				topologyRequest: &kueue.PodSetTopologyRequest{
+					Preferred: new(tasRackLabel),
+				},
+				nodeAffinity: &corev1.NodeAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: utiltesting.MakePreferredSchedulingTerms().
+						Term(10, "region", corev1.NodeSelectorOpIn, "us-west").
+						Obj(),
+				},
+				requests: map[corev1.ResourceName]int64{
+					corev1.ResourceCPU: 1000,
+				},
+				count: 2,
+				wantAssignment: &tas.TopologyAssignment{
+					Levels: defaultOneLevel,
+					Domains: []tas.TopologyDomainAssignment{
+						{
+							Count:  2,
+							Values: []string{"x1"},
+						},
+					},
+				},
+			}},
+		},
 		"block required for podset; rack required for slices; podset fits in a block, but slices do not fit in racks": {
 
 			//         b1


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area tas

#### What this PR does / why we need it?

TASBalancedPlacement can ignore preferred node affinity when it selects topology domains. With a topology that declares `kubernetes.io/hostname` and `TASNodeFeasibilityForAllLevels` disabled, two domains can have equal capacity while only one matches the preferred affinity. Without balanced placement, TAS places pods on the matching domain. With balanced placement, the selection path sorts candidate domains by level values only and can pick the non-matching domain.

This change makes `selectOptimalDomainSetToFit` sort candidate domains by preferred node affinity score before falling back to level values, gated on the `TASRespectNodeAffinityPreferred` feature gate. Balanced placement now selects the higher-ranked domain when equal-capacity domains differ by affinity, consistent with non-balanced TAS placement.

Fixes #15334

#### Useful notes for your reviewer

Added `compareDomainsForBalancedPlacement` to order domains by affinity score and then level values, plus a regression test for the two-domain equal-capacity case.

#### Release note

```release-note
TAS: balanced placement now honors preferred node affinity when selecting between equivalent topology domains.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## AI summary

- Balanced TAS placement now honors preferred node affinity when selecting between equal-capacity topology domains.
- Added regression coverage for affinity-based selection and feature-gate behavior.

### Suggested release note

TAS: Fixed a bug that caused balanced placement to select a lower-ranked topology domain when equal-capacity domains differed by preferred node affinity. Now Kueue selects the higher-ranked domain. This behavior is gated by the `TASRespectNodeAffinityPreferred` feature gate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->