### PR TITLE
Reconcile AFS consumed usage for stopped LocalQueues

### DIFF
--- a/pkg/controller/core/localqueue_controller.go
+++ b/pkg/controller/core/localqueue_controller.go
@@ -193,7 +193,21 @@ func (r *LocalQueueReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	if ptr.Deref(queueObj.Spec.StopPolicy, kueue.None) != kueue.None {
 		err := r.UpdateStatusIfChanged(ctx, &queueObj, metav1.ConditionFalse, StoppedReason, localQueueIsInactiveMsg)
-		return ctrl.Result{}, client.IgnoreNotFound(err)
+		if err != nil {
+			return ctrl.Result{}, client.IgnoreNotFound(err)
+		}
+		if afs.Enabled(r.admissionFSConfig) {
+			// A stopped LocalQueue no longer admits new Workloads, but already
+			// admitted Workloads keep running. Reconcile AFS consumed usage so
+			// their usage during Hold is still counted instead of decaying as
+			// idle time (#15383).
+			result, _, err := r.reconcileAfsUsage(ctx, &queueObj)
+			if err != nil {
+				return ctrl.Result{}, client.IgnoreNotFound(err)
+			}
+			return result, nil
+		}
+		return ctrl.Result{}, nil
 	}
 
 	var cq kueue.ClusterQueue
@@ -213,25 +227,40 @@ func (r *LocalQueueReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	if afs.Enabled(r.admissionFSConfig) {
-		lqKey := utilqueue.Key(&queueObj)
-		hadCache, entry := r.initializeAfsIfNeeded(&queueObj)
-		sinceLastUpdate := r.clock.Now().Sub(entry.LastUpdate)
-		// Enforce the sampling interval when the cache already existed
-		// before this reconcile. Without this, self-triggered status
-		// updates cause sub-millisecond reconciles where the decay math
-		// truncates CPU consumed resources to zero.
-		if interval := r.admissionFSConfig.UsageSamplingInterval.Duration; hadCache && sinceLastUpdate < interval && !r.queues.AfsUsageLedger.HasPendingPenalty(lqKey) {
-			return ctrl.Result{RequeueAfter: interval - sinceLastUpdate}, nil
-		}
-		if err := r.reconcileConsumedUsage(ctx, &queueObj); err != nil {
+		result, reconciled, err := r.reconcileAfsUsage(ctx, &queueObj)
+		if err != nil {
 			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
-		if err := r.queues.RebuildClusterQueue(log, &cq, queueObj.Name); err != nil {
-			return ctrl.Result{}, err
+		if reconciled {
+			if err := r.queues.RebuildClusterQueue(log, &cq, queueObj.Name); err != nil {
+				return ctrl.Result{}, err
+			}
 		}
-		return ctrl.Result{RequeueAfter: r.admissionFSConfig.UsageSamplingInterval.Duration}, nil
+		return result, nil
 	}
 	return ctrl.Result{}, nil
+}
+
+// reconcileAfsUsage updates the LocalQueue's Admission Fair Sharing consumed
+// usage history. It returns the result to requeue, whether a sampling tick
+// actually ran (reconciled), and any error. The reconciled flag lets callers
+// skip downstream work (like rebuilding the ClusterQueue) when the tick was
+// deferred to respect the sampling interval.
+func (r *LocalQueueReconciler) reconcileAfsUsage(ctx context.Context, lq *kueue.LocalQueue) (ctrl.Result, bool, error) {
+	lqKey := utilqueue.Key(lq)
+	hadCache, entry := r.initializeAfsIfNeeded(lq)
+	sinceLastUpdate := r.clock.Now().Sub(entry.LastUpdate)
+	// Enforce the sampling interval when the cache already existed
+	// before this reconcile. Without this, self-triggered status
+	// updates cause sub-millisecond reconciles where the decay math
+	// truncates CPU consumed resources to zero.
+	if interval := r.admissionFSConfig.UsageSamplingInterval.Duration; hadCache && sinceLastUpdate < interval && !r.queues.AfsUsageLedger.HasPendingPenalty(lqKey) {
+		return ctrl.Result{RequeueAfter: interval - sinceLastUpdate}, false, nil
+	}
+	if err := r.reconcileConsumedUsage(ctx, lq); err != nil {
+		return ctrl.Result{}, false, err
+	}
+	return ctrl.Result{RequeueAfter: r.admissionFSConfig.UsageSamplingInterval.Duration}, true, nil
 }
 
 func (r *LocalQueueReconciler) Create(e event.TypedCreateEvent[*kueue.LocalQueue]) bool {

--- a/pkg/controller/core/localqueue_controller_test.go
+++ b/pkg/controller/core/localqueue_controller_test.go
@@ -92,6 +92,70 @@ func TestLocalQueueReconcile(t *testing.T) {
 				Obj(),
 			wantError: nil,
 		},
+		"held local queue still updates AFS consumed usage": {
+			clusterQueue: utiltestingapi.MakeClusterQueue("cq-hold-afs").
+				Active(metav1.ConditionTrue).
+				Obj(),
+			localQueue: utiltestingapi.MakeLocalQueue("lq-hold-afs", "default").
+				ClusterQueue("cq-hold-afs").
+				StopPolicy(kueue.Hold).
+				Generation(1).
+				FairSharing(&kueue.FairSharing{
+					Weight: new(resource.MustParse("1")),
+				}).
+				Obj(),
+			initialConsumedResources: queueafs.UsageLedgerEntry{
+				Resources: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("8"),
+				},
+				LastUpdate:      now.Add(-5 * time.Minute),
+				StatusAccounted: true,
+			},
+			runningWls: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-hold-afs", "default").
+					Queue("lq-hold-afs").
+					Request(corev1.ResourceCPU, "4").
+					SimpleReserveQuota("cq-hold-afs", "rf", clock.Now()).
+					AdmittedAt(true, now).
+					Obj(),
+			},
+			wantLocalQueue: utiltestingapi.MakeLocalQueue("lq-hold-afs", "default").
+				ClusterQueue("cq-hold-afs").
+				StopPolicy(kueue.Hold).
+				Generation(1).
+				ReservingWorkloads(1).
+				AdmittedWorkloads(1).
+				Condition(
+					kueue.LocalQueueActive,
+					metav1.ConditionFalse,
+					StoppedReason,
+					localQueueIsInactiveMsg,
+					1,
+				).
+				FairSharing(&kueue.FairSharing{
+					Weight: new(resource.MustParse("1")),
+				}).
+				FairSharingStatus(
+					&kueue.LocalQueueFairSharingStatus{
+						AdmissionFairSharingStatus: &kueue.LocalQueueAdmissionFairSharingStatus{
+							ConsumedResources: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceCPU: resource.MustParse("6"),
+							},
+						},
+					}).
+				Obj(),
+			wantConsumedResources: &queueafs.UsageLedgerEntry{
+				Resources: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("6"),
+				},
+				LastUpdate:      clock.Now(),
+				StatusAccounted: true,
+			},
+			afsConfig: &config.AdmissionFairSharing{
+				UsageHalfLifeTime:     metav1.Duration{Duration: 5 * time.Minute},
+				UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
+			},
+		},
 		"local queue with HoldAndDrain StopPolicy": {
 			clusterQueue: utiltestingapi.MakeClusterQueue("test-cluster-queue").
 				Obj(),

--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -1304,6 +1304,60 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing"), func()
 				g.Expect(penalty).To(gomega.BeFalse(), "entry penalty should be absent for lq-a")
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
+
+		ginkgo.It("keeps reconciling AFS consumed usage while the LocalQueue is held", func() {
+			ginkgo.By("Admitting a workload so the LocalQueue accrues AFS consumed usage")
+			wl := createWorkload("lq-a", "4")
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+			util.ExpectLocalQueueFairSharingUsageToBe(ctx, k8sClient, client.ObjectKeyFromObject(lqA), ">", 0)
+
+			ginkgo.By("Stopping the LocalQueue with Hold so admitted workloads keep running")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lqA), lqA)).To(gomega.Succeed())
+				lqA.Spec.StopPolicy = new(kueue.Hold)
+				g.Expect(k8sClient.Update(ctx, lqA)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Waiting for the LocalQueue to become inactive")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lqA), lqA)).To(gomega.Succeed())
+				g.Expect(lqA.Status.Conditions).To(gomega.ContainElements(
+					gomega.BeComparableTo(metav1.Condition{
+						Type:    kueue.LocalQueueActive,
+						Status:  metav1.ConditionFalse,
+						Reason:  core.StoppedReason,
+						Message: "LocalQueue is stopped",
+					}, util.IgnoreConditionTimestampsAndObservedGeneration),
+				))
+				g.Expect(lqA.Status.AdmittedWorkloads).To(gomega.Equal(int32(1)))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+
+			ginkgo.By("Recording AFS status after the LocalQueue is held")
+			heldLq := &kueue.LocalQueue{}
+			gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lqA), heldLq)).To(gomega.Succeed())
+			gomega.Expect(heldLq.Status.FairSharing).NotTo(gomega.BeNil())
+			gomega.Expect(heldLq.Status.FairSharing.AdmissionFairSharingStatus).NotTo(gomega.BeNil())
+			usageAtHold := heldLq.Status.FairSharing.AdmissionFairSharingStatus.ConsumedResources[corev1.ResourceCPU]
+			lastUpdateAtHold := heldLq.Status.FairSharing.AdmissionFairSharingStatus.LastUpdate.Time
+			gomega.Expect(usageAtHold.MilliValue()).To(gomega.BeNumerically(">", 0))
+
+			ginkgo.By("Waiting for a sampling tick while held")
+			gomega.Eventually(func(g gomega.Gomega) {
+				updatedLq := &kueue.LocalQueue{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lqA), updatedLq)).To(gomega.Succeed())
+				afsStatus := updatedLq.Status.FairSharing.AdmissionFairSharingStatus
+				g.Expect(afsStatus).NotTo(gomega.BeNil())
+				// LastUpdate is second-granular; a tick after Hold must advance it.
+				g.Expect(afsStatus.LastUpdate.Time).To(gomega.BeTemporally(">", lastUpdateAtHold),
+					"AFS usage history was not sampled while the LocalQueue was held")
+				usage := afsStatus.ConsumedResources[corev1.ResourceCPU]
+				// Running usage must keep being folded in. If the tick treated the
+				// queue as idle, ConsumedResources would decay toward zero.
+				g.Expect(usage.MilliValue()).To(gomega.BeNumerically(">", usageAtHold.MilliValue()*7/10),
+					"consumed usage decayed as idle while the LocalQueue was held")
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
 	})
 
 	ginkgo.When("Using AdmissionFairSharing with AdmissionChecks", ginkgo.Label("feature:admissionfairsharing"), func() {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it?

When a LocalQueue's `StopPolicy` is set to `Hold` (or `HoldAndDrain`), the
reconciler returned early, before reconciling its Admission Fair Sharing (AFS)
consumed usage. Admitted Workloads that kept running during the hold therefore
had their usage decay as though the queue were idle, and the queue's usage
history stopped being sampled because no requeue was scheduled.

This change makes the reconciler keep reconciling AFS consumed usage for
stopped queues, so running Workloads continue contributing to the queue's
consumption history while it is held.

Fixes #15383

#### Useful notes for your reviewer

The AFS reconciliation is extracted into a `reconcileAfsUsage` helper so it can
run for both active and stopped queues. The helper reports whether a sampling
tick actually ran, so the active path still only rebuilds the ClusterQueue when
usage was actually updated.

I used AI assistance during the investigation and drafting of this PR.

#### Release note

```release-note
Admission Fair Sharing: a LocalQueue that is put on Hold now keeps accumulating usage from already-admitted Workloads, so its consumption history no longer decays as idle time while held.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## AI summary

- Fixed AFS usage reconciliation for LocalQueues with `Hold` or `HoldAndDrain`.
- Held queues now continue updating usage history for running admitted Workloads.
- Added unit and integration test coverage.

### Suggested release note

AFS: Fixed a bug that caused usage history to stop updating for held LocalQueues with running admitted Workloads. Kueue now continues tracking their consumed usage during the hold.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->