### PR TITLE
AgentSkills: add CLI prefix guidance to release-notes skill

### DIFF
--- a/cmd/experimental/skills/kueue-release-notes/SKILL.md
+++ b/cmd/experimental/skills/kueue-release-notes/SKILL.md
@@ -49,7 +49,8 @@ Read the PR description, linked issue, release-note text, and relevant changed f
 
 Identify:
 
-- the affected Kueue area or component;
+- the affected Kueue area or component; if changed files are under `cmd/kueuectl/` or
+  the PR touches `kueuectl` commands, flags, or output, the area is `CLI`;
 - whether this is a bugfix, feature, observability improvement, documentation-only change, cleanup, or breaking change;
 - the scenario users could observe before the change;
 - the behavior users should expect after the change;
@@ -132,6 +133,10 @@ MultiKueue: Fixed a bug where one slow or unresponsive remote cluster could stal
 KueueViz: Fixed the navigation bar to avoid layout breakage on narrow mobile screens.
 ```
 
+```text
+CLI: Fixed a bug where `kueuectl list workloads` could omit workloads when the `--namespace` flag was combined with a label selector.
+```
+
 Avoid starting with implementation details:
 
 ```text
@@ -202,6 +207,10 @@ Start the note with a prefix that narrows the scope.
 
 Prefer the smallest accurate user-facing area, for example:
 
+- `CLI:` — for changes to `kueuectl` commands, flags, output format, or any behavior
+  visible to users of the `kueuectl` CLI. Triggered by changes under `cmd/kueuectl/`,
+  new or removed `kueuectl` subcommands, changed flag semantics, or modified command
+  output.
 - `MultiKueue:`
 - `TAS:`
 - `Helm:`


### PR DESCRIPTION
<!-- Thank you for contributing! Check CONTRIBUTING.md for details. -->

#### What type of PR is this?
<!-- Choose one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep
-->
/kind cleanup

<!-- Optionally choose one or more of the following kinds:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


<!-- Consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->


#### What this PR does / why we need it?
AgentSkills: add CLI prefix guidance to release-notes skill

<!--
Use `Fixes #123` for an issue addressed by this PR; it will be closed when the PR merges.
Use `Related:` or `Part of:` to reference an issue without closing it.
-->
Fixes #

#### Useful notes for your reviewer


#### Release note

<!-- Describe the behavior change accurately from the user's perspective. Hints:
- Do not leave this block blank.
- Use "NONE" when there is no user-facing change.
- When feasible use a prefix for the sub-component or feature, e.g. "FairSharing:" or "MultiKueue:".
- If upgrade steps are required, include an "ACTION REQUIRED:" section.
You may consider AI assistance using the skill: cmd/experimental/skills/kueue-release-notes/SKILL.md.
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## AI summary

Updated the release-notes AgentSkill with `CLI:` guidance for `kueuectl` changes, including a namespace and label selector bugfix example.

### Suggested release note

NONE

<!-- end of auto-generated comment: release notes by coderabbit.ai -->