### PR TITLE
Improve naming and comments for the FlavorScanState

### DIFF
--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -570,7 +570,7 @@ func (c *ClusterQueue) requeueIfNotPresent(log logr.Logger, wInfo *workload.Info
 	inadmissibleWl := c.workloads.GetInadmissible(key)
 
 	if c.backoffWaitingTimeExpired(wInfo) &&
-		(immediate || c.queueInadmissibleCycle >= c.popCycle || wInfo.LastAssignment.PendingFlavors()) {
+		(immediate || c.queueInadmissibleCycle >= c.popCycle || wInfo.FlavorScanState.PendingFlavors()) {
 		// If the workload was inadmissible, move it back into the queue.
 		if inadmissibleWl != nil {
 			return c.workloads.MoveToActive(key, inadmissibleWl)

--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -1390,7 +1390,7 @@ func TestBackoffWaitingTimeExpired(t *testing.T) {
 func TestBestEffortFIFORequeueIfNotPresent(t *testing.T) {
 	tests := map[string]struct {
 		reason           RequeueReason
-		lastAssignment   *workload.FlavorScanState
+		flavorScanState  *workload.FlavorScanState
 		wantInadmissible bool
 		wantSticky       bool
 	}{
@@ -1413,7 +1413,7 @@ func TestBestEffortFIFORequeueIfNotPresent(t *testing.T) {
 		},
 		"didn't fit and no pending flavors": {
 			reason: RequeueReasonGeneric,
-			lastAssignment: &workload.FlavorScanState{
+			flavorScanState: &workload.FlavorScanState{
 				LastTriedFlavorIndexes: []map[corev1.ResourceName]int{
 					{
 						corev1.ResourceMemory: -1,
@@ -1428,7 +1428,7 @@ func TestBestEffortFIFORequeueIfNotPresent(t *testing.T) {
 		},
 		"didn't fit but pending flavors": {
 			reason: RequeueReasonGeneric,
-			lastAssignment: &workload.FlavorScanState{
+			flavorScanState: &workload.FlavorScanState{
 				LastTriedFlavorIndexes: []map[corev1.ResourceName]int{
 					{
 						corev1.ResourceCPU:    -1,
@@ -1464,7 +1464,7 @@ func TestBestEffortFIFORequeueIfNotPresent(t *testing.T) {
 				nil, nil)
 			wl := utiltestingapi.MakeWorkload("workload-1", defaultNamespace).Obj()
 			info := workload.NewInfo(log, wl)
-			info.FlavorScanState = tc.lastAssignment
+			info.FlavorScanState = tc.flavorScanState
 			if ok := cq.RequeueIfNotPresent(ctx, info, tc.reason, ""); !ok {
 				t.Error("failed to requeue nonexistent workload")
 			}

--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -1390,7 +1390,7 @@ func TestBackoffWaitingTimeExpired(t *testing.T) {
 func TestBestEffortFIFORequeueIfNotPresent(t *testing.T) {
 	tests := map[string]struct {
 		reason           RequeueReason
-		lastAssignment   *workload.AssignmentClusterQueueState
+		lastAssignment   *workload.FlavorScanState
 		wantInadmissible bool
 		wantSticky       bool
 	}{
@@ -1413,8 +1413,8 @@ func TestBestEffortFIFORequeueIfNotPresent(t *testing.T) {
 		},
 		"didn't fit and no pending flavors": {
 			reason: RequeueReasonGeneric,
-			lastAssignment: &workload.AssignmentClusterQueueState{
-				LastTriedFlavorIdx: []map[corev1.ResourceName]int{
+			lastAssignment: &workload.FlavorScanState{
+				LastTriedFlavorIndexes: []map[corev1.ResourceName]int{
 					{
 						corev1.ResourceMemory: -1,
 					},
@@ -1428,8 +1428,8 @@ func TestBestEffortFIFORequeueIfNotPresent(t *testing.T) {
 		},
 		"didn't fit but pending flavors": {
 			reason: RequeueReasonGeneric,
-			lastAssignment: &workload.AssignmentClusterQueueState{
-				LastTriedFlavorIdx: []map[corev1.ResourceName]int{
+			lastAssignment: &workload.FlavorScanState{
+				LastTriedFlavorIndexes: []map[corev1.ResourceName]int{
 					{
 						corev1.ResourceCPU:    -1,
 						corev1.ResourceMemory: 0,
@@ -1464,7 +1464,7 @@ func TestBestEffortFIFORequeueIfNotPresent(t *testing.T) {
 				nil, nil)
 			wl := utiltestingapi.MakeWorkload("workload-1", defaultNamespace).Obj()
 			info := workload.NewInfo(log, wl)
-			info.LastAssignment = tc.lastAssignment
+			info.FlavorScanState = tc.lastAssignment
 			if ok := cq.RequeueIfNotPresent(ctx, info, tc.reason, ""); !ok {
 				t.Error("failed to requeue nonexistent workload")
 			}

--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -724,7 +724,7 @@ func (m *Manager) AddOrUpdateWorkloadWithoutLock(log logr.Logger, w *kueue.Workl
 	// carry it over. Any update to the Workload lands here, and on a busy cluster those
 	// arrive constantly, which would otherwise send the scan back to the first flavor every
 	// time. The progress still expires on its own, since it keeps the scheduling cycle it
-	// was recorded in and lastAssignmentOutdated discards it once it is older than that.
+	// was recorded in and flavorScanStateOutdated discards it once it is older than that.
 	if features.Enabled(features.FlavorFungibilityPreserveScanProgress) && cq != nil {
 		if tracked := cq.trackedInfo(wlKey); tracked != nil && tracked.FlavorScanState != nil &&
 			tracked.FlavorScanState.MatchesSchedulingShape(wInfo.SchedulingHash) {

--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -726,9 +726,9 @@ func (m *Manager) AddOrUpdateWorkloadWithoutLock(log logr.Logger, w *kueue.Workl
 	// time. The progress still expires on its own, since it keeps the scheduling cycle it
 	// was recorded in and lastAssignmentOutdated discards it once it is older than that.
 	if features.Enabled(features.FlavorFungibilityPreserveScanProgress) && cq != nil {
-		if tracked := cq.trackedInfo(wlKey); tracked != nil && tracked.LastAssignment != nil &&
-			tracked.LastAssignment.MatchesSchedulingShape(wInfo.SchedulingHash) {
-			wInfo.LastAssignment = tracked.LastAssignment.Clone()
+		if tracked := cq.trackedInfo(wlKey); tracked != nil && tracked.FlavorScanState != nil &&
+			tracked.FlavorScanState.MatchesSchedulingShape(wInfo.SchedulingHash) {
+			wInfo.FlavorScanState = tracked.FlavorScanState.Clone()
 		}
 	}
 	m.addWorkload(wInfo, q)

--- a/pkg/cache/queue/manager_test.go
+++ b/pkg/cache/queue/manager_test.go
@@ -2635,15 +2635,15 @@ func TestDeleteLocalQueue_UnadmittedWorkloads(t *testing.T) {
 	}
 }
 
-// TestAddOrUpdateWorkloadCarriesLastAssignment covers the flavor scan progress surviving a
+// TestAddOrUpdateWorkloadCarriesFlavorScanState covers the flavor scan progress surviving a
 // Workload update. Updating a Workload rebuilds its Info, and rebuilding it used to drop
-// LastAssignment, so a cluster where Workloads are updated frequently sent the scan back to
+// FlavorScanState, so a cluster where Workloads are updated frequently sent the scan back to
 // the first flavor no matter what an earlier cycle had recorded.
 //
 // Both places a pending Workload can be tracked are covered. A Workload with flavors still
 // to try is pushed back onto the heap, while one whose scan has been exhausted is held in
 // inadmissibleWorkloads, which ClusterQueue.Info deliberately does not consult.
-func TestAddOrUpdateWorkloadCarriesLastAssignment(t *testing.T) {
+func TestAddOrUpdateWorkloadCarriesFlavorScanState(t *testing.T) {
 	// pendingFlavors has a flavor left to try, so requeueing puts the Workload back on the
 	// heap. exhaustedScan has none, so requeueing holds it as inadmissible.
 	pendingFlavors := func() *workload.FlavorScanState {
@@ -2787,10 +2787,10 @@ func TestAddOrUpdateWorkloadCarriesLastAssignment(t *testing.T) {
 				want = tc.recorded
 			}
 			if diff := gocmp.Diff(want, got.FlavorScanState); diff != "" {
-				t.Errorf("LastAssignment after the update (-want,+got):\n%s", diff)
+				t.Errorf("FlavorScanState after the update (-want,+got):\n%s", diff)
 			}
 			if tc.wantCarried && got.FlavorScanState == tc.recorded {
-				t.Error("LastAssignment was carried by reference; it must be cloned so the two Infos do not alias")
+				t.Error("FlavorScanState was carried by reference; it must be cloned so the two Infos do not alias")
 			}
 		})
 	}

--- a/pkg/cache/queue/manager_test.go
+++ b/pkg/cache/queue/manager_test.go
@@ -2646,18 +2646,18 @@ func TestDeleteLocalQueue_UnadmittedWorkloads(t *testing.T) {
 func TestAddOrUpdateWorkloadCarriesLastAssignment(t *testing.T) {
 	// pendingFlavors has a flavor left to try, so requeueing puts the Workload back on the
 	// heap. exhaustedScan has none, so requeueing holds it as inadmissible.
-	pendingFlavors := func() *workload.AssignmentClusterQueueState {
-		return &workload.AssignmentClusterQueueState{
-			LastTriedFlavorIdx:     []map[corev1.ResourceName]int{{corev1.ResourceCPU: 1}},
-			ClusterQueueGeneration: 3,
-			SchedulingCycle:        7,
+	pendingFlavors := func() *workload.FlavorScanState {
+		return &workload.FlavorScanState{
+			LastTriedFlavorIndexes:        []map[corev1.ResourceName]int{{corev1.ResourceCPU: 1}},
+			AllocatableResourceGeneration: 3,
+			SchedulingCycle:               7,
 		}
 	}
-	exhaustedScan := func() *workload.AssignmentClusterQueueState {
-		return &workload.AssignmentClusterQueueState{
-			LastTriedFlavorIdx:     []map[corev1.ResourceName]int{{corev1.ResourceCPU: -1}},
-			ClusterQueueGeneration: 3,
-			SchedulingCycle:        7,
+	exhaustedScan := func() *workload.FlavorScanState {
+		return &workload.FlavorScanState{
+			LastTriedFlavorIndexes:        []map[corev1.ResourceName]int{{corev1.ResourceCPU: -1}},
+			AllocatableResourceGeneration: 3,
+			SchedulingCycle:               7,
 		}
 	}
 
@@ -2672,7 +2672,7 @@ func TestAddOrUpdateWorkloadCarriesLastAssignment(t *testing.T) {
 		// changeShape alters the Workload's requests in the update, so its scheduling
 		// equivalence hash no longer matches the one the assignment was recorded for.
 		changeShape bool
-		recorded    *workload.AssignmentClusterQueueState
+		recorded    *workload.FlavorScanState
 		wantCarried bool
 	}{
 		"tracked in the heap": {
@@ -2747,7 +2747,7 @@ func TestAddOrUpdateWorkloadCarriesLastAssignment(t *testing.T) {
 				t.Fatal("Workload is not tracked by the ClusterQueue after being added")
 			}
 			tc.recorded.SchedulingHash = tracked.SchedulingHash
-			tracked.LastAssignment = tc.recorded
+			tracked.FlavorScanState = tc.recorded
 			if tc.inadmissible || tc.inflight {
 				if popped := cqImpl.Pop(); popped == nil {
 					t.Fatal("Popping the Workload returned nothing")
@@ -2782,14 +2782,14 @@ func TestAddOrUpdateWorkloadCarriesLastAssignment(t *testing.T) {
 			if got == nil {
 				t.Fatal("Workload is not tracked after the update")
 			}
-			var want *workload.AssignmentClusterQueueState
+			var want *workload.FlavorScanState
 			if tc.wantCarried {
 				want = tc.recorded
 			}
-			if diff := gocmp.Diff(want, got.LastAssignment); diff != "" {
+			if diff := gocmp.Diff(want, got.FlavorScanState); diff != "" {
 				t.Errorf("LastAssignment after the update (-want,+got):\n%s", diff)
 			}
-			if tc.wantCarried && got.LastAssignment == tc.recorded {
+			if tc.wantCarried && got.FlavorScanState == tc.recorded {
 				t.Error("LastAssignment was carried by reference; it must be cloned so the two Infos do not alias")
 			}
 		})

--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -1066,7 +1066,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.wantClusterQueues, cache.hm.ClusterQueues(),
 				cmpopts.IgnoreFields(clusterQueue{}, "ResourceGroups"),
-				cmpopts.IgnoreFields(workload.Info{}, "Obj", "LastAssignment", "SchedulingHash"),
+				cmpopts.IgnoreFields(workload.Info{}, "Obj", "FlavorScanState", "SchedulingHash"),
 				cmpopts.IgnoreUnexported(clusterQueue{}, hierarchy.ClusterQueue[*cohort]{}),
 				cmp.Comparer(resources.Equal),
 				cmpopts.EquateEmpty()); diff != "" {

--- a/pkg/cache/scheduler/clusterqueue_test.go
+++ b/pkg/cache/scheduler/clusterqueue_test.go
@@ -128,22 +128,22 @@ func TestClusterQueueUpdate(t *testing.T) {
 					Resource(corev1.ResourceCPU, "100", "0").Obj(),
 			).Obj()
 	cases := []struct {
-		name                         string
-		cq                           *kueue.ClusterQueue
-		newcq                        *kueue.ClusterQueue
-		wantLastAssignmentGeneration int64
+		name                              string
+		cq                                *kueue.ClusterQueue
+		newcq                             *kueue.ClusterQueue
+		wantAllocatableResourceGeneration int64
 	}{
 		{
-			name:                         "RGs not change",
-			cq:                           &clusterQueue,
-			newcq:                        clusterQueue.DeepCopy(),
-			wantLastAssignmentGeneration: 1,
+			name:                              "RGs not change",
+			cq:                                &clusterQueue,
+			newcq:                             clusterQueue.DeepCopy(),
+			wantAllocatableResourceGeneration: 1,
 		},
 		{
-			name:                         "RGs changed",
-			cq:                           &clusterQueue,
-			newcq:                        &newClusterQueue,
-			wantLastAssignmentGeneration: 2,
+			name:                              "RGs changed",
+			cq:                                &clusterQueue,
+			newcq:                             &newClusterQueue,
+			wantAllocatableResourceGeneration: 2,
 		},
 	}
 	for _, tc := range cases {
@@ -171,7 +171,7 @@ func TestClusterQueueUpdate(t *testing.T) {
 				t.Fatalf("unexpected error while building snapshot: %v", err)
 			}
 			if diff := cmp.Diff(
-				tc.wantLastAssignmentGeneration,
+				tc.wantAllocatableResourceGeneration,
 				snapshot.ClusterQueue("eng-alpha").AllocatableResourceGeneration); diff != "" {
 				t.Errorf("Unexpected assigned clusterQueues in cache (-want,+got):\n%s", diff)
 			}

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -54,7 +54,10 @@ type Assignment struct {
 	// Borrowing is the height of the smallest cohort tree that fits
 	// the additional Usage. It equals to 0 if no borrowing is required.
 	Borrowing int
-	LastState workload.FlavorScanState
+
+	// FlavorScanState records flavor scan progress from this assignment attempt
+	// for reuse in subsequent scheduling attempts.
+	FlavorScanState workload.FlavorScanState
 
 	// Usage is the accumulated Usage of resources as pod sets get
 	// flavors assigned. When workload slicing is enabled and replaceWorkloadSlice
@@ -728,7 +731,7 @@ func (a *FlavorAssigner) assignFlavors(ctx context.Context, log logr.Logger, cou
 				Unassigned: make(resources.MapRequests),
 			},
 		},
-		LastState: workload.FlavorScanState{
+		FlavorScanState: workload.FlavorScanState{
 			LastTriedFlavorIndexes:        make([]map[corev1.ResourceName]int, 0, len(requests)),
 			AllocatableResourceGeneration: a.cq.AllocatableResourceGeneration,
 			SchedulingCycle:               a.schedulingCycle,
@@ -1037,7 +1040,7 @@ func (a *Assignment) append(requests resources.Requests, psAssignment *PodSetAss
 		a.Usage.Quota.Assigned[fr] = a.Usage.Quota.Assigned[fr].AddInt64(requestAmount)
 		flavorIdx[resource] = flvAssignment.TriedFlavorIdx
 	}
-	a.LastState.LastTriedFlavorIndexes = append(a.LastState.LastTriedFlavorIndexes, flavorIdx)
+	a.FlavorScanState.LastTriedFlavorIndexes = append(a.FlavorScanState.LastTriedFlavorIndexes, flavorIdx)
 }
 
 // findOldPodSetRequest returns the resource request from the old workload slice

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -54,7 +54,7 @@ type Assignment struct {
 	// Borrowing is the height of the smallest cohort tree that fits
 	// the additional Usage. It equals to 0 if no borrowing is required.
 	Borrowing int
-	LastState workload.AssignmentClusterQueueState
+	LastState workload.FlavorScanState
 
 	// Usage is the accumulated Usage of resources as pod sets get
 	// flavors assigned. When workload slicing is enabled and replaceWorkloadSlice
@@ -728,11 +728,11 @@ func (a *FlavorAssigner) assignFlavors(ctx context.Context, log logr.Logger, cou
 				Unassigned: make(resources.MapRequests),
 			},
 		},
-		LastState: workload.AssignmentClusterQueueState{
-			LastTriedFlavorIdx:     make([]map[corev1.ResourceName]int, 0, len(requests)),
-			ClusterQueueGeneration: a.cq.AllocatableResourceGeneration,
-			SchedulingCycle:        a.schedulingCycle,
-			SchedulingHash:         a.wl.SchedulingHash,
+		LastState: workload.FlavorScanState{
+			LastTriedFlavorIndexes:        make([]map[corev1.ResourceName]int, 0, len(requests)),
+			AllocatableResourceGeneration: a.cq.AllocatableResourceGeneration,
+			SchedulingCycle:               a.schedulingCycle,
+			SchedulingHash:                a.wl.SchedulingHash,
 		},
 		replaceWorkloadSlice: a.replaceWorkloadSlice,
 	}
@@ -1037,7 +1037,7 @@ func (a *Assignment) append(requests resources.Requests, psAssignment *PodSetAss
 		a.Usage.Quota.Assigned[fr] = a.Usage.Quota.Assigned[fr].AddInt64(requestAmount)
 		flavorIdx[resource] = flvAssignment.TriedFlavorIdx
 	}
-	a.LastState.LastTriedFlavorIdx = append(a.LastState.LastTriedFlavorIdx, flavorIdx)
+	a.LastState.LastTriedFlavorIndexes = append(a.LastState.LastTriedFlavorIndexes, flavorIdx)
 }
 
 // findOldPodSetRequest returns the resource request from the old workload slice
@@ -1091,7 +1091,7 @@ func (a *FlavorAssigner) findFlavorForPodSets(
 
 	// We will only check against the flavors' labels for the resource.
 	attemptedFlavorIdx := -1
-	idx := a.wl.LastAssignment.NextFlavorToTryForPodSetResource(psIDs[0], resName)
+	idx := a.wl.FlavorScanState.NextFlavorToTryForPodSetResource(psIDs[0], resName)
 	for ; idx < len(resourceGroup.Flavors); idx++ {
 		attemptedFlavorIdx = idx
 		fName := resourceGroup.Flavors[idx]

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -6300,10 +6300,10 @@ const bookmarkTestCycle int64 = 7
 
 // lastTriedFlavorIdx reads the bookmark the assignment recorded for the first PodSet.
 func lastTriedFlavorIdx(a Assignment, res corev1.ResourceName) (int, bool) {
-	if len(a.LastState.LastTriedFlavorIdx) == 0 {
+	if len(a.LastState.LastTriedFlavorIndexes) == 0 {
 		return 0, false
 	}
-	idx, ok := a.LastState.LastTriedFlavorIdx[0][res]
+	idx, ok := a.LastState.LastTriedFlavorIndexes[0][res]
 	return idx, ok
 }
 
@@ -6590,7 +6590,7 @@ func TestRecomputeRecordsLastTriedFlavorIdx(t *testing.T) {
 			// The scheduler clears LastAssignment and pins the nominated flavors before
 			// replaying the assignment, so that the recomputation stays on the flavor
 			// quota was computed for.
-			wlInfo.LastAssignment = nil
+			wlInfo.FlavorScanState = nil
 			mapping := workload.PodSetResourcesToFlavors{}
 			for _, psa := range nominated.PodSets {
 				perResource := workload.ResourceToFlavor{}

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -3664,7 +3664,7 @@ func TestAssignFlavors(t *testing.T) {
 					append(cmpOpts,
 						cmpopts.EquateEmpty(),
 						cmpopts.IgnoreUnexported(Assignment{}, FlavorAssignment{}),
-						statusComparer, cmpopts.IgnoreFields(Assignment{}, "LastState"),
+						statusComparer, cmpopts.IgnoreFields(Assignment{}, "FlavorScanState"),
 						cmpopts.IgnoreFields(PodSetAssignment{}, "FlavorAssignmentAttempts"),
 					)...,
 				); diff != "" {
@@ -4006,7 +4006,7 @@ func TestDeletedFlavors(t *testing.T) {
 				if diff := cmp.Diff(tc.wantAssignment, assignment,
 					append(cmpOpts,
 						cmpopts.EquateEmpty(),
-						cmpopts.IgnoreUnexported(Assignment{}, FlavorAssignment{}), statusComparer, cmpopts.IgnoreFields(Assignment{}, "LastState"),
+						cmpopts.IgnoreUnexported(Assignment{}, FlavorAssignment{}), statusComparer, cmpopts.IgnoreFields(Assignment{}, "FlavorScanState"),
 					)...,
 				); diff != "" {
 					t.Errorf("Unexpected assignment (-want,+got):\n%s", diff)

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -6300,10 +6300,10 @@ const bookmarkTestCycle int64 = 7
 
 // lastTriedFlavorIdx reads the bookmark the assignment recorded for the first PodSet.
 func lastTriedFlavorIdx(a Assignment, res corev1.ResourceName) (int, bool) {
-	if len(a.LastState.LastTriedFlavorIndexes) == 0 {
+	if len(a.FlavorScanState.LastTriedFlavorIndexes) == 0 {
 		return 0, false
 	}
-	idx, ok := a.LastState.LastTriedFlavorIndexes[0][res]
+	idx, ok := a.FlavorScanState.LastTriedFlavorIndexes[0][res]
 	return idx, ok
 }
 
@@ -6587,7 +6587,7 @@ func TestRecomputeRecordsLastTriedFlavorIdx(t *testing.T) {
 				cqSnapshot.AddUsage(workload.Usage{Quota: workload.ResourceUsage{Assigned: tc.quotaUsageAtRecompute}})
 			}
 
-			// The scheduler clears LastAssignment and pins the nominated flavors before
+			// The scheduler clears FlavorScanState and pins the nominated flavors before
 			// replaying the assignment, so that the recomputation stays on the flavor
 			// quota was computed for.
 			wlInfo.FlavorScanState = nil

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -249,7 +249,7 @@ func (e *entry) markSkipped(msg string) {
 	e.status = skipped
 	e.inadmissibleMsg = msg
 	if !features.Enabled(features.FlavorFungibilityPreserveScanProgress) {
-		e.LastAssignment = nil
+		e.FlavorScanState = nil
 	}
 }
 
@@ -260,7 +260,7 @@ func (e *entry) markPreemptionGated(msg string) {
 	e.status = preemptionGated
 	e.inadmissibleMsg = msg
 	e.requeueReason = qcache.RequeueReasonPreemptionGated
-	e.LastAssignment = nil
+	e.FlavorScanState = nil
 }
 
 func (e *entry) markEvicted() {
@@ -282,14 +282,14 @@ func (e *entry) recordAssignment(a flavorassigner.Assignment, targets []*preempt
 	e.assignment = a
 	e.preemptionTargets = targets
 	e.inadmissibleMsg = e.assignment.Message()
-	e.LastAssignment = &e.assignment.LastState
+	e.FlavorScanState = &e.assignment.LastState
 }
 
 // markPreemptionOutcome records the outcome of IssuePreemptions and
 // clears the cached flavor assignment so the next cycle reconsiders
 // every flavor.
 func (e *entry) markPreemptionOutcome(preempted, errors int) {
-	e.LastAssignment = nil
+	e.FlavorScanState = nil
 	if preempted != 0 {
 		e.inadmissibleMsg += fmt.Sprintf(". Pending the preemption of %d workload(s)", preempted)
 		e.requeueReason = qcache.RequeueReasonPendingPreemption
@@ -487,7 +487,7 @@ func (s *Scheduler) processEntry(
 		// state will change. Retaining the current assignment could lock the workload into a
 		// suboptimal flavor, preventing it from claiming a more preferred flavor that might
 		// become available.
-		e.LastAssignment = nil
+		e.FlavorScanState = nil
 		snapshot.AddUsage(cq, usage)
 		return
 	}
@@ -581,7 +581,7 @@ func (s *Scheduler) issueMigration(ctx context.Context, log logr.Logger, e *entr
 	if err != nil {
 		log.Error(err, "Failed to evict workload for migration")
 	}
-	e.LastAssignment = nil
+	e.FlavorScanState = nil
 	e.requeueReason = qcache.RequeueReasonPendingMigration
 	e.inadmissibleMsg += ". Pending the migration of 1 workload(s)"
 }
@@ -771,7 +771,7 @@ func (s *Scheduler) updateAssignmentIfNeeded(
 	}
 	// Clear the last assignment so that we can start from the first flavor again and
 	// reach all flavors from the nomination.
-	e.LastAssignment = nil
+	e.FlavorScanState = nil
 	e.NominationMapping = e.readResourceToFlavorMapping()
 	newAssignment, newTargets := s.getAssignments(ctx, &e.Info, snapshot)
 	e.recordAssignment(newAssignment, newTargets)
@@ -862,11 +862,11 @@ func (s *Scheduler) getAssignments(ctx context.Context, wl *workload.Info, snap 
 	// dropped once it no longer describes the current state. Deciding that here rather than
 	// inside the assigner keeps it to one place per Workload per cycle: the assigner runs
 	// again for each reduced pod count when partial admission is in play.
-	if wl.LastAssignment != nil && lastAssignmentOutdated(wl.LastAssignment, cq.AllocatableResourceGeneration, s.schedulingCycle, wl.SchedulingHash) {
+	if wl.FlavorScanState != nil && lastAssignmentOutdated(wl.FlavorScanState, cq.AllocatableResourceGeneration, s.schedulingCycle, wl.SchedulingHash) {
 		log.FromContext(ctx).V(6).Info("Clearing Workload's last assignment because it was outdated",
 			"cq.AllocatableResourceGeneration", cq.AllocatableResourceGeneration,
-			"wl.LastAssignment.ClusterQueueGeneration", wl.LastAssignment.ClusterQueueGeneration)
-		wl.LastAssignment = nil
+			"wl.FlavorScanState.AllocatableResourceGeneration", wl.FlavorScanState.AllocatableResourceGeneration)
+		wl.FlavorScanState = nil
 	}
 	assignment, targets := s.getInitialAssignments(ctx, wl, snap)
 	updateAssignmentForTAS(ctx, snap, cq, wl, &assignment, targets)
@@ -875,7 +875,7 @@ func (s *Scheduler) getAssignments(ctx context.Context, wl *workload.Info, snap 
 
 // lastAssignmentOutdated reports whether the recorded flavor assignment no longer describes
 // the current state, in which case the flavor scan has to start over.
-func lastAssignmentOutdated(last *workload.AssignmentClusterQueueState, currentCQGeneration, currentSchedulingCycle int64, currentSchedulingHash workload.EquivalenceHash) bool {
+func lastAssignmentOutdated(last *workload.FlavorScanState, currentCQGeneration, currentSchedulingCycle int64, currentSchedulingHash workload.EquivalenceHash) bool {
 	if features.Enabled(features.FlavorFungibilityPreserveScanProgress) {
 		// Checked before the cycle age, so that a Workload whose shape changed starts over
 		// even when it was assigned in the preceding cycle.
@@ -890,7 +890,7 @@ func lastAssignmentOutdated(last *workload.AssignmentClusterQueueState, currentC
 			return false
 		}
 	}
-	return currentCQGeneration > last.ClusterQueueGeneration
+	return currentCQGeneration > last.AllocatableResourceGeneration
 }
 
 // getInitialAssignments computes the initial resource flavor assignment and any required preemption targets

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -277,7 +277,7 @@ func (e *entry) markAssumed() {
 
 // recordAssignment stores a flavor assignment and its preemption
 // targets from nominate. FlavorScanState aliases the stored
-// assignment's LastState so it tracks any later mutation.
+// assignment's FlavorScanState so it tracks any later mutation.
 func (e *entry) recordAssignment(a flavorassigner.Assignment, targets []*preemption.Target) {
 	e.assignment = a
 	e.preemptionTargets = targets

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -276,13 +276,13 @@ func (e *entry) markAssumed() {
 }
 
 // recordAssignment stores a flavor assignment and its preemption
-// targets from nominate. LastAssignment aliases the stored
+// targets from nominate. FlavorScanState aliases the stored
 // assignment's LastState so it tracks any later mutation.
 func (e *entry) recordAssignment(a flavorassigner.Assignment, targets []*preemption.Target) {
 	e.assignment = a
 	e.preemptionTargets = targets
 	e.inadmissibleMsg = e.assignment.Message()
-	e.FlavorScanState = &e.assignment.LastState
+	e.FlavorScanState = &e.assignment.FlavorScanState
 }
 
 // markPreemptionOutcome records the outcome of IssuePreemptions and
@@ -482,7 +482,7 @@ func (s *Scheduler) processEntry(
 		e.inadmissibleMsg = "Workload has overlapping preemption targets with another workload, but will fit after these preemptions complete"
 		e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads
 		e.requeueReason = qcache.RequeueReasonPendingPreemption
-		// Clear LastAssignment to force a full re-evaluation of all flavors in the next cycle.
+		// Clear FlavorScanState to force a full re-evaluation of all flavors in the next cycle.
 		// Since we are deferring admission until in-flight preemptions complete, the cluster
 		// state will change. Retaining the current assignment could lock the workload into a
 		// suboptimal flavor, preventing it from claiming a more preferred flavor that might
@@ -858,11 +858,11 @@ type partialAssignment struct {
 
 func (s *Scheduler) getAssignments(ctx context.Context, wl *workload.Info, snap *schdcache.Snapshot) (flavorassigner.Assignment, []*preemption.Target) {
 	cq := snap.ClusterQueue(wl.ClusterQueue)
-	// The flavor scan resumes from the progress recorded in LastAssignment, so it has to be
+	// The flavor scan resumes from the progress recorded in FlavorScanState, so it has to be
 	// dropped once it no longer describes the current state. Deciding that here rather than
 	// inside the assigner keeps it to one place per Workload per cycle: the assigner runs
 	// again for each reduced pod count when partial admission is in play.
-	if wl.FlavorScanState != nil && lastAssignmentOutdated(wl.FlavorScanState, cq.AllocatableResourceGeneration, s.schedulingCycle, wl.SchedulingHash) {
+	if wl.FlavorScanState != nil && flavorScanStateOutdated(wl.FlavorScanState, cq.AllocatableResourceGeneration, s.schedulingCycle, wl.SchedulingHash) {
 		log.FromContext(ctx).V(6).Info("Clearing Workload's last assignment because it was outdated",
 			"cq.AllocatableResourceGeneration", cq.AllocatableResourceGeneration,
 			"wl.FlavorScanState.AllocatableResourceGeneration", wl.FlavorScanState.AllocatableResourceGeneration)
@@ -873,9 +873,9 @@ func (s *Scheduler) getAssignments(ctx context.Context, wl *workload.Info, snap 
 	return assignment, targets
 }
 
-// lastAssignmentOutdated reports whether the recorded flavor assignment no longer describes
+// flavorScanStateOutdated reports whether the recorded flavor assignment no longer describes
 // the current state, in which case the flavor scan has to start over.
-func lastAssignmentOutdated(last *workload.FlavorScanState, currentCQGeneration, currentSchedulingCycle int64, currentSchedulingHash workload.EquivalenceHash) bool {
+func flavorScanStateOutdated(last *workload.FlavorScanState, currentCQGeneration, currentSchedulingCycle int64, currentSchedulingHash workload.EquivalenceHash) bool {
 	if features.Enabled(features.FlavorFungibilityPreserveScanProgress) {
 		// Checked before the cycle age, so that a Workload whose shape changed starts over
 		// even when it was assigned in the preceding cycle.

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -769,7 +769,7 @@ func (s *Scheduler) updateAssignmentIfNeeded(
 		// Short-circuit, nothing to recompute.
 		return usage, schdcache.FitsCheckOk == fitsCheck
 	}
-	// Clear the last assignment so that we can start from the first flavor again and
+	// Clear the flavor scan state so that we can start from the first flavor again and
 	// reach all flavors from the nomination.
 	e.FlavorScanState = nil
 	e.NominationMapping = e.readResourceToFlavorMapping()
@@ -863,7 +863,7 @@ func (s *Scheduler) getAssignments(ctx context.Context, wl *workload.Info, snap 
 	// inside the assigner keeps it to one place per Workload per cycle: the assigner runs
 	// again for each reduced pod count when partial admission is in play.
 	if wl.FlavorScanState != nil && flavorScanStateOutdated(wl.FlavorScanState, cq.AllocatableResourceGeneration, s.schedulingCycle, wl.SchedulingHash) {
-		log.FromContext(ctx).V(6).Info("Clearing Workload's last assignment because it was outdated",
+		log.FromContext(ctx).V(6).Info("Clearing Workload's flavor scan state because it was outdated",
 			"cq.AllocatableResourceGeneration", cq.AllocatableResourceGeneration,
 			"wl.FlavorScanState.AllocatableResourceGeneration", wl.FlavorScanState.AllocatableResourceGeneration)
 		wl.FlavorScanState = nil

--- a/pkg/scheduler/scheduler_preserve_flavor_scan_progress_test.go
+++ b/pkg/scheduler/scheduler_preserve_flavor_scan_progress_test.go
@@ -56,7 +56,7 @@ const equalTestPriority = 10
 // Workload whose TAS placement fails on the flavor that quota selected can ever reach the
 // next flavor of its ResourceGroup.
 //
-// It exists because the two smaller tests for this gate (TestLastAssignmentOutdated and
+// It exists because the two smaller tests for this gate (TestFlavorScanStateOutdated and
 // TestEntryMarkSkipped) each assert one mechanism in isolation, and neither shows what a
 // Workload actually ends up admitted on. Only a multi-cycle run does, because the gate's
 // whole purpose is to carry flavor progress from one cycle into the next.
@@ -257,7 +257,7 @@ func TestScheduleForPreserveFlavorScanProgress(t *testing.T) {
 				// Reproduce a busy Cohort. AllocatableResourceGeneration only advances when
 				// the quotas actually change (see updateQuotasAndResourceGroups), so flip
 				// flavor-2's quota between two values to force a real bump every cycle. The
-				// bump is what discards LastAssignment in lastAssignmentOutdated, and with
+				// bump is what discards FlavorScanState in flavorScanStateOutdated, and with
 				// it the flavor progress recorded one cycle earlier. On a cluster with
 				// steady admissions and evictions that bump happens continuously, which is
 				// the condition this gate exists to survive.

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -9274,8 +9274,8 @@ func TestEntryMarkSkipped(t *testing.T) {
 			e := entry{
 				Head: qcache.Head{
 					Info: workload.Info{
-						LastAssignment: &workload.AssignmentClusterQueueState{
-							LastTriedFlavorIdx: []map[corev1.ResourceName]int{
+						FlavorScanState: &workload.FlavorScanState{
+							LastTriedFlavorIndexes: []map[corev1.ResourceName]int{
 								{corev1.ResourceCPU: 0},
 							},
 						},
@@ -9291,13 +9291,13 @@ func TestEntryMarkSkipped(t *testing.T) {
 			if want := "Workload no longer fits after processing another workload"; e.inadmissibleMsg != want {
 				t.Errorf("inadmissibleMsg = %q, want %q", e.inadmissibleMsg, want)
 			}
-			if got := e.LastAssignment == nil; got != tc.wantLastAssignmentNil {
+			if got := e.FlavorScanState == nil; got != tc.wantLastAssignmentNil {
 				t.Errorf("LastAssignment == nil is %v, want %v", got, tc.wantLastAssignmentNil)
 			}
 			if !tc.wantLastAssignmentNil {
 				// The retained progress must still name the flavor that was tried, since
 				// that is what NextFlavorToTryForPodSetResource reads.
-				if got := e.LastAssignment.LastTriedFlavorIdx[0][corev1.ResourceCPU]; got != 0 {
+				if got := e.FlavorScanState.LastTriedFlavorIndexes[0][corev1.ResourceCPU]; got != 0 {
 					t.Errorf("retained LastTriedFlavorIdx = %d, want 0", got)
 				}
 			}
@@ -9306,7 +9306,7 @@ func TestEntryMarkSkipped(t *testing.T) {
 }
 
 func TestEntryMarkPreemptionOutcome(t *testing.T) {
-	assignmentState := &workload.AssignmentClusterQueueState{}
+	assignmentState := &workload.FlavorScanState{}
 
 	cases := map[string]struct {
 		preempted             int
@@ -9347,7 +9347,7 @@ func TestEntryMarkPreemptionOutcome(t *testing.T) {
 				inadmissibleMsg: "fits with preemption",
 				Head: qcache.Head{
 					Info: workload.Info{
-						LastAssignment: assignmentState,
+						FlavorScanState: assignmentState,
 					},
 				},
 			}
@@ -9360,7 +9360,7 @@ func TestEntryMarkPreemptionOutcome(t *testing.T) {
 			if e.requeueReason != tc.wantRequeueReason {
 				t.Errorf("Unexpected requeue reason\nwant: %q\ngot:  %q", tc.wantRequeueReason, e.requeueReason)
 			}
-			if got := e.LastAssignment == nil; got != tc.wantLastAssignmentNil {
+			if got := e.FlavorScanState == nil; got != tc.wantLastAssignmentNil {
 				t.Errorf("Unexpected LastAssignment nil status\nwant: %v\ngot:  %v", tc.wantLastAssignmentNil, got)
 			}
 		})
@@ -10175,7 +10175,7 @@ func (r *workloadUpdateWatcherRecorder) NotifyWorkloadUpdate(oldWl, newWl *kueue
 func TestLastAssignmentOutdated(t *testing.T) {
 	type args struct {
 		currentSchedulingCycle int64
-		last                   *workload.AssignmentClusterQueueState
+		last                   *workload.FlavorScanState
 		currentCQGeneration    int64
 		currentSchedulingHash  workload.EquivalenceHash
 	}
@@ -10190,9 +10190,9 @@ func TestLastAssignmentOutdated(t *testing.T) {
 			name: "Cluster queue allocatableResourceIncreasedGen increased",
 			args: args{
 				currentSchedulingCycle: 5,
-				last: &workload.AssignmentClusterQueueState{
-					ClusterQueueGeneration: 0,
-					SchedulingCycle:        1,
+				last: &workload.FlavorScanState{
+					AllocatableResourceGeneration: 0,
+					SchedulingCycle:               1,
 				},
 				currentCQGeneration: 1,
 			},
@@ -10202,9 +10202,9 @@ func TestLastAssignmentOutdated(t *testing.T) {
 			name: "AllocatableResourceGeneration not increased",
 			args: args{
 				currentSchedulingCycle: 5,
-				last: &workload.AssignmentClusterQueueState{
-					ClusterQueueGeneration: 0,
-					SchedulingCycle:        1,
+				last: &workload.FlavorScanState{
+					AllocatableResourceGeneration: 0,
+					SchedulingCycle:               1,
 				},
 				currentCQGeneration: 0,
 			},
@@ -10215,9 +10215,9 @@ func TestLastAssignmentOutdated(t *testing.T) {
 			preserveProgress: true,
 			args: args{
 				currentSchedulingCycle: 5,
-				last: &workload.AssignmentClusterQueueState{
-					ClusterQueueGeneration: 0,
-					SchedulingCycle:        4,
+				last: &workload.FlavorScanState{
+					AllocatableResourceGeneration: 0,
+					SchedulingCycle:               4,
 				},
 				currentCQGeneration: 1,
 			},
@@ -10228,9 +10228,9 @@ func TestLastAssignmentOutdated(t *testing.T) {
 			preserveProgress: true,
 			args: args{
 				currentSchedulingCycle: 5,
-				last: &workload.AssignmentClusterQueueState{
-					ClusterQueueGeneration: 0,
-					SchedulingCycle:        5,
+				last: &workload.FlavorScanState{
+					AllocatableResourceGeneration: 0,
+					SchedulingCycle:               5,
 				},
 				currentCQGeneration: 1,
 			},
@@ -10241,9 +10241,9 @@ func TestLastAssignmentOutdated(t *testing.T) {
 			preserveProgress: true,
 			args: args{
 				currentSchedulingCycle: 5,
-				last: &workload.AssignmentClusterQueueState{
-					ClusterQueueGeneration: 0,
-					SchedulingCycle:        3,
+				last: &workload.FlavorScanState{
+					AllocatableResourceGeneration: 0,
+					SchedulingCycle:               3,
 				},
 				currentCQGeneration: 1,
 			},
@@ -10254,10 +10254,10 @@ func TestLastAssignmentOutdated(t *testing.T) {
 			preserveProgress: true,
 			args: args{
 				currentSchedulingCycle: 5,
-				last: &workload.AssignmentClusterQueueState{
-					ClusterQueueGeneration: 0,
-					SchedulingCycle:        4,
-					SchedulingHash:         "shape-a",
+				last: &workload.FlavorScanState{
+					AllocatableResourceGeneration: 0,
+					SchedulingCycle:               4,
+					SchedulingHash:                "shape-a",
 				},
 				currentCQGeneration:   0,
 				currentSchedulingHash: "shape-b",
@@ -10269,10 +10269,10 @@ func TestLastAssignmentOutdated(t *testing.T) {
 			preserveProgress: true,
 			args: args{
 				currentSchedulingCycle: 5,
-				last: &workload.AssignmentClusterQueueState{
-					ClusterQueueGeneration: 0,
-					SchedulingCycle:        4,
-					SchedulingHash:         "shape-a",
+				last: &workload.FlavorScanState{
+					AllocatableResourceGeneration: 0,
+					SchedulingCycle:               4,
+					SchedulingHash:                "shape-a",
 				},
 				currentCQGeneration:   1,
 				currentSchedulingHash: "shape-a",
@@ -10284,10 +10284,10 @@ func TestLastAssignmentOutdated(t *testing.T) {
 			preserveProgress: true,
 			args: args{
 				currentSchedulingCycle: 5,
-				last: &workload.AssignmentClusterQueueState{
-					ClusterQueueGeneration: 0,
-					SchedulingCycle:        4,
-					SchedulingHash:         workload.SchedulingHashUnknown,
+				last: &workload.FlavorScanState{
+					AllocatableResourceGeneration: 0,
+					SchedulingCycle:               4,
+					SchedulingHash:                workload.SchedulingHashUnknown,
 				},
 				currentCQGeneration:   1,
 				currentSchedulingHash: "shape-b",
@@ -10299,10 +10299,10 @@ func TestLastAssignmentOutdated(t *testing.T) {
 			preserveProgress: false,
 			args: args{
 				currentSchedulingCycle: 5,
-				last: &workload.AssignmentClusterQueueState{
-					ClusterQueueGeneration: 0,
-					SchedulingCycle:        4,
-					SchedulingHash:         "shape-a",
+				last: &workload.FlavorScanState{
+					AllocatableResourceGeneration: 0,
+					SchedulingCycle:               4,
+					SchedulingHash:                "shape-a",
 				},
 				currentCQGeneration:   0,
 				currentSchedulingHash: "shape-b",
@@ -10314,9 +10314,9 @@ func TestLastAssignmentOutdated(t *testing.T) {
 			preserveProgress: false,
 			args: args{
 				currentSchedulingCycle: 5,
-				last: &workload.AssignmentClusterQueueState{
-					ClusterQueueGeneration: 0,
-					SchedulingCycle:        4,
+				last: &workload.FlavorScanState{
+					AllocatableResourceGeneration: 0,
+					SchedulingCycle:               4,
 				},
 				currentCQGeneration: 1,
 			},

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -9254,16 +9254,16 @@ func TestRequeueAndUpdate(t *testing.T) {
 // cycle resumes the scan or restarts it from the first flavor.
 func TestEntryMarkSkipped(t *testing.T) {
 	cases := map[string]struct {
-		preserveProgress      bool
-		wantLastAssignmentNil bool
+		preserveProgress       bool
+		wantFlavorScanStateNil bool
 	}{
 		"without the gate the assignment is discarded so every flavor is retried": {
-			preserveProgress:      false,
-			wantLastAssignmentNil: true,
+			preserveProgress:       false,
+			wantFlavorScanStateNil: true,
 		},
 		"with the gate the assignment is kept so the scan resumes": {
-			preserveProgress:      true,
-			wantLastAssignmentNil: false,
+			preserveProgress:       true,
+			wantFlavorScanStateNil: false,
 		},
 	}
 
@@ -9291,10 +9291,10 @@ func TestEntryMarkSkipped(t *testing.T) {
 			if want := "Workload no longer fits after processing another workload"; e.inadmissibleMsg != want {
 				t.Errorf("inadmissibleMsg = %q, want %q", e.inadmissibleMsg, want)
 			}
-			if got := e.FlavorScanState == nil; got != tc.wantLastAssignmentNil {
-				t.Errorf("LastAssignment == nil is %v, want %v", got, tc.wantLastAssignmentNil)
+			if got := e.FlavorScanState == nil; got != tc.wantFlavorScanStateNil {
+				t.Errorf("FlavorScanState == nil is %v, want %v", got, tc.wantFlavorScanStateNil)
 			}
-			if !tc.wantLastAssignmentNil {
+			if !tc.wantFlavorScanStateNil {
 				// The retained progress must still name the flavor that was tried, since
 				// that is what NextFlavorToTryForPodSetResource reads.
 				if got := e.FlavorScanState.LastTriedFlavorIndexes[0][corev1.ResourceCPU]; got != 0 {
@@ -9309,35 +9309,35 @@ func TestEntryMarkPreemptionOutcome(t *testing.T) {
 	assignmentState := &workload.FlavorScanState{}
 
 	cases := map[string]struct {
-		preempted             int
-		errors                int
-		wantMessage           string
-		wantRequeueReason     qcache.RequeueReason
-		wantLastAssignmentNil bool
+		preempted              int
+		errors                 int
+		wantMessage            string
+		wantRequeueReason      qcache.RequeueReason
+		wantFlavorScanStateNil bool
 	}{
 		"pending preemption": {
-			preempted:             2,
-			wantMessage:           "fits with preemption. Pending the preemption of 2 workload(s)",
-			wantRequeueReason:     qcache.RequeueReasonPendingPreemption,
-			wantLastAssignmentNil: true,
+			preempted:              2,
+			wantMessage:            "fits with preemption. Pending the preemption of 2 workload(s)",
+			wantRequeueReason:      qcache.RequeueReasonPendingPreemption,
+			wantFlavorScanStateNil: true,
 		},
 		"failed preemption": {
-			errors:                2,
-			wantMessage:           "fits with preemption. Preempting 2 workload(s) failed, will retry.",
-			wantRequeueReason:     qcache.RequeueReasonPreemptionFailed,
-			wantLastAssignmentNil: true,
+			errors:                 2,
+			wantMessage:            "fits with preemption. Preempting 2 workload(s) failed, will retry.",
+			wantRequeueReason:      qcache.RequeueReasonPreemptionFailed,
+			wantFlavorScanStateNil: true,
 		},
 		"preempted takes precedence over errors": {
-			preempted:             1,
-			errors:                1,
-			wantMessage:           "fits with preemption. Pending the preemption of 1 workload(s)",
-			wantRequeueReason:     qcache.RequeueReasonPendingPreemption,
-			wantLastAssignmentNil: true,
+			preempted:              1,
+			errors:                 1,
+			wantMessage:            "fits with preemption. Pending the preemption of 1 workload(s)",
+			wantRequeueReason:      qcache.RequeueReasonPendingPreemption,
+			wantFlavorScanStateNil: true,
 		},
 		"no outcome": {
-			wantMessage:           "fits with preemption",
-			wantRequeueReason:     qcache.RequeueReasonGeneric,
-			wantLastAssignmentNil: true,
+			wantMessage:            "fits with preemption",
+			wantRequeueReason:      qcache.RequeueReasonGeneric,
+			wantFlavorScanStateNil: true,
 		},
 	}
 
@@ -9360,8 +9360,8 @@ func TestEntryMarkPreemptionOutcome(t *testing.T) {
 			if e.requeueReason != tc.wantRequeueReason {
 				t.Errorf("Unexpected requeue reason\nwant: %q\ngot:  %q", tc.wantRequeueReason, e.requeueReason)
 			}
-			if got := e.FlavorScanState == nil; got != tc.wantLastAssignmentNil {
-				t.Errorf("Unexpected LastAssignment nil status\nwant: %v\ngot:  %v", tc.wantLastAssignmentNil, got)
+			if got := e.FlavorScanState == nil; got != tc.wantFlavorScanStateNil {
+				t.Errorf("Unexpected FlavorScanState nil status\nwant: %v\ngot:  %v", tc.wantFlavorScanStateNil, got)
 			}
 		})
 	}
@@ -10172,7 +10172,7 @@ func (r *workloadUpdateWatcherRecorder) NotifyWorkloadUpdate(oldWl, newWl *kueue
 	}
 }
 
-func TestLastAssignmentOutdated(t *testing.T) {
+func TestFlavorScanStateOutdated(t *testing.T) {
 	type args struct {
 		currentSchedulingCycle int64
 		last                   *workload.FlavorScanState
@@ -10326,8 +10326,8 @@ func TestLastAssignmentOutdated(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			features.SetFeatureGateDuringTest(t, features.FlavorFungibilityPreserveScanProgress, tt.preserveProgress)
-			if got := lastAssignmentOutdated(tt.args.last, tt.args.currentCQGeneration, tt.args.currentSchedulingCycle, tt.args.currentSchedulingHash); got != tt.want {
-				t.Errorf("LastAssignmentOutdated() = %v, want %v", got, tt.want)
+			if got := flavorScanStateOutdated(tt.args.last, tt.args.currentCQGeneration, tt.args.currentSchedulingCycle, tt.args.currentSchedulingHash); got != tt.want {
+				t.Errorf("FlavorScanStatesOutdated() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -469,7 +469,7 @@ func computeSchedulingHash(log logr.Logger, wl *kueue.Workload, totalRequests []
 		}
 		// The name identifies a PodSet but does not affect how it is assigned.
 		// Two readers depend on this shape: the queue's equivalence classes, and
-		// LastAssignment reuse through MatchesSchedulingShape.
+		// FlavorScanState reuse through MatchesSchedulingShape.
 		if !features.Enabled(features.SchedulingEquivalenceHashingIgnorePodSetName) {
 			podSetShape["name"] = ps.Name
 		}

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -112,13 +112,22 @@ func FromQuotaReservedOrAdmittedToPending(prevStatus, newStatus string) bool {
 	return (prevStatus == StatusQuotaReserved || prevStatus == StatusAdmitted) && newStatus == StatusPending
 }
 
-type AssignmentClusterQueueState struct {
-	LastTriedFlavorIdx     []map[corev1.ResourceName]int
-	ClusterQueueGeneration int64
+type FlavorScanState struct {
+	// LastTriedFlavorIndexes records the last examined flavor index for each PodSet
+	// and resource, within the corresponding resource group's flavor list.
+	// A value of -1 means that pair's scan reached the end; its next attempt starts
+	// at index zero. Missing entries also start at zero.
+	LastTriedFlavorIndexes []map[corev1.ResourceName]int
+
+	// AllocatableResourceGeneration records the ClusterQueue's allocatable resource
+	// generation at the time of the scan, used to check whether the scan progress is stale.
+	AllocatableResourceGeneration int64
+
 	// SchedulingCycle is the scheduling cycle that computed this assignment. It lets the
 	// assignment from the immediately preceding cycle be treated as current even when the
 	// ClusterQueue generation has moved on.
 	SchedulingCycle int64
+
 	// SchedulingHash is the scheduling equivalence hash of the Workload this assignment was
 	// computed for. LastTriedFlavorIdx is indexed by PodSet and holds flavor indices chosen
 	// for a particular set of requests, so it only carries meaning while the Workload keeps
@@ -178,15 +187,15 @@ func WithPreprocessedDRAResources(
 	}
 }
 
-func (s *AssignmentClusterQueueState) Clone() *AssignmentClusterQueueState {
-	c := AssignmentClusterQueueState{
-		LastTriedFlavorIdx:     make([]map[corev1.ResourceName]int, len(s.LastTriedFlavorIdx)),
-		ClusterQueueGeneration: s.ClusterQueueGeneration,
-		SchedulingCycle:        s.SchedulingCycle,
-		SchedulingHash:         s.SchedulingHash,
+func (s *FlavorScanState) Clone() *FlavorScanState {
+	c := FlavorScanState{
+		LastTriedFlavorIndexes:        make([]map[corev1.ResourceName]int, len(s.LastTriedFlavorIndexes)),
+		AllocatableResourceGeneration: s.AllocatableResourceGeneration,
+		SchedulingCycle:               s.SchedulingCycle,
+		SchedulingHash:                s.SchedulingHash,
 	}
-	for ps, flavorIdx := range s.LastTriedFlavorIdx {
-		c.LastTriedFlavorIdx[ps] = maps.Clone(flavorIdx)
+	for ps, flavorIdx := range s.LastTriedFlavorIndexes {
+		c.LastTriedFlavorIndexes[ps] = maps.Clone(flavorIdx)
 	}
 	return &c
 }
@@ -199,7 +208,7 @@ func (s *AssignmentClusterQueueState) Clone() *AssignmentClusterQueueState {
 // An unknown hash on either side means SchedulingEquivalenceHashing is disabled and there is
 // nothing to compare, so the shape is taken to be unchanged. That keeps the two features
 // independent, and NextFlavorToTryForPodSetResource still bounds-checks the PodSet index.
-func (s *AssignmentClusterQueueState) MatchesSchedulingShape(current EquivalenceHash) bool {
+func (s *FlavorScanState) MatchesSchedulingShape(current EquivalenceHash) bool {
 	if s.SchedulingHash == SchedulingHashUnknown || current == SchedulingHashUnknown {
 		return true
 	}
@@ -208,12 +217,12 @@ func (s *AssignmentClusterQueueState) MatchesSchedulingShape(current Equivalence
 
 // PendingFlavors returns whether there are pending flavors to try
 // after the last attempt.
-func (s *AssignmentClusterQueueState) PendingFlavors() bool {
+func (s *FlavorScanState) PendingFlavors() bool {
 	if s == nil {
 		// This is only reached in unit tests.
 		return false
 	}
-	for _, podSetIdxs := range s.LastTriedFlavorIdx {
+	for _, podSetIdxs := range s.LastTriedFlavorIndexes {
 		for _, idx := range podSetIdxs {
 			if idx != -1 {
 				return true
@@ -223,14 +232,14 @@ func (s *AssignmentClusterQueueState) PendingFlavors() bool {
 	return false
 }
 
-func (s *AssignmentClusterQueueState) NextFlavorToTryForPodSetResource(ps int, res corev1.ResourceName) int {
+func (s *FlavorScanState) NextFlavorToTryForPodSetResource(ps int, res corev1.ResourceName) int {
 	if !features.Enabled(features.FlavorFungibility) {
 		return 0
 	}
-	if s == nil || ps >= len(s.LastTriedFlavorIdx) {
+	if s == nil || ps >= len(s.LastTriedFlavorIndexes) {
 		return 0
 	}
-	idx, ok := s.LastTriedFlavorIdx[ps][res]
+	idx, ok := s.LastTriedFlavorIndexes[ps][res]
 	if !ok {
 		return 0
 	}
@@ -248,8 +257,11 @@ type Info struct {
 	TotalRequests []PodSetResources
 	// Populated from the queue during admission or from the admission field if
 	// already admitted.
-	ClusterQueue   kueue.ClusterQueueReference
-	LastAssignment *AssignmentClusterQueueState
+	ClusterQueue kueue.ClusterQueueReference
+
+	// FlavorScanState records progress of the flavor scan for reuse in subsequent scheduling cycles.
+	// If nil, the next attempt scans flavors from the beginning.
+	FlavorScanState *FlavorScanState
 
 	// LocalQueueFSUsage indicates the historical usage of resource in the LocalQueue, needed for the
 	// AdmissionFairSharing feature, it is only populated for Infos in cache.Snapshot (not in queue manager).

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -1635,15 +1635,15 @@ func TestLimitReclaimablePodsToPodSetSizes(t *testing.T) {
 
 func TestAssignmentClusterQueueState(t *testing.T) {
 	cases := map[string]struct {
-		state              *AssignmentClusterQueueState
+		state              *FlavorScanState
 		wantPendingFlavors bool
 	}{
 		"no info": {
 			wantPendingFlavors: false,
 		},
 		"all done": {
-			state: &AssignmentClusterQueueState{
-				LastTriedFlavorIdx: []map[corev1.ResourceName]int{
+			state: &FlavorScanState{
+				LastTriedFlavorIndexes: []map[corev1.ResourceName]int{
 					{
 						corev1.ResourceCPU:    -1,
 						corev1.ResourceMemory: -1,
@@ -1656,8 +1656,8 @@ func TestAssignmentClusterQueueState(t *testing.T) {
 			wantPendingFlavors: false,
 		},
 		"some pending": {
-			state: &AssignmentClusterQueueState{
-				LastTriedFlavorIdx: []map[corev1.ResourceName]int{
+			state: &FlavorScanState{
+				LastTriedFlavorIndexes: []map[corev1.ResourceName]int{
 					{
 						corev1.ResourceCPU:    0,
 						corev1.ResourceMemory: -1,
@@ -1670,8 +1670,8 @@ func TestAssignmentClusterQueueState(t *testing.T) {
 			wantPendingFlavors: true,
 		},
 		"all pending": {
-			state: &AssignmentClusterQueueState{
-				LastTriedFlavorIdx: []map[corev1.ResourceName]int{
+			state: &FlavorScanState{
+				LastTriedFlavorIndexes: []map[corev1.ResourceName]int{
 					{
 						corev1.ResourceCPU:    1,
 						corev1.ResourceMemory: 0,


### PR DESCRIPTION
<!-- Thank you for contributing! Check CONTRIBUTING.md for details. -->

#### What type of PR is this?
/kind cleanup


#### What this PR does / why we need it?


To improve the naming and comments for the field. 

The current one is very confusing:
- This field does not represent Assignment
- This structure does not represent "ClusterQueueState"

This field represents the state of the FlavorScan within ClusterQueue. ClusterQueue is obvious, so I think FlavorScanState is enough.

#### Useful notes for your reviewer

I would like to cherrypick to make other cherrypicks.

There is no code change beyond comments and naming.

#### Release note

<!-- Describe the behavior change accurately from the user's perspective. Hints:
- Do not leave this block blank.
- Use "NONE" when there is no user-facing change.
- When feasible use a prefix for the sub-component or feature, e.g. "FairSharing:" or "MultiKueue:".
- If upgrade steps are required, include an "ACTION REQUIRED:" section.
You may consider AI assistance using the skill: cmd/experimental/skills/kueue-release-notes/SKILL.md.
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## AI summary

Renames the workload scheduling state to `FlavorScanState` and updates related fields, methods, comments, scheduler logic, queue handling, and tests. The change clarifies that this state tracks flavor-scan progress, not an assignment or `ClusterQueueState`. No behavioral or user-facing changes are introduced.

### Suggested release note

NONE
<!-- end of auto-generated comment: release notes by coderabbit.ai -->