### PR TITLE
TAS: key benchmark workload usage by the topology's lowest declared level

### DIFF
--- a/pkg/cache/scheduler/tas_flavor_snapshot_bench_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_bench_test.go
@@ -312,11 +312,15 @@ func BenchmarkTASFlavorSnapshotWithWorkloadUsage(b *testing.B) {
 					n := i % topo.nodes
 					rack := n / topo.nodesPerRack
 					block := rack / topo.racksPerBlock
-					values := []string{fmt.Sprintf("block-%d", block), fmt.Sprintf("rack-%d", rack)}
-					if len(scheme.levels) == 3 {
-						values = append(values, fmt.Sprintf("node-%d", n))
+					var values []string
+					switch len(scheme.levels) {
+					case 3:
+						values = []string{fmt.Sprintf("node-%d", n)}
+					case 2:
+						values = []string{fmt.Sprintf("block-%d", block), fmt.Sprintf("rack-%d", rack)}
+					default:
+						values = []string{fmt.Sprintf("block-%d", block)}
 					}
-					values = values[:len(scheme.levels)]
 					fc.addUsage(log, workload.Reference(fmt.Sprintf("wl-%d", i)), []workload.TopologyDomainRequests{{
 						Values:            values,
 						SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000}),


### PR DESCRIPTION


<!-- Thank you for contributing! Check CONTRIBUTING.md for details. -->

#### What type of PR is this?
<!-- Choose one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep
-->
/kind cleanup

<!-- Optionally choose one or more of the following kinds:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


<!-- Consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->


#### What this PR does / why we need it?


<!--
Use `Fixes #123` for an issue addressed by this PR; it will be closed when the PR merges.
Use `Related:` or `Part of:` to reference an issue without closing it.
-->
Fixes https://github.com/kubernetes-sigs/kueue/issues/15359

#### Useful notes for your reviewer


#### Release note

<!-- Describe the behavior change accurately from the user's perspective. Hints:
- Do not leave this block blank.
- Use "NONE" when there is no user-facing change.
- When feasible use a prefix for the sub-component or feature, e.g. "FairSharing:" or "MultiKueue:".
- If upgrade steps are required, include an "ACTION REQUIRED:" section.
You may consider AI assistance using the skill: cmd/experimental/skills/kueue-release-notes/SKILL.md.
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## AI summary

- Updated `BenchmarkTASFlavorSnapshotWithWorkloadUsage` to generate topology-domain values that match each scheme’s declared hierarchy.
- Preserved workload distribution across selected domains.
- No user-facing change.

### Suggested release note

NONE

<!-- end of auto-generated comment: release notes by coderabbit.ai -->