### PR TITLE
kueuectl: Fix ClusterQueue and LocalQueue flag completion after a positional argument

### DIFF
--- a/cmd/kueuectl/app/completion/completion.go
+++ b/cmd/kueuectl/app/completion/completion.go
@@ -30,6 +30,20 @@ import (
 
 const completionLimit = 100
 
+// SingleArg wraps a completion function so that it offers no suggestions once
+// a positional argument has already been provided. Use it for commands that
+// accept exactly one positional argument, such as stop and resume. Do not use
+// it for flag completion: there, args holds the positional arguments already
+// typed, which are unrelated to the flag value being completed.
+func SingleArg(fn func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective)) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) > 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		return fn(cmd, args, toComplete)
+	}
+}
+
 func NamespaceNameFunc(clientGetter clientgetter.ClientGetter) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		clientSet, err := clientGetter.K8sClientSet()
@@ -139,10 +153,6 @@ func WorkloadNameFunc(clientGetter clientgetter.ClientGetter, activeStatus *bool
 
 func ClusterQueueNameFunc(clientGetter clientgetter.ClientGetter, activeStatus *bool) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		if len(args) > 0 {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
 		clientSet, err := clientGetter.KueueClientSet()
 		if err != nil {
 			return []string{}, cobra.ShellCompDirectiveError
@@ -177,10 +187,6 @@ func ClusterQueueNameFunc(clientGetter clientgetter.ClientGetter, activeStatus *
 
 func LocalQueueNameFunc(clientGetter clientgetter.ClientGetter, activeStatus *bool) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		if len(args) > 0 {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
 		clientSet, err := clientGetter.KueueClientSet()
 		if err != nil {
 			return []string{}, cobra.ShellCompDirectiveError

--- a/cmd/kueuectl/app/completion/completion_test.go
+++ b/cmd/kueuectl/app/completion/completion_test.go
@@ -135,13 +135,14 @@ func TestClusterQueueNameCompletionFunc(t *testing.T) {
 			wantNames:     []string{"cq2", "cq3"},
 			wantDirective: cobra.ShellCompDirectiveNoFileComp,
 		},
-		"shouldn't return cluster queue names because only one argument can be passed": {
+		"should return cluster queue names when positional args are present, as in flag completion": {
 			objs: []runtime.Object{
 				utiltestingapi.MakeClusterQueue("cq1").StopPolicy(kueue.None).Obj(),
 				utiltestingapi.MakeClusterQueue("cq2").StopPolicy(kueue.Hold).Obj(),
 				utiltestingapi.MakeClusterQueue("cq3").StopPolicy(kueue.HoldAndDrain).Obj(),
 			},
-			args:          []string{"cq2"},
+			args:          []string{"my-lq"},
+			wantNames:     []string{"cq1", "cq2", "cq3"},
 			wantDirective: cobra.ShellCompDirectiveNoFileComp,
 		},
 	}
@@ -204,12 +205,13 @@ func TestLocalQueueNameCompletionFunc(t *testing.T) {
 			wantNames:     []string{"lq2", "lq3"},
 			wantDirective: cobra.ShellCompDirectiveNoFileComp,
 		},
-		"shouldn't return local queue names because only one argument can be passed": {
+		"should return local queue names when positional args are present, as in flag completion": {
 			objs: []runtime.Object{
 				utiltestingapi.MakeLocalQueue("lq1", metav1.NamespaceDefault).Obj(),
 				utiltestingapi.MakeLocalQueue("lq2", metav1.NamespaceDefault).Obj(),
 			},
-			args:          []string{"lq1"},
+			args:          []string{"wl1"},
+			wantNames:     []string{"lq1", "lq2"},
 			wantDirective: cobra.ShellCompDirectiveNoFileComp,
 		},
 	}
@@ -226,6 +228,37 @@ func TestLocalQueueNameCompletionFunc(t *testing.T) {
 				t.Errorf("Unexpected names (-want/+got)\n%s", diff)
 			}
 
+			if diff := cmp.Diff(tc.wantDirective, directive); diff != "" {
+				t.Errorf("Unexpected directive (-want/+got)\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSingleArgCompletionFunc(t *testing.T) {
+	testCases := map[string]struct {
+		args          []string
+		wantNames     []string
+		wantDirective cobra.ShellCompDirective
+	}{
+		"should delegate when no positional args are present": {
+			wantNames:     []string{"cq1", "cq2"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		"shouldn't return names once a positional arg is present": {
+			args:          []string{"cq1"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			inner := func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+				return []string{"cq1", "cq2"}, cobra.ShellCompDirectiveNoFileComp
+			}
+			names, directive := SingleArg(inner)(&cobra.Command{}, tc.args, "")
+			if diff := cmp.Diff(tc.wantNames, names); diff != "" {
+				t.Errorf("Unexpected names (-want/+got)\n%s", diff)
+			}
 			if diff := cmp.Diff(tc.wantDirective, directive); diff != "" {
 				t.Errorf("Unexpected directive (-want/+got)\n%s", diff)
 			}

--- a/cmd/kueuectl/app/delete/delete_workload.go
+++ b/cmd/kueuectl/app/delete/delete_workload.go
@@ -93,7 +93,7 @@ func NewWorkloadCmd(clientGetter clientgetter.ClientGetter, streams genericioopt
 		Short:                 "Delete the given Workload and its corresponding Job",
 		Long:                  wlLong,
 		Example:               wlExample,
-		ValidArgsFunction:     completion.WorkloadNameFunc(clientGetter, new(true)),
+		ValidArgsFunction:     completion.WorkloadNameFunc(clientGetter, nil),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 

--- a/cmd/kueuectl/app/resume/resume_clusterqueue.go
+++ b/cmd/kueuectl/app/resume/resume_clusterqueue.go
@@ -71,7 +71,7 @@ func NewClusterQueueCmd(clientGetter clientgetter.ClientGetter, streams generici
 		Long:                  cqLong,
 		Example:               cqExample,
 		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
-		ValidArgsFunction:     completion.ClusterQueueNameFunc(clientGetter, new(false)),
+		ValidArgsFunction:     completion.SingleArg(completion.ClusterQueueNameFunc(clientGetter, new(false))),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 			err := o.Complete(clientGetter, cmd, args)

--- a/cmd/kueuectl/app/resume/resume_localqueue.go
+++ b/cmd/kueuectl/app/resume/resume_localqueue.go
@@ -75,7 +75,7 @@ func NewLocalQueueCmd(clientGetter clientgetter.ClientGetter, streams genericioo
 		Long:                  lqLong,
 		Example:               lqExample,
 		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
-		ValidArgsFunction:     completion.LocalQueueNameFunc(clientGetter, new(false)),
+		ValidArgsFunction:     completion.SingleArg(completion.LocalQueueNameFunc(clientGetter, new(false))),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 			err := o.Complete(clientGetter, cmd, args)

--- a/cmd/kueuectl/app/stop/stop_clusterqueue.go
+++ b/cmd/kueuectl/app/stop/stop_clusterqueue.go
@@ -72,7 +72,7 @@ func NewClusterQueueCmd(clientGetter clientgetter.ClientGetter, streams generici
 		Long:                  cqLong,
 		Example:               cqExample,
 		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
-		ValidArgsFunction:     completion.ClusterQueueNameFunc(clientGetter, new(true)),
+		ValidArgsFunction:     completion.SingleArg(completion.ClusterQueueNameFunc(clientGetter, new(true))),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 			err := o.Complete(clientGetter, cmd, args)

--- a/cmd/kueuectl/app/stop/stop_localqueue.go
+++ b/cmd/kueuectl/app/stop/stop_localqueue.go
@@ -76,7 +76,7 @@ func NewLocalQueueCmd(clientGetter clientgetter.ClientGetter, streams genericioo
 		Long:                  lqLong,
 		Example:               lqExample,
 		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
-		ValidArgsFunction:     completion.LocalQueueNameFunc(clientGetter, new(true)),
+		ValidArgsFunction:     completion.SingleArg(completion.LocalQueueNameFunc(clientGetter, new(true))),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 			err := o.Complete(clientGetter, cmd, args)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it?

`ClusterQueueNameFunc` and `LocalQueueNameFunc` return no suggestions whenever a positional argument is present. That guard exists for `stop` / `resume`, which take exactly one name, but the same functions also back the `--clusterqueue` and `--localqueue` flag completion, where `args` holds the unrelated positional argument already typed. As a result `kueuectl create localqueue NAME -c <TAB>` never suggests any ClusterQueue.

This PR removes the guard from the shared functions and moves it into a `SingleArg` wrapper that only the `stop` / `resume` commands apply. It also drops the active-only filter from `delete workload` completion so that Workloads stopped with `kueuectl stop workload` can still be completed when deleting them.

#### Useful notes for your reviewer

Flag completion registrations in `create localqueue`, `list workload`, and `list localqueue` are unchanged; they now receive the unguarded function.

#### Release note

```release-note
CLI: Fixed shell completion for the `--clusterqueue` and `--localqueue` flags, which returned no suggestions once a positional argument was typed, for example in `kueuectl create localqueue NAME -c <TAB>`. `kueuectl delete workload` completion now also includes inactive Workloads.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## AI summary

- Fixed `kueuectl` completion for ClusterQueue and LocalQueue flags after entering a positional argument.
- Restricted `stop` and `resume` commands to a single positional argument.
- Included inactive Workloads in `delete workload` completion.

### Suggested release note

CLI: Fixed a bug that prevented ClusterQueue and LocalQueue flag completion after entering a positional argument. `delete workload` completion now includes inactive Workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->