### PR TITLE
Revert "Guard against a nil controller owner in EquivalentToWorkload (#15212)"

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1476,10 +1476,7 @@ func expectedRunningPodSets(ctx context.Context, c client.Client, wl *kueue.Work
 // EquivalentToWorkload checks if the job corresponds to the workload
 func EquivalentToWorkload(ctx context.Context, c client.Client, job GenericJob, wl *kueue.Workload) (bool, error) {
 	owner := metav1.GetControllerOf(wl)
-	// A Workload without a controller owner reference cannot belong to this job.
-	// The owner index that selects candidates matches any owner reference, not only
-	// controller ones, so wl may reach here with no controller owner.
-	if owner == nil || owner.Name != job.Object().GetName() {
+	if owner.Name != job.Object().GetName() {
 		return false, nil
 	}
 

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -602,55 +602,6 @@ func TestReconcileGenericJob(t *testing.T) {
 					Obj(),
 			},
 		},
-		"non-controller owner reference matching the job name is not equivalent and gets updated in place": {
-			req:     baseReq,
-			job:     baseJob.DeepCopy(),
-			podSets: basePodSets,
-			objs: []client.Object{
-				utiltestingapi.MakeWorkload("job-test-job-1", metav1.NamespaceDefault).
-					ResourceVersion("1").
-					Finalizers(kueue.ResourceInUseFinalizerName).
-					OwnerReference(testGVK, testJobName, testJobName).
-					Queue(testLocalQueueName).
-					PodSets(*utiltestingapi.MakePodSet("old", 2).Obj()).
-					Priority(0).
-					Obj(),
-			},
-			wantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("job-test-job-1", metav1.NamespaceDefault).
-					ResourceVersion("2").
-					Finalizers(kueue.ResourceInUseFinalizerName).
-					OwnerReference(testGVK, testJobName, testJobName).
-					Queue(testLocalQueueName).
-					PodSets(*utiltestingapi.MakePodSet("main", 1).Obj()).
-					Priority(0).
-					Obj(),
-			},
-		},
-		"workload with no owner references at all is not matched and a new workload is created": {
-			req:     baseReq,
-			job:     baseJob.DeepCopy(),
-			podSets: basePodSets,
-			objs: []client.Object{
-				utiltestingapi.MakeWorkload("orphan-wl", metav1.NamespaceDefault).
-					ResourceVersion("1").
-					Finalizers(kueue.ResourceInUseFinalizerName).
-					Queue(testLocalQueueName).
-					PodSets(*utiltestingapi.MakePodSet("main", 1).Obj()).
-					Priority(0).
-					Obj(),
-			},
-			wantWorkloads: []kueue.Workload{
-				*baseWl.Clone().Name("job-test-job-ce737").Obj(),
-				*utiltestingapi.MakeWorkload("orphan-wl", metav1.NamespaceDefault).
-					ResourceVersion("1").
-					Finalizers(kueue.ResourceInUseFinalizerName).
-					Queue(testLocalQueueName).
-					PodSets(*utiltestingapi.MakePodSet("main", 1).Obj()).
-					Priority(0).
-					Obj(),
-			},
-		},
 		// Same group and kind, so the rename is legal while reserved.
 		"quota-reserved workload follows the owner to another workload priority class": {
 			req:     baseReq,

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -105,40 +105,6 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:batch", "area:jobs")
 		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
 	})
 
-	ginkgo.It("Should not crash the reconcile when a Workload has a non-controller owner reference matching the job", func() {
-		ginkgo.By("creating a Workload that references the job name through a non-controller owner reference")
-		craftedWl := utiltestingapi.MakeWorkload("crafted", ns.Name).
-			PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Obj()).
-			Obj()
-		// The owner index that FindMatchingWorkloads uses matches any owner reference
-		// of the job's kind, not only controller ones, so this Workload is selected
-		// for the job below even though it has no controller owner.
-		craftedWl.OwnerReferences = []metav1.OwnerReference{{
-			APIVersion: batchv1.SchemeGroupVersion.String(),
-			Kind:       "Job",
-			Name:       jobName,
-			UID:        "not-the-real-job-uid",
-		}}
-		util.MustCreate(ctx, k8sClient, craftedWl)
-
-		ginkgo.By("creating the job, with a distinctive parallelism, whose name the crafted Workload references")
-		job := testingjob.MakeJob(jobName, ns.Name).Suspend(true).Parallelism(3).Completions(3).Obj()
-		util.MustCreate(ctx, k8sClient, job)
-
-		ginkgo.By("verifying the reconcile ran to completion: it adopts the crafted Workload and rewrites its PodSet count to the job's parallelism")
-		// A suspended job with a single non-matching Workload has that Workload's
-		// spec rewritten to match the job (reconciler.go updateWorkloadToMatchJob).
-		// Without the guard, FindMatchingWorkloads panics on the crafted Workload
-		// before reaching this point, so the count stays at its original value.
-		craftedKey := types.NamespacedName{Name: craftedWl.Name, Namespace: ns.Name}
-		updatedWl := &kueue.Workload{}
-		gomega.Eventually(func(g gomega.Gomega) {
-			g.Expect(k8sClient.Get(ctx, craftedKey, updatedWl)).Should(gomega.Succeed())
-			g.Expect(updatedWl.Spec.PodSets).ShouldNot(gomega.BeEmpty())
-			g.Expect(updatedWl.Spec.PodSets[0].Count).Should(gomega.Equal(int32(3)))
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-	})
-
 	ginkgo.It("Should reconcile workload and job for all jobs", framework.SlowSpec, func() {
 		ginkgo.By("checking the job gets suspended when created unsuspended")
 		priorityClass := utiltesting.MakePriorityClass(priorityClassName).


### PR DESCRIPTION
<!-- Thank you for contributing! Check CONTRIBUTING.md for details. -->

#### What type of PR is this?
<!-- Choose one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally choose one or more of the following kinds:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it?
Revert "Guard against a nil controller owner in EquivalentToWorkload (#15212)"
<!--
Use `Fixes #123` for an issue addressed by this PR; it will be closed when the PR merges.
Use `Related:` or `Part of:` to reference an issue without closing it.
-->
Fixes #

#### Useful notes for your reviewer
The user HARSH RAJ was banned, and all PRs created by that user are invisible. So now `/sync-release-notes` command doesn't work because it can't find this PR through the API.

So we are planning to do the following:

1. Revert the main [commit](https://github.com/kubernetes-sigs/kueue/commit/e70623ffae246c9b96a5c8bbecf1c9d9892cc615) (not PR due to invisible pr).
2. Revert the [0.18](https://github.com/kubernetes-sigs/kueue/pull/15233) and [0.19](https://github.com/kubernetes-sigs/kueue/pull/15232) cherry pick prs and reset release note.
3. Open new PR to the main and cherrypick it to the release branches.

#### Release note
<!-- Describe the behavior change accurately from the user's perspective. Hints:
- Do not leave this block blank.
- Use "NONE" when there is no user-facing change.
- When feasible use a prefix for the sub-component or feature, e.g. "FairSharing:" or "MultiKueue:".
- If upgrade steps are required, include an "ACTION REQUIRED:" section.
You may consider AI assistance using the skill: cmd/experimental/skills/kueue-release-notes/SKILL.md.
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## AI summary

Reverts the nil controller-owner guard in `EquivalentToWorkload` and removes its related tests. The change is planned for reapplication.

### Suggested release note

NONE
<!-- end of auto-generated comment: release notes by coderabbit.ai -->