### PR TITLE
CodeRabbit AI improve the list of prefixes

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -34,7 +34,7 @@ reviews:
         `Observability:`, `VisibilityOnDemand:`, `Security:`, `RBAC:`.
       - Tools and documentation: `CLI:`, `Helm:`, `KueueViz:`, `Kueue-populator:`,
         `Importer:`, `PriorityBooster:`, `Documentation:`, `Examples:`, `AgentSkills:`.
-      - Integrations: `JobSet:`, `Pod:`, `PodGroup:`, `LeaderWorkerSet:`, `StatefulSet:`,
+      - Integrations: `JobSet:`, `Pod:`, `PodGroup:`, `LeaderWorkerSet:`, `StatefulSet:`, `Deployment:`,
         `RayJob:`, `RayCluster:`, `RayService:`, `SparkApplication:`, `MPIJob:`.
       These examples are non-exhaustive. Use another feature, sub-component,
       or integration name when it describes the change more accurately.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -21,9 +21,24 @@ reviews:
     * Describe the user-facing behavior change rather than implementation details.
     * For bug fixes, prefer wording such as: <ScopingPrefix>: Fixed a bug that caused
       [<incorrect behavior>] when <scenario>. Now Kueue <correct behavior>.
-    * When feasible, use the corresponding feature or sub-component name as the scoping prefix.
-      Examples: `FairSharing:`, `MultiKueue:`, `Observability:`, `TAS:`, `Workloads:`.
-      For integrations you may use the integration name as prefix, eg. `JobSet:`.
+    * When feasible, scope the release note to the affected feature, sub-component,
+      or integration. Choose the most specific prefix that describes the user-facing
+      change. Examples include:
+      - Scheduling and admission: `Scheduling:`, `TAS:`, `DRA:`, `FairSharing:`,
+        `AFS:`, `ConcurrentAdmission:`, `AdmissionChecks:`, `MultiKueue:`,
+        `ProvisioningRequest:`, `WorkloadAwareScheduler:`.
+      - Workload lifecycle and resources: `Workloads:`, `LocalQueues:`,
+        `ElasticJobsViaWorkloadSlices:`, `WaitForPodsReady:`, `FailureRecovery:`,
+        `ObjectRetentionPolicies:`, `ResourceTransformations:`.
+      - Configuration and observability: `ConfigAPI:`, `FeatureGates:`,
+        `Observability:`, `VisibilityOnDemand:`, `Security:`, `RBAC:`.
+      - Tools and documentation: `CLI:`, `Helm:`, `KueueViz:`, `Kueue-populator:`,
+        `Importer:`, `PriorityBooster:`, `Documentation:`, `Examples:`, `AgentSkills:`.
+      - Integrations: `JobSet:`, `Pod:`, `PodGroup:`, `LeaderWorkerSet:`, `StatefulSet:`,
+        `RayJob:`, `RayCluster:`, `RayService:`, `SparkApplication:`, `MPIJob:`.
+      These examples are non-exhaustive. Use another feature, sub-component,
+      or integration name when it describes the change more accurately.
+      Combined scopes are also valid, e.g. `MultiKueue Observability:`.
     * Treat logs, metrics, events, and visibility endpoints as user-facing observability changes.
     * If the behavior change is controlled by a feature gate, mention that, e.g.
       This behavior is gated by the <FeatureGate> feature gate.


### PR DESCRIPTION
<!-- Thank you for contributing! Check CONTRIBUTING.md for details. -->

#### What type of PR is this?
/kind cleanup


#### What this PR does / why we need it?
<!--
Use `Fixes #123` for an issue addressed by this PR; it will be closed when the PR merges.
Use `Related:` or `Part of:` to reference an issue without closing it.
-->
Extend the list of prefixes so that:
1. code rabbit consistently reuses the established ones consistently KueueViz, no kueueviz, Kueueviz etc
2. CodeRabbit has affinity to the listed ones, for example here: https://github.com/kubernetes-sigs/kueue/pull/15336 

#### Useful notes for your reviewer

#### Release note
<!-- Describe the behavior change accurately from the user's perspective. Hints:
- Do not leave this block blank.
- Use "NONE" when there is no user-facing change.
- When feasible use a prefix for the sub-component or feature, e.g. "FairSharing:" or "MultiKueue:".
- If upgrade steps are required, include an "ACTION REQUIRED:" section.
You may consider AI assistance using the skill: cmd/experimental/skills/kueue-release-notes/SKILL.md.
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## AI summary

Expanded CodeRabbit’s release-note prefix guidance with categorized prefixes, combined scopes, and consistent capitalization such as `KueueViz`.

### Suggested release note

NONE
<!-- end of auto-generated comment: release notes by coderabbit.ai -->