### PR TITLE
Validate grouped PodSet slicing on Workloads

### DIFF
--- a/pkg/webhooks/workload_webhook.go
+++ b/pkg/webhooks/workload_webhook.go
@@ -164,6 +164,7 @@ func ValidateWorkload(obj, oldObj *kueue.Workload) field.ErrorList {
 	return allErrs
 }
 
+// validatePodSet validates the pod template and topology request of a Workload PodSet.
 func validatePodSet(ps *kueue.PodSet, path *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
@@ -541,8 +542,8 @@ func validateTASSliceSize(tr *kueue.PodSetTopologyRequest, path *field.Path) fie
 	return allErrs
 }
 
-// Direct Workload writes bypass the job framework's TAS validation, so enforce
-// the grouped PodSet slicing feature gate at the Workload API boundary as well.
+// validateTASGroupedPodSetSlicing enforces the feature gate at the Workload API
+// boundary because direct Workload writes bypass the job framework's TAS validation.
 func validateTASGroupedPodSetSlicing(tr *kueue.PodSetTopologyRequest, path *field.Path) field.ErrorList {
 	if features.Enabled(features.TASGroupedPodSetSlicing) || tr == nil || tr.PodSetGroupName == nil {
 		return nil

--- a/pkg/webhooks/workload_webhook.go
+++ b/pkg/webhooks/workload_webhook.go
@@ -193,6 +193,7 @@ func validatePodSet(ps *kueue.PodSet, path *field.Path) field.ErrorList {
 	if features.Enabled(features.TASValidateWorkloadSliceSize) {
 		allErrs = append(allErrs, validateTASSliceSize(ps.TopologyRequest, path.Child("topologyRequest"))...)
 	}
+	allErrs = append(allErrs, validateTASGroupedPodSetSlicing(ps.TopologyRequest, path.Child("topologyRequest"))...)
 
 	return allErrs
 }
@@ -538,4 +539,22 @@ func validateTASSliceSize(tr *kueue.PodSetTopologyRequest, path *field.Path) fie
 		}
 	}
 	return allErrs
+}
+
+// Direct Workload writes bypass the job framework's TAS validation, so enforce
+// the grouped PodSet slicing feature gate at the Workload API boundary as well.
+func validateTASGroupedPodSetSlicing(tr *kueue.PodSetTopologyRequest, path *field.Path) field.ErrorList {
+	if features.Enabled(features.TASGroupedPodSetSlicing) || tr == nil || tr.PodSetGroupName == nil {
+		return nil
+	}
+
+	usesSlicing := tr.PodSetSliceRequiredTopology != nil ||
+		tr.PodSetSliceSize != nil ||
+		len(tr.PodsetSliceRequiredTopologyConstraints) > 0
+	if !usesSlicing {
+		return nil
+	}
+
+	return field.ErrorList{field.Forbidden(path.Child("podSetGroupName"),
+		fmt.Sprintf("may not be set with PodSet slicing unless the %s feature gate is enabled", features.TASGroupedPodSetSlicing))}
 }

--- a/pkg/webhooks/workload_webhook_test.go
+++ b/pkg/webhooks/workload_webhook_test.go
@@ -392,6 +392,76 @@ func TestValidateWorkload(t *testing.T) {
 				Obj(),
 			wantErr: nil,
 		},
