### PR TITLE
DRA: Fix E2E execution problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Read the [overview](https://kueue.sigs.k8s.io/docs/overview/) and watch the Kueu
         - ✔️ [shard-0](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-sequential-extended-shard-0-main)
         - ✔️ [shard-1](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-sequential-extended-shard-1-main)
     - ✔️ E2E Cert Manager test [testgrid](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-certmanager-main).
-    - ✔️ DRA test [testgrid](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-dra-main).
+    - ✔️ DRA test [testgrid](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-dra-baseline-main).
     - ✔️ MultiKueue:
       - ✔️ Baseline suite [testgrid](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-multikueue-baseline-main).
       - ✔️ Extended suites:

--- a/cmd/experimental/skills/kueue-e2e-cluster-singlecluster/SKILL.md
+++ b/cmd/experimental/skills/kueue-e2e-cluster-singlecluster/SKILL.md
@@ -12,7 +12,7 @@ You are an expert in Kueue's e2e testing infrastructure (`hack/testing/e2e-test.
 
 Stand up a single kind cluster with Kueue (and any required job-framework operators) deployed, ready for e2e tests or manual poking, and leave it running for fast iteration.
 
-This skill is for **single-cluster** suites: `test-e2e-baseline`, `test-e2e-extended`, `test-e2e-sequential-baseline`, `test-e2e-sequential-extended`, `test-tas-e2e-baseline`, `test-tas-e2e-extended`, `test-e2e-certmanager`, `test-e2e-dra`, `test-e2e-dra-counter`. If the user wants MultiKueue (manager + worker clusters), use the `kueue-e2e-cluster-multikueue` skill instead.
+This skill is for **single-cluster** suites: `test-e2e-baseline`, `test-e2e-extended`, `test-e2e-sequential-baseline`, `test-e2e-sequential-extended`, `test-tas-e2e-baseline`, `test-tas-e2e-extended`, `test-e2e-certmanager`, `test-e2e-dra-baseline`, `test-e2e-dra-counter`, `test-e2e-dra-capacity`. If the user wants MultiKueue (manager + worker clusters), use the `kueue-e2e-cluster-multikueue` skill instead.
 
 ## Step 1 - Confirm platform and build the Kueue image
 
@@ -32,16 +32,16 @@ Skip this step only if the user explicitly wants to use a released/staging image
 
 Map the user's request to a Makefile target:
 
-| Suite | Target |
-|---|---|
-| Baseline (default) | `test-e2e-baseline` |
-| Extended (job-framework integrations) | `test-e2e-extended` |
-| Sequential baseline | `test-e2e-sequential-baseline` |
-| Sequential extended | `test-e2e-sequential-extended` |
-| Topology-Aware Scheduling baseline | `test-tas-e2e-baseline` |
-| Topology-Aware Scheduling extended | `test-tas-e2e-extended` |
-| cert-manager | `test-e2e-certmanager` |
-| Dynamic Resource Allocation | `test-e2e-dra` / `test-e2e-dra-counter` |
+| Suite | Target                                                                     |
+|---|----------------------------------------------------------------------------|
+| Baseline (default) | `test-e2e-baseline`                                                        |
+| Extended (job-framework integrations) | `test-e2e-extended`                                                        |
+| Sequential baseline | `test-e2e-sequential-baseline`                                             |
+| Sequential extended | `test-e2e-sequential-extended`                                             |
+| Topology-Aware Scheduling baseline | `test-tas-e2e-baseline`                                                    |
+| Topology-Aware Scheduling extended | `test-tas-e2e-extended`                                                    |
+| cert-manager | `test-e2e-certmanager`                                                     |
+| Dynamic Resource Allocation | `test-e2e-dra-baseline` / `test-e2e-dra-counter` / `test-e2e-dra-capacity` |
 
 Default to `test-e2e-baseline` if the user has no preference — it is the fastest to bring up and covers the core scheduling flows.
 

--- a/hack/make/test.mk
+++ b/hack/make/test.mk
@@ -395,7 +395,7 @@ test-e2e-sequential-extended-helm: E2E_USE_HELM=true
 test-e2e-sequential-extended-helm: test-e2e-sequential-extended
 
 .PHONY: test-e2e-dra
-test-e2e-dra: setup-e2e-env run-test-e2e-dra-$(E2E_KIND_VERSION:kindest/node:v%=%) ## Run the Dynamic Resource Allocation (DRA) e2e test suite.
+test-e2e-dra: setup-e2e-env run-test-e2e-dra-baseline-$(E2E_KIND_VERSION:kindest/node:v%=%) ## Run the Dynamic Resource Allocation (DRA) e2e test suite.
 
 .PHONY: test-e2e-multikueue-dra
 test-e2e-multikueue-dra: setup-e2e-env run-test-e2e-multikueue-dra-$(E2E_KIND_VERSION:kindest/node:v%=%) ## Run the MultiKueue Dynamic Resource Allocation (DRA) e2e test suite.
@@ -530,8 +530,8 @@ run-test-e2e-certmanager-%:
 		E2E_USE_HELM=$(E2E_USE_HELM) \
 		./hack/testing/e2e-test.sh
 
-run-test-e2e-dra-%: K8S_VERSION = $(@:run-test-e2e-dra-%=%)
-run-test-e2e-dra-%:
+run-test-e2e-dra-baseline-%: K8S_VERSION = $(@:run-test-e2e-dra-baseline-%=%)
+run-test-e2e-dra-baseline-%:
 	@echo Running DRA e2e for k8s ${K8S_VERSION}
 	E2E_KIND_VERSION="kindest/node:v$(K8S_VERSION)" KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) \
 		ARTIFACTS="$(ARTIFACTS)/$@" IMAGE_TAG=$(IMAGE_TAG) GINKGO_ARGS="$(E2E_GINKGO_ARGS)" \

