### PR TITLE
revert: remove obsolete scheduling.quotaReleaseStrategy API (PR 13224)

### DIFF
--- a/apis/config/v1beta1/zz_generated.conversion.go
+++ b/apis/config/v1beta1/zz_generated.conversion.go
@@ -397,7 +397,6 @@ func autoConvert_v1beta2_Configuration_To_v1beta1_Configuration(in *v1beta2.Conf
 	} else {
 		out.WaitForPodsReady = nil
 	}
-	// WARNING: in.QuotaReleaseStrategy requires manual conversion: does not exist in peer-type
 	out.ClientConnection = (*ClientConnection)(unsafe.Pointer(in.ClientConnection))
 	if in.Integrations != nil {
 		in, out := &in.Integrations, &out.Integrations

--- a/apis/config/v1beta2/configuration_types.go
+++ b/apis/config/v1beta2/configuration_types.go
@@ -78,10 +78,6 @@ type Configuration struct {
 	// is exceeded, then the workload is evicted.
 	WaitForPodsReady *WaitForPodsReady `json:"waitForPodsReady,omitempty"`
 
-	// QuotaReleaseStrategy provides configuration options for controlling quota release timing.
-	// +optional
-	QuotaReleaseStrategy *QuotaReleaseStrategy `json:"quotaReleaseStrategy,omitempty"`
-
 	// ClientConnection provides additional configuration options for Kubernetes
 	// API server client.
 	ClientConnection *ClientConnection `json:"clientConnection,omitempty"`
@@ -302,27 +298,6 @@ type ControllerConfigurationSpec struct {
 	// +optional
 	CacheSyncTimeout *time.Duration `json:"cacheSyncTimeout,omitempty"`
 }
-
-// QuotaReleaseStrategy defines when Kueue releases quota for a terminating workload.
-//
-// Valid values are:
-// - "OnTerminating" (default): releases quota as soon as all pods have a deletionTimestamp set.
-// - "OnTerminal": holds quota until all underlying pods have fully reached a terminal phase (Succeeded or Failed).
-//
-// +enum
-type QuotaReleaseStrategy string
-
-const (
-	// QuotaReleaseOnTerminating releases quota as soon as all pods have a
-	// deletionTimestamp set. This is the default and matches the existing
-	// behaviour of the batch/v1 Job integration.
-	QuotaReleaseOnTerminating QuotaReleaseStrategy = "OnTerminating"
-	// QuotaReleaseOnTerminal holds quota until all underlying pods
-	// have fully reached a terminal phase (Succeeded or Failed). This prevents
-	// scheduling failures for TopologyAwareScheduling (TAS) workloads where new
-	// pods cannot be placed until old pods physically release the hardware.
-	QuotaReleaseOnTerminal QuotaReleaseStrategy = "OnTerminal"
-)
 
 // WaitForPodsReady defines configuration for the Wait For Pods Ready feature,
 // which is used to ensure that all Pods are ready within the specified time.

--- a/apis/config/v1beta2/defaults.go
+++ b/apis/config/v1beta2/defaults.go
@@ -116,8 +116,6 @@ func SetDefaults_Configuration(cfg *Configuration) {
 		cfg.WaitForPodsReady.RequeuingStrategy.BackoffMaxSeconds = cmp.Or(cfg.WaitForPodsReady.RequeuingStrategy.BackoffMaxSeconds, new(int32(DefaultRequeuingBackoffMaxSeconds)))
 	}
 
-	cfg.QuotaReleaseStrategy = cmp.Or(cfg.QuotaReleaseStrategy, new(QuotaReleaseOnTerminating))
-
 	cfg.Integrations = cmp.Or(cfg.Integrations, &Integrations{})
 	if len(cfg.Integrations.Frameworks) == 0 {
 		cfg.Integrations.Frameworks = []string{defaultJobFrameworkName}

--- a/apis/config/v1beta2/defaults_test.go
+++ b/apis/config/v1beta2/defaults_test.go
@@ -131,9 +131,8 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 			},
 			want: &Configuration{
-				QuotaReleaseStrategy: new(QuotaReleaseOnTerminating),
-				Namespace:            new(DefaultNamespace),
-				ControllerManager:    defaultCtrlManagerConfigurationSpec,
+				Namespace:         new(DefaultNamespace),
+				ControllerManager: defaultCtrlManagerConfigurationSpec,
 				InternalCertManagement: &InternalCertManagement{
 					Enable: new(false),
 				},
@@ -157,8 +156,7 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 			},
 			want: &Configuration{
-				QuotaReleaseStrategy: new(QuotaReleaseOnTerminating),
-				Namespace:            new(DefaultNamespace),
+				Namespace: new(DefaultNamespace),
 				ControllerManager: ControllerManager{
 					Webhook: ControllerWebhook{
 						Port:    new(DefaultWebhookPort),
@@ -225,8 +223,7 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				VisibilityServer: defaultVisibilityServer,
 			},
 			want: &Configuration{
-				QuotaReleaseStrategy: new(QuotaReleaseOnTerminating),
-				Namespace:            new(DefaultNamespace),
+				Namespace: new(DefaultNamespace),
 				ControllerManager: ControllerManager{
 					Webhook: ControllerWebhook{
 						Port:    new(overwriteWebhookPort),
@@ -273,8 +270,7 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 			},
 			want: &Configuration{
-				QuotaReleaseStrategy: new(QuotaReleaseOnTerminating),
-				Namespace:            new(DefaultNamespace),
+				Namespace: new(DefaultNamespace),
 				ControllerManager: ControllerManager{
 					Webhook: ControllerWebhook{
 						Port:    new(DefaultWebhookPort),
@@ -314,9 +310,8 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				Namespace: new(overwriteNamespace),
 			},
 			want: &Configuration{
-				QuotaReleaseStrategy: new(QuotaReleaseOnTerminating),
-				Namespace:            new(overwriteNamespace),
-				ControllerManager:    defaultCtrlManagerConfigurationSpec,
+				Namespace:         new(overwriteNamespace),
+				ControllerManager: defaultCtrlManagerConfigurationSpec,
 				InternalCertManagement: &InternalCertManagement{
 					Enable:             new(true),
 					WebhookServiceName: new(DefaultWebhookServiceName),
@@ -338,9 +333,8 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 			},
 			want: &Configuration{
-				QuotaReleaseStrategy: new(QuotaReleaseOnTerminating),
-				Namespace:            new(overwriteNamespace),
-				ControllerManager:    defaultCtrlManagerConfigurationSpec,
+				Namespace:         new(overwriteNamespace),
+				ControllerManager: defaultCtrlManagerConfigurationSpec,
 				InternalCertManagement: &InternalCertManagement{
 					Enable: new(false),
 				},
@@ -364,9 +358,8 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 			},
 			want: &Configuration{
-				QuotaReleaseStrategy: new(QuotaReleaseOnTerminating),
-				Namespace:            new(overwriteNamespace),
-				ControllerManager:    defaultCtrlManagerConfigurationSpec,
+				Namespace:         new(overwriteNamespace),
+				ControllerManager: defaultCtrlManagerConfigurationSpec,
 				InternalCertManagement: &InternalCertManagement{
 					Enable: new(false),
 				},
@@ -390,9 +383,8 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				ClientConnection: &ClientConnection{},
 			},
 			want: &Configuration{
-				QuotaReleaseStrategy: new(QuotaReleaseOnTerminating),
-				Namespace:            new(overwriteNamespace),
-				ControllerManager:    defaultCtrlManagerConfigurationSpec,
+				Namespace:         new(overwriteNamespace),
+				ControllerManager: defaultCtrlManagerConfigurationSpec,
 				InternalCertManagement: &InternalCertManagement{
 					Enable: new(false),
 				},
@@ -412,7 +404,6 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 			},
 			want: &Configuration{
-				QuotaReleaseStrategy: new(QuotaReleaseOnTerminating),
 				WaitForPodsReady: &WaitForPodsReady{
 					Timeout: metav1.Duration{
 						Duration: 30 * time.Minute,
@@ -449,7 +440,6 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 			},
 			want: &Configuration{
-				QuotaReleaseStrategy: new(QuotaReleaseOnTerminating),
 				WaitForPodsReady: &WaitForPodsReady{
 					Timeout:         customTimeout,
 					BlockAdmission:  new(false),
@@ -488,7 +478,6 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 			},
 			want: &Configuration{
-				QuotaReleaseStrategy: new(QuotaReleaseOnTerminating),
 				WaitForPodsReady: &WaitForPodsReady{
 					BlockAdmission:  new(false),
 					Timeout:         podsReadyTimeoutOverwrite,
@@ -522,7 +511,6 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 			},
 			want: &Configuration{
-				QuotaReleaseStrategy: new(QuotaReleaseOnTerminating),
 				WaitForPodsReady: &WaitForPodsReady{
 					Timeout:         customTimeout,
 					BlockAdmission:  new(false),
@@ -555,9 +543,8 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 			},
 			want: &Configuration{
-				QuotaReleaseStrategy: new(QuotaReleaseOnTerminating),
-				Namespace:            new(DefaultNamespace),
-				ControllerManager:    defaultCtrlManagerConfigurationSpec,
+				Namespace:         new(DefaultNamespace),
+				ControllerManager: defaultCtrlManagerConfigurationSpec,
 				InternalCertManagement: &InternalCertManagement{
 					Enable: new(false),
 				},
@@ -584,9 +571,8 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 			},
 			want: &Configuration{
-				QuotaReleaseStrategy: new(QuotaReleaseOnTerminating),
-				Namespace:            new(DefaultNamespace),
-				ControllerManager:    defaultCtrlManagerConfigurationSpec,
+				Namespace:         new(DefaultNamespace),
+				ControllerManager: defaultCtrlManagerConfigurationSpec,
 				InternalCertManagement: &InternalCertManagement{
 					Enable: new(false),
 				},
@@ -619,9 +605,8 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 			},
 			want: &Configuration{
-				QuotaReleaseStrategy: new(QuotaReleaseOnTerminating),
-				Namespace:            new(DefaultNamespace),
-				ControllerManager:    defaultCtrlManagerConfigurationSpec,
+				Namespace:         new(DefaultNamespace),
+				ControllerManager: defaultCtrlManagerConfigurationSpec,
 				InternalCertManagement: &InternalCertManagement{
 					Enable: new(false),
 				},
@@ -649,9 +634,8 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 			},
 			want: &Configuration{
-				QuotaReleaseStrategy: new(QuotaReleaseOnTerminating),
-				Namespace:            new(DefaultNamespace),
-				ControllerManager:    defaultCtrlManagerConfigurationSpec,
+				Namespace:         new(DefaultNamespace),
+				ControllerManager: defaultCtrlManagerConfigurationSpec,
 				InternalCertManagement: &InternalCertManagement{
 					Enable: new(false),
 				},
@@ -681,9 +665,8 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 			},
 			want: &Configuration{
-				QuotaReleaseStrategy: new(QuotaReleaseOnTerminating),
-				Namespace:            new(DefaultNamespace),
-				ControllerManager:    defaultCtrlManagerConfigurationSpec,
+				Namespace:         new(DefaultNamespace),
+				ControllerManager: defaultCtrlManagerConfigurationSpec,
 				InternalCertManagement: &InternalCertManagement{
 					Enable: new(false),
 				},
@@ -715,9 +698,8 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 			},
 			want: &Configuration{
-				QuotaReleaseStrategy: new(QuotaReleaseOnTerminating),
-				Namespace:            new(DefaultNamespace),
-				ControllerManager:    defaultCtrlManagerConfigurationSpec,
+				Namespace:         new(DefaultNamespace),
+				ControllerManager: defaultCtrlManagerConfigurationSpec,
 				InternalCertManagement: &InternalCertManagement{
 					Enable: new(false),
 				},

--- a/apis/config/v1beta2/zz_generated.deepcopy.go
+++ b/apis/config/v1beta2/zz_generated.deepcopy.go
@@ -147,11 +147,6 @@ func (in *Configuration) DeepCopyInto(out *Configuration) {
 		*out = new(WaitForPodsReady)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.QuotaReleaseStrategy != nil {
-		in, out := &in.QuotaReleaseStrategy, &out.QuotaReleaseStrategy
-		*out = new(QuotaReleaseStrategy)
-		**out = **in
-	}
 	if in.ClientConnection != nil {
 		in, out := &in.ClientConnection, &out.ClientConnection
 		*out = new(ClientConnection)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -41,7 +41,6 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/component-base/featuregate"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -479,7 +478,6 @@ objectRetentionPolicies:
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 				VisibilityServer:             defaultVisibility,
 				WaitForPodsReady:             defaultWaitForPodsReady,
-				QuotaReleaseStrategy:         ptr.To[configapi.QuotaReleaseStrategy](configapi.QuotaReleaseOnTerminating),
 			},
 			wantOptions: defaultControlOptions(configapi.DefaultNamespace),
 		},
@@ -499,7 +497,6 @@ objectRetentionPolicies:
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 				VisibilityServer:             defaultVisibility,
 				WaitForPodsReady:             defaultWaitForPodsReady,
-				QuotaReleaseStrategy:         ptr.To[configapi.QuotaReleaseStrategy](configapi.QuotaReleaseOnTerminating),
 			},
 			wantOptions: defaultControlOptions(configapi.DefaultNamespace),
 		},
@@ -537,9 +534,8 @@ objectRetentionPolicies:
 						},
 					},
 				},
-				VisibilityServer:     defaultVisibility,
-				WaitForPodsReady:     defaultWaitForPodsReady,
-				QuotaReleaseStrategy: ptr.To[configapi.QuotaReleaseStrategy](configapi.QuotaReleaseOnTerminating),
+				VisibilityServer: defaultVisibility,
+				WaitForPodsReady: defaultWaitForPodsReady,
 			},
 			wantOptions: defaultControlOptions("kueue-tenant-a"),
 		},
@@ -560,7 +556,6 @@ objectRetentionPolicies:
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 				VisibilityServer:             defaultVisibility,
 				WaitForPodsReady:             defaultWaitForPodsReady,
-				QuotaReleaseStrategy:         ptr.To[configapi.QuotaReleaseStrategy](configapi.QuotaReleaseOnTerminating),
 			},
 			wantOptions: ctrl.Options{
 				Cache:                  defaultControlCacheOptions(configapi.DefaultNamespace),
@@ -598,7 +593,6 @@ objectRetentionPolicies:
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 				VisibilityServer:             defaultVisibility,
 				WaitForPodsReady:             defaultWaitForPodsReady,
-				QuotaReleaseStrategy:         ptr.To[configapi.QuotaReleaseStrategy](configapi.QuotaReleaseOnTerminating),
 			},
 			wantOptions: defaultControlOptions(configapi.DefaultNamespace),
 		},
@@ -621,7 +615,6 @@ objectRetentionPolicies:
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 				VisibilityServer:             defaultVisibility,
 				WaitForPodsReady:             defaultWaitForPodsReady,
-				QuotaReleaseStrategy:         ptr.To[configapi.QuotaReleaseStrategy](configapi.QuotaReleaseOnTerminating),
 			},
 			wantOptions: defaultControlOptions(configapi.DefaultNamespace),
 		},
@@ -642,7 +635,6 @@ objectRetentionPolicies:
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 				VisibilityServer:             defaultVisibility,
 				WaitForPodsReady:             defaultWaitForPodsReady,
-				QuotaReleaseStrategy:         ptr.To[configapi.QuotaReleaseStrategy](configapi.QuotaReleaseOnTerminating),
 			},
 			wantOptions: ctrl.Options{
 				Cache:                  defaultControlCacheOptions("kueue-system"),
@@ -681,7 +673,6 @@ objectRetentionPolicies:
 						BackoffMaxSeconds:  new(int32(1800)),
 					},
 				},
-				QuotaReleaseStrategy:         ptr.To[configapi.QuotaReleaseStrategy](configapi.QuotaReleaseOnTerminating),
 				ClientConnection:             defaultClientConnection,
 				Integrations:                 defaultIntegrations,
 				MultiKueue:                   defaultMultiKueue,
@@ -710,7 +701,6 @@ objectRetentionPolicies:
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 				VisibilityServer:             defaultVisibility,
 				WaitForPodsReady:             defaultWaitForPodsReady,
-				QuotaReleaseStrategy:         ptr.To[configapi.QuotaReleaseStrategy](configapi.QuotaReleaseOnTerminating),
 			},
 			wantOptions: defaultControlOptions(configapi.DefaultNamespace),
 		},
