### PR TITLE
kueuectl: Sort job names and types in list workload output

### DIFF
--- a/cmd/kueuectl/app/list/list_workload_printer.go
+++ b/cmd/kueuectl/app/list/list_workload_printer.go
@@ -188,7 +188,7 @@ func (p *listWorkloadPrinter) crdTypes(wl *kueue.Workload) []string {
 		}
 	}
 
-	return crdTypes.UnsortedList()
+	return sets.List(crdTypes)
 }
 
 func (p *listWorkloadPrinter) crdNames(wl *kueue.Workload) []string {
@@ -198,7 +198,7 @@ func (p *listWorkloadPrinter) crdNames(wl *kueue.Workload) []string {
 		crdNames.Insert(ref.Name)
 	}
 
-	return crdNames.UnsortedList()
+	return sets.List(crdNames)
 }
 
 func (p *listWorkloadPrinter) apiResourceType(resource *metav1.APIResource) string {

--- a/cmd/kueuectl/app/list/list_workload_test.go
+++ b/cmd/kueuectl/app/list/list_workload_test.go
@@ -564,7 +564,7 @@ wl2    rayjob.ray.io             j2         lq2          cq2            PENDING 
 wl3    pytorchjob.kubeflow....   j3         lq3          cq3            PENDING                                   3h
 `,
 		},
-		"should print sorted job names for a workload with multiple owners": {
+		"should print sorted job types and names for a workload with multiple owners": {
 			apiResourceLists: []*metav1.APIResourceList{
 				{
 					GroupVersion: "v1",
@@ -576,11 +576,21 @@ wl3    pytorchjob.kubeflow....   j3         lq3          cq3            PENDING 
 						},
 					},
 				},
+				{
+					GroupVersion: "batch/v1",
+					APIResources: []metav1.APIResource{
+						{
+							SingularName: "job",
+							Kind:         "Job",
+							Group:        "",
+						},
+					},
+				},
 			},
 			objs: []runtime.Object{
 				utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod-c", "pod-uid-c").
-					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod-a", "pod-uid-a").
+					OwnerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job-a", "job-uid-a").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod-b", "pod-uid-b").
 					Queue("lq1").
 					Active(true).
@@ -589,7 +599,7 @@ wl3    pytorchjob.kubeflow....   j3         lq3          cq3            PENDING 
 					Obj(),
 			},
 			wantOut: `NAME   JOB TYPE   JOB NAME              LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   EXEC TIME   AGE
-wl1    pod        pod-a, pod-b, pod-c   lq1          cq1            PENDING                                   60m
+wl1    job, pod   job-a, pod-b, pod-c   lq1          cq1            PENDING                                   60m
 `,
 		},
 		"should print workload list with resource filter": {

--- a/cmd/kueuectl/app/list/list_workload_test.go
+++ b/cmd/kueuectl/app/list/list_workload_test.go
@@ -564,6 +564,34 @@ wl2    rayjob.ray.io             j2         lq2          cq2            PENDING 
 wl3    pytorchjob.kubeflow....   j3         lq3          cq3            PENDING                                   3h
 `,
 		},
+		"should print sorted job names for a workload with multiple owners": {
+			apiResourceLists: []*metav1.APIResourceList{
+				{
+					GroupVersion: "v1",
+					APIResources: []metav1.APIResource{
+						{
+							SingularName: "pod",
+							Kind:         "Pod",
+							Group:        "",
+						},
+					},
+				},
+			},
+			objs: []runtime.Object{
+				utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).
+					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod-c", "pod-uid-c").
+					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod-a", "pod-uid-a").
+					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod-b", "pod-uid-b").
+					Queue("lq1").
+					Active(true).
+					Admission(utiltestingapi.MakeAdmission("cq1").Obj()).
+					Creation(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)).
+					Obj(),
+			},
+			wantOut: `NAME   JOB TYPE   JOB NAME              LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   EXEC TIME   AGE
+wl1    pod        pod-a, pod-b, pod-c   lq1          cq1            PENDING                                   60m
+`,
+		},
 		"should print workload list with resource filter": {
 			args: []string{"--for", "job.batch/job-test"},
 			apiResourceLists: []*metav1.APIResourceList{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it?

`kueuectl list workload` builds the JOB TYPE and JOB NAME columns from a `sets.Set` and reads them back with `UnsortedList()`, so a Workload with multiple owner references (for example a pod group, where the pod controller adds one owner per Pod) prints its owners in a random order on each run. This is distracting to read and produces spurious diffs for `watch` or scripts that compare the output.

This PR switches to `sets.List()` so the columns are printed in sorted, deterministic order, and adds a unit test with a multi-owner Workload.

#### Useful notes for your reviewer

The new test fails nondeterministically against the previous code and passes reliably with the fix.

#### Release note

```release-note
CLI: Fixed a bug where `kueuectl list workload` could print the JOB TYPE and JOB NAME columns in a random order for Workloads with multiple owner references, such as pod groups.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## AI summary

`kueuectl list workload` now sorts multiple owner job types and names deterministically. Added test coverage for sorted owner job types and names.

### Suggested release note

Workloads: Fixed a bug that caused inconsistent `JOB TYPE` and `JOB NAME` output when a workload had multiple owner references. Now `kueuectl list workload` displays these values in a deterministic order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->