### PR TITLE
kueuectl: Print a single document when list output spans multiple pages

### DIFF
--- a/cmd/kueuectl/app/list/helpers.go
+++ b/cmd/kueuectl/app/list/helpers.go
@@ -18,13 +18,16 @@ package list
 
 import (
 	"errors"
+	"io"
 	"os"
 	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/printers"
 )
 
 const (
@@ -113,4 +116,49 @@ func decodeResourceTypeName(mapper meta.RESTMapper, s string) (gvk schema.GroupV
 	found = true
 
 	return
+}
+
+// pagedListPrinter prints the pages of a paginated list. Table output is
+// printed page by page. When an output format such as -o yaml or -o json is
+// set, the pages are merged and printed once as the last page arrives, so that
+// the output is a single valid document, as with kubectl.
+type pagedListPrinter struct {
+	merge  bool
+	merged runtime.Object
+}
+
+func newPagedListPrinter(merge bool) *pagedListPrinter {
+	return &pagedListPrinter{merge: merge}
+}
+
+func (p *pagedListPrinter) printPage(page runtime.Object, lastPage bool, printer printers.ResourcePrinterFunc, w io.Writer) error {
+	if !p.merge {
+		return printer(page, w)
+	}
+	if p.merged == nil {
+		p.merged = page
+	} else {
+		items, err := meta.ExtractList(p.merged)
+		if err != nil {
+			return err
+		}
+		pageItems, err := meta.ExtractList(page)
+		if err != nil {
+			return err
+		}
+		if err := meta.SetList(p.merged, append(items, pageItems...)); err != nil {
+			return err
+		}
+	}
+	if !lastPage {
+		return nil
+	}
+	// The pagination metadata of the first page is meaningless for the merged list.
+	listMeta, err := meta.ListAccessor(p.merged)
+	if err != nil {
+		return err
+	}
+	listMeta.SetContinue("")
+	listMeta.SetRemainingItemCount(nil)
+	return printer(p.merged, w)
 }

--- a/cmd/kueuectl/app/list/list_clusterqueue.go
+++ b/cmd/kueuectl/app/list/list_clusterqueue.go
@@ -172,6 +172,7 @@ func (o *ClusterQueueOptions) Run(ctx context.Context) error {
 	}
 
 	tabWriter := printers.GetNewTabWriter(o.Out)
+	pager := newPagedListPrinter(o.PrintFlags.OutputFlagSpecified())
 
 	for {
 		headers := totalCount == 0
@@ -190,7 +191,7 @@ func (o *ClusterQueueOptions) Run(ctx context.Context) error {
 			return err
 		}
 
-		if err := printer.PrintObj(list, tabWriter); err != nil {
+		if err := pager.printPage(list, list.Continue == "", printer, tabWriter); err != nil {
 			return err
 		}
 

--- a/cmd/kueuectl/app/list/list_clusterqueue_test.go
+++ b/cmd/kueuectl/app/list/list_clusterqueue_test.go
@@ -40,6 +40,7 @@ func TestClusterQueueRun(t *testing.T) {
 	testCases := map[string]struct {
 		ns         string
 		objs       []runtime.Object
+		listPages  []runtime.Object
 		args       []string
 		wantOut    string
 		wantOutErr string
@@ -140,12 +141,47 @@ cq1    cohort1   1                   2                    true     60m
 		"should print not found error": {
 			wantOutErr: "No resources found\n",
 		},
+		"should print a single yaml document across pages": {
+			args: []string{"-o", "yaml"},
+			listPages: []runtime.Object{
+				&kueue.ClusterQueueList{
+					ListMeta: metav1.ListMeta{Continue: "page2"},
+					Items:    []kueue.ClusterQueue{{ObjectMeta: metav1.ObjectMeta{Name: "a"}}},
+				},
+				&kueue.ClusterQueueList{
+					Items: []kueue.ClusterQueue{{ObjectMeta: metav1.ObjectMeta{Name: "b"}}},
+				},
+			},
+			wantOut: `apiVersion: kueue.x-k8s.io/v1beta2
+items:
+- metadata:
+    name: a
+  spec: {}
+  status:
+    admittedWorkloads: 0
+    pendingWorkloads: 0
+    reservingWorkloads: 0
+- metadata:
+    name: b
+  spec: {}
+  status:
+    admittedWorkloads: 0
+    pendingWorkloads: 0
+    reservingWorkloads: 0
+kind: ClusterQueueList
+metadata: {}
+`,
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			streams, _, out, outErr := genericiooptions.NewTestIOStreams()
 
-			tcg := cmdtesting.NewTestClientGetter().WithKueueClientset(fake.NewSimpleClientset(tc.objs...))
+			clientset := fake.NewSimpleClientset(tc.objs...)
+			if len(tc.listPages) > 0 {
+				prependPagedListReactor(clientset, "clusterqueues", tc.listPages)
+			}
+			tcg := cmdtesting.NewTestClientGetter().WithKueueClientset(clientset)
 
 			cmd := NewClusterQueueCmd(tcg, streams, testingclock.NewFakeClock(testStartTime))
 			cmd.SetArgs(tc.args)

--- a/cmd/kueuectl/app/list/list_localqueue.go
+++ b/cmd/kueuectl/app/list/list_localqueue.go
@@ -162,6 +162,7 @@ func (o *LocalQueueOptions) Run(ctx context.Context) error {
 	}
 
 	tabWriter := printers.GetNewTabWriter(o.Out)
+	pager := newPagedListPrinter(o.PrintFlags.OutputFlagSpecified())
 
 	for {
 		headers := totalCount == 0
@@ -180,7 +181,7 @@ func (o *LocalQueueOptions) Run(ctx context.Context) error {
 			return err
 		}
 
-		if err := printer.PrintObj(list, tabWriter); err != nil {
+		if err := pager.printPage(list, list.Continue == "", printer, tabWriter); err != nil {
 			return err
 		}
 

--- a/cmd/kueuectl/app/list/list_localqueue_test.go
+++ b/cmd/kueuectl/app/list/list_localqueue_test.go
@@ -102,6 +102,7 @@ func TestLocalQueueCmd(t *testing.T) {
 	testCases := map[string]struct {
 		ns         string
 		objs       []runtime.Object
+		listPages  []runtime.Object
 		args       []string
 		wantOut    string
 		wantOutErr string
@@ -197,12 +198,49 @@ lq1    cq1            1                   1                    60m
 			args:       []string{"-A"},
 			wantOutErr: "No resources found\n",
 		},
+		"should print a single yaml document across pages": {
+			args: []string{"-o", "yaml"},
+			listPages: []runtime.Object{
+				&kueue.LocalQueueList{
+					ListMeta: metav1.ListMeta{Continue: "page2"},
+					Items:    []kueue.LocalQueue{{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: metav1.NamespaceDefault}}},
+				},
+				&kueue.LocalQueueList{
+					Items: []kueue.LocalQueue{{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: metav1.NamespaceDefault}}},
+				},
+			},
+			wantOut: `apiVersion: kueue.x-k8s.io/v1beta2
+items:
+- metadata:
+    name: a
+    namespace: default
+  spec: {}
+  status:
+    admittedWorkloads: 0
+    pendingWorkloads: 0
+    reservingWorkloads: 0
+- metadata:
+    name: b
+    namespace: default
+  spec: {}
+  status:
+    admittedWorkloads: 0
+    pendingWorkloads: 0
+    reservingWorkloads: 0
+kind: LocalQueueList
+metadata: {}
+`,
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			streams, _, out, outErr := genericiooptions.NewTestIOStreams()
 
-			tcg := cmdtesting.NewTestClientGetter().WithKueueClientset(fake.NewSimpleClientset(tc.objs...))
+			clientset := fake.NewSimpleClientset(tc.objs...)
+			if len(tc.listPages) > 0 {
+				prependPagedListReactor(clientset, "localqueues", tc.listPages)
+			}
+			tcg := cmdtesting.NewTestClientGetter().WithKueueClientset(clientset)
 			if len(tc.ns) > 0 {
 				tcg.WithNamespace(tc.ns)
 			}

--- a/cmd/kueuectl/app/list/list_resourceflavor.go
+++ b/cmd/kueuectl/app/list/list_resourceflavor.go
@@ -132,6 +132,7 @@ func (o *ResourceFlavorOptions) Run(ctx context.Context) error {
 	}
 
 	tabWriter := printers.GetNewTabWriter(o.Out)
+	pager := newPagedListPrinter(o.PrintFlags.OutputFlagSpecified())
 
 	for {
 		headers := totalCount == 0
@@ -148,7 +149,7 @@ func (o *ResourceFlavorOptions) Run(ctx context.Context) error {
 			return err
 		}
 
-		if err := printer.PrintObj(list, tabWriter); err != nil {
+		if err := pager.printPage(list, list.Continue == "", printer, tabWriter); err != nil {
 			return err
 		}
 

--- a/cmd/kueuectl/app/list/list_resourceflavor_test.go
+++ b/cmd/kueuectl/app/list/list_resourceflavor_test.go
@@ -22,10 +22,12 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	testingclock "k8s.io/utils/clock/testing"
 
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/client-go/clientset/versioned/fake"
 	cmdtesting "sigs.k8s.io/kueue/cmd/kueuectl/app/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
@@ -36,6 +38,7 @@ func TestResourceFlavorCmd(t *testing.T) {
 
 	testCases := map[string]struct {
 		objs       []runtime.Object
+		listPages  []runtime.Object
 		args       []string
 		wantOut    string
 		wantOutErr string
@@ -107,12 +110,39 @@ rf1                  60m
 		"should print not found error": {
 			wantOutErr: "No resources found\n",
 		},
+		"should print a single yaml document across pages": {
+			args: []string{"-o", "yaml"},
+			listPages: []runtime.Object{
+				&kueue.ResourceFlavorList{
+					ListMeta: metav1.ListMeta{Continue: "page2"},
+					Items:    []kueue.ResourceFlavor{{ObjectMeta: metav1.ObjectMeta{Name: "a"}}},
+				},
+				&kueue.ResourceFlavorList{
+					Items: []kueue.ResourceFlavor{{ObjectMeta: metav1.ObjectMeta{Name: "b"}}},
+				},
+			},
+			wantOut: `apiVersion: kueue.x-k8s.io/v1beta2
+items:
+- metadata:
+    name: a
+  spec: {}
+- metadata:
+    name: b
+  spec: {}
+kind: ResourceFlavorList
+metadata: {}
+`,
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			streams, _, out, outErr := genericiooptions.NewTestIOStreams()
 
-			tcg := cmdtesting.NewTestClientGetter().WithKueueClientset(fake.NewSimpleClientset(tc.objs...))
+			clientset := fake.NewSimpleClientset(tc.objs...)
+			if len(tc.listPages) > 0 {
+				prependPagedListReactor(clientset, "resourceflavors", tc.listPages)
+			}
+			tcg := cmdtesting.NewTestClientGetter().WithKueueClientset(clientset)
 
 			cmd := NewResourceFlavorCmd(tcg, streams, testingclock.NewFakeClock(testStartTime))
 			cmd.SetOut(out)

--- a/cmd/kueuectl/app/list/list_test.go
+++ b/cmd/kueuectl/app/list/list_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+	kubetesting "k8s.io/client-go/testing"
 	testingclock "k8s.io/utils/clock/testing"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -184,4 +185,18 @@ ns2         wl2               j2         lq2          cq2            PENDING    
 			}
 		})
 	}
+}
+
+// prependPagedListReactor makes List calls for the resource return the given
+// pages in order, simulating server-side pagination.
+func prependPagedListReactor(clientset *fake.Clientset, resource string, pages []runtime.Object) {
+	var page int
+	clientset.PrependReactor("list", resource, func(kubetesting.Action) (bool, runtime.Object, error) {
+		if page >= len(pages) {
+			return false, nil, nil
+		}
+		obj := pages[page]
+		page++
+		return true, obj, nil
+	})
 }

--- a/cmd/kueuectl/app/list/list_workload.go
+++ b/cmd/kueuectl/app/list/list_workload.go
@@ -279,6 +279,7 @@ func (o *WorkloadOptions) Run(ctx context.Context) error {
 	}
 
 	tabWriter := printers.GetNewTabWriter(o.Out)
+	pager := newPagedListPrinter(o.PrintFlags.OutputFlagSpecified())
 
 	var enableOwnerReferenceFilter bool
 	for {
@@ -325,7 +326,7 @@ func (o *WorkloadOptions) Run(ctx context.Context) error {
 			return err
 		}
 
-		if err := printer.PrintObj(list, tabWriter); err != nil {
+		if err := pager.printPage(list, list.Continue == "", printer, tabWriter); err != nil {
 			return err
 		}
 

--- a/cmd/kueuectl/app/list/list_workload_test.go
+++ b/cmd/kueuectl/app/list/list_workload_test.go
@@ -67,6 +67,7 @@ func TestWorkloadCmd(t *testing.T) {
 		job              []runtime.Object
 		// forbiddenLocalQueues makes Get on these LocalQueues return Forbidden.
 		forbiddenLocalQueues []string
+		listPages            []runtime.Object
 		wantOut              string
 		wantOutErr           string
 		wantErr              error
@@ -928,6 +929,35 @@ wl1               j1         lq1          cq1            PENDING   12           
 wl2               j2         lq2          cq2            PENDING   22                              120m
 `,
 		},
+		"should print a single yaml document across pages": {
+			args: []string{"-o", "yaml"},
+			listPages: []runtime.Object{
+				&kueue.WorkloadList{
+					ListMeta: metav1.ListMeta{Continue: "page2"},
+					Items:    []kueue.Workload{{ObjectMeta: metav1.ObjectMeta{Name: "wl1", Namespace: metav1.NamespaceDefault}}},
+				},
+				&kueue.WorkloadList{
+					Items: []kueue.Workload{{ObjectMeta: metav1.ObjectMeta{Name: "wl2", Namespace: metav1.NamespaceDefault}}},
+				},
+			},
+			wantOut: `apiVersion: kueue.x-k8s.io/v1beta2
+items:
+- metadata:
+    name: wl1
+    namespace: default
+  spec:
+    podSets: null
+  status: {}
+- metadata:
+    name: wl2
+    namespace: default
+  spec:
+    podSets: null
+  status: {}
+kind: WorkloadList
+metadata: {}
+`,
+		},
 		"should print not found error": {
 			wantOutErr: fmt.Sprintf("No resources found in %s namespace.\n", metav1.NamespaceDefault),
 		},
@@ -941,6 +971,9 @@ wl2               j2         lq2          cq2            PENDING   22           
 			streams, _, out, outErr := genericiooptions.NewTestIOStreams()
 
 			clientset := fake.NewSimpleClientset(tc.objs...)
+			if len(tc.listPages) > 0 {
+				prependPagedListReactor(clientset, "workloads", tc.listPages)
+			}
 
 			tcg := cmdtesting.NewTestClientGetter().WithKueueClientset(clientset)
 			if len(tc.ns) > 0 {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`kueuectl list workload|localqueue|clusterqueue|resourceflavor` fetch results in pages of `KUEUECTL_LIST_REQUEST_LIMIT` items and print each page with a new printer. With `-o yaml` the pages are concatenated without a `---` separator, so the output is one document with duplicate top-level keys. With `-o json` several JSON objects are emitted. Either way, any script parsing the output breaks or silently loses data once a list exceeds one page, and the first page also leaks its pagination `continue` token.

When an output format is set, this PR merges the items of all pages into a single list, clears the pagination metadata and prints it once, matching `kubectl get`. Table output keeps printing page by page.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

- With `-o`, all pages are held in memory before printing, as `kubectl` does. Table output is unchanged.
- Tests use a `prependPagedListReactor` helper in `list_test.go` to make the fake clientset return two pages.

#### Does this PR introduce a user-facing change?

```release-note
CLI: Fixed a bug where `kueuectl list` with `-o yaml` or `-o json` produced invalid output when the result spanned more than one page (`KUEUECTL_LIST_REQUEST_LIMIT`, 100 by default). All pages are now merged into a single document.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## AI summary

Fixes paginated `kueuectl list` output for `workload`, `localqueue`, `clusterqueue`, and `resourceflavor`. YAML and JSON output now combines all pages into one document and clears pagination metadata. Table output remains page-by-page. Tests cover the multi-page behavior.

### Suggested release note

`Kueuectl`: Fixed a bug that caused paginated list results to produce multiple YAML or JSON documents. Now `kueuectl list` combines all pages into one structured-output document and clears pagination metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->