### PR TITLE
kueuectl: Aggregate Matching Pods into One PodList for Structured Output

### DIFF
--- a/cmd/kueuectl/app/list/list_pods.go
+++ b/cmd/kueuectl/app/list/list_pods.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -276,9 +277,19 @@ func (o *PodOptions) Run(clientGetter clientgetter.ClientGetter) error {
 		return err
 	}
 
-	for _, pod := range infos {
-		if err = printer.PrintObj(pod.Object, tabWriter); err != nil {
+	if o.shouldPrintPodList() && len(infos) > 0 {
+		podList, err := podListFromInfos(infos)
+		if err != nil {
 			return err
+		}
+		if err = printer.PrintObj(podList, tabWriter); err != nil {
+			return err
+		}
+	} else {
+		for _, pod := range infos {
+			if err = printer.PrintObj(pod.Object, tabWriter); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -291,6 +302,28 @@ func (o *PodOptions) Run(clientGetter clientgetter.ClientGetter) error {
 	}
 
 	return nil
+}
+
+func (o *PodOptions) shouldPrintPodList() bool {
+	outputFormat := ptr.Deref(o.PrintFlags.OutputFormat, "")
+	return outputFormat == "json" || outputFormat == "yaml"
+}
+
+func podListFromInfos(infos []*resource.Info) (*unstructured.UnstructuredList, error) {
+	podList := &unstructured.UnstructuredList{
+		Items: make([]unstructured.Unstructured, len(infos)),
+	}
+	podList.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("PodList"))
+
+	for i, info := range infos {
+		pod, ok := info.Object.(*unstructured.Unstructured)
+		if !ok {
+			return nil, fmt.Errorf("unexpected type %T", info.Object)
+		}
+		podList.Items[i] = *pod
+	}
+
+	return podList, nil
 }
 
 func (o *PodOptions) ToPrinter() (printers.ResourcePrinterFunc, error) {

--- a/cmd/kueuectl/app/list/list_pods_test.go
+++ b/cmd/kueuectl/app/list/list_pods_test.go
@@ -43,20 +43,23 @@ import (
 	"k8s.io/cli-runtime/pkg/resource"
 	restfake "k8s.io/client-go/rest/fake"
 	jobsetapi "sigs.k8s.io/jobset/api/jobset/v1alpha2"
+	"sigs.k8s.io/yaml"
 
 	kueuecmdtesting "sigs.k8s.io/kueue/cmd/kueuectl/app/testing"
 	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
 )
 
 type podTestCase struct {
-	name       string
-	job        runtime.Object
-	pods       []corev1.Pod
-	mapperGVKs []schema.GroupVersionKind
-	args       []string
-	wantOut    string
-	wantOutErr string
-	wantErr    error
+	name             string
+	job              runtime.Object
+	pods             []corev1.Pod
+	mapperGVKs       []schema.GroupVersionKind
+	args             []string
+	wantOut          string
+	wantPodListNames []string
+	podListFormat    string
+	wantOutErr       string
+	wantErr          error
 }
 
 func TestPodCmd(t *testing.T) {
@@ -105,6 +108,82 @@ func TestPodCmd(t *testing.T) {
 valid-pod-1   1/1     Running   0          <unknown>   <none>   <none>   <none>           <none>
 valid-pod-2   1/1     Running   0          <unknown>   <none>   <none>   <none>           <none>
 `,
+		}, {
+			name: "list pods of batch/job with json output",
+			job: &batchv1.Job{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "Job",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-job",
+					Namespace: metav1.NamespaceDefault,
+					Labels: map[string]string{
+						batchv1.JobNameLabel: "test-job",
+					},
+				},
+			},
+			pods: []corev1.Pod{
+				*basePod.Clone().
+					Name("valid-pod-1").
+					Label(batchv1.JobNameLabel, "test-job").
+					Obj(),
+				*basePod.Clone().
+					Name("valid-pod-2").
+					Label(batchv1.JobNameLabel, "test-job").
+					Obj(),
+			},
+			mapperGVKs: []schema.GroupVersionKind{
+				{
+					Group:   "batch",
+					Version: "v1",
+					Kind:    "Job",
+				}, {
+					Group:   "",
+					Version: "v1",
+					Kind:    "Pod",
+				},
+			},
+			args:             []string{"--for", "job/test-job", "-o", "json"},
+			wantPodListNames: []string{"valid-pod-1", "valid-pod-2"},
+			podListFormat:    "json",
+		}, {
+			name: "list pods of batch/job with yaml output",
+			job: &batchv1.Job{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "Job",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-job",
+					Namespace: metav1.NamespaceDefault,
+					Labels: map[string]string{
+						batchv1.JobNameLabel: "test-job",
+					},
+				},
+			},
+			pods: []corev1.Pod{
+				*basePod.Clone().
+					Name("valid-pod-1").
+					Label(batchv1.JobNameLabel, "test-job").
+					Obj(),
+				*basePod.Clone().
+					Name("valid-pod-2").
+					Label(batchv1.JobNameLabel, "test-job").
+					Obj(),
+			},
+			mapperGVKs: []schema.GroupVersionKind{
+				{
+					Group:   "batch",
+					Version: "v1",
+					Kind:    "Job",
+				}, {
+					Group:   "",
+					Version: "v1",
+					Kind:    "Pod",
+				},
+			},
+			args:             []string{"--for", "job/test-job", "-o", "yaml"},
+			wantPodListNames: []string{"valid-pod-1", "valid-pod-2"},
+			podListFormat:    "yaml",
 		}, {
 			name: "list pods with JSONPath containing wide",
 			job: &batchv1.Job{
@@ -649,7 +728,37 @@ valid-pod-1   1/1     Running   0          <unknown>
 			}
 
 			gotOut := out.String()
-			if diff := cmp.Diff(tc.wantOut, gotOut); diff != "" {
+			if tc.wantPodListNames != nil {
+				var podList corev1.PodList
+				var err error
+				switch tc.podListFormat {
+				case "json":
+					err = json.Unmarshal([]byte(gotOut), &podList)
+				case "yaml":
+					err = yaml.Unmarshal([]byte(gotOut), &podList)
+				default:
+					t.Fatalf("Unsupported PodList output format: %q", tc.podListFormat)
+				}
+				if err != nil {
+					t.Fatalf("Unexpected %s output: %v", tc.podListFormat, err)
+				}
+				if podList.APIVersion != "v1" {
+					t.Errorf("Unexpected apiVersion: %q", podList.APIVersion)
+				}
+				if podList.Kind != "PodList" {
+					t.Errorf("Unexpected kind: %q", podList.Kind)
+				}
+				if len(podList.Items) != len(tc.wantPodListNames) {
+					t.Errorf("Unexpected number of Pods: got %d, want %d", len(podList.Items), len(tc.wantPodListNames))
+				}
+				gotPodNames := make([]string, len(podList.Items))
+				for i := range podList.Items {
+					gotPodNames[i] = podList.Items[i].Name
+				}
+				if diff := cmp.Diff(tc.wantPodListNames, gotPodNames); diff != "" {
+					t.Errorf("Unexpected Pod names (-want/+got)\n%s", diff)
+				}
+			} else if diff := cmp.Diff(tc.wantOut, gotOut); diff != "" {
 				t.Errorf("Unexpected output (-want/+got)\n%s", diff)
 			}
 


### PR DESCRIPTION
<!-- Thank you for contributing! Check CONTRIBUTING.md for details. -->

#### What type of PR is this?

/kind bug


<!-- Optionally choose one or more of the following kinds:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


<!-- Consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->


#### What this PR does / why we need it?

JSON output from commands such as  `kueuectl list workload -o json`  was a single List document, while  `kueuectl list pods --for <job> -o json `  uniquely emitted multiple individual Pod objects.

`kueuectl list pods --for <job> -o json`  retrieves all Pods associated with specified Job. When parallel Job has multiple Pods, previous implementation serialized each Pod separately:

```
{"kind":"Pod","metadata":{"name":"batch-a-xxxxx"}}
{"kind":"Pod","metadata":{"name":"batch-a-yyyyy"}}
```

These consecutive objects do not form valid single JSON document. 
As result, tools such as  `jq`  cannot reliably process complete result, and output does not follow standard semantics of list-oriented CLI commands.

JSON output should instead aggregate all matching Pods into standard  PodList :

```
{
  "apiVersion": "v1",
  "kind": "PodList",
  "items": [
    {"metadata": {"name": "batch-a-xxxxx"}},
    {"metadata": {"name": "batch-a-yyyyy"}}
  ]
}
```

This produces valid, complete JSON document suitable for reliable automated processing


#### Useful notes for your reviewer


#### Release note

<!-- Describe the behavior change accurately from the user's perspective. Hints:
- Do not leave this block blank.
- Use "NONE" when there is no user-facing change.
- When feasible use a prefix for the sub-component or feature, e.g. "FairSharing:" or "MultiKueue:".
- If upgrade steps are required, include an "ACTION REQUIRED:" section.
You may consider AI assistance using the skill: cmd/experimental/skills/kueue-release-notes/SKILL.md.
-->
```release-note
CLI: Aggregate Matching Pods into One PodList for Structured Output
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## AI summary

`kueuectl list pods --for <job> -o json` and YAML output now return one standard Kubernetes `PodList` containing all matching Pods. This produces valid list documents for tools such as `jq`. Tests cover both formats.

### Suggested release note

`CLI:` Fixed a bug that caused `kueuectl list pods --for <job> -o json` to output separate Pod objects instead of one valid `PodList`. The command now returns one aggregated `PodList`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->