### PR TITLE
Automated cherry pick of #14366: Fix a bug for TASHandleOverlappingFlavors + RecomputeAssignmentUponPreemptionTargetsOverlap

### DIFF
--- a/pkg/cache/scheduler/clusterqueue_snapshot.go
+++ b/pkg/cache/scheduler/clusterqueue_snapshot.go
@@ -108,6 +108,7 @@ func (c *ClusterQueueSnapshot) SimulateUsageRemoval(usage workload.Usage) func()
 	}
 }
 
+// AddUsage skips sibling TAS flavors. Use Snapshot methods to sync them.
 func (c *ClusterQueueSnapshot) AddUsage(usage workload.Usage) {
 	for fr, q := range usage.Quota {
 		addUsage(c, fr, q)
@@ -115,6 +116,7 @@ func (c *ClusterQueueSnapshot) AddUsage(usage workload.Usage) {
 	c.updateTASUsage(usage.TAS, add)
 }
 
+// RemoveUsage skips sibling TAS flavors. Use Snapshot methods to sync them.
 func (c *ClusterQueueSnapshot) RemoveUsage(usage workload.Usage) {
 	for fr, q := range usage.Quota {
 		removeUsage(c, fr, q)

--- a/pkg/cache/scheduler/snapshot.go
+++ b/pkg/cache/scheduler/snapshot.go
@@ -52,6 +52,9 @@ type Snapshot struct {
 	hierarchy.Manager[*ClusterQueueSnapshot, *CohortSnapshot]
 	ResourceFlavors          map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor
 	InactiveClusterQueueSets sets.Set[kueue.ClusterQueueReference]
+	// hostnameLeafTASFlavors holds the flavor snapshots sharing topology
+	// capacity, fixed once the snapshot is built.
+	hostnameLeafTASFlavors map[kueue.ResourceFlavorReference]*TASFlavorSnapshot
 }
 
 // RemoveWorkload removes a workload from its corresponding ClusterQueue and
@@ -59,7 +62,7 @@ type Snapshot struct {
 func (s *Snapshot) RemoveWorkload(wl *workload.Info) {
 	cq := s.ClusterQueue(wl.ClusterQueue)
 	delete(cq.Workloads, workload.Key(wl.Obj))
-	cq.RemoveUsage(wl.Usage())
+	s.removeUsage(cq, wl.Usage())
 }
 
 // AddWorkload adds a workload to its corresponding ClusterQueue and
@@ -67,7 +70,38 @@ func (s *Snapshot) RemoveWorkload(wl *workload.Info) {
 func (s *Snapshot) AddWorkload(wl *workload.Info) {
 	cq := s.ClusterQueue(wl.ClusterQueue)
 	cq.Workloads[workload.Key(wl.Obj)] = wl
-	cq.AddUsage(wl.Usage())
+	s.AddUsage(cq, wl.Usage())
+}
+
+// AddUsage adds usage to the ClusterQueue and updates overlapping TAS flavors.
+func (s *Snapshot) AddUsage(cq *ClusterQueueSnapshot, usage workload.Usage) {
+	cq.AddUsage(usage)
+	s.updateOverlappingTASUsage(cq.TASFlavors, usage.TAS, add)
+}
+
+func (s *Snapshot) removeUsage(cq *ClusterQueueSnapshot, usage workload.Usage) {
+	cq.RemoveUsage(usage)
+	s.updateOverlappingTASUsage(cq.TASFlavors, usage.TAS, subtract)
+}
+
+// updateOverlappingTASUsage keeps hostname-leaf flavor snapshots consistent
+// with the cross-flavor usage aggregated when the snapshot is built.
+func (s *Snapshot) updateOverlappingTASUsage(sourceFlavors map[kueue.ResourceFlavorReference]*TASFlavorSnapshot, usage workload.TASUsage, op usageOp) {
+	if len(usage) == 0 || !features.Enabled(features.TASHandleOverlappingFlavors) {
+		return
+	}
+
+	for sourceFlavor, tasUsage := range usage {
+		if sourceFlavors[sourceFlavor] == nil || s.hostnameLeafTASFlavors[sourceFlavor] == nil {
+			continue
+		}
+		for flavor, tasFlavor := range s.hostnameLeafTASFlavors {
+			if flavor == sourceFlavor {
+				continue
+			}
+			tasFlavor.updateTASUsageForHeldDomains(tasUsage, op)
+		}
+	}
 }
 
 // SimulateWorkloadUsageRemoval modifies the snapshot by removing the usage
@@ -84,11 +118,11 @@ func (s *Snapshot) SimulateWorkloadUsageRemoval(workloads []*workload.Info) func
 		cqUsages = append(cqUsages, cqUsage{cq: w.ClusterQueue, usage: w.Usage()})
 	}
 	for _, cqUsage := range cqUsages {
-		s.ClusterQueue(cqUsage.cq).RemoveUsage(cqUsage.usage)
+		s.removeUsage(s.ClusterQueue(cqUsage.cq), cqUsage.usage)
 	}
 	return func() {
 		for _, cqUsage := range cqUsages {
-			s.ClusterQueue(cqUsage.cq).AddUsage(cqUsage.usage)
+			s.AddUsage(s.ClusterQueue(cqUsage.cq), cqUsage.usage)
 		}
 	}
 }
@@ -205,6 +239,7 @@ func (c *Cache) Snapshot(ctx context.Context, options ...SnapshotOption) (*Snaps
 		flvTASCache := c.tasCache.Clone()
 
 		if features.Enabled(features.TASHandleOverlappingFlavors) {
+			snap.hostnameLeafTASFlavors = make(map[kueue.ResourceFlavorReference]*TASFlavorSnapshot)
 			aggregatedDomainUsages = make(map[utiltas.TopologyDomainID]resources.Requests)
 			for _, cache := range flvTASCache {
 				c.snapshotTopologyDomainUsages(cache, aggregatedDomainUsages)
@@ -222,6 +257,9 @@ func (c *Cache) Snapshot(ctx context.Context, options ...SnapshotOption) (*Snaps
 			tasSnapshots[flavor], err = cache.snapshot(ctx, log, aggregatedDomainUsagesForFlavor)
 			if err != nil {
 				return nil, err
+			}
+			if features.Enabled(features.TASHandleOverlappingFlavors) && utiltas.IsLowestLevelHostname(cache.topology.Levels) {
+				snap.hostnameLeafTASFlavors[flavor] = tasSnapshots[flavor]
 			}
 		}
 	}

--- a/pkg/cache/scheduler/snapshot_test.go
+++ b/pkg/cache/scheduler/snapshot_test.go
@@ -19,6 +19,8 @@ package scheduler
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
+	"slices"
 	"testing"
 	"time"
 
@@ -32,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/component-base/featuregate"
+	testingclock "k8s.io/utils/clock/testing"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/cache/hierarchy"
@@ -51,6 +54,7 @@ var snapCmpOpts = cmp.Options{
 	cmpopts.IgnoreUnexported(hierarchy.ClusterQueue[*CohortSnapshot]{}),
 	cmpopts.IgnoreUnexported(hierarchy.Manager[*ClusterQueueSnapshot, *CohortSnapshot]{}),
 	cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime"),
+	cmpopts.IgnoreFields(Snapshot{}, "hostnameLeafTASFlavors"),
 }
 
 func TestSnapshot(t *testing.T) {
@@ -1074,6 +1078,7 @@ func TestSnapshot(t *testing.T) {
 				if cqSnapshot == nil {
 					t.Fatalf("ClusterQueue %q is missing from the snapshot", cqName)
 				}
+
 				gotTASUsage := make(map[kueue.ResourceFlavorReference]map[utiltas.TopologyDomainID]resources.Requests, len(tc.wantTASUsage))
 				for flavor := range tc.wantTASUsage {
 					flavorSnapshot := cqSnapshot.TASFlavors[flavor]
@@ -1106,6 +1111,250 @@ func TestSnapshot(t *testing.T) {
 						}
 					}
 				}
+			}
+		})
+	}
+}
+
+func TestSnapshotWithOverlappingTASUsage(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Now().Truncate(time.Second))
+	testCases := map[string]struct {
+		cqs                            []*kueue.ClusterQueue
+		rfs                            []*kueue.ResourceFlavor
+		topologies                     []*kueue.Topology
+		wls                            []*kueue.Workload
+		nodes                          []*corev1.Node
+		wantTASUsage                   map[kueue.ResourceFlavorReference]map[utiltas.TopologyDomainID]resources.Requests
+		removalSimulationWorkload      workload.Reference
+		usageRemovalSimulationWorkload workload.Reference
+		wantSimulatedTASUsage          map[kueue.ResourceFlavorReference]map[utiltas.TopologyDomainID]resources.Requests
+		wantSimulatedWorkloads         []workload.Reference
+		featureGates                   map[featuregate.Feature]bool
+	}{
+		"overlapping flavors: simulated removal of a Workload frees its node on the sibling flavor": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:     true,
+				features.TASHandleOverlappingFlavors: true,
+			},
+			topologies: []*kueue.Topology{utiltestingapi.MakeDefaultOneLevelTopology("topology")},
+			rfs: []*kueue.ResourceFlavor{
+				utiltestingapi.MakeResourceFlavor("tas-victim").
+					TopologyName("topology").
+					NodeLabel("zone", "a").
+					Obj(),
+				utiltestingapi.MakeResourceFlavor("tas-sibling").
+					TopologyName("topology").
+					NodeLabel("zone", "a").
+					Obj(),
+			},
+			cqs: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("tas-victim").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+						*utiltestingapi.MakeFlavorQuotas("tas-sibling").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj(),
+			},
+			nodes: []*corev1.Node{
+				node.MakeNode("x1").
+					Label(corev1.LabelHostname, "x1").
+					Label("zone", "a").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			wls: []*kueue.Workload{
+				utiltestingapi.MakeWorkload("victim", "").
+					PodSets(*utiltestingapi.MakePodSet("main", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "1").
+						Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("cq").
+							PodSets(utiltestingapi.MakePodSetAssignment("main").
+								Assignment(corev1.ResourceCPU, "tas-victim", "1").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x1"}, 1).
+										Obj()).
+									Obj()).
+								Obj()).
+							Obj(),
+						fakeClock.Now(),
+					).
+					AdmittedAt(true, fakeClock.Now()).
+					Obj(),
+			},
+			wantTASUsage: map[kueue.ResourceFlavorReference]map[utiltas.TopologyDomainID]resources.Requests{
+				"tas-victim":  {"x1": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000, corev1.ResourcePods: 1})},
+				"tas-sibling": {"x1": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000, corev1.ResourcePods: 1})},
+			},
+			removalSimulationWorkload: "/victim",
+			wantSimulatedTASUsage: map[kueue.ResourceFlavorReference]map[utiltas.TopologyDomainID]resources.Requests{
+				"tas-victim":  {"x1": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 0, corev1.ResourcePods: 0})},
+				"tas-sibling": {"x1": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 0, corev1.ResourcePods: 0})},
+			},
+			wantSimulatedWorkloads: nil,
+		},
+		"overlapping flavors: simulated removal of a Workload's usage keeps it on the ClusterQueue": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:     true,
+				features.TASHandleOverlappingFlavors: true,
+			},
+			topologies: []*kueue.Topology{utiltestingapi.MakeDefaultOneLevelTopology("topology")},
+			rfs: []*kueue.ResourceFlavor{
+				utiltestingapi.MakeResourceFlavor("tas-victim").
+					TopologyName("topology").
+					NodeLabel("zone", "a").
+					Obj(),
+				utiltestingapi.MakeResourceFlavor("tas-sibling").
+					TopologyName("topology").
+					NodeLabel("zone", "a").
+					Obj(),
+			},
+			cqs: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("tas-victim").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+						*utiltestingapi.MakeFlavorQuotas("tas-sibling").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj(),
+			},
+			nodes: []*corev1.Node{
+				node.MakeNode("x1").
+					Label(corev1.LabelHostname, "x1").
+					Label("zone", "a").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			wls: []*kueue.Workload{
+				utiltestingapi.MakeWorkload("victim", "").
+					PodSets(*utiltestingapi.MakePodSet("main", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "1").
+						Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("cq").
+							PodSets(utiltestingapi.MakePodSetAssignment("main").
+								Assignment(corev1.ResourceCPU, "tas-victim", "1").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x1"}, 1).
+										Obj()).
+									Obj()).
+								Obj()).
+							Obj(),
+						fakeClock.Now(),
+					).
+					AdmittedAt(true, fakeClock.Now()).
+					Obj(),
+			},
+			wantTASUsage: map[kueue.ResourceFlavorReference]map[utiltas.TopologyDomainID]resources.Requests{
+				"tas-victim":  {"x1": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000, corev1.ResourcePods: 1})},
+				"tas-sibling": {"x1": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000, corev1.ResourcePods: 1})},
+			},
+			usageRemovalSimulationWorkload: "/victim",
+			wantSimulatedTASUsage: map[kueue.ResourceFlavorReference]map[utiltas.TopologyDomainID]resources.Requests{
+				"tas-victim":  {"x1": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 0, corev1.ResourcePods: 0})},
+				"tas-sibling": {"x1": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 0, corev1.ResourcePods: 0})},
+			},
+			wantSimulatedWorkloads: []workload.Reference{"/victim"},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
+			ctx, log := utiltesting.ContextWithLog(t)
+			cache := New(utiltesting.NewFakeClient())
+			for _, cq := range tc.cqs {
+				if err := cache.AddClusterQueue(ctx, cq); err != nil {
+					t.Fatalf("Failed adding ClusterQueue: %v", err)
+				}
+			}
+			for _, rf := range tc.rfs {
+				cache.AddOrUpdateResourceFlavor(log, rf)
+			}
+			for _, topology := range tc.topologies {
+				cache.AddOrUpdateTopology(log, topology)
+			}
+			for _, wl := range tc.wls {
+				cache.AddOrUpdateWorkload(log, wl)
+			}
+			for _, n := range tc.nodes {
+				cache.TASCache().SyncNode(n)
+			}
+			snapshot, err := cache.Snapshot(ctx)
+			if err != nil {
+				t.Fatalf("unexpected error while building snapshot: %v", err)
+			}
+			cqName := kueue.ClusterQueueReference(tc.cqs[0].Name)
+			cqSnapshot := snapshot.ClusterQueue(cqName)
+			if cqSnapshot == nil {
+				t.Fatalf("ClusterQueue %q is missing from the snapshot", cqName)
+			}
+
+			workloadsAsBuilt := slices.Sorted(maps.Keys(cqSnapshot.Workloads))
+			var revert func()
+			if tc.removalSimulationWorkload != "" {
+				revert = snapshot.SimulateWorkloadRemoval([]*workload.Info{cqSnapshot.Workloads[tc.removalSimulationWorkload]})
+			} else {
+				revert = snapshot.SimulateWorkloadUsageRemoval([]*workload.Info{cqSnapshot.Workloads[tc.usageRemovalSimulationWorkload]})
+			}
+			gotSimulatedTASUsage := make(map[kueue.ResourceFlavorReference]map[utiltas.TopologyDomainID]resources.Requests, len(tc.wantSimulatedTASUsage))
+			for flavor := range tc.wantSimulatedTASUsage {
+				flavorSnapshot := cqSnapshot.TASFlavors[flavor]
+				if flavorSnapshot == nil {
+					t.Fatalf("flavor %q is missing from the ClusterQueue snapshot", flavor)
+				}
+				domainUsage := make(map[utiltas.TopologyDomainID]resources.Requests)
+				for domainID, leaf := range flavorSnapshot.leaves {
+					if leafCapacity := flavorSnapshot.leafCapacityOf(leaf); leafCapacity.tasUsage != nil {
+						domainUsage[domainID] = leafCapacity.tasUsage
+					}
+				}
+				gotSimulatedTASUsage[flavor] = domainUsage
+			}
+			if diff := cmp.Diff(tc.wantSimulatedTASUsage, gotSimulatedTASUsage, cmp.Comparer(resources.Equal)); diff != "" {
+				t.Errorf("unexpected TAS usage while the simulation is in effect (-want,+got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantSimulatedWorkloads, slices.Sorted(maps.Keys(cqSnapshot.Workloads))); diff != "" {
+				t.Errorf("unexpected Workloads while the simulation is in effect (-want,+got):\n%s", diff)
+			}
+			revert()
+			if diff := cmp.Diff(workloadsAsBuilt, slices.Sorted(maps.Keys(cqSnapshot.Workloads))); diff != "" {
+				t.Errorf("unexpected Workloads after the simulation was reverted (-want,+got):\n%s", diff)
+			}
+
+			gotTASUsage := make(map[kueue.ResourceFlavorReference]map[utiltas.TopologyDomainID]resources.Requests, len(tc.wantTASUsage))
+			for flavor := range tc.wantTASUsage {
+				flavorSnapshot := cqSnapshot.TASFlavors[flavor]
+				if flavorSnapshot == nil {
+					t.Fatalf("flavor %q is missing from the ClusterQueue snapshot", flavor)
+				}
+				domainUsage := make(map[utiltas.TopologyDomainID]resources.Requests)
+				for domainID, leaf := range flavorSnapshot.leaves {
+					if leafCapacity := flavorSnapshot.leafCapacityOf(leaf); leafCapacity.tasUsage != nil {
+						domainUsage[domainID] = leafCapacity.tasUsage
+					}
+				}
+				gotTASUsage[flavor] = domainUsage
+			}
+			if diff := cmp.Diff(tc.wantTASUsage, gotTASUsage, cmp.Comparer(resources.Equal)); diff != "" {
+				t.Errorf("unexpected TAS usage in the flavor snapshots (-want,+got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -308,6 +308,20 @@ func (s *TASFlavorSnapshot) addTASUsageForHeldDomains(usages map[utiltas.Topolog
 	}
 }
 
+// updateTASUsageForHeldDomains applies the requests only to the domains this
+// snapshot has a leaf for. An overlapping flavor holds only some of them, so an
+// unheld domain must not reach the skip report in addTASUsage and
+// removeTASUsage, which means the backing node went away.
+func (s *TASFlavorSnapshot) updateTASUsageForHeldDomains(usage workload.TASFlavorUsage, op usageOp) {
+	for _, tr := range usage {
+		domainID := utiltas.DomainID(tr.Values)
+		if !s.hasDomain(domainID) {
+			continue
+		}
+		s.updateTASUsage(domainID, tr.TotalRequests(), op, tr.Count)
+	}
+}
+
 func (s *TASFlavorSnapshot) addTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests) {
 	if s.leaves[domainID] == nil {
 		// this can happen if there is an admitted workload for which the

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -54,6 +54,7 @@ var snapCmpOpts = cmp.Options{
 	// ignore zero values during comparison, as we consider
 	// zero FlavorResource usage to be same as no map entry.
 	cmpopts.IgnoreMapEntries(func(_ resources.FlavorResource, v resources.Amount) bool { return v.CmpInt64(0) == 0 }),
+	cmpopts.IgnoreFields(schdcache.Snapshot{}, "hostnameLeafTASFlavors"),
 	cmp.AllowUnexported(hierarchy.Manager[*schdcache.ClusterQueueSnapshot, *schdcache.CohortSnapshot]{}),
 	cmpopts.IgnoreFields(hierarchy.Manager[*schdcache.ClusterQueueSnapshot, *schdcache.CohortSnapshot]{}, "cohortFactory"),
 	cmpopts.IgnoreFields(schdcache.CohortSnapshot{}, "Cohort"),

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -456,7 +456,7 @@ func (s *Scheduler) processEntry(
 		if len(e.preemptionTargets) == 0 {
 			e.requeueReason = qcache.RequeueReasonPreemptionNoCandidates
 			e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonWaitingForQuota
-			s.reserveCapacityForUnreclaimablePreempt(log, e, cq)
+			s.reserveCapacityForUnreclaimablePreempt(log, e, snapshot, cq)
 			return
 		}
 		if (features.Enabled(features.ConcurrentAdmission) || features.Enabled(features.MultiKueueOrchestratedPreemption)) && workload.HasClosedPreemptionGate(e.Obj) {
@@ -480,7 +480,7 @@ func (s *Scheduler) processEntry(
 		// suboptimal flavor, preventing it from claiming a more preferred flavor that might
 		// become available.
 		e.LastAssignment = nil
-		cq.AddUsage(usage)
+		snapshot.AddUsage(cq, usage)
 		return
 	}
 
@@ -501,7 +501,7 @@ func (s *Scheduler) processEntry(
 		return
 	}
 	preemptedWorkloads.Insert(e.preemptionTargets)
-	cq.AddUsage(usage)
+	snapshot.AddUsage(cq, usage)
 
 	// Filter out the old workload slice from the preemption targets.
 	// The old workload slice is initially included in the preemption targets because it is treated
@@ -553,10 +553,10 @@ func (s *Scheduler) handleFailedTASReplacement(ctx context.Context, log logr.Log
 // nominal capacity, or if the workload is an active preemptor waiting for evictions
 // to complete, we reserve up to the borrowing limit so that lower-priority
 // workloads in another Cohort cannot admit before us.
-func (s *Scheduler) reserveCapacityForUnreclaimablePreempt(log logr.Logger, e *entry, cq *schdcache.ClusterQueueSnapshot) {
+func (s *Scheduler) reserveCapacityForUnreclaimablePreempt(log logr.Logger, e *entry, snapshot *schdcache.Snapshot, cq *schdcache.ClusterQueueSnapshot) {
 	log.V(2).Info("Workload requires preemption, but there are no candidate workloads allowed for preemption", "preemption", cq.Preemption)
 	if !preemption.CanAlwaysReclaim(cq) || (features.Enabled(features.PrioritizePreemptorWorkloads) && e.IsPreemptor) {
-		cq.AddUsage(resourcesToReserve(log, e, cq))
+		snapshot.AddUsage(cq, resourcesToReserve(log, e, cq))
 	}
 }
 

--- a/pkg/scheduler/scheduler_recompute_preemption_test.go
+++ b/pkg/scheduler/scheduler_recompute_preemption_test.go
@@ -29,6 +29,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	testingnode "sigs.k8s.io/kueue/pkg/util/testingjobs/node"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 
@@ -1347,6 +1348,396 @@ func TestScheduleRecomputePreemptionTargets(t *testing.T) {
 			wantSkippedPreemptions: map[string]int{
 				"cq-1": 1,
 				"cq-2": 0,
+			},
+		},
+		"sibling TAS flavor usage is updated for overlapping preemption targets": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                         true,
+				features.TASHandleOverlappingFlavors:                     true,
+				features.TASRecomputeAssignmentWithinSchedulingCycle:     true,
+				features.RecomputeAssignmentUponPreemptionTargetsOverlap: true,
+				features.TASCachingRemainingResources:                    true,
+			},
+			cohorts: []kueue.Cohort{
+				*utiltestingapi.MakeCohort("tas-cohort").Obj(),
+			},
+			additionalClusterQueues: []kueue.ClusterQueue{
+				*utiltestingapi.MakeClusterQueue("preemptor-a").
+					Cohort("tas-cohort").
+					Preemption(kueue.ClusterQueuePreemption{ReclaimWithinCohort: kueue.PreemptionPolicyAny}).
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("flavor-a").
+							Resource(corev1.ResourceCPU, "3").
+							Obj(),
+					).
+					Obj(),
+				*utiltestingapi.MakeClusterQueue("preemptor-b").
+					Cohort("tas-cohort").
+					Preemption(kueue.ClusterQueuePreemption{ReclaimWithinCohort: kueue.PreemptionPolicyAny}).
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("flavor-b").
+							Resource(corev1.ResourceCPU, "3").
+							Obj(),
+					).
+					Obj(),
+				*utiltestingapi.MakeClusterQueue("overlapping").
+					Cohort("tas-cohort").
+					Preemption(kueue.ClusterQueuePreemption{ReclaimWithinCohort: kueue.PreemptionPolicyAny}).
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("flavor-b").
+							Resource(corev1.ResourceCPU, "3").
+							Obj(),
+					).
+					Obj(),
+				*utiltestingapi.MakeClusterQueue("victim-a").
+					Cohort("tas-cohort").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("flavor-a").
+							ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("0").BorrowingLimit("3").Append().
+							Obj(),
+					).
+					Obj(),
+				*utiltestingapi.MakeClusterQueue("victim-b").
+					Cohort("tas-cohort").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("flavor-b").
+							ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("0").BorrowingLimit("5").Append().
+							Obj(),
+					).
+					Obj(),
+			},
+			additionalLocalQueues: []kueue.LocalQueue{
+				*utiltestingapi.MakeLocalQueue("preemptor-a", "default").ClusterQueue("preemptor-a").Obj(),
+				*utiltestingapi.MakeLocalQueue("preemptor-b", "default").ClusterQueue("preemptor-b").Obj(),
+				*utiltestingapi.MakeLocalQueue("overlapping", "default").ClusterQueue("overlapping").Obj(),
+				*utiltestingapi.MakeLocalQueue("victim-a", "default").ClusterQueue("victim-a").Obj(),
+				*utiltestingapi.MakeLocalQueue("victim-b", "default").ClusterQueue("victim-b").Obj(),
+			},
+			additionalResourceFlavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("flavor-a").
+					NodeLabel("flavor-a", "true").
+					TopologyName("tas-single-level").
+					Obj(),
+				*utiltestingapi.MakeResourceFlavor("flavor-b").
+					NodeLabel("flavor-b", "true").
+					TopologyName("tas-single-level").
+					Obj(),
+			},
+			topologies: []kueue.Topology{
+				*utiltestingapi.MakeDefaultOneLevelTopology("tas-single-level"),
+			},
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("x1").
+					Label("flavor-a", "true").
+					Label("flavor-b", "true").
+					Label(corev1.LabelHostname, "x1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("5"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("y1").
+					Label("flavor-b", "true").
+					Label(corev1.LabelHostname, "y1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("5"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("z1").
+					Label("flavor-a", "true").
+					Label(corev1.LabelHostname, "z1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("5"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			// flavor-a selects x1/z1, flavor-b selects x1/y1, and x1 is shared.
+			// The first two pending workloads preempt one victim in each flavor and
+			// reserve z1 and y1. The third initially nominates y1 by targeting victim-b.
+			// Once y1 is reserved, overlap recomputation temporarily removes both
+			// victims and must observe victim-a's x1 removal through flavor-b.
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("victim-a", "default").
+					UID("victim-a-uid").
+					Queue("victim-a").
+					Priority(1).
+					PodSets(*utiltestingapi.MakePodSet("main", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						NodeSelector(map[string]string{corev1.LabelHostname: "x1"}).
+						Request(corev1.ResourceCPU, "3").
+						Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("victim-a").
+							PodSets(utiltestingapi.MakePodSetAssignment("main").
+								Assignment(corev1.ResourceCPU, "flavor-a", "3").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(),
+						now,
+					).
+					AdmittedAt(true, now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("victim-b", "default").
+					UID("victim-b-uid").
+					Queue("victim-b").
+					Priority(1).
+					PodSets(*utiltestingapi.MakePodSet("main", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						NodeSelector(map[string]string{corev1.LabelHostname: "y1"}).
+						// Fills y1, leaving x1 as the only candidate for the overlapping Workload.
+						Request(corev1.ResourceCPU, "5").
+						Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("victim-b").
+							PodSets(utiltestingapi.MakePodSetAssignment("main").
+								Assignment(corev1.ResourceCPU, "flavor-b", "5").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(),
+						now,
+					).
+					AdmittedAt(true, now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("preemptor-a", "default").
+					UID("preemptor-a-uid").
+					JobUID("preemptor-a-job-uid").
+					Queue("preemptor-a").
+					Priority(30).
+					Creation(now).
+					PodSets(*utiltestingapi.MakePodSet("main", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						// Keeps preemptor-a off x1 so nothing but the overlapping Workload
+						// can take the capacity victim-a frees there.
+						NodeSelector(map[string]string{corev1.LabelHostname: "z1"}).
+						Request(corev1.ResourceCPU, "3").
+						Obj()).
+					Obj(),
+				*utiltestingapi.MakeWorkload("preemptor-b", "default").
+					UID("preemptor-b-uid").
+					JobUID("preemptor-b-job-uid").
+					Queue("preemptor-b").
+					Priority(20).
+					Creation(now.Add(time.Second)).
+					PodSets(*utiltestingapi.MakePodSet("main", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						NodeSelector(map[string]string{corev1.LabelHostname: "y1"}).
+						Request(corev1.ResourceCPU, "3").
+						Obj()).
+					Obj(),
+				*utiltestingapi.MakeWorkload("overlapping", "default").
+					UID("overlapping-uid").
+					JobUID("overlapping-job-uid").
+					Queue("overlapping").
+					Priority(10).
+					Creation(now.Add(2 * time.Second)).
+					PodSets(*utiltestingapi.MakePodSet("main", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "3").
+						Obj()).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("overlapping", "default").
+					UID("overlapping-uid").
+					JobUID("overlapping-job-uid").
+					Queue("overlapping").
+					Priority(10).
+					Creation(now.Add(2 * time.Second)).
+					PodSets(*utiltestingapi.MakePodSet("main", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "3").
+						Obj()).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads,
+						Message:            "Workload has overlapping preemption targets with another workload, but will fit after these preemptions complete",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadAdmittedReasonNoReservation,
+						Message:            "The workload has no reservation",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "main",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("3"),
+						},
+					}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("preemptor-a", "default").
+					UID("preemptor-a-uid").
+					JobUID("preemptor-a-job-uid").
+					Queue("preemptor-a").
+					Priority(30).
+					Creation(now).
+					PodSets(*utiltestingapi.MakePodSet("main", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						NodeSelector(map[string]string{corev1.LabelHostname: "z1"}).
+						Request(corev1.ResourceCPU, "3").
+						Obj()).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads,
+						Message:            "couldn't assign flavors to pod set main: insufficient unused quota for cpu in flavor flavor-a, 3 more needed. Pending the preemption of 1 workload(s)",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadAdmittedReasonNoReservation,
+						Message:            "The workload has no reservation",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "main",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("3"),
+						},
+					}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("preemptor-b", "default").
+					UID("preemptor-b-uid").
+					JobUID("preemptor-b-job-uid").
+					Queue("preemptor-b").
+					Priority(20).
+					Creation(now.Add(time.Second)).
+					PodSets(*utiltestingapi.MakePodSet("main", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						NodeSelector(map[string]string{corev1.LabelHostname: "y1"}).
+						Request(corev1.ResourceCPU, "3").
+						Obj()).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads,
+						Message:            "couldn't assign flavors to pod set main: insufficient unused quota for cpu in flavor flavor-b, 2 more needed. Pending the preemption of 1 workload(s)",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadAdmittedReasonNoReservation,
+						Message:            "The workload has no reservation",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "main",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("3"),
+						},
+					}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("victim-a", "default").
+					UID("victim-a-uid").
+					Queue("victim-a").
+					Priority(1).
+					PodSets(*utiltestingapi.MakePodSet("main", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						NodeSelector(map[string]string{corev1.LabelHostname: "x1"}).
+						Request(corev1.ResourceCPU, "3").
+						Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("victim-a").
+							PodSets(utiltestingapi.MakePodSetAssignment("main").
+								Assignment(corev1.ResourceCPU, "flavor-a", "3").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(),
+						now,
+					).
+					AdmittedAt(true, now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadEvicted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Preempted",
+						Message:            "Preempted to accommodate a workload (UID: preemptor-a-uid, JobUID: preemptor-a-job-uid) due to reclamation within the cohort; preemptor path: /tas-cohort/preemptor-a; preemptee path: /tas-cohort/victim-a",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadPreempted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "InCohortReclamation",
+						Message:            "Preempted to accommodate a workload (UID: preemptor-a-uid, JobUID: preemptor-a-job-uid) due to reclamation within the cohort; preemptor path: /tas-cohort/preemptor-a; preemptee path: /tas-cohort/victim-a",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Preempted", Count: 1}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("victim-b", "default").
+					UID("victim-b-uid").
+					Queue("victim-b").
+					Priority(1).
+					PodSets(*utiltestingapi.MakePodSet("main", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						NodeSelector(map[string]string{corev1.LabelHostname: "y1"}).
+						Request(corev1.ResourceCPU, "5").
+						Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("victim-b").
+							PodSets(utiltestingapi.MakePodSetAssignment("main").
+								Assignment(corev1.ResourceCPU, "flavor-b", "5").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(),
+						now,
+					).
+					AdmittedAt(true, now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadEvicted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Preempted",
+						Message:            "Preempted to accommodate a workload (UID: preemptor-b-uid, JobUID: preemptor-b-job-uid) due to reclamation within the cohort; preemptor path: /tas-cohort/preemptor-b; preemptee path: /tas-cohort/victim-b",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadPreempted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "InCohortReclamation",
+						Message:            "Preempted to accommodate a workload (UID: preemptor-b-uid, JobUID: preemptor-b-job-uid) due to reclamation within the cohort; preemptor path: /tas-cohort/preemptor-b; preemptee path: /tas-cohort/victim-b",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Preempted", Count: 1}).
+					Obj(),
+			},
+			wantAssignments: map[workload.Reference]kueue.Admission{
+				"default/victim-a": *utiltestingapi.MakeAdmission("victim-a").
+					PodSets(utiltestingapi.MakePodSetAssignment("main").
+						Assignment(corev1.ResourceCPU, "flavor-a", "3").
+						TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+							Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
+						Obj()).
+					Obj(),
+				"default/victim-b": *utiltestingapi.MakeAdmission("victim-b").
+					PodSets(utiltestingapi.MakePodSetAssignment("main").
+						Assignment(corev1.ResourceCPU, "flavor-b", "5").
+						TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+							Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+							Obj()).
+						Obj()).
+					Obj(),
+			},
+			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+				"overlapping": {"default/overlapping"},
+				"preemptor-a": {"default/preemptor-a"},
+				"preemptor-b": {"default/preemptor-b"},
 			},
 		},
 	}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -82,6 +82,10 @@ type scheduleTestCase struct {
 	objects        []client.Object
 	admissionError error
 
+	additionalResourceFlavors []kueue.ResourceFlavor
+	topologies                []kueue.Topology
+	nodes                     []corev1.Node
+
 	// additional*Queues can hold any extra queues needed by the tc
 	additionalClusterQueues []kueue.ClusterQueue
 	additionalLocalQueues   []kueue.LocalQueue
@@ -217,6 +221,15 @@ func runScheduleTestCases(t *testing.T, cfg scheduleTestConfig, cases map[string
 					}
 					for i := range cfg.resourceFlavors {
 						cqCache.AddOrUpdateResourceFlavor(log, cfg.resourceFlavors[i])
+					}
+					for i := range tc.additionalResourceFlavors {
+						cqCache.AddOrUpdateResourceFlavor(log, &tc.additionalResourceFlavors[i])
+					}
+					for i := range tc.topologies {
+						cqCache.AddOrUpdateTopology(log, &tc.topologies[i])
+					}
+					for i := range tc.nodes {
+						cqCache.TASCache().SyncNode(&tc.nodes[i])
 					}
 					for _, cq := range allClusterQueues {
 						if err := cqCache.AddClusterQueue(ctx, &cq); err != nil {


### PR DESCRIPTION
Cherry pick of #14366 on release-0.19.

#14366: Fix a bug for TASHandleOverlappingFlavors + RecomputeAssignmentUponPreemptionTargetsOverlap

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
TAS: Fix a bug where RecomputeAssignmentUponPreemptionTargetsOverlap doesn't work correctly when TASHandleOverlappingFlavors is enabled.
```