--- a/hack/make/test.mk
+++ b/hack/make/test.mk
@@ -394,8 +394,8 @@ test-e2e-sequential-extended-shard-1: setup-e2e-env run-test-e2e-sequential-exte
 test-e2e-sequential-extended-helm: E2E_USE_HELM=true
 test-e2e-sequential-extended-helm: test-e2e-sequential-extended
 
-.PHONY: test-e2e-dra
-test-e2e-dra: setup-e2e-env run-test-e2e-dra-baseline-$(E2E_KIND_VERSION:kindest/node:v%=%) ## Run the Dynamic Resource Allocation (DRA) e2e test suite.
+.PHONY: test-e2e-dra-baseline
+test-e2e-dra-baseline: setup-e2e-env run-test-e2e-dra-baseline-$(E2E_KIND_VERSION:kindest/node:v%=%) ## Run the Dynamic Resource Allocation (DRA) e2e test suite.
 
 .PHONY: test-e2e-multikueue-dra
 test-e2e-multikueue-dra: setup-e2e-env run-test-e2e-multikueue-dra-$(E2E_KIND_VERSION:kindest/node:v%=%) ## Run the MultiKueue Dynamic Resource Allocation (DRA) e2e test suite.

--- a/test/e2e/dra/capacity/dra_test.go
+++ b/test/e2e/dra/capacity/dra_test.go
@@ -297,7 +297,7 @@ var _ = ginkgo.Describe("DRA Consumable Capacity", func() {
 				g.Expect(createdWorkload.Status.Conditions).To(gomega.ContainElement(gomega.And(
 					gomega.HaveField("Type", kueue.WorkloadQuotaReserved),
 					gomega.HaveField("Status", metav1.ConditionFalse),
-					gomega.HaveField("Reason", kueue.WorkloadInadmissible),
+					gomega.HaveField("Reason", kueue.WorkloadQuotaReservedReasonMisconfigured),
 				)))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})


### PR DESCRIPTION
<!-- Thank you for contributing! Check CONTRIBUTING.md for details. -->

#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it?

We had a couple of DRA E2E problems in the following: 

1. The dra-e2e-counter and dra-e2e-capacity were not executed due to https://github.com/kubernetes-sigs/kueue/pull/15429#discussion_r3982216339 even if we specify those via make command
2. dra-e2e-capacigy doesn't have the correct QuotaReserved assertion and is not dected in our CI due to (1 problem


For (2 problem, I observed the following error in the following:

```shell
451  [FAILED] Timed out after 10.001s.
453  Expected
454      <[]v1.Condition | len:4, cap:4>: [
455          {
456              Type: "QuotaReserved",
457              Status: "False",
462              Reason: "Misconfigured",
464          },
475          {
476              Type: "Requeued",
477              Status: "False",
482              Reason: "Inadmissible",
484          },
495      ]
496  to contain element matching
500                  Field: "Type",
501                  Expected: <string>"QuotaReserved",
504                  Field: "Status",
505                  Expected: <v1.ConditionStatus>"False",
508                  Field: "Reason",
509                  Expected: <string>"Inadmissible",
```

<!--
Use `Fixes #123` for an issue addressed by this PR; it will be closed when the PR merges.
Use `Related:` or `Part of:` to reference an issue without closing it.
-->
Fixes #

#### Useful notes for your reviewer


#### Release note

<!-- Describe the behavior change accurately from the user's perspective. Hints:
- Do not leave this block blank.
- Use "NONE" when there is no user-facing change.
- When feasible use a prefix for the sub-component or feature, e.g. "FairSharing:" or "MultiKueue:".
- If upgrade steps are required, include an "ACTION REQUIRED:" section.
You may consider AI assistance using the skill: cmd/experimental/skills/kueue-release-notes/SKILL.md.
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## AI summary

Updates the DRA E2E test to expect `WorkloadQuotaReservedReasonMisconfigured` for an unmatchable CEL device selector. Renames the DRA baseline E2E Make target and updates related documentation and test references.

### Suggested release note

NONE
<!-- end of auto-generated comment: release notes by coderabbit.ai -->