### PR TITLE
Automated cherry pick of #15116: Parallelize per-platform builds in multiplatform-build.sh

### DIFF
--- a/hack/multiplatform-build.sh
+++ b/hack/multiplatform-build.sh
@@ -28,26 +28,44 @@ PLATFORMS=${PLATFORMS:-linux/amd64}
 CURRENT_DIR=$(dirname "${BASH_SOURCE[0]}")
 ROOT_PATH=$(realpath "${CURRENT_DIR}/..")
 BUILD_PATH=${BUILD_PATH:-${ROOT_PATH}/artifacts}
+MAIN_PACKAGE=$1
 
 mkdir -p "${BUILD_PATH}"
 
-IFS=","
-for PLATFORM in ${PLATFORMS} ; do
-  export GOOS="${PLATFORM%/*}"
-  export GOARCH="${PLATFORM#*/}"
-  EXTENSION=""
+# Builds a single platform in its own subshell so that build_platform
+# invocations can run concurrently in the background; each uses a
+# platform-scoped tmp dir so parallel runs don't race on the same files.
+build_platform() {
+  local PLATFORM=$1
+  local GOOS="${PLATFORM%/*}"
+  local GOARCH="${PLATFORM#*/}"
+  local EXTENSION=""
 
   if [ "${GOOS}" == "windows" ]; then
     EXTENSION=".exe"
   fi
 
-  echo "Building for $PLATFORM platform"
-  FULL_NAME=${BUILD_NAME}-${GOOS}-${GOARCH}
-  "${GO_CMD}" build -ldflags="${LD_FLAGS}" -o "${BUILD_PATH}/${FULL_NAME}${EXTENSION}" "$1"
+  echo "Building for ${PLATFORM} platform"
+  local FULL_NAME=${BUILD_NAME}-${GOOS}-${GOARCH}
+  local TMP_PATH="${BUILD_PATH}/tmp-${GOOS}-${GOARCH}"
+  GOOS="${GOOS}" GOARCH="${GOARCH}" "${GO_CMD}" build -ldflags="${LD_FLAGS}" -o "${BUILD_PATH}/${FULL_NAME}${EXTENSION}" "${MAIN_PACKAGE}"
 
-  mkdir -p "${BUILD_PATH}/tmp"
-  cp "${ROOT_PATH}/LICENSE" "${BUILD_PATH}/tmp"
-  cp "${BUILD_PATH}/${FULL_NAME}${EXTENSION}" "${BUILD_PATH}/tmp/${BUILD_NAME}${EXTENSION}"
-  (cd "${BUILD_PATH}/tmp" && tar -czf "${BUILD_PATH}/${FULL_NAME}.tar.gz" ./*)
-  rm -R "${BUILD_PATH}/tmp"
+  mkdir -p "${TMP_PATH}"
+  cp "${ROOT_PATH}/LICENSE" "${TMP_PATH}"
+  cp "${BUILD_PATH}/${FULL_NAME}${EXTENSION}" "${TMP_PATH}/${BUILD_NAME}${EXTENSION}"
+  (cd "${TMP_PATH}" && tar -czf "${BUILD_PATH}/${FULL_NAME}.tar.gz" ./*)
+  rm -R "${TMP_PATH}"
+}
+
+IFS=","
+PIDS=()
+for PLATFORM in ${PLATFORMS} ; do
+  build_platform "${PLATFORM}" &
+  PIDS+=("$!")
 done
+
+STATUS=0
+for PID in "${PIDS[@]}"; do
+  wait "${PID}" || STATUS=1
+done
+exit "${STATUS}"


### PR DESCRIPTION
Cherry pick of #15116 on release-0.19.

#15116: Parallelize per-platform builds in multiplatform-build.sh

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```