### PR TITLE
Release Automation: restrict ChatOps commands after release is published

### DIFF
--- a/.github/workflows/release-utils.yml
+++ b/.github/workflows/release-utils.yml
@@ -161,12 +161,27 @@ jobs:
             echo "${EOF_DELIM}"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Check if Release is Already Published
+        id: check_published
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.parse.outputs.version }}
+          TARGET_REPO: ${{ github.repository }}
+        run: |
+          RELEASE_STATE=$(gh release view "$VERSION" --repo "$TARGET_REPO" --json isDraft \
+            --jq 'if .isDraft then "draft" else "published" end' 2>/dev/null || echo "")
+
+          if [ "$RELEASE_STATE" = "published" ]; then
+            echo "error_message=❌ Release \`$VERSION\` has already been published. No further commands are allowed." >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
       - name: Report Parse Failure
         if: ${{ failure() }}
         uses: ./.github/actions/report-result
         with:
           alias: "Authorization"
-          message: ${{ steps.parse.outputs.error_message || steps.auth.outputs.error_message }}
+          message: ${{ steps.parse.outputs.error_message || steps.auth.outputs.error_message || steps.check_published.outputs.error_message }}
 
       - name: Clear Authorization Log
         if: ${{ success() }}
@@ -174,7 +189,7 @@ jobs:
         with:
           alias: "Authorization"
           cleanup: true
-      
+
       - name: Log command start
         if: ${{ success() }}
         uses: ./.github/actions/report-result
@@ -273,22 +288,6 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
-
-      - name: Check if Release is Already Published
-        id: check_published
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TARGET_REPO: ${{ github.repository }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-        run: |
-          RELEASE_STATE=$(gh release view "$VERSION" --repo "$TARGET_REPO" --json isDraft \
-            --jq 'if .isDraft then "draft" else "published" end' 2>/dev/null || echo "")
-
-          if [ "$RELEASE_STATE" = "published" ]; then
-            BODY="❌ Release \`$VERSION\` has already been published. Skipping release candidate creation."
-            echo "message=$BODY" >> "$GITHUB_OUTPUT"
-            exit 1
-          fi
 
       - name: Calculate Release Candidate Version
         id: rc-version


### PR DESCRIPTION
<!-- Thank you for contributing! Check CONTRIBUTING.md for details. -->

#### What type of PR is this?
<!-- Choose one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep
-->
/kind cleanup

<!-- Optionally choose one or more of the following kinds:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


<!-- Consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->


#### What this PR does / why we need it?
Release Automation: restrict ChatOps commands after release is published

<!--
Use `Fixes #123` for an issue addressed by this PR; it will be closed when the PR merges.
Use `Related:` or `Part of:` to reference an issue without closing it.
-->
Fixes #13628

#### Useful notes for your reviewer


#### Release note

<!-- Describe the behavior change accurately from the user's perspective. Hints:
- Do not leave this block blank.
- Use "NONE" when there is no user-facing change.
- When feasible use a prefix for the sub-component or feature, e.g. "FairSharing:" or "MultiKueue:".
- If upgrade steps are required, include an "ACTION REQUIRED:" section.
You may consider AI assistance using the skill: cmd/experimental/skills/kueue-release-notes/SKILL.md.
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## AI summary

Release Automation ChatOps commands are now blocked after the release is published. Draft and nonexistent releases remain allowed. Authorization errors include the publication check failure.

### Suggested release note

`Release Automation: Fixed a bug that allowed ChatOps commands after a release was published. Now Release Automation rejects commands for published releases.`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->