@@ -734,7 +724,6 @@ objectRetentionPolicies:
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 				VisibilityServer:             defaultVisibility,
 				WaitForPodsReady:             defaultWaitForPodsReady,
-				QuotaReleaseStrategy:         ptr.To[configapi.QuotaReleaseStrategy](configapi.QuotaReleaseOnTerminating),
 			},
 			wantOptions: ctrl.Options{
 				Cache:                  defaultControlCacheOptions(configapi.DefaultNamespace),
@@ -783,7 +772,6 @@ objectRetentionPolicies:
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 				VisibilityServer:             defaultVisibility,
 				WaitForPodsReady:             defaultWaitForPodsReady,
-				QuotaReleaseStrategy:         ptr.To[configapi.QuotaReleaseStrategy](configapi.QuotaReleaseOnTerminating),
 			},
 			wantOptions: defaultControlOptions(configapi.DefaultNamespace),
 		},
@@ -829,7 +817,6 @@ objectRetentionPolicies:
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 				VisibilityServer:             defaultVisibility,
 				WaitForPodsReady:             defaultWaitForPodsReady,
-				QuotaReleaseStrategy:         ptr.To[configapi.QuotaReleaseStrategy](configapi.QuotaReleaseOnTerminating),
 			},
 			wantOptions: defaultControlOptions(configapi.DefaultNamespace),
 		},
