### PR TITLE
Automated cherry pick of #15214: fix: prevent PodSetReducer int32 overflow

### DIFF
--- a/pkg/scheduler/flavorassigner/podset_reducer.go
+++ b/pkg/scheduler/flavorassigner/podset_reducer.go
@@ -17,6 +17,8 @@ limitations under the License.
 package flavorassigner
 
 import (
+	"sort"
+
 	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -70,8 +72,8 @@ func (psr *PodSetReducer[R]) Search() (R, bool) {
 	}
 
 	current := make([]int32, len(psr.podSets))
-	_, found := searchInt64(psr.totalDelta, func(i int64) bool {
-		fillPodSetSizesForSearchIndex(current, psr.fullCounts, psr.deltas, i, psr.totalDelta)
+	idx := sort.Search(int(psr.totalDelta), func(i int) bool {
+		fillPodSetSizesForSearchIndex(current, psr.fullCounts, psr.deltas, int64(i), psr.totalDelta)
 		r, f := psr.fits(current)
 		if f {
 			lastR = r
@@ -79,21 +81,11 @@ func (psr *PodSetReducer[R]) Search() (R, bool) {
 		return f
 	})
 
-	return lastR, found
-}
-
-func searchInt64(max int64, f func(int64) bool) (int64, bool) {
-	var i int64
-	j := max
-
-	for i < j {
-		h := i + (j-i)/2
-		if f(h) {
-			j = h
-		} else {
-			i = h + 1
-		}
+	if idx < int(psr.totalDelta) {
+		return lastR, true
 	}
 
-	return i, f(i)
+	// sort.Search searches [0, totalDelta), so check totalDelta separately.
+	fillPodSetSizesForSearchIndex(current, psr.fullCounts, psr.deltas, psr.totalDelta, psr.totalDelta)
+	return psr.fits(current)
 }

--- a/pkg/scheduler/flavorassigner/podset_reducer.go
+++ b/pkg/scheduler/flavorassigner/podset_reducer.go
@@ -17,8 +17,6 @@ limitations under the License.
 package flavorassigner
 
 import (
-	"sort"
-
 	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -30,7 +28,7 @@ type PodSetReducer[R any] struct {
 	podSets    []kueue.PodSet
 	fullCounts []int32
 	deltas     []int32
-	totalDelta int32
+	totalDelta int64
 	fits       func([]int32) (R, bool)
 }
 
@@ -48,15 +46,15 @@ func NewPodSetReducer[R any](podSets []kueue.PodSet, fits func([]int32) (R, bool
 
 		d := ps.Count - ptr.Deref(ps.MinCount, ps.Count)
 		psr.deltas[i] = d
-		psr.totalDelta += d
+		psr.totalDelta += int64(d)
 	}
 	return psr
 }
 
-func fillPodSetSizesForSearchIndex(out, fullCounts, deltas []int32, upFactor int32, downFactor int32) {
+func fillPodSetSizesForSearchIndex(out, fullCounts, deltas []int32, upFactor, downFactor int64) {
 	// this will panic if len(out) < len(deltas)
 	for i, v := range deltas {
-		tmp := int32(int64(v) * int64(upFactor) / int64(downFactor))
+		tmp := int32(int64(v) * upFactor / downFactor)
 		out[i] = fullCounts[i] - tmp
 	}
 }
@@ -65,7 +63,7 @@ func fillPodSetSizesForSearchIndex(out, fullCounts, deltas []int32, upFactor int
 // binary Search so the last call to fits() might not be a successful one
 // Returns nil if no solution was found
 func (psr *PodSetReducer[R]) Search() (R, bool) {
-	var lastGoodIdx int
+	var lastGoodIdx int64
 	var lastR R
 
 	if psr.totalDelta == 0 {
@@ -73,8 +71,8 @@ func (psr *PodSetReducer[R]) Search() (R, bool) {
 	}
 
 	current := make([]int32, len(psr.podSets))
-	idx := sort.Search(int(psr.totalDelta)+1, func(i int) bool {
-		fillPodSetSizesForSearchIndex(current, psr.fullCounts, psr.deltas, int32(i), psr.totalDelta)
+	idx := searchInt64(psr.totalDelta+1, func(i int64) bool {
+		fillPodSetSizesForSearchIndex(current, psr.fullCounts, psr.deltas, i, psr.totalDelta)
 		r, f := psr.fits(current)
 		if f {
 			lastGoodIdx = i
@@ -83,4 +81,19 @@ func (psr *PodSetReducer[R]) Search() (R, bool) {
 		return f
 	})
 	return lastR, idx == lastGoodIdx
+}
+
+func searchInt64(n int64, f func(int64) bool) int64 {
+	var i int64
+	j := n
+
+	for i < j {
+		h := i + (j-i)/2
+		if !f(h) {
+			i = h + 1
+		} else {
+			j = h
+		}
+	}
+	return i
 }

--- a/pkg/scheduler/flavorassigner/podset_reducer.go
+++ b/pkg/scheduler/flavorassigner/podset_reducer.go
@@ -63,7 +63,6 @@ func fillPodSetSizesForSearchIndex(out, fullCounts, deltas []int32, upFactor, do
 // binary Search so the last call to fits() might not be a successful one
 // Returns nil if no solution was found
 func (psr *PodSetReducer[R]) Search() (R, bool) {
-	var lastGoodIdx int64
 	var lastR R
 
 	if psr.totalDelta == 0 {
@@ -71,29 +70,30 @@ func (psr *PodSetReducer[R]) Search() (R, bool) {
 	}
 
 	current := make([]int32, len(psr.podSets))
-	idx := searchInt64(psr.totalDelta+1, func(i int64) bool {
+	_, found := searchInt64(psr.totalDelta, func(i int64) bool {
 		fillPodSetSizesForSearchIndex(current, psr.fullCounts, psr.deltas, i, psr.totalDelta)
 		r, f := psr.fits(current)
 		if f {
-			lastGoodIdx = i
 			lastR = r
 		}
 		return f
 	})
-	return lastR, idx == lastGoodIdx
+
+	return lastR, found
 }
 
-func searchInt64(n int64, f func(int64) bool) int64 {
+func searchInt64(max int64, f func(int64) bool) (int64, bool) {
 	var i int64
-	j := n
+	j := max
 
 	for i < j {
 		h := i + (j-i)/2
-		if !f(h) {
-			i = h + 1
-		} else {
+		if f(h) {
 			j = h
+		} else {
+			i = h + 1
 		}
 	}
-	return i
+
+	return i, f(i)
 }

--- a/pkg/scheduler/flavorassigner/podset_reducer_test.go
+++ b/pkg/scheduler/flavorassigner/podset_reducer_test.go
@@ -19,6 +19,8 @@ package flavorassigner
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 )
@@ -146,5 +148,39 @@ func TestSearch(t *testing.T) {
 				t.Errorf("Unexpected found:%v, want: %v", found, tc.wantFound)
 			}
 		})
+	}
+}
+
+func TestSearchTotalDeltaOverflow(t *testing.T) {
+	podSets := []kueue.PodSet{
+		*utiltestingapi.MakePodSet("ps1", 1_500_000_000).SetMinimumCount(1).Obj(),
+		*utiltestingapi.MakePodSet("ps2", 1_500_000_000).SetMinimumCount(1).Obj(),
+	}
+
+	fits := func(counts []int32) ([]int32, bool) {
+		total := int64(counts[0]) + int64(counts[1])
+		if total > 1_000_000_000 {
+			return nil, false
+		}
+
+		out := make([]int32, len(counts))
+		copy(out, counts)
+		return out, true
+	}
+
+	red := NewPodSetReducer(podSets, fits)
+
+	if want, got := int64(2_999_999_998), red.totalDelta; got != want {
+		t.Errorf("Unexpected totalDelta: %d, want %d", got, want)
+	}
+
+	count, found := red.Search()
+	if !found {
+		t.Fatal("Expected a solution")
+	}
+
+	wantCount := []int32{500_000_000, 500_000_000}
+	if diff := cmp.Diff(wantCount, count); diff != "" {
+		t.Errorf("Unexpected counts (-want,+got):\n%s", diff)
 	}
 }

--- a/pkg/scheduler/flavorassigner/podset_reducer_test.go
+++ b/pkg/scheduler/flavorassigner/podset_reducer_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package flavorassigner
 
 import (
+	"math"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -182,5 +183,18 @@ func TestSearchTotalDeltaOverflow(t *testing.T) {
 	wantCount := []int32{500_000_000, 500_000_000}
 	if diff := cmp.Diff(wantCount, count); diff != "" {
 		t.Errorf("Unexpected counts (-want,+got):\n%s", diff)
+	}
+}
+
+func TestSearchInt64MaxInt64(t *testing.T) {
+	got, found := searchInt64(math.MaxInt64, func(i int64) bool {
+		return i == math.MaxInt64
+	})
+
+	if !found {
+		t.Fatal("Expected to find a solution")
+	}
+	if got != math.MaxInt64 {
+		t.Errorf("Unexpected index: %d, want %d", got, math.MaxInt64)
 	}
 }

--- a/pkg/scheduler/flavorassigner/podset_reducer_test.go
+++ b/pkg/scheduler/flavorassigner/podset_reducer_test.go
@@ -152,15 +152,16 @@ func TestSearch(t *testing.T) {
 	}
 }
 
-func TestSearchTotalDeltaOverflow(t *testing.T) {
+func TestSearchTotalDeltaLarge(t *testing.T) {
 	podSets := []kueue.PodSet{
-		*utiltestingapi.MakePodSet("ps1", 1_500_000_000).SetMinimumCount(1).Obj(),
-		*utiltestingapi.MakePodSet("ps2", 1_500_000_000).SetMinimumCount(1).Obj(),
+		*utiltestingapi.MakePodSet("ps1", math.MaxInt32).SetMinimumCount(0).Obj(),
+		*utiltestingapi.MakePodSet("ps2", math.MaxInt32).SetMinimumCount(0).Obj(),
+		*utiltestingapi.MakePodSet("ps3", 1).SetMinimumCount(0).Obj(),
 	}
 
 	fits := func(counts []int32) ([]int32, bool) {
-		total := int64(counts[0]) + int64(counts[1])
-		if total > 1_000_000_000 {
+		total := int64(counts[0]) + int64(counts[1]) + int64(counts[2])
+		if total > 1 {
 			return nil, false
 		}
 
@@ -171,8 +172,8 @@ func TestSearchTotalDeltaOverflow(t *testing.T) {
 
 	red := NewPodSetReducer(podSets, fits)
 
-	if want, got := int64(2_999_999_998), red.totalDelta; got != want {
-		t.Errorf("Unexpected totalDelta: %d, want %d", got, want)
+	if want, got := int64(4_294_967_295), red.totalDelta; got != want {
+		t.Fatalf("Unexpected totalDelta: %d, want %d", got, want)
 	}
 
 	count, found := red.Search()
@@ -180,21 +181,8 @@ func TestSearchTotalDeltaOverflow(t *testing.T) {
 		t.Fatal("Expected a solution")
 	}
 
-	wantCount := []int32{500_000_000, 500_000_000}
+	wantCount := []int32{0, 0, 0}
 	if diff := cmp.Diff(wantCount, count); diff != "" {
 		t.Errorf("Unexpected counts (-want,+got):\n%s", diff)
-	}
-}
-
-func TestSearchInt64MaxInt64(t *testing.T) {
-	got, found := searchInt64(math.MaxInt64, func(i int64) bool {
-		return i == math.MaxInt64
-	})
-
-	if !found {
-		t.Fatal("Expected to find a solution")
-	}
-	if got != math.MaxInt64 {
-		t.Errorf("Unexpected index: %d, want %d", got, math.MaxInt64)
 	}
 }


### PR DESCRIPTION
Cherry pick of #15214 on release-0.18.

#15214: fix: prevent PodSetReducer int32 overflow

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
NONE
```