### PR TITLE
kueuectl: Resolve --clusterqueue filter through LocalQueue for pending Workloads

### DIFF
--- a/cmd/kueuectl/app/list/list_workload.go
+++ b/cmd/kueuectl/app/list/list_workload.go
@@ -295,9 +295,9 @@ func (o *WorkloadOptions) Run(ctx context.Context) error {
 			continue
 		}
 
+		// Apply the filters that do not need LocalQueues first, so LocalQueues
+		// are only fetched for Workloads that can still be listed.
 		o.filterList(list, enableOwnerReferenceFilter, jobUID)
-
-		totalCount += len(list.Items)
 
 		r := newListWorkloadResources()
 
@@ -305,6 +305,10 @@ func (o *WorkloadOptions) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+
+		o.filterListByClusterQueue(list, r.localQueues)
+
+		totalCount += len(list.Items)
 
 		r.pendingWorkloads, err = o.pendingWorkloads(ctx, list, r.localQueues)
 		if err != nil {
@@ -353,8 +357,21 @@ func (o *WorkloadOptions) filterList(list *kueue.WorkloadList, enableOwnerRefere
 	}
 	filteredItems := make([]kueue.Workload, 0, len(o.LocalQueueFilter))
 	for _, wl := range list.Items {
-		if o.filterByLocalQueue(&wl) && o.filterByClusterQueue(&wl) && o.filterByStatuses(&wl) &&
+		if o.filterByLocalQueue(&wl) && o.filterByStatuses(&wl) &&
 			o.filterByOwnerReference(&wl, enableOwnerReferenceFilter, uid) {
+			filteredItems = append(filteredItems, wl)
+		}
+	}
+	list.Items = filteredItems
+}
+
+func (o *WorkloadOptions) filterListByClusterQueue(list *kueue.WorkloadList, localQueues map[string]*kueue.LocalQueue) {
+	if len(o.ClusterQueueFilter) == 0 || len(list.Items) == 0 {
+		return
+	}
+	filteredItems := make([]kueue.Workload, 0, len(list.Items))
+	for _, wl := range list.Items {
+		if o.filterByClusterQueue(&wl, localQueues) {
 			filteredItems = append(filteredItems, wl)
 		}
 	}
@@ -365,9 +382,9 @@ func (o *WorkloadOptions) filterByLocalQueue(wl *kueue.Workload) bool {
 	return len(o.LocalQueueFilter) == 0 || string(wl.Spec.QueueName) == o.LocalQueueFilter
 }
 
-func (o *WorkloadOptions) filterByClusterQueue(wl *kueue.Workload) bool {
-	return len(o.ClusterQueueFilter) == 0 || wl.Status.Admission != nil &&
-		wl.Status.Admission.ClusterQueue == kueue.ClusterQueueReference(o.ClusterQueueFilter)
+func (o *WorkloadOptions) filterByClusterQueue(wl *kueue.Workload, localQueues map[string]*kueue.LocalQueue) bool {
+	return len(o.ClusterQueueFilter) == 0 ||
+		clusterQueueNameForWorkload(wl, localQueues) == kueue.ClusterQueueReference(o.ClusterQueueFilter)
 }
 
 func (o *WorkloadOptions) filterByStatuses(wl *kueue.Workload) bool {
@@ -441,12 +458,7 @@ func (o *WorkloadOptions) pendingWorkloads(ctx context.Context, list *kueue.Work
 		if !workloadPending(&wl) {
 			continue
 		}
-		var clusterQueueName kueue.ClusterQueueReference
-		if wl.Status.Admission != nil && len(wl.Status.Admission.ClusterQueue) > 0 {
-			clusterQueueName = wl.Status.Admission.ClusterQueue
-		} else if lq := localQueues[localQueueKeyForWorkload(&wl)]; lq != nil {
-			clusterQueueName = lq.Spec.ClusterQueue
-		}
+		clusterQueueName := clusterQueueNameForWorkload(&wl, localQueues)
 		if len(clusterQueueName) == 0 {
 			continue
 		}
@@ -500,4 +512,17 @@ func workloadPending(wl *kueue.Workload) bool {
 
 func localQueueKeyForWorkload(wl *kueue.Workload) string {
 	return fmt.Sprintf("%s/%s", wl.Namespace, wl.Spec.QueueName)
+}
+
+// clusterQueueNameForWorkload returns the ClusterQueue the workload belongs to.
+// Pending workloads have no admission yet, so the name is resolved through
+// their LocalQueue in that case.
+func clusterQueueNameForWorkload(wl *kueue.Workload, localQueues map[string]*kueue.LocalQueue) kueue.ClusterQueueReference {
+	if wl.Status.Admission != nil && len(wl.Status.Admission.ClusterQueue) > 0 {
+		return wl.Status.Admission.ClusterQueue
+	}
+	if lq := localQueues[localQueueKeyForWorkload(wl)]; lq != nil {
+		return lq.Spec.ClusterQueue
+	}
+	return ""
 }

--- a/cmd/kueuectl/app/list/list_workload_printer.go
+++ b/cmd/kueuectl/app/list/list_workload_printer.go
@@ -128,12 +128,7 @@ func (p *listWorkloadPrinter) printWorkload(wl *kueue.Workload) metav1.TableRow 
 		Object: runtime.RawExtension{Object: wl},
 	}
 
-	var clusterQueueName string
-	if wl.Status.Admission != nil && len(wl.Status.Admission.ClusterQueue) > 0 {
-		clusterQueueName = string(wl.Status.Admission.ClusterQueue)
-	} else if lq := p.resources.localQueues[localQueueKeyForWorkload(wl)]; lq != nil {
-		clusterQueueName = string(lq.Spec.ClusterQueue)
-	}
+	clusterQueueName := string(clusterQueueNameForWorkload(wl, p.resources.localQueues))
 
 	var positionInQueue string
 	if pendingWorkload, ok := p.resources.pendingWorkloads[workload.Key(wl)]; ok {

--- a/cmd/kueuectl/app/list/list_workload_test.go
+++ b/cmd/kueuectl/app/list/list_workload_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -30,6 +31,7 @@ import (
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -63,9 +65,11 @@ func TestWorkloadCmd(t *testing.T) {
 		args             []string
 		mapperKinds      []schema.GroupVersionKind
 		job              []runtime.Object
-		wantOut          string
-		wantOutErr       string
-		wantErr          error
+		// forbiddenLocalQueues makes Get on these LocalQueues return Forbidden.
+		forbiddenLocalQueues []string
+		wantOut              string
+		wantOutErr           string
+		wantErr              error
 	}{
 		"should print workload list with namespace filter": {
 			ns: "ns1",
@@ -151,6 +155,67 @@ wl1               j1         lq1          cq1            PENDING                
 					Creation(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
 					Obj(),
 			},
+			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   EXEC TIME   AGE
+wl1               j1         lq1          cq1            PENDING                                   60m
+`,
+		},
+		"should print pending workload list with clusterqueue filter resolved through localqueue": {
+			args: []string{"--clusterqueue", "cq1", "--status", "pending"},
+			objs: []runtime.Object{
+				utiltestingapi.MakeLocalQueue("lq1", metav1.NamespaceDefault).ClusterQueue("cq1").Obj(),
+				utiltestingapi.MakeLocalQueue("lq2", metav1.NamespaceDefault).ClusterQueue("cq2").Obj(),
+				utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).
+					OwnerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "j1", "test-uid").
+					Queue("lq1").
+					Active(true).
+					Creation(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)).
+					Obj(),
+				utiltestingapi.MakeWorkload("wl2", metav1.NamespaceDefault).
+					OwnerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "j2", "test-uid").
+					Queue("lq2").
+					Active(true).
+					Creation(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
+					Obj(),
+				utiltestingapi.MakeWorkload("wl3", metav1.NamespaceDefault).
+					OwnerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "j3", "test-uid").
+					Queue("lq1").
+					Active(true).
+					Admission(utiltestingapi.MakeAdmission("cq1").Obj()).
+					Condition(metav1.Condition{
+						Type:   kueue.WorkloadQuotaReserved,
+						Status: metav1.ConditionTrue,
+						Reason: "Admitted",
+					}).
+					Condition(metav1.Condition{
+						Type:   kueue.WorkloadAdmitted,
+						Status: metav1.ConditionTrue,
+						Reason: "Admitted",
+					}).
+					Creation(testStartTime.Add(-3 * time.Hour).Truncate(time.Second)).
+					Obj(),
+			},
+			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   EXEC TIME   AGE
+wl1               j1         lq1          cq1            PENDING                                   60m
+`,
+		},
+		"should not read localqueues of workloads excluded by other filters": {
+			args: []string{"--localqueue", "lq1", "--clusterqueue", "cq1"},
+			objs: []runtime.Object{
+				utiltestingapi.MakeLocalQueue("lq1", metav1.NamespaceDefault).ClusterQueue("cq1").Obj(),
+				utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).
+					OwnerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "j1", "test-uid").
+					Queue("lq1").
+					Active(true).
+					Creation(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)).
+					Obj(),
+				utiltestingapi.MakeWorkload("wl2", metav1.NamespaceDefault).
+					OwnerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "j2", "test-uid").
+					Queue("lq2").
+					Active(true).
+					Creation(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
+					Obj(),
+			},
+			forbiddenLocalQueues: []string{"lq2"},
 			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   EXEC TIME   AGE
 wl1               j1         lq1          cq1            PENDING                                   60m
 `,
@@ -917,6 +982,16 @@ wl2               j2         lq2          cq2            PENDING   22           
 			// because of `PendingWorkload` resources not implement `runtime.Object`.
 			// Default `Reaction` handle all verbs and resources, so need to add on
 			// head of chain.
+			if len(tc.forbiddenLocalQueues) > 0 {
+				clientset.PrependReactor("get", "localqueues", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+					name := action.(kubetesting.GetAction).GetName()
+					if slices.Contains(tc.forbiddenLocalQueues, name) {
+						return true, nil, apierrors.NewForbidden(kueue.Resource("localqueues"), name, nil)
+					}
+					return false, nil, nil
+				})
+			}
+
 			clientset.PrependReactor("get", "clusterqueues", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
 				obj := &visibility.PendingWorkloadsSummary{Items: tc.pendingWorkloads}
 				return true, obj, err


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The `--clusterqueue` filter of `kueuectl list workload` only compares `status.admission.clusterQueue`, which is set once a Workload is admitted. Pending Workloads have no admission yet, so `--clusterqueue X --status pending` never returns anything.

This PR resolves the ClusterQueue through the Workload's LocalQueue when there is no admission, the same way the `CLUSTERQUEUE` column already does.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

LocalQueues are now fetched before filtering instead of after. Fetches are deduplicated per LocalQueue, so the extra API calls are bounded by the number of LocalQueues.

#### Does this PR introduce a user-facing change?

```release-note
CLI: Fixed a bug where `kueuectl list workload --clusterqueue` never matched pending Workloads, so combining it with `--status pending` always returned no results.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## AI summary

Fixed `kueuectl list workload --clusterqueue` filtering for pending Workloads. The command now resolves the ClusterQueue through the Workload’s LocalQueue when admission is not set. LocalQueue lookups are fetched only for eligible Workloads and deduplicated.

### Suggested release note

Workloads: Fixed a bug that caused pending Workloads to be excluded from `kueuectl list workload --clusterqueue` results. Now Kueue resolves the ClusterQueue through the Workload’s LocalQueue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->