### PR TITLE
[release-0.18] Adjust resources before requeueing a workload after backoff

### DIFF
--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -562,7 +562,12 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 					return ctrl.Result{}, nil
 				}
 
-				if err := r.queues.AddOrUpdateWorkload(log, wl.DeepCopy()); err != nil {
+				// Adjust the copy before queueing, as every sibling producer
+				// does; the queue accounting must reflect the effective
+				// resources, not the raw spec.
+				wlCopy := wl.DeepCopy()
+				workload.AdjustResources(ctx, r.client, wlCopy)
+				if err := r.queues.AddOrUpdateWorkload(log, wlCopy); err != nil {
 					log.V(2).Info("failed to put the workload back into queue", "error", err)
 					return ctrl.Result{}, err
 				}

--- a/pkg/controller/core/workload_controller_requeue_test.go
+++ b/pkg/controller/core/workload_controller_requeue_test.go
@@ -24,7 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	testingclock "k8s.io/utils/clock/testing"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -771,7 +770,7 @@ func TestRequeueAfterBackoffUsesAdjustedResources(t *testing.T) {
 		Queue("lq").
 		Active(true).
 		Limit(corev1.ResourceCPU, "3").
-		RequeueState(ptr.To(int32(1)), ptr.To(metav1.NewTime(now.Add(-time.Minute)))).
+		RequeueState(new(int32(1)), new(metav1.NewTime(now.Add(-time.Minute)))).
 		Obj()
 
 	cl := utiltesting.NewClientBuilder().

--- a/pkg/controller/core/workload_controller_requeue_test.go
+++ b/pkg/controller/core/workload_controller_requeue_test.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	testingclock "k8s.io/utils/clock/testing"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"

--- a/pkg/controller/core/workload_controller_requeue_test.go
+++ b/pkg/controller/core/workload_controller_requeue_test.go
@@ -28,6 +28,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
+	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
+	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 )
@@ -753,4 +757,51 @@ func TestReconcileRequeue(t *testing.T) {
 		},
 	}
 	runReconcileTestCases(t, cases, fakeClock)
+}
+
+// The requeue-after-backoff path must account the workload by its effective
+// resources: a container that declares only a cpu limit is charged that limit
+// (mirroring the requests the created Pods will carry), not the raw empty
+// requests.
+func TestRequeueAfterBackoffUsesAdjustedResources(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	fakeClock := testingclock.NewFakeClock(now)
+
+	wl := utiltestingapi.MakeWorkload("wl", "ns").
+		Queue("lq").
+		Active(true).
+		Limit(corev1.ResourceCPU, "3").
+		RequeueState(ptr.To(int32(1)), ptr.To(metav1.NewTime(now.Add(-time.Minute)))).
+		Obj()
+
+	cl := utiltesting.NewClientBuilder().
+		WithObjects(wl).
+		WithStatusSubresource(wl).
+		WithIndex(&corev1.LimitRange{}, indexer.LimitRangeHasContainerOrPodType, indexer.IndexLimitRangeHasContainerOrPodType).
+		Build()
+	recorder := &utiltesting.EventRecorder{}
+	cqCache := schdcache.New(cl)
+	qManager := qcache.NewManagerForUnitTests(cl, cqCache,
+		qcache.WithClock(fakeClock),
+		qcache.WithPreemptionExpectations(preemptexpectations.New()))
+	reconciler := NewWorkloadReconciler(cl, qManager, cqCache, recorder)
+
+	ctx, _ := utiltesting.ContextWithLog(t)
+
+	setupClusterQueue(ctx, t, cl, qManager, cqCache, utiltestingapi.MakeClusterQueue("cq").Obj(), false)
+	setupLocalQueue(ctx, t, cl, qManager, utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(), false)
+
+	if _, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "wl"}}); err != nil {
+		t.Fatalf("Reconcile() failed: %v", err)
+	}
+
+	pending := qManager.PendingWorkloadsInfo("cq")
+	if len(pending) != 1 {
+		t.Fatalf("expected 1 pending workload after the backoff requeue, got %d", len(pending))
+	}
+	// The effective cpu request is the limit (3 CPU = 3000m); raw accounting
+	// would report 0.
+	if got := pending[0].TotalRequests[0].Requests.ResourceValue(corev1.ResourceCPU); got != 3000 {
+		t.Errorf("requeued workload accounted cpu=%dm, want 3000m", got)
+	}
 }

--- a/test/integration/singlecluster/controller/core/workload_backoff_accounting_test.go
+++ b/test/integration/singlecluster/controller/core/workload_backoff_accounting_test.go
@@ -72,7 +72,7 @@ var _ = ginkgo.Describe("Workload accounting after requeue backoff", ginkgo.Labe
 		metrics.InitMetricVectors(nil)
 	})
 