+		"should reject grouped PodSet slicing when TASGroupedPodSetSlicing is disabled": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TASGroupedPodSetSlicing: false,
+			},
+			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("worker", 4).
+						RequiredTopologyRequest("cloud.com/block").
+						PodSetGroup("group").
+						SliceRequiredTopologyRequest("kubernetes.io/hostname").
+						SliceSizeTopologyRequest(2).
+						Obj(),
+					*utiltestingapi.MakePodSet("launcher", 2).
+						RequiredTopologyRequest("cloud.com/block").
+						PodSetGroup("group").
+						SliceRequiredTopologyRequest("kubernetes.io/hostname").
+						SliceSizeTopologyRequest(1).
+						Obj(),
+				).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Forbidden(podSetsPath.Index(0).Child("topologyRequest", "podSetGroupName"), ""),
+				field.Forbidden(podSetsPath.Index(1).Child("topologyRequest", "podSetGroupName"), ""),
+			}.ToAggregate(),
+		},
+		"should reject grouped multi-layer PodSet slicing when TASGroupedPodSetSlicing is disabled": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TASGroupedPodSetSlicing: false,
+			},
+			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("worker", 4).
+						RequiredTopologyRequest("cloud.com/block").
+						PodSetGroup("group").
+						SliceRequiredTopologyConstraints(kueue.PodsetSliceRequiredTopologyConstraint{Topology: "kubernetes.io/hostname", Size: 2}).
+						Obj(),
+				).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Forbidden(podSetsPath.Index(0).Child("topologyRequest", "podSetGroupName"), ""),
+			}.ToAggregate(),
+		},
+		"should accept grouped PodSet slicing when TASGroupedPodSetSlicing is enabled": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TASGroupedPodSetSlicing: true,
+			},
+			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("worker", 4).
+						RequiredTopologyRequest("cloud.com/block").
+						PodSetGroup("group").
+						SliceRequiredTopologyRequest("kubernetes.io/hostname").
+						SliceSizeTopologyRequest(2).
+						Obj(),
+				).
+				Obj(),
+		},
+		"should accept PodSet grouping without slicing when TASGroupedPodSetSlicing is disabled": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TASGroupedPodSetSlicing: false,
+			},
+			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("worker", 4).
+						RequiredTopologyRequest("cloud.com/block").
+						PodSetGroup("group").
+						Obj(),
+				).
+				Obj(),
+		},
 		"empty podSetUpdates": {
 			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).AdmissionChecks(kueue.AdmissionCheckState{}).Obj(),
 			wantErr:  nil,

--- a/pkg/webhooks/workload_webhook_test.go
+++ b/pkg/webhooks/workload_webhook_test.go
@@ -62,6 +62,7 @@ func quotaReservedWithoutAdmission(now time.Time) *kueue.Workload {
 	return wl
 }
 
+// TestValidateWorkload verifies validation of directly created Workloads.
 func TestValidateWorkload(t *testing.T) {
 	now := time.Now().Truncate(time.Second)
 	specPath := field.NewPath("spec")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area tas

#### What this PR does / why we need it?
fix #15364  
Enforces the `TASGroupedPodSetSlicing` feature gate when validating directly-created Workloads.

Previously, job integrations rejected PodSet grouping combined with PodSet slicing when the feature gate was disabled, but Workloads created directly through the API bypassed that validation. Such Workloads could reach the TAS scheduler and receive grouped+sliced topology assignments.

This change adds equivalent validation to the Workload webhook for both legacy and multi-layer slice topology fields.

#### Useful notes for your reviewer

Unit tests cover:

- grouped PodSet slicing with the feature gate disabled
- multi-layer grouped PodSet slicing with the feature gate disabled
- grouped PodSet slicing with the feature gate enabled
- PodSet grouping without slicing


#### Release note
```
TAS: Fixed a bug that allowed directly created Workloads to use grouped PodSet slicing when `TASGroupedPodSetSlicing` was disabled. 
```

AI tools were used to assist with implementation, and drafting. The changes and tests were reviewed and verified by the submitter.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## AI summary

The Workload webhook now rejects grouped PodSet slicing when `TASGroupedPodSetSlicing` is disabled. It validates legacy and multi-layer slice topology fields while allowing grouping without slicing. Tests cover enabled and disabled gate behavior.

### Suggested release note

TAS: Fixed a bug that allowed directly created Workloads to use grouped PodSet slicing when `TASGroupedPodSetSlicing` was disabled. Kueue now rejects these Workloads. This behavior is gated by the `TASGroupedPodSetSlicing` feature gate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->