### PR TITLE
Enforce TASGroupedPodSetSlicing gate in the Workload webhook

### DIFF
--- a/pkg/webhooks/workload_webhook.go
+++ b/pkg/webhooks/workload_webhook.go
@@ -194,6 +194,10 @@ func validatePodSet(ps *kueue.PodSet, path *field.Path) field.ErrorList {
 		allErrs = append(allErrs, validateTASSliceSize(ps.TopologyRequest, path.Child("topologyRequest"))...)
 	}
 
+	if !features.Enabled(features.TASGroupedPodSetSlicing) {
+		allErrs = append(allErrs, validatePodSetGroupName(ps.TopologyRequest, path.Child("topologyRequest"))...)
+	}
+
 	return allErrs
 }
 
@@ -504,6 +508,30 @@ func validateClusterNameUpdate(newObj, oldObj *kueue.Workload, statusPath *field
 		}
 	}
 
+	return allErrs
+}
+
+// validatePodSetGroupName enforces the TASGroupedPodSetSlicing feature gate for
+// directly-created Workloads. When the gate is disabled, a PodSet cannot combine
+// PodSetGroupName with any slice-level topology field. This mirrors the check
+// that job integrations apply to their replica metadata annotations in
+// pkg/controller/jobframework/tas_validation.go.
+func validatePodSetGroupName(tr *kueue.PodSetTopologyRequest, path *field.Path) field.ErrorList {
+	if tr == nil || tr.PodSetGroupName == nil || features.Enabled(features.TASGroupedPodSetSlicing) {
+		return nil
+	}
+
+	groupPath := path.Child("podSetGroupName")
+	var allErrs field.ErrorList
+	if tr.PodSetSliceRequiredTopology != nil {
+		allErrs = append(allErrs, field.Forbidden(groupPath, "may not be set when 'podSetSliceRequiredTopology' is specified"))
+	}
+	if tr.PodSetSliceSize != nil {
+		allErrs = append(allErrs, field.Forbidden(groupPath, "may not be set when 'podSetSliceSize' is specified"))
+	}
+	if len(tr.PodsetSliceRequiredTopologyConstraints) > 0 {
+		allErrs = append(allErrs, field.Forbidden(groupPath, "may not be set when 'podsetSliceRequiredTopologyConstraints' is specified"))
+	}
 	return allErrs
 }
 

--- a/pkg/webhooks/workload_webhook_test.go
+++ b/pkg/webhooks/workload_webhook_test.go
@@ -392,6 +392,55 @@ func TestValidateWorkload(t *testing.T) {
 				Obj(),
 			wantErr: nil,
 		},
+		"should reject podSetGroupName combined with slice topology when TASGroupedPodSetSlicing is disabled": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TASGroupedPodSetSlicing: false,
+			},
+			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("bad", 1).
+						PodSetGroup("group1").
+						SliceRequiredTopologyRequest("kubernetes.io/hostname").
+						SliceSizeTopologyRequest(1).
+						Obj(),
+				).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Forbidden(podSetsPath.Index(0).Child("topologyRequest", "podSetGroupName"), "may not be set when 'podSetSliceRequiredTopology' is specified"),
+				field.Forbidden(podSetsPath.Index(0).Child("topologyRequest", "podSetGroupName"), "may not be set when 'podSetSliceSize' is specified"),
+			}.ToAggregate(),
+		},
+		"should reject podSetGroupName combined with multi-layer slice constraints when TASGroupedPodSetSlicing is disabled": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TASGroupedPodSetSlicing: false,
+			},
+			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("bad", 1).
+						PodSetGroup("group1").
+						SliceRequiredTopologyConstraints(kueue.PodsetSliceRequiredTopologyConstraint{Topology: "kubernetes.io/hostname", Size: 1}).
+						Obj(),
+				).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Forbidden(podSetsPath.Index(0).Child("topologyRequest", "podSetGroupName"), "may not be set when 'podsetSliceRequiredTopologyConstraints' is specified"),
+			}.ToAggregate(),
+		},
+		"should accept podSetGroupName combined with slice topology when TASGroupedPodSetSlicing is enabled": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TASGroupedPodSetSlicing: true,
+			},
+			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("ok", 1).
+						PodSetGroup("group1").
+						SliceRequiredTopologyRequest("kubernetes.io/hostname").
+						SliceSizeTopologyRequest(1).
+						Obj(),
+				).
+				Obj(),
+			wantErr: nil,
+		},
 		"empty podSetUpdates": {
 			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).AdmissionChecks(kueue.AdmissionCheckState{}).Obj(),
 			wantErr:  nil,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area tas

#### What this PR does / why we need it?

The `TASGroupedPodSetSlicing` feature gate is enforced by the job integrations in `pkg/controller/jobframework/tas_validation.go`, but not for Workloads created directly. A Workload that sets `podSetGroupName` together with slice-level topology fields is accepted and scheduled even when the gate is disabled, while an equivalent job is rejected.

This change adds the missing check to the Workload webhook. When `TASGroupedPodSetSlicing` is disabled, a PodSet cannot combine `podSetGroupName` with `podSetSliceRequiredTopology`, `podSetSliceSize`, or `podsetSliceRequiredTopologyConstraints`.

Fixes #15364

#### Useful notes for your reviewer

The new `validatePodSetGroupName` helper mirrors the annotation-level checks in `tas_validation.go`, operating on the structured `PodSetTopologyRequest` fields instead. It only rejects the grouped-plus-sliced combination when the gate is disabled; plain grouping (without slicing) remains allowed, matching the job-framework behavior.

#### Release note

```release-note
TAS: the Workload webhook now rejects directly-created Workloads that combine podSetGroupName with slice topology fields when the TASGroupedPodSetSlicing feature gate is disabled.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## AI summary

The Workload webhook now rejects grouped PodSets with slice-level topology fields when `TASGroupedPodSetSlicing` is disabled. Plain grouping remains allowed. Tests cover enabled and disabled gate behavior.

### Suggested release note

TAS: Fixed a bug that allowed directly created Workloads to use grouped PodSet slicing when `TASGroupedPodSetSlicing` was disabled. The webhook now rejects these configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->