-	ginkgo.It("preserves effective resource requests when readmitting a workload after backoff", func() {
+	ginkgo.It("considers effective resource requests when readmitting a workload after backoff", func() {
 		wl := utiltestingapi.MakeWorkload("adjusted", ns.Name).
 			Queue(kueue.LocalQueueName(lq.Name)).Limit(corev1.ResourceCPU, "3").RuntimeClass(runtimeClass.Name).Obj()
 		other := utiltestingapi.MakeWorkload("other", ns.Name).
@@ -91,9 +91,10 @@ var _ = ginkgo.Describe("Workload accounting after requeue backoff", ginkgo.Labe
 				g.Expect(k8sClient.Get(ctx, wlKey, wl)).To(gomega.Succeed())
 				g.Expect(workloadpatching.PatchAdmissionStatus(ctx, k8sClient, wl, util.RealClock, func(wl *kueue.Workload) (bool, error) {
 					workload.UnsetQuotaReservationWithCondition(wl, kueue.WorkloadQuotaReservedReasonPendingEvaluation, "By test", time.Now())
+					// Hold backoff until the other workload has quota; expire it explicitly below.
 					wl.Status.RequeueState = &kueue.RequeueState{
 						Count:     new(int32(1)),
-						RequeueAt: new(metav1.NewTime(time.Now().Add(3 * time.Second))),
+						RequeueAt: new(metav1.NewTime(time.Now().Add(time.Hour))),
 					}
 					return true, nil
 				})).To(gomega.Succeed())
@@ -101,7 +102,18 @@ var _ = ginkgo.Describe("Workload accounting after requeue backoff", ginkgo.Labe
 			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, cq.Name, other)
 		})
 
-		ginkgo.By("waiting for backoff to expire while only 4 CPU remain available", func() {
+		ginkgo.By("ending backoff after the other workload has reserved quota", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updated kueue.Workload
+				g.Expect(k8sClient.Get(ctx, wlKey, &updated)).To(gomega.Succeed())
+				g.Expect(workloadpatching.PatchAdmissionStatus(ctx, k8sClient, &updated, util.RealClock, func(wl *kueue.Workload) (bool, error) {
+					wl.Status.RequeueState.RequeueAt = new(metav1.NewTime(time.Now().Add(-time.Second)))
+					return true, nil
+				})).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("keeping the workload pending after backoff while only 4 CPU remain available", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
 				var updated kueue.Workload
 				g.Expect(k8sClient.Get(ctx, wlKey, &updated)).To(gomega.Succeed())

--- a/test/integration/singlecluster/controller/core/workload_backoff_accounting_test.go
+++ b/test/integration/singlecluster/controller/core/workload_backoff_accounting_test.go
@@ -32,7 +32,6 @@ import (
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	"sigs.k8s.io/kueue/pkg/workload"
-	workloadpatching "sigs.k8s.io/kueue/pkg/workload/patching"
 	"sigs.k8s.io/kueue/test/util"
 )
 
@@ -89,7 +88,7 @@ var _ = ginkgo.Describe("Workload accounting after requeue backoff", ginkgo.Labe
 		ginkgo.By("releasing its quota with a requeue backoff, allowing the other workload to run", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, wlKey, wl)).To(gomega.Succeed())
-				g.Expect(workloadpatching.PatchAdmissionStatus(ctx, k8sClient, wl, util.RealClock, func(wl *kueue.Workload) (bool, error) {
+				g.Expect(workload.PatchAdmissionStatus(ctx, k8sClient, wl, util.RealClock, func(wl *kueue.Workload) (bool, error) {
 					workload.UnsetQuotaReservationWithCondition(wl, kueue.WorkloadQuotaReservedReasonPendingEvaluation, "By test", time.Now())
 					// Hold backoff until the other workload has quota; expire it explicitly below.
 					wl.Status.RequeueState = &kueue.RequeueState{
@@ -106,7 +105,7 @@ var _ = ginkgo.Describe("Workload accounting after requeue backoff", ginkgo.Labe
 			gomega.Eventually(func(g gomega.Gomega) {
 				var updated kueue.Workload
 				g.Expect(k8sClient.Get(ctx, wlKey, &updated)).To(gomega.Succeed())
-				g.Expect(workloadpatching.PatchAdmissionStatus(ctx, k8sClient, &updated, util.RealClock, func(wl *kueue.Workload) (bool, error) {
+				g.Expect(workload.PatchAdmissionStatus(ctx, k8sClient, &updated, util.RealClock, func(wl *kueue.Workload) (bool, error) {
 					wl.Status.RequeueState.RequeueAt = new(metav1.NewTime(time.Now().Add(-time.Second)))
 					return true, nil
 				})).To(gomega.Succeed())

--- a/test/integration/singlecluster/controller/core/workload_backoff_accounting_test.go
+++ b/test/integration/singlecluster/controller/core/workload_backoff_accounting_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	nodev1 "k8s.io/api/node/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/metrics"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/pkg/workload"
+	workloadpatching "sigs.k8s.io/kueue/pkg/workload/patching"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var _ = ginkgo.Describe("Workload accounting after requeue backoff", ginkgo.Label("controller:workload", "area:core"), func() {
+	var (
+		ns           *corev1.Namespace
+		flavor       *kueue.ResourceFlavor
+		runtimeClass *nodev1.RuntimeClass
+		cq           *kueue.ClusterQueue
+		lq           *kueue.LocalQueue
+	)
+
+	ginkgo.BeforeEach(func() {
+		fwk.StartManager(ctx, cfg, managerAndSchedulerSetup)
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "backoff-accounting-")
+		flavor = utiltestingapi.MakeResourceFlavor("backoff-flavor").Obj()
+		util.MustCreate(ctx, k8sClient, flavor)
+		runtimeClass = utiltesting.MakeRuntimeClass("backoff-runtime", "handler").
+			PodOverhead(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")}).Obj()
+		util.MustCreate(ctx, k8sClient, runtimeClass)
+		cq = utiltestingapi.MakeClusterQueue("backoff-cq").
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas(flavor.Name).Resource(corev1.ResourceCPU, "8").Obj()).Obj()
+		util.MustCreate(ctx, k8sClient, cq)
+		util.ExpectClusterQueuesToBeActive(ctx, k8sClient, cq)
+		lq = utiltestingapi.MakeLocalQueue("queue", ns.Name).ClusterQueue(cq.Name).Obj()
+		util.MustCreate(ctx, k8sClient, lq)
+		util.ExpectLocalQueuesToBeActive(ctx, k8sClient, lq)
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, flavor, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, runtimeClass, true)
+		fwk.StopManager(ctx)
+		metrics.InitMetricVectors(nil)
+	})
+
+	ginkgo.It("preserves effective resource requests when readmitting a workload after backoff", func() {
+		wl := utiltestingapi.MakeWorkload("adjusted", ns.Name).
+			Queue(kueue.LocalQueueName(lq.Name)).Limit(corev1.ResourceCPU, "3").RuntimeClass(runtimeClass.Name).Obj()
+		other := utiltestingapi.MakeWorkload("other", ns.Name).
+			Queue(kueue.LocalQueueName(lq.Name)).Request(corev1.ResourceCPU, "4").Obj()
+		wlKey := client.ObjectKeyFromObject(wl)
+
+		ginkgo.By("admitting the workload with 3 CPU from limits and 2 CPU overhead", func() {
+			util.MustCreate(ctx, k8sClient, wl)
+			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, cq.Name, wl)
+			util.MustCreate(ctx, k8sClient, other)
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, other)
+		})
+
+		ginkgo.By("releasing its quota with a requeue backoff, allowing the other workload to run", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlKey, wl)).To(gomega.Succeed())
+				g.Expect(workloadpatching.PatchAdmissionStatus(ctx, k8sClient, wl, util.RealClock, func(wl *kueue.Workload) (bool, error) {
+					workload.UnsetQuotaReservationWithCondition(wl, kueue.WorkloadQuotaReservedReasonPendingEvaluation, "By test", time.Now())
+					wl.Status.RequeueState = &kueue.RequeueState{
+						Count:     new(int32(1)),
+						RequeueAt: new(metav1.NewTime(time.Now().Add(3 * time.Second))),
+					}
+					return true, nil
+				})).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, cq.Name, other)
+		})
+
+		ginkgo.By("waiting for backoff to expire while only 4 CPU remain available", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updated kueue.Workload
+				g.Expect(k8sClient.Get(ctx, wlKey, &updated)).To(gomega.Succeed())
+				g.Expect(updated.Status.RequeueState).NotTo(gomega.BeNil())
+				g.Expect(updated.Status.RequeueState.RequeueAt).To(gomega.BeNil())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			gomega.Consistently(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlKey, wl)).To(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(wl)).To(gomega.BeFalse())
+			}, util.LongConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("readmitting the workload with its full effective request once quota is released", func() {
+			util.FinishWorkloads(ctx, k8sClient, other)
+			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, cq.Name, wl)
+			gomega.Expect(k8sClient.Get(ctx, wlKey, wl)).To(gomega.Succeed())
+			gomega.Expect(wl.Status.Admission.PodSetAssignments).To(gomega.HaveLen(1))
+			gomega.Expect(wl.Status.Admission.PodSetAssignments[0].ResourceUsage).To(gomega.Equal(corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("5"),
+			}))
+		})
+	})
+})


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it?

Manual cherry-pick of #15096 to release-0.18, replacing the closed automated PR #15349 as requested by mimowo.

Adjust effective resources before requeueing a Workload after backoff, so limits-derived requests, LimitRange defaults, and RuntimeClass overhead remain included in queue accounting.

#### Useful notes for your reviewer

The production fix is unchanged. The tests use `workload.PatchAdmissionStatus`, since release-0.18 does not have `pkg/workload/patching`, and retain the `ptr` import still used by this branch's existing unit tests.

Validation: requeue unit tests passed. The focused envtest integration regression passed with the fix and failed at the quota-reservation assertion when the `AdjustResources` call was removed; the fix was then restored.

AI assistance was used to prepare and validate this backport.

#### Release note

```release-note
Workloads: Fixed a bug where a workload requeued after a backoff period was accounted using its raw spec rather than its effective resources, dropping requests derived from limits, LimitRange defaults, and RuntimeClass overhead. Kueue now correctly accounts the adjusted resources on requeue, preventing ClusterQueue overcommitment.
```
