### PR TITLE
Automated cherry pick of #15356: workloadslicing: Commonize listing Pods belonged to the Workload Slice 

### DIFF
--- a/pkg/controller/elasticjobs/elastic_job_ungater.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater.go
@@ -43,7 +43,6 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/core"
-	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	utilclient "sigs.k8s.io/kueue/pkg/util/client"
 	"sigs.k8s.io/kueue/pkg/util/expectations"
 	"sigs.k8s.io/kueue/pkg/util/parallelize"
@@ -294,11 +293,8 @@ func (r *elasticJobUngater) podsToUngate(ctx context.Context, wl *kueue.Workload
 	// wl is the chain's active slice (resolved in Reconcile), so its granted
 	// PodSet counts are the right cap for ungating any of them.
 	sliceName := workloadslicing.SliceName(wl)
-	var podList corev1.PodList
-	if err := r.client.List(ctx, &podList,
-		client.InNamespace(wl.Namespace),
-		client.MatchingFields{indexer.WorkloadSliceNameKey: sliceName},
-	); err != nil {
+	pods, err := workloadslicing.ListPodsForWorkloadSlice(ctx, r.client, wl.Namespace, sliceName)
+	if err != nil {
 		return nil, fmt.Errorf("listing pods for workload slice: %w", err)
 	}
 
@@ -306,8 +302,7 @@ func (r *elasticJobUngater) podsToUngate(ctx context.Context, wl *kueue.Workload
 	gatedPerPodSet := make(map[kueue.PodSetReference][]*corev1.Pod)
 	ungatedPerPodSet := make(map[kueue.PodSetReference]int32)
 	admissionUpdates := make(map[kueue.PodSetReference]podAdmissionUpdate)
-	for i := range podList.Items {
-		p := &podList.Items[i]
+	for _, p := range pods {
 		if utilpod.IsTerminated(p) {
 			continue
 		}
@@ -420,17 +415,16 @@ func (h *elasticPodHandler) queueReconcileForPod(ctx context.Context, object cli
 	}
 	// Expectations are keyed by the stable chain key (the origin slice name the
 	// pod carries), so observations survive scale rollovers.
-	sliceName := podSliceName(pod)
-	if sliceName == "" {
+	sliceKey := workloadslicing.KeyForPod(pod)
+	if sliceKey == nil {
 		return
 	}
-	sliceKey := types.NamespacedName{Name: sliceName, Namespace: pod.Namespace}
 	// Mark expectation as observed when the gate has been removed or the pod is deleted.
 	if !utilpod.HasGate(pod, kueue.ElasticJobSchedulingGate) || deleted {
 		log := ctrl.LoggerFrom(ctx).WithValues("pod", klog.KObj(pod), "workloadSlice", sliceKey.String())
-		h.expectationsStore.ObservedUID(log, sliceKey, pod.UID)
+		h.expectationsStore.ObservedUID(log, *sliceKey, pod.UID)
 	}
-	active, err := workloadslicing.FindLatestAdmittedWorkloadForSlice(ctx, h.client, pod.Namespace, sliceName)
+	active, err := workloadslicing.FindLatestAdmittedWorkloadForSlice(ctx, h.client, sliceKey.Namespace, sliceKey.Name)
 	if err != nil || active == nil {
 		return
 	}
@@ -438,14 +432,4 @@ func (h *elasticPodHandler) queueReconcileForPod(ctx context.Context, object cli
 		Namespace: active.Namespace,
 		Name:      active.Name,
 	}}, constants.UpdatesBatchPeriod)
-}
-
-// podSliceName returns the slice-chain key for a pod: the WorkloadSliceName
-// annotation if present, otherwise the stamped Workload annotation. Mirrors
-// indexer.IndexPodWorkloadSliceName so the key matches the pod index.
-func podSliceName(pod *corev1.Pod) string {
-	if v, found := pod.Annotations[kueue.WorkloadSliceNameAnnotation]; found {
-		return v
-	}
-	return pod.Annotations[kueue.WorkloadAnnotation]
 }

--- a/pkg/controller/tas/node_controller.go
+++ b/pkg/controller/tas/node_controller.go
@@ -712,7 +712,7 @@ func (r *nodeReconciler) getPodsToTerminate(ctx context.Context, wl *kueue.Workl
 
 func (r *nodeReconciler) hasProgressingPods(ctx context.Context, wl *kueue.Workload, nodeName string) (bool, error) {
 	sliceName := workloadslicing.SliceName(wl)
-	pods, err := ListPodsForWorkloadSlice(ctx, r.client, wl.Namespace, sliceName, client.MatchingFields{
+	pods, err := workloadslicing.ListPodsForWorkloadSlice(ctx, r.client, wl.Namespace, sliceName, client.MatchingFields{
 		indexer.PodNodeNameKey: nodeName,
 	})
 	if err != nil {

--- a/pkg/controller/tas/node_controller_test.go
+++ b/pkg/controller/tas/node_controller_test.go
@@ -1347,7 +1347,7 @@ func TestGetWorkloadStatus(t *testing.T) {
 			_ = cl.Get(ctx, wlKey, wl)
 
 			sliceName := workloadslicing.SliceName(wl)
-			pods, err := ListPodsForWorkloadSlice(ctx, cl, wl.Namespace, sliceName, client.MatchingFields{indexer.PodNodeSelectorHostnameKey: tc.nodeName})
+			pods, err := workloadslicing.ListPodsForWorkloadSlice(ctx, cl, wl.Namespace, sliceName, client.MatchingFields{indexer.PodNodeSelectorHostnameKey: tc.nodeName})
 			if err != nil {
 				t.Fatalf("Failed to list pods: %v", err)
 			}

--- a/pkg/controller/tas/topology_ungater.go
+++ b/pkg/controller/tas/topology_ungater.go
@@ -356,7 +356,7 @@ func shouldReconcileWorkload(wl *kueue.Workload) bool {
 }
 
 func (r *topologyUngater) podsForPodSet(ctx context.Context, ns, workloadSliceName string, psName kueue.PodSetReference) ([]*corev1.Pod, error) {
-	pods, err := ListPodsForWorkloadSlice(ctx, r.client, ns, workloadSliceName,
+	pods, err := workloadslicing.ListPodsForWorkloadSlice(ctx, r.client, ns, workloadSliceName,
 		client.MatchingLabels{constants.PodSetLabel: string(psName)})
 	if err != nil {
 		return nil, err

--- a/pkg/workloadslicing/pods.go
+++ b/pkg/workloadslicing/pods.go
@@ -14,16 +14,34 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tas
+package workloadslicing
 
 import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 )
+
+// nameForPod returns the annotated Workload name, preferring a present slice-chain annotation.
+func nameForPod(pod *corev1.Pod) string {
+	if name, found := pod.Annotations[kueue.WorkloadSliceNameAnnotation]; found {
+		return name
+	}
+	return pod.Annotations[kueue.WorkloadAnnotation]
+}
+
+// KeyForPod returns the annotated Workload key, or nil if the name is empty.
+func KeyForPod(pod *corev1.Pod) *types.NamespacedName {
+	if name := nameForPod(pod); name != "" {
+		return &types.NamespacedName{Namespace: pod.Namespace, Name: name}
+	}
+	return nil
+}
 
 // ListPodsForWorkloadSlice lists pods belonging to a workload slice by querying
 // the WorkloadSliceNameKey index. Additional list options (e.g., label selectors)

--- a/pkg/workloadslicing/pods_test.go
+++ b/pkg/workloadslicing/pods_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workloadslicing
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
+)
+
+func TestKeyForPod(t *testing.T) {
+	testCases := map[string]struct {
+		pod     *corev1.Pod
+		wantKey *types.NamespacedName
+	}{
+		"no annotations": {
+			pod: testingpod.MakePod("pod", "ns").Obj(),
+		},
+		"workload annotation": {
+			pod: testingpod.MakePod("pod", "ns").
+				Annotation(kueue.WorkloadAnnotation, "wl").
+				Obj(),
+			wantKey: &types.NamespacedName{Namespace: "ns", Name: "wl"},
+		},
+		"slice annotation only": {
+			pod: testingpod.MakePod("pod", "ns").
+				Annotation(kueue.WorkloadSliceNameAnnotation, "origin").
+				Obj(),
+			wantKey: &types.NamespacedName{Namespace: "ns", Name: "origin"},
+		},
+		"slice annotation takes precedence": {
+			pod: testingpod.MakePod("pod", "ns").
+				Annotation(kueue.WorkloadSliceNameAnnotation, "origin").
+				Annotation(kueue.WorkloadAnnotation, "wl").
+				Obj(),
+			wantKey: &types.NamespacedName{Namespace: "ns", Name: "origin"},
+		},
+		"empty slice annotation does not fall back to workload": {
+			pod: testingpod.MakePod("pod", "ns").
+				Annotation(kueue.WorkloadSliceNameAnnotation, "").
+				Annotation(kueue.WorkloadAnnotation, "wl").
+				Obj(),
+		},
+		"empty workload annotation": {
+			pod: testingpod.MakePod("pod", "ns").
+				Annotation(kueue.WorkloadAnnotation, "").
+				Obj(),
+		},
+		"both annotations empty": {
+			pod: testingpod.MakePod("pod", "ns").
+				Annotation(kueue.WorkloadSliceNameAnnotation, "").
+				Annotation(kueue.WorkloadAnnotation, "").
+				Obj(),
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			gotKey := KeyForPod(tc.pod)
+			if diff := cmp.Diff(tc.wantKey, gotKey); diff != "" {
+				t.Errorf("Unexpected key (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/workloadslicing/workloadslicing_test.go
+++ b/pkg/workloadslicing/workloadslicing_test.go
@@ -47,6 +47,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/scheduler/preemption"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
 	"sigs.k8s.io/kueue/pkg/workload"
 	workloadfinish "sigs.k8s.io/kueue/pkg/workload/finish"
 )
@@ -102,6 +103,76 @@ func TestEnabled(t *testing.T) {
 			features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, true)
 			if got := Enabled(tt.args.object); got != tt.want {
 				t.Errorf("Enabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestListPodsForWorkloadSlice(t *testing.T) {
+	errListPods := errors.New("list pods failed")
+	pods := []client.Object{
+		testingpod.MakePod("origin-pod", "ns").Annotation(kueue.WorkloadSliceNameAnnotation, "origin").Annotation(kueue.WorkloadAnnotation, "origin").Obj(),
+		testingpod.MakePod("replacement-pod", "ns").Annotation(kueue.WorkloadSliceNameAnnotation, "origin").Annotation(kueue.WorkloadAnnotation, "replacement").Label("role", "worker").Obj(),
+		testingpod.MakePod("succeeded-pod", "ns").Annotation(kueue.WorkloadSliceNameAnnotation, "origin").StatusPhase(corev1.PodSucceeded).Obj(),
+		testingpod.MakePod("failed-pod", "ns").Annotation(kueue.WorkloadSliceNameAnnotation, "origin").StatusPhase(corev1.PodFailed).Obj(),
+		testingpod.MakePod("other-namespace", "other").Annotation(kueue.WorkloadSliceNameAnnotation, "origin").Obj(),
+		testingpod.MakePod("regular-pod", "ns").Annotation(kueue.WorkloadAnnotation, "regular").Obj(),
+		testingpod.MakePod("unrelated-pod", "ns").Obj(),
+	}
+	testCases := map[string]struct {
+		sliceName   string
+		listOptions []client.ListOption
+		wantNames   []string
+		wantErr     error
+	}{
+		"all pods in the slice chain, including terminal pods": {
+			sliceName: "origin",
+			wantNames: []string{"failed-pod", "origin-pod", "replacement-pod", "succeeded-pod"},
+		},
+		"additional label selector": {
+			sliceName:   "origin",
+			listOptions: []client.ListOption{client.MatchingLabels{"role": "worker"}},
+			wantNames:   []string{"replacement-pod"},
+		},
+		"regular workload uses the workload annotation": {
+			sliceName: "regular",
+			wantNames: []string{"regular-pod"},
+		},
+		"no matching pods": {
+			sliceName: "missing",
+		},
+		"list failure is returned": {
+			sliceName: "origin",
+			wantErr:   errListPods,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctx, _ := utiltesting.ContextWithLog(t)
+			cl := utiltesting.NewClientBuilder().
+				WithObjects(pods...).
+				WithIndex(&corev1.Pod{}, indexer.WorkloadSliceNameKey, indexer.IndexPodWorkloadSliceName).
+				WithInterceptorFuncs(interceptor.Funcs{
+					List: func(ctx context.Context, c client.WithWatch, objs client.ObjectList, opts ...client.ListOption) error {
+						if _, ok := objs.(*corev1.PodList); ok && errors.Is(tc.wantErr, errListPods) {
+							return errListPods
+						}
+						return c.List(ctx, objs, opts...)
+					},
+				}).
+				Build()
+			got, err := ListPodsForWorkloadSlice(ctx, cl, "ns", tc.sliceName, tc.listOptions...)
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("Unexpected error (-want,+got):\n%s", diff)
+			}
+			var gotNames []string
+			for _, pod := range got {
+				gotNames = append(gotNames, pod.Name)
+			}
+			if diff := cmp.Diff(tc.wantNames, gotNames, cmpopts.SortSlices(func(a, b string) bool {
+				return a < b
+			})); diff != "" {
+				t.Errorf("Unexpected pods (-want,+got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Cherry pick of #15356 on release-0.19.

#15356: workloadslicing: Commonize listing Pods belonged to the Workload Slice 

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```