### PR TITLE
Revert "[release-0.19] Guard against a nil controller owner in EquivalentToWorkload"

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1444,10 +1444,7 @@ func expectedRunningPodSets(ctx context.Context, c client.Client, wl *kueue.Work
 // EquivalentToWorkload checks if the job corresponds to the workload
 func EquivalentToWorkload(ctx context.Context, c client.Client, job GenericJob, wl *kueue.Workload) (bool, error) {
 	owner := metav1.GetControllerOf(wl)
-	// A Workload without a controller owner reference cannot belong to this job.
-	// The owner index that selects candidates matches any owner reference, not only
-	// controller ones, so wl may reach here with no controller owner.
-	if owner == nil || owner.Name != job.Object().GetName() {
+	if owner.Name != job.Object().GetName() {
 		return false, nil
 	}
 

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -104,40 +104,6 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:batch", "area:jobs")
 		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
 	})
 
-	ginkgo.It("Should not crash the reconcile when a Workload has a non-controller owner reference matching the job", func() {
-		ginkgo.By("creating a Workload that references the job name through a non-controller owner reference")
-		craftedWl := utiltestingapi.MakeWorkload("crafted", ns.Name).
-			PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Obj()).
-			Obj()
-		// The owner index that FindMatchingWorkloads uses matches any owner reference
-		// of the job's kind, not only controller ones, so this Workload is selected
-		// for the job below even though it has no controller owner.
-		craftedWl.OwnerReferences = []metav1.OwnerReference{{
-			APIVersion: batchv1.SchemeGroupVersion.String(),
-			Kind:       "Job",
-			Name:       jobName,
-			UID:        "not-the-real-job-uid",
-		}}
-		util.MustCreate(ctx, k8sClient, craftedWl)
-
-		ginkgo.By("creating the job, with a distinctive parallelism, whose name the crafted Workload references")
-		job := testingjob.MakeJob(jobName, ns.Name).Suspend(true).Parallelism(3).Completions(3).Obj()
-		util.MustCreate(ctx, k8sClient, job)
-
-		ginkgo.By("verifying the reconcile ran to completion: it adopts the crafted Workload and rewrites its PodSet count to the job's parallelism")
-		// A suspended job with a single non-matching Workload has that Workload's
-		// spec rewritten to match the job (reconciler.go updateWorkloadToMatchJob).
-		// Without the guard, FindMatchingWorkloads panics on the crafted Workload
-		// before reaching this point, so the count stays at its original value.
-		craftedKey := types.NamespacedName{Name: craftedWl.Name, Namespace: ns.Name}
-		updatedWl := &kueue.Workload{}
-		gomega.Eventually(func(g gomega.Gomega) {
-			g.Expect(k8sClient.Get(ctx, craftedKey, updatedWl)).Should(gomega.Succeed())
-			g.Expect(updatedWl.Spec.PodSets).ShouldNot(gomega.BeEmpty())
-			g.Expect(updatedWl.Spec.PodSets[0].Count).Should(gomega.Equal(int32(3)))
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-	})
-
 	ginkgo.It("Should reconcile workload and job for all jobs", framework.SlowSpec, func() {
 		ginkgo.By("checking the job gets suspended when created unsuspended")
 		priorityClass := utiltesting.MakePriorityClass(priorityClassName).


### PR DESCRIPTION
Reverts kubernetes-sigs/kueue#15232

Reverts the nil controller-owner guard in `EquivalentToWorkload` and removes its integration test. No user-facing change is intended. We are planning to re-apply this changes.