@@ -870,7 +857,6 @@ objectRetentionPolicies:
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 				VisibilityServer:             defaultVisibility,
 				WaitForPodsReady:             defaultWaitForPodsReady,
-				QuotaReleaseStrategy:         ptr.To[configapi.QuotaReleaseStrategy](configapi.QuotaReleaseOnTerminating),
 			},
 			wantOptions: defaultControlOptions(configapi.DefaultNamespace),
 		},
@@ -891,7 +877,6 @@ objectRetentionPolicies:
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 				VisibilityServer:             defaultVisibility,
 				WaitForPodsReady:             defaultWaitForPodsReady,
-				QuotaReleaseStrategy:         ptr.To[configapi.QuotaReleaseStrategy](configapi.QuotaReleaseOnTerminating),
 				Resources: &configapi.Resources{
 					Transformations: []configapi.ResourceTransformation{
 						{
@@ -947,7 +932,6 @@ objectRetentionPolicies:
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 				VisibilityServer:             defaultVisibility,
 				WaitForPodsReady:             defaultWaitForPodsReady,
-				QuotaReleaseStrategy:         ptr.To[configapi.QuotaReleaseStrategy](configapi.QuotaReleaseOnTerminating),
 				ObjectRetentionPolicies: &configapi.ObjectRetentionPolicies{
 					Workloads: &configapi.WorkloadRetentionPolicy{
 						AfterFinished:           &metav1.Duration{Duration: 30 * time.Minute},
@@ -1053,8 +1037,7 @@ webhook:
 					WebhookServiceName: new(configapi.DefaultWebhookServiceName),
 					WebhookSecretName:  new(configapi.DefaultWebhookSecretName),
 				},
-				WaitForPodsReady:     defaultWaitForPodsReady,
-				QuotaReleaseStrategy: ptr.To[configapi.QuotaReleaseStrategy](configapi.QuotaReleaseOnTerminating),
+				WaitForPodsReady: defaultWaitForPodsReady,
 				ClientConnection: &configapi.ClientConnection{
 					QPS:   new(configapi.DefaultClientConnectionQPS),
 					Burst: new(configapi.DefaultClientConnectionBurst),
@@ -1103,8 +1086,7 @@ webhook:
 					WebhookServiceName: new(configapi.DefaultWebhookServiceName),
 					WebhookSecretName:  new(configapi.DefaultWebhookSecretName),
 				},
-				WaitForPodsReady:     defaultWaitForPodsReady,
-				QuotaReleaseStrategy: ptr.To[configapi.QuotaReleaseStrategy](configapi.QuotaReleaseOnTerminating),
+				WaitForPodsReady: defaultWaitForPodsReady,
 
 				ClientConnection: &configapi.ClientConnection{
 					QPS:   new(configapi.DefaultClientConnectionQPS),
@@ -1117,7 +1099,7 @@ webhook:
 					GCInterval:        &metav1.Duration{Duration: configapi.DefaultMultiKueueGCInterval},
 					Origin:            new(configapi.DefaultMultiKueueOrigin),
 					WorkerLostTimeout: &metav1.Duration{Duration: configapi.DefaultMultiKueueWorkerLostTimeout},
-					DispatcherName:    ptr.To(configapi.MultiKueueDispatcherModeAllAtOnce),
+					DispatcherName:    new(configapi.MultiKueueDispatcherModeAllAtOnce),
 				},
 				ManagedJobsNamespaceSelector: &metav1.LabelSelector{
 					MatchExpressions: []metav1.LabelSelectorRequirement{
@@ -1285,7 +1267,6 @@ func TestEncode(t *testing.T) {
 					},
 					"timeout": "30m0s",
 				},
-				"quotaReleaseStrategy": "OnTerminating",
 			},
 		},
 	}
@@ -1323,8 +1304,7 @@ func TestWaitForPodsReadyIsEnabled(t *testing.T) {
 
 		"waitforpodsready.Enabled() is false when DisableWaitForPodsReady feature gate is enabled": {
 			cfg: &configapi.Configuration{
-				WaitForPodsReady:     defaultWaitForPodsReady,
-				QuotaReleaseStrategy: ptr.To[configapi.QuotaReleaseStrategy](configapi.QuotaReleaseOnTerminating),
+				WaitForPodsReady: defaultWaitForPodsReady,
 			},
 			featureGates: map[featuregate.Feature]bool{
 				features.DisableWaitForPodsReady: true,
@@ -1334,8 +1314,7 @@ func TestWaitForPodsReadyIsEnabled(t *testing.T) {
 
 		"waitforpodsready.Enabled() is true when DisableWaitForPodsReady feature gate is disabled": {
 			cfg: &configapi.Configuration{
-				WaitForPodsReady:     defaultWaitForPodsReady,
-				QuotaReleaseStrategy: ptr.To[configapi.QuotaReleaseStrategy](configapi.QuotaReleaseOnTerminating),
+				WaitForPodsReady: defaultWaitForPodsReady,
 			},
 			featureGates: map[featuregate.Feature]bool{
 				features.DisableWaitForPodsReady: false,

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -63,7 +63,6 @@ var (
 	integrationsFrameworksPath            = integrationsPath.Child("frameworks")
 	integrationsExternalFrameworkPath     = integrationsPath.Child("externalFrameworks")
 	managedJobsNamespaceSelectorPath      = field.NewPath("managedJobsNamespaceSelector")
-	quotaReleaseStrategyPath              = field.NewPath("quotaReleaseStrategy")
 	waitForPodsReadyPath                  = field.NewPath("waitForPodsReady")
 	requeuingStrategyPath                 = waitForPodsReadyPath.Child("requeuingStrategy")
 	multiKueuePath                        = field.NewPath("multiKueue")
@@ -109,7 +108,6 @@ func Validate(c *configapi.Configuration, scheme *runtime.Scheme, integrationMan
 	allErrs = append(allErrs, validateVisibilityServer(c)...)
 	allErrs = append(allErrs, validateCustomLabels(c)...)
 	allErrs = append(allErrs, validateQuotaCheckStrategy(c)...)
-	allErrs = append(allErrs, validateQuotaReleaseStrategy(c)...)
 	return allErrs
 }
 
@@ -134,24 +132,6 @@ func validateQuotaCheckStrategy(c *configapi.Configuration) field.ErrorList {
 				[]configapi.QuotaCheckStrategy{
 					configapi.QuotaCheckIgnoreUndeclared,
 					configapi.QuotaCheckBlockUndeclared,
-				},
-			))
-		}
-	}
-	return allErrs
-}
-
-func validateQuotaReleaseStrategy(c *configapi.Configuration) field.ErrorList {
-	var allErrs field.ErrorList
-	if c.QuotaReleaseStrategy != nil {
-		strategy := *c.QuotaReleaseStrategy
-		if strategy != configapi.QuotaReleaseOnTerminating && strategy != configapi.QuotaReleaseOnTerminal {
-			allErrs = append(allErrs, field.NotSupported(
-				quotaReleaseStrategyPath,
-				strategy,
-				[]configapi.QuotaReleaseStrategy{
-					configapi.QuotaReleaseOnTerminating,
-					configapi.QuotaReleaseOnTerminal,
 				},
 			))
 		}

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -34,7 +34,6 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/component-base/featuregate"
-	"k8s.io/utils/ptr"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/jobs"
@@ -74,18 +73,6 @@ func TestValidate(t *testing.T) {
 				&field.Error{
 					Type:  field.ErrorTypeRequired,
 					Field: "integrations",
-				},
-			},
-		},
-		"invalid quota release strategy": {
-			cfg: &configapi.Configuration{
-				Integrations:         defaultIntegrations,
-				QuotaReleaseStrategy: ptr.To(configapi.QuotaReleaseStrategy("InvalidStrategy")),
-			},
-			wantErr: field.ErrorList{
-				&field.Error{
-					Type:  field.ErrorTypeNotSupported,
-					Field: "quotaReleaseStrategy",
 				},
 			},
 		},

--- a/site/content/en/docs/reference/kueue-config.v1beta2.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta2.md
@@ -93,13 +93,6 @@ and passing the readiness probe) within the specified time. If the timeout
 is exceeded, then the workload is evicted.</p>
 </td>
 </tr>
-<tr><td><code>quotaReleaseStrategy</code><br/>
-<a href="#config-kueue-x-k8s-io-v1beta2-QuotaReleaseStrategy"><code>QuotaReleaseStrategy</code></a>
-</td>
-<td>
-   <p>QuotaReleaseStrategy provides configuration options for controlling quota release timing.</p>
-</td>
-</tr>
 <tr><td><code>clientConnection</code> <B>[Required]</B><br/>
 <a href="#config-kueue-x-k8s-io-v1beta2-ClientConnection"><code>ClientConnection</code></a>
 </td>
@@ -1258,25 +1251,6 @@ A nil value disables automatic deletion of Workloads.</p>
 
 <p>QuotaCheckStrategy determines how Kueue checks resources against quota
 during admission.</p>
-
-
-
-
-## `QuotaReleaseStrategy`     {#config-kueue-x-k8s-io-v1beta2-QuotaReleaseStrategy}
-    
-(Alias of `string`)
-
-**Appears in:**
-
-- [Configuration](#config-kueue-x-k8s-io-v1beta2-Configuration)
-
-
-<p>QuotaReleaseStrategy defines when Kueue releases quota for a terminating workload.</p>
-<p>Valid values are:</p>
-<ul>
-<li>&quot;OnTerminating&quot; (default): releases quota as soon as all pods have a deletionTimestamp set.</li>
-<li>&quot;OnTerminal&quot;: holds quota until all underlying pods have fully reached a terminal phase (Succeeded or Failed).</li>
-</ul>
 
 
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind api-change

#### What this PR does / why we need it:
Reverts the obsolete `scheduling.quotaReleaseStrategy` Configuration API change introduced in #13224.

As discussed in KEP-10076 (#15146), we updated the design to configure quota release per-integration under `.integrations.frameworkConfigs[].quotaReleaseStrategy` instead of a top-level scheduling field. Reverting the old API ensures v0.20 release safety ahead of code freeze while the new API is finalized.

Requested by @tenzen-y in https://github.com/kubernetes-sigs/kueue/pull/15146.

#### Which issue(s) this PR fixes:
Part of #10076

#### Does this PR introduce a user-facing change?
```release-note
Revert `scheduling.quotaReleaseStrategy` from Kueue Configuration API.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## AI summary

Removed `scheduling.quotaReleaseStrategy` from the Kueue Configuration API, including its type, defaults, validation, tests, and reference documentation.

### Suggested release note

ConfigAPI: Removed the obsolete `scheduling.quotaReleaseStrategy` configuration field. Configure quota release per integration with `.integrations.frameworkConfigs[].quotaReleaseStrategy`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->