### PR TITLE
workloadslicing: commonize active slice resolution

### DIFF
--- a/pkg/controller/elasticjobs/elastic_job_ungater.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater.go
@@ -85,13 +85,10 @@ func SetupWithManager(mgr ctrl.Manager, cfg *configapi.Configuration, roleTracke
 		client:            r.client,
 		expectationsStore: r.expectationsStore,
 	}
-	// Reconcile by the chain's active slice, resolved from whichever slice fired
-	// the event. Every slice maps to the single currently-admitted slice, whose
-	// granted counts cap ungating; Reconcile then loads it directly (no lookup
-	// through a possibly-deleted origin).
+	// Enqueue the active slice; Reconcile resolves it again in case of a rollover.
 	sliceKeyHandler := handler.TypedEnqueueRequestsFromMapFunc(
 		func(ctx context.Context, wl *kueue.Workload) []reconcile.Request {
-			active, err := r.activeSlice(ctx, wl)
+			active, err := workloadslicing.FindLatestAdmittedWorkload(ctx, r.client, wl, false)
 			if err != nil || active == nil {
 				return nil
 			}
@@ -122,35 +119,12 @@ func (r *elasticJobUngater) Reconcile(ctx context.Context, req reconcile.Request
 	log := ctrl.LoggerFrom(ctx)
 	log.V(2).Info("Reconcile ElasticJobUngater")
 
-	// req.Name is whichever slice the enqueue handlers resolved as active when the
-	// event fired. It is only a snapshot: a requeue (e.g. after a pod-patch
-	// conflict) can re-run this against a slice that has since finished, so the
-	// eligibility check below redirects to the current active slice rather than
-	// trusting req.Name. If nothing in the chain is admitted anymore, there is
-	// nothing to ungate.
-	active := &kueue.Workload{}
-	if err := r.client.Get(ctx, req.NamespacedName, active); err != nil {
-		return reconcile.Result{}, client.IgnoreNotFound(err)
+	active, err := workloadslicing.FindActiveWorkload(ctx, r.client, req.NamespacedName, false)
+	if err != nil || active == nil {
+		return reconcile.Result{}, err
 	}
-	// The handlers only enqueue active elastic slices, but req.Name is a snapshot:
-	// by the time this runs (especially on a requeue after a pod-patch conflict),
-	// the enqueued slice may have finished as part of a scale rollover. Bailing
-	// here would strand any pending ungate until the next periodic resync, so
-	// redirect to the chain's current active slice instead. Eviction is two
-	// writes — the condition is set before the reservation is released — so an
-	// evicted slice still reports a reservation while its capacity is on the way
-	// out; treat it as ineligible too, matching workloadslicing.FindLatestActiveWorkload.
 	if !shouldUngate(active) || workloadevict.IsEvicted(active) {
-		redirected, err := r.activeSlice(ctx, active)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-		// No eligible active slice, or it is the same (still-ineligible) object we
-		// just loaded: nothing new to ungate against.
-		if redirected == nil || redirected.Name == active.Name {
-			return reconcile.Result{}, nil
-		}
-		active = redirected
+		return reconcile.Result{}, nil
 	}
 
 	// Expectations are keyed by the stable chain key (the origin slice name shared
@@ -357,12 +331,6 @@ func (r *elasticJobUngater) podsToUngate(ctx context.Context, wl *kueue.Workload
 	return gated, nil
 }
 
-// activeSlice resolves the admitted slice of the chain the workload anyWl belongs
-// to, or nil if none is admitted.
-func (r *elasticJobUngater) activeSlice(ctx context.Context, anyWl *kueue.Workload) (*kueue.Workload, error) {
-	return workloadslicing.FindLatestAdmittedWorkloadForSlice(ctx, r.client, anyWl.Namespace, workloadslicing.SliceName(anyWl))
-}
-
 // Workload predicates
 
 func (r *elasticJobUngater) Create(e event.TypedCreateEvent[*kueue.Workload]) bool {
@@ -427,7 +395,7 @@ func (h *elasticPodHandler) queueReconcileForPod(ctx context.Context, object cli
 		log := ctrl.LoggerFrom(ctx).WithValues("pod", klog.KObj(pod), "workloadSlice", sliceKey.String())
 		h.expectationsStore.ObservedUID(log, *sliceKey, pod.UID)
 	}
-	active, err := workloadslicing.FindLatestAdmittedWorkloadForSlice(ctx, h.client, sliceKey.Namespace, sliceKey.Name)
+	active, err := workloadslicing.FindLatestAdmittedWorkloadForSlice(ctx, h.client, sliceKey.Namespace, sliceKey.Name, false)
 	if err != nil || active == nil {
 		return
 	}

--- a/pkg/controller/elasticjobs/elastic_job_ungater_test.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater_test.go
@@ -886,7 +886,7 @@ func TestReconcile(t *testing.T) {
 		"no-op for finished slice": {
 			// Slice replacement marks the previous slice Finished while keeping
 			// its Admitted and QuotaReserved conditions True. Reconciling the chain
-			// must not ungate any pods using this slice's stale count: activeSlice
+			// must not ungate any pods using this slice's stale count: the shared lookup
 			// skips finished slices and, with no other live slice in the chain,
 			// returns nil so nothing is ungated.
 			workloads: []kueue.Workload{
@@ -1127,10 +1127,10 @@ func TestReconcile(t *testing.T) {
 			}
 
 			// The ungater now reconciles by the chain's ACTIVE slice: the enqueue
-			// handlers resolve it via activeSlice, so mirror that here to pick the
+			// handlers resolve it via FindLatestAdmittedWorkload, so mirror that here to pick the
 			// request key. Expectations stay keyed by the stable chain key (the
 			// active slice's origin name).
-			active, err := ungater.activeSlice(ctx, &tc.workloads[0])
+			active, err := workloadslicing.FindLatestAdmittedWorkload(ctx, kClient, &tc.workloads[0], false)
 			if err != nil {
 				t.Fatalf("resolving active slice: %v", err)
 			}

--- a/pkg/workloadslicing/workloadslicing.go
+++ b/pkg/workloadslicing/workloadslicing.go
@@ -23,9 +23,11 @@ import (
 	"fmt"
 	"slices"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -38,6 +40,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/scheduler/preemption"
 	"sigs.k8s.io/kueue/pkg/workload"
+	"sigs.k8s.io/kueue/pkg/workload/concurrentadmission"
 	workloadevict "sigs.k8s.io/kueue/pkg/workload/evict"
 	workloadfinish "sigs.k8s.io/kueue/pkg/workload/finish"
 )
@@ -101,6 +104,52 @@ func SliceName(wl *kueue.Workload) string {
 	return wl.Name
 }
 
+func FindActiveWorkload(ctx context.Context, c client.Client, key types.NamespacedName, excludeVariants bool) (*kueue.Workload, error) {
+	wl := &kueue.Workload{}
+	if err := c.Get(ctx, key, wl); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil, err
+		}
+		wl = nil
+	}
+	// The slice index is only registered when elastic jobs are enabled.
+	if !features.Enabled(features.ElasticJobsViaWorkloadSlices) ||
+		(wl != nil && !IsElasticWorkload(wl)) {
+		return wl, nil
+	}
+	if wl != nil {
+		if sliceName, found := wl.Annotations[kueue.WorkloadSliceNameAnnotation]; found {
+			key.Name = sliceName
+		}
+	}
+	active, err := FindLatestAdmittedWorkloadForSlice(ctx, c, key.Namespace, key.Name, excludeVariants)
+	if err != nil || active != nil {
+		return active, err
+	}
+	return wl, nil
+}
+
+func FindLatestAdmittedWorkloadForSlice(ctx context.Context, c client.Client, namespace, sliceName string, excludeVariants bool) (*kueue.Workload, error) {
+	wls := &kueue.WorkloadList{}
+	if err := c.List(ctx, wls, client.InNamespace(namespace),
+		client.MatchingFields{indexer.WorkloadSliceNameKey: sliceName}); err != nil {
+		return nil, err
+	}
+	var latestAdmittedWl *kueue.Workload
+	for i := range wls.Items {
+		wl := &wls.Items[i]
+		if !workload.IsAdmitted(wl) || workloadfinish.IsFinished(wl) || workloadevict.IsEvicted(wl) ||
+			(excludeVariants && features.Enabled(features.ConcurrentAdmission) && concurrentadmission.IsVariant(wl)) {
+			continue
+		}
+		if latestAdmittedWl == nil || wl.CreationTimestamp.After(latestAdmittedWl.CreationTimestamp.Time) ||
+			(wl.CreationTimestamp.Equal(&latestAdmittedWl.CreationTimestamp) && cmp.Compare(wl.UID, latestAdmittedWl.UID) > 0) {
+			latestAdmittedWl = wl
+		}
+	}
+	return latestAdmittedWl, nil
+}
+
 func sortAndFilterNotFinishedWorkloads(workloads []kueue.Workload) []kueue.Workload {
 	workloads = slices.Clone(workloads)
 
@@ -129,27 +178,14 @@ func FindNotFinishedWorkloads(ctx context.Context, clnt client.Client, jobObject
 	return sortAndFilterNotFinishedWorkloads(list.Items), nil
 }
 
-// FindLatestAdmittedWorkloadForSlice returns the admitted slice of the chain
-// identified by its first slice's name (sliceName), which every slice and pod of an
-// elastic job carries, or nil if none is admitted.
-func FindLatestAdmittedWorkloadForSlice(ctx context.Context, clnt client.Client, namespace, sliceName string) (*kueue.Workload, error) {
-	list := &kueue.WorkloadList{}
-	if err := clnt.List(ctx, list, client.InNamespace(namespace),
-		client.MatchingFields{indexer.WorkloadSliceNameKey: sliceName}); err != nil {
-		return nil, err
+// FindLatestAdmittedWorkload returns the latest admitted slice in wl's chain,
+// or nil if wl is nil or the chain has no admitted slice.
+// excludeVariants lets scheduling observation select only Parent slices.
+func FindLatestAdmittedWorkload(ctx context.Context, clnt client.Client, wl *kueue.Workload, excludeVariants bool) (*kueue.Workload, error) {
+	if wl == nil {
+		return nil, nil
 	}
-
-	workloads := sortAndFilterNotFinishedWorkloads(list.Items)
-	for i := range slices.Backward(workloads) {
-		wl := &workloads[i]
-		// Eviction is two writes: the condition is set before the reservation is
-		// released, so an evicted slice can still report itself admitted while its
-		// capacity is on the way out.
-		if workload.IsAdmitted(wl) && !workloadevict.IsEvicted(wl) {
-			return wl, nil
-		}
-	}
-	return nil, nil
+	return FindLatestAdmittedWorkloadForSlice(ctx, clnt, wl.Namespace, SliceName(wl), excludeVariants)
 }
 
 // FindLatestActiveWorkload returns the newest non-finished, non-evicted workload

--- a/pkg/workloadslicing/workloadslicing_test.go
+++ b/pkg/workloadslicing/workloadslicing_test.go
@@ -178,6 +178,394 @@ func TestListPodsForWorkloadSlice(t *testing.T) {
 	}
 }
 
+func TestFindActiveWorkload(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	errGetWorkload := errors.New("get workload failed")
+	errListWorkload := errors.New("list workloads failed")
+	origin := utiltestingapi.MakeWorkload("origin", "ns").
+		Request(corev1.ResourceCPU, "1").
+		Annotation(EnabledAnnotationKey, EnabledAnnotationValue).
+		Creation(now.Add(-time.Minute)).
+		SimpleReserveQuota("cq", "flavor", now).
+		AdmittedAt(true, now)
+	replacement := utiltestingapi.MakeWorkload("replacement", "ns").
+		Request(corev1.ResourceCPU, "1").
+		Annotation(EnabledAnnotationKey, EnabledAnnotationValue).
+		Annotation(kueue.WorkloadSliceNameAnnotation, "origin").
+		Creation(now).
+		SimpleReserveQuota("cq", "flavor", now).
+		AdmittedAt(true, now)
+	variant := utiltestingapi.MakeWorkload("variant", "ns").
+		Request(corev1.ResourceCPU, "1").
+		Annotation(EnabledAnnotationKey, EnabledAnnotationValue).
+		Annotation(kueue.WorkloadSliceNameAnnotation, "origin").
+		OwnerReference(kueue.SchemeGroupVersion.WithKind("Workload"), "replacement", "parent").
+		Creation(now.Add(time.Second)).
+		SimpleReserveQuota("cq", "flavor", now).
+		AdmittedAt(true, now)
+
+	testCases := map[string]struct {
+		featureGates    map[featuregate.Feature]bool
+		excludeVariants bool
+		requestName     string
+		workloads       []*kueue.Workload
+		wantWorkload    *kueue.Workload
+		wantError       error
+	}{
+		"ordinary workload does not require the slice index": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: false},
+			workloads: []*kueue.Workload{
+				utiltestingapi.MakeWorkload("origin", "ns").
+					Request(corev1.ResourceCPU, "1").
+					Obj(),
+			},
+			wantWorkload: utiltestingapi.MakeWorkload("origin", "ns").
+				Request(corev1.ResourceCPU, "1").
+				Obj(),
+		},
+		"ordinary workload is not redirected with elastic jobs enabled": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			workloads: []*kueue.Workload{
+				utiltestingapi.MakeWorkload("origin", "ns").
+					Request(corev1.ResourceCPU, "1").
+					Obj(),
+				replacement.Obj(),
+			},
+			wantWorkload: utiltestingapi.MakeWorkload("origin", "ns").
+				Request(corev1.ResourceCPU, "1").
+				Obj(),
+		},
+		"disabled elastic jobs retain the requested slice": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: false},
+			workloads:    []*kueue.Workload{origin.Obj(), replacement.Obj()},
+			wantWorkload: origin.Obj(),
+		},
+		"missing workload without elastic jobs does not require the slice index": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: false},
+		},
+		"missing workload without a replacement": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+		},
+		"get error is returned": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			wantError:    errGetWorkload,
+		},
+		"list error after a missing origin is returned": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			wantError:    errListWorkload,
+		},
+		"list error after an existing origin is returned": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			workloads:    []*kueue.Workload{origin.Obj()},
+			wantError:    errListWorkload,
+		},
+		"latest admitted slice replaces an admitted origin": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			workloads:    []*kueue.Workload{origin.Obj(), replacement.Obj()},
+			wantWorkload: replacement.Obj(),
+		},
+		"finished origin resolves to the replacement": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			workloads:    []*kueue.Workload{origin.Clone().FinishedAt(now).Obj(), replacement.Obj()},
+			wantWorkload: replacement.Obj(),
+		},
+		"deleted origin resolves to the replacement": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			workloads:    []*kueue.Workload{replacement.Obj()},
+			wantWorkload: replacement.Obj(),
+		},
+		"request for a replacement uses the chain annotation": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			requestName:  "replacement",
+			workloads:    []*kueue.Workload{origin.Obj(), replacement.Obj()},
+			wantWorkload: replacement.Obj(),
+		},
+		"non-admitted workload is retained for condition reset": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			workloads:    []*kueue.Workload{origin.Clone().AdmittedAt(false, now).Obj()},
+			wantWorkload: origin.Clone().AdmittedAt(false, now).Obj(),
+		},
+		"finished workload is retained when there is no active slice": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			workloads:    []*kueue.Workload{origin.Clone().FinishedAt(now).Obj()},
+			wantWorkload: origin.Clone().FinishedAt(now).Obj(),
+		},
+		"evicted replacement is ignored even before quota release": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			workloads:    []*kueue.Workload{origin.Obj(), replacement.Clone().EvictedAt(now).Obj()},
+			wantWorkload: origin.Obj(),
+		},
+		"finished replacement is ignored": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			workloads:    []*kueue.Workload{origin.Obj(), replacement.Clone().FinishedAt(now).Obj()},
+			wantWorkload: origin.Obj(),
+		},
+		"quota reserved but not admitted replacement is ignored": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			workloads:    []*kueue.Workload{origin.Obj(), replacement.Clone().AdmittedAt(false, now).Obj()},
+			wantWorkload: origin.Obj(),
+		},
+		"replacement in another namespace is ignored": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			workloads: []*kueue.Workload{
+				origin.Obj(),
+				utiltestingapi.MakeWorkload("replacement", "other").
+					Request(corev1.ResourceCPU, "1").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "origin").
+					SimpleReserveQuota("cq", "flavor", now).
+					AdmittedAt(true, now).
+					Obj(),
+			},
+			wantWorkload: origin.Obj(),
+		},
+		"tracker excludes variants": {
+			featureGates: map[featuregate.Feature]bool{
+				features.ElasticJobsViaWorkloadSlices: true,
+				features.ConcurrentAdmission:          true,
+			},
+			workloads:       []*kueue.Workload{origin.Obj(), replacement.Obj(), variant.Obj()},
+			excludeVariants: true,
+			wantWorkload:    replacement.Obj(),
+		},
+		"ungaters retain variant selection": {
+			featureGates: map[featuregate.Feature]bool{
+				features.ElasticJobsViaWorkloadSlices: true,
+				features.ConcurrentAdmission:          true,
+			},
+			workloads:    []*kueue.Workload{origin.Obj(), replacement.Obj(), variant.Obj()},
+			wantWorkload: variant.Obj(),
+		},
+		"concurrent admission disabled retains variant selection": {
+			featureGates: map[featuregate.Feature]bool{
+				features.ElasticJobsViaWorkloadSlices: true,
+				features.ConcurrentAdmission:          false,
+			},
+			workloads:       []*kueue.Workload{origin.Obj(), replacement.Obj(), variant.Obj()},
+			excludeVariants: true,
+			wantWorkload:    variant.Obj(),
+		},
+		"same creation timestamp is ordered by UID": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			workloads:    []*kueue.Workload{origin.Clone().Creation(now).UID("z").Obj(), replacement.Clone().UID("a").Obj()},
+			wantWorkload: origin.Clone().Creation(now).UID("z").Obj(),
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
+			ctx, _ := utiltesting.ContextWithLog(t)
+			builder := utiltesting.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if _, ok := obj.(*kueue.Workload); ok && errors.Is(tc.wantError, errGetWorkload) {
+						return errGetWorkload
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+				List: func(ctx context.Context, c client.WithWatch, objs client.ObjectList, opts ...client.ListOption) error {
+					if _, ok := objs.(*kueue.WorkloadList); ok && errors.Is(tc.wantError, errListWorkload) {
+						return errListWorkload
+					}
+					return c.List(ctx, objs, opts...)
+				},
+			})
+			if tc.featureGates[features.ElasticJobsViaWorkloadSlices] {
+				builder.WithIndex(&kueue.Workload{}, indexer.WorkloadSliceNameKey, indexer.IndexWorkloadSliceName)
+			}
+			for _, wl := range tc.workloads {
+				builder.WithObjects(wl)
+			}
+			key := types.NamespacedName{Namespace: "ns", Name: "origin"}
+			if tc.requestName != "" {
+				key.Name = tc.requestName
+			}
+			got, err := FindActiveWorkload(ctx, builder.Build(), key, tc.excludeVariants)
+			if diff := cmp.Diff(tc.wantError, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("Unexpected error (-want,+got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantWorkload, got, cmpopts.IgnoreFields(kueue.Workload{}, "TypeMeta", "ObjectMeta.ResourceVersion")); diff != "" {
+				t.Errorf("Unexpected Workload (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFindLatestAdmittedWorkload(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Now().Truncate(time.Second))
+	errListWorkloads := errors.New("list workloads failed")
+
+	origin := utiltestingapi.MakeWorkload("origin", "ns").
+		Annotation(EnabledAnnotationKey, EnabledAnnotationValue).
+		Creation(fakeClock.Now().Add(-time.Minute)).
+		ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").Obj(), fakeClock.Now().Add(-time.Minute)).
+		AdmittedAt(true, fakeClock.Now().Add(-time.Minute))
+	replacement := utiltestingapi.MakeWorkload("replacement", "ns").
+		Annotation(EnabledAnnotationKey, EnabledAnnotationValue).
+		Annotation(kueue.WorkloadSliceNameAnnotation, "origin").
+		Creation(fakeClock.Now()).
+		ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").Obj(), fakeClock.Now()).
+		AdmittedAt(true, fakeClock.Now())
+	variant := utiltestingapi.MakeWorkload("variant", "ns").
+		Annotation(EnabledAnnotationKey, EnabledAnnotationValue).
+		Annotation(kueue.WorkloadSliceNameAnnotation, "origin").
+		Creation(fakeClock.Now().Add(time.Second)).
+		OwnerReference(kueue.SchemeGroupVersion.WithKind("Workload"), "replacement", "parent-uid").
+		ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").Obj(), fakeClock.Now()).
+		AdmittedAt(true, fakeClock.Now())
+
+	testCases := map[string]struct {
+		featureGates    map[featuregate.Feature]bool
+		excludeVariants bool
+		workload        *kueue.Workload
+		workloads       []*kueue.Workload
+		wantName        string
+		wantErr         error
+	}{
+		"nil workload": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+		},
+		"origin without the elastic annotation retains the slice lookup": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			workload:     utiltestingapi.MakeWorkload("origin", "ns").Obj(),
+			workloads:    []*kueue.Workload{origin.Obj(), replacement.Obj()},
+			wantName:     "replacement",
+		},
+		"elastic feature gate disabled retains the slice lookup": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: false},
+			workload:     origin.Obj(),
+			workloads:    []*kueue.Workload{origin.Obj(), replacement.Obj()},
+			wantName:     "replacement",
+		},
+		"no admitted slice": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			workload:     origin.Obj(),
+		},
+		"list failure is returned": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			workload:     origin.Obj(),
+			wantErr:      errListWorkloads,
+		},
+		"finished origin resolves to the replacement": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			workload: origin.Clone().
+				FinishedAt(fakeClock.Now()).
+				Obj(),
+			workloads: []*kueue.Workload{origin.Clone().
+				FinishedAt(fakeClock.Now()).
+				Obj(), replacement.Obj()},
+			wantName: "replacement",
+		},
+		"latest admitted replacement is selected": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			workload:     origin.Obj(),
+			workloads:    []*kueue.Workload{origin.Obj(), replacement.Obj()},
+			wantName:     "replacement",
+		},
+		"newer admitted variant does not hide the replacement slice": {
+			excludeVariants: true,
+			featureGates: map[featuregate.Feature]bool{
+				features.ElasticJobsViaWorkloadSlices: true,
+				features.ConcurrentAdmission:          true,
+			},
+			workload: origin.Obj(),
+			workloads: []*kueue.Workload{
+				origin.Clone().
+					FinishedAt(fakeClock.Now()).
+					Obj(),
+				replacement.Obj(),
+				variant.Obj(),
+			},
+			wantName: "replacement",
+		},
+		"ungater lookup preserves variant selection": {
+			featureGates: map[featuregate.Feature]bool{
+				features.ElasticJobsViaWorkloadSlices: true,
+				features.ConcurrentAdmission:          true,
+			},
+			workload:  origin.Obj(),
+			workloads: []*kueue.Workload{origin.Obj(), replacement.Obj(), variant.Obj()},
+			wantName:  "variant",
+		},
+
+		"concurrent admission disabled preserves variant selection": {
+			excludeVariants: true,
+			featureGates: map[featuregate.Feature]bool{
+				features.ElasticJobsViaWorkloadSlices: true,
+				features.ConcurrentAdmission:          false,
+			},
+			workload:  origin.Obj(),
+			workloads: []*kueue.Workload{origin.Obj(), replacement.Obj(), variant.Obj()},
+			wantName:  "variant",
+		},
+		"elastic feature gate disabled still excludes variants": {
+			featureGates: map[featuregate.Feature]bool{
+				features.ElasticJobsViaWorkloadSlices: false,
+				features.ConcurrentAdmission:          true,
+			},
+			excludeVariants: true,
+			workload:        origin.Obj(),
+			workloads:       []*kueue.Workload{origin.Obj(), replacement.Obj(), variant.Obj()},
+			wantName:        "replacement",
+		},
+		"evicted replacement is ignored": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			workload:     replacement.Obj(),
+			workloads: []*kueue.Workload{origin.Obj(), replacement.Clone().
+				EvictedAt(fakeClock.Now()).
+				Obj()},
+			wantName: "origin",
+		},
+		"finished replacement is ignored": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			workload:     replacement.Obj(),
+			workloads: []*kueue.Workload{origin.Obj(), replacement.Clone().
+				FinishedAt(fakeClock.Now()).
+				Obj()},
+			wantName: "origin",
+		},
+		"replacement in another namespace is ignored": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			workload:     origin.Obj(),
+			workloads: []*kueue.Workload{origin.Obj(),
+				utiltestingapi.MakeWorkload("replacement", "other").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "origin").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").Obj(), fakeClock.Now()).
+					AdmittedAt(true, fakeClock.Now()).
+					Obj()},
+			wantName: "origin",
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
+			ctx, _ := utiltesting.ContextWithLog(t)
+			builder := utiltesting.NewClientBuilder().
+				WithIndex(&kueue.Workload{}, indexer.WorkloadSliceNameKey, indexer.IndexWorkloadSliceName).
+				WithInterceptorFuncs(interceptor.Funcs{
+					List: func(ctx context.Context, c client.WithWatch, objs client.ObjectList, opts ...client.ListOption) error {
+						if _, ok := objs.(*kueue.WorkloadList); ok && errors.Is(tc.wantErr, errListWorkloads) {
+							return errListWorkloads
+						}
+						return c.List(ctx, objs, opts...)
+					},
+				})
+			for _, wl := range tc.workloads {
+				builder = builder.WithObjects(wl)
+			}
+			got, err := FindLatestAdmittedWorkload(ctx, builder.Build(), tc.workload, tc.excludeVariants)
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("Unexpected error (-want,+got):\n%s", diff)
+			}
+			var gotName string
+			if got != nil {
+				gotName = got.Name
+			}
+			if diff := cmp.Diff(tc.wantName, gotName); diff != "" {
+				t.Errorf("Unexpected workload name (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestPreemptibleSliceKey(t *testing.T) {
 	type args struct {
 		wl *kueue.Workload


### PR DESCRIPTION
<!-- Thank you for contributing! Check CONTRIBUTING.md for details. -->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it?
I generalized the Workload Slice resolution mechanism using FindLatestAdmittedWorkload across elastic job ungater and topology ungater.

This is a preparation PR for the KEP-13502.

<!--
Use `Fixes #123` for an issue addressed by this PR; it will be closed when the PR merges.
Use `Related:` or `Part of:` to reference an issue without closing it.
-->
Part of https://github.com/kubernetes-sigs/kueue/issues/13502

#### Useful notes for your reviewer
This was extracted from the https://github.com/kubernetes-sigs/kueue/pull/15257.

#### Release note

<!-- Describe the behavior change accurately from the user's perspective. Hints:
- Do not leave this block blank.
- Use "NONE" when there is no user-facing change.
- When feasible use a prefix for the sub-component or feature, e.g. "FairSharing:" or "MultiKueue:".
- If upgrade steps are required, include an "ACTION REQUIRED:" section.
You may consider AI assistance using the skill: cmd/experimental/skills/kueue-release-notes/SKILL.md.
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## AI summary

Centralizes active workload-slice resolution in `workloadslicing`. Updates the elastic-job and TAS ungaters to use the shared helpers. Adds coverage for workload-slice replacement scenarios.

### Suggested release note

NONE
<!-- end of auto-generated comment: release notes by coderabbit.ai -->