### PR TITLE
kueuectl: Reject unmatched borrowing and lending limits when creating a ClusterQueue

### DIFF
--- a/cmd/kueuectl/app/create/create_clusterqueue.go
+++ b/cmd/kueuectl/app/create/create_clusterqueue.go
@@ -19,6 +19,7 @@ package create
 import (
 	"context"
 	"errors"
+	"fmt"
 	"regexp"
 	"slices"
 	"strings"
@@ -78,11 +79,10 @@ var (
 )
 
 var (
-	errResourceQuotaNotFound = errors.New("resource quota not found")
-	errInvalidFlavor         = errors.New("invalid flavor")
-	errInvalidResourceGroup  = errors.New("invalid resource group")
-	errInvalidResourceQuota  = errors.New("invalid resource quota")
-	errInvalidResourcesSpec  = errors.New("invalid resources specification")
+	errMisconfiguredFlavor  = errors.New("misconfigured flavor")
+	errInvalidResourceGroup = errors.New("invalid resource group")
+	errInvalidResourceQuota = errors.New("invalid resource quota")
+	errInvalidResourcesSpec = errors.New("invalid resources specification")
 )
 
 type ClusterQueueOptions struct {
@@ -424,39 +424,75 @@ func mergeResourcesByFlavor(resourceGroups []kueue.ResourceGroup) ([]kueue.Resou
 		var err error
 		mergedResources[idx].Flavors[0].Resources, err = mergeResourceQuotas(mergedResources[idx].Flavors[0].Resources, rg.Flavors[0].Resources)
 		if err != nil {
-			// multiple FlavorQuotas with same name have been found but resources listed don't match
-			return mergedResources, errInvalidFlavor
+			return mergedResources, fmt.Errorf("%w %q: %w", errMisconfiguredFlavor, flavorName, err)
 		}
 	}
 
 	return mergedResources, nil
 }
 
+// mergeResourceQuotas merges rQuotas2, the ResourceQuotas freshly parsed from
+// one flag for a flavor, into rQuotas1, the quotas already accumulated for that
+// flavor. Flags are concatenated in nominal, borrowing, lending order, so when
+// --nominal-quota names the flavor it is always the first list seen.
+//
+// Every resource in rQuotas1 is kept, whether or not rQuotas2 mentions it,
+// because borrowingLimit and lendingLimit are optional per resource. A resource
+// that appears only in rQuotas2 is rejected rather than silently dropped, as is
+// a resource whose value is given twice by the same flag.
 func mergeResourceQuotas(rQuotas1, rQuotas2 []kueue.ResourceQuota) ([]kueue.ResourceQuota, error) {
-	var mergedResourceQuotas []kueue.ResourceQuota
+	mergedResourceQuotas := make([]kueue.ResourceQuota, 0, len(rQuotas1))
+	matched := make([]bool, len(rQuotas2))
 
 	for _, rq1 := range rQuotas1 {
 		idx := slices.IndexFunc(rQuotas2, func(rq kueue.ResourceQuota) bool { return rq.Name == rq1.Name })
-		if idx == -1 {
-			// both ResourceQuota lists should contain exactly the same resource names
-			return mergedResourceQuotas, errResourceQuotaNotFound
+		if idx != -1 {
+			matched[idx] = true
+			rq2 := rQuotas2[idx]
+			// --nominal-quota is always the first list for a flavor, so a matched
+			// nominal entry in rQuotas2 is a repeat regardless of its value.
+			quotaType := quotaTypeOf(rq2)
+			if quotaType == nominalQuota ||
+				(quotaType == borrowingLimit && rq1.BorrowingLimit != nil) ||
+				(quotaType == lendingLimit && rq1.LendingLimit != nil) {
+				return nil, fmt.Errorf("resource %q is specified more than once in --%s", rq1.Name, quotaType)
+			}
+			if rq1.BorrowingLimit == nil {
+				rq1.BorrowingLimit = rq2.BorrowingLimit
+			}
+			if rq1.LendingLimit == nil {
+				rq1.LendingLimit = rq2.LendingLimit
+			}
 		}
-
-		rq2 := rQuotas2[idx]
-		if rq1.NominalQuota.IsZero() {
-			rq1.NominalQuota = rq2.NominalQuota
-		}
-		if rq1.BorrowingLimit == nil {
-			rq1.BorrowingLimit = rq2.BorrowingLimit
-		}
-		if rq1.LendingLimit == nil {
-			rq1.LendingLimit = rq2.LendingLimit
-		}
-
 		mergedResourceQuotas = append(mergedResourceQuotas, rq1)
 	}
 
+	for idx, rq2 := range rQuotas2 {
+		if matched[idx] {
+			continue
+		}
+		quotaType := quotaTypeOf(rq2)
+		if quotaType == nominalQuota {
+			return nil, fmt.Errorf("flavor is specified more than once in --%s", nominalQuota)
+		}
+		return nil, fmt.Errorf("resource %q is set in --%s but has no matching --%s", rq2.Name, quotaType, nominalQuota)
+	}
+
 	return mergedResourceQuotas, nil
+}
+
+// quotaTypeOf returns the flag a freshly parsed ResourceQuota came from.
+// toResourceQuota sets exactly one of the three fields, so the set field
+// identifies the flag. Only call it on an unmerged ResourceQuota.
+func quotaTypeOf(rq kueue.ResourceQuota) string {
+	switch {
+	case rq.BorrowingLimit != nil:
+		return borrowingLimit
+	case rq.LendingLimit != nil:
+		return lendingLimit
+	default:
+		return nominalQuota
+	}
 }
 
 func mergeFlavorsByCoveredResources(resourceGroups []kueue.ResourceGroup) ([]kueue.ResourceGroup, error) {

--- a/cmd/kueuectl/app/create/create_clusterqueue_test.go
+++ b/cmd/kueuectl/app/create/create_clusterqueue_test.go
@@ -99,6 +99,7 @@ func TestParseResourceQuotas(t *testing.T) {
 		borrowingArgs      []string
 		lendingArgs        []string
 		wantErr            error
+		wantErrMessage     string
 		wantResourceGroups []kueue.ResourceGroup
 	}{
 		"should create one resource group with one flavor and nominalQuota set": {
@@ -313,17 +314,19 @@ func TestParseResourceQuotas(t *testing.T) {
 			},
 		},
 		"should fail to create a resource group with an invalid flavor and one quota set": {
-			quotaArgs: []string{"alpha:cpu=1;memory=1", "alpha:example.com/gpu=2"},
-			wantErr:   errInvalidFlavor,
+			quotaArgs:      []string{"alpha:cpu=1;memory=1", "alpha:example.com/gpu=2"},
+			wantErr:        errMisconfiguredFlavor,
+			wantErrMessage: `misconfigured flavor "alpha": flavor is specified more than once in --nominal-quota`,
 		},
 		"should fail to create when one resource is shared by multiple resource groups": {
 			quotaArgs: []string{"alpha:cpu=1;memory=1", "beta:cpu=1"},
 			wantErr:   errInvalidResourceGroup,
 		},
 		"should fail to create a resource group with an invalid flavor and multiple quotas set": {
-			quotaArgs:     []string{"alpha:cpu=1;memory=1"},
-			borrowingArgs: []string{"alpha:example.com/gpu=2"},
-			wantErr:       errInvalidFlavor,
+			quotaArgs:      []string{"alpha:cpu=1;memory=1"},
+			borrowingArgs:  []string{"alpha:example.com/gpu=2"},
+			wantErr:        errMisconfiguredFlavor,
+			wantErrMessage: `misconfigured flavor "alpha": resource "example.com/gpu" is set in --borrowing-limit but has no matching --nominal-quota`,
 		},
 		"should create one resource group with decimal quantities": {
 			quotaArgs:     []string{"alpha:cpu=1.5;memory=1.5Gi"},
@@ -339,6 +342,50 @@ func TestParseResourceQuotas(t *testing.T) {
 					},
 				},
 			},
+		},
+		"should keep borrowingLimit and lendingLimit optional per resource": {
+			quotaArgs:     []string{"alpha:cpu=1;memory=1Gi"},
+			borrowingArgs: []string{"alpha:cpu=2"},
+			lendingArgs:   []string{"alpha:memory=512Mi"},
+			wantResourceGroups: []kueue.ResourceGroup{
+				{
+					CoveredResources: []corev1.ResourceName{"cpu", "memory"},
+					Flavors: []kueue.FlavorQuotas{
+						*utiltestingapi.MakeFlavorQuotas("alpha").
+							Resource("cpu", "1", "2").
+							Resource("memory", "1Gi", "", "512Mi").
+							Obj(),
+					},
+				},
+			},
+		},
+		"should fail when borrowingLimit is set for a resource without nominalQuota": {
+			quotaArgs:      []string{"alpha:cpu=1"},
+			borrowingArgs:  []string{"alpha:cpu=2;memory=1Gi"},
+			wantErr:        errMisconfiguredFlavor,
+			wantErrMessage: `misconfigured flavor "alpha": resource "memory" is set in --borrowing-limit but has no matching --nominal-quota`,
+		},
+		"should fail when lendingLimit is set for a resource without nominalQuota": {
+			quotaArgs:      []string{"alpha:cpu=1"},
+			lendingArgs:    []string{"alpha:memory=1Gi"},
+			wantErr:        errMisconfiguredFlavor,
+			wantErrMessage: `misconfigured flavor "alpha": resource "memory" is set in --lending-limit but has no matching --nominal-quota`,
+		},
+		"should fail when the same resource is repeated for a flavor within nominalQuota": {
+			quotaArgs:      []string{"alpha:cpu=1;memory=1", "alpha:cpu=2"},
+			wantErr:        errMisconfiguredFlavor,
+			wantErrMessage: `misconfigured flavor "alpha": resource "cpu" is specified more than once in --nominal-quota`,
+		},
+		"should fail when the same resource is repeated for a flavor within nominalQuota with a zero value": {
+			quotaArgs:      []string{"alpha:cpu=0", "alpha:cpu=1"},
+			wantErr:        errMisconfiguredFlavor,
+			wantErrMessage: `misconfigured flavor "alpha": resource "cpu" is specified more than once in --nominal-quota`,
+		},
+		"should fail when the same resource is repeated for a flavor within borrowingLimit": {
+			quotaArgs:      []string{"alpha:cpu=1"},
+			borrowingArgs:  []string{"alpha:cpu=1", "alpha:cpu=2"},
+			wantErr:        errMisconfiguredFlavor,
+			wantErrMessage: `misconfigured flavor "alpha": resource "cpu" is specified more than once in --borrowing-limit`,
 		},
 		"should fail when invalid resource quotas": {
 			quotaArgs: []string{"alpha:cpu=;memory=1"},
@@ -376,6 +423,15 @@ func TestParseResourceQuotas(t *testing.T) {
 
 			if diff := cmp.Diff(tc.wantErr, gotErr, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("Unexpected error (-want,+got):\n%s", diff)
+			}
+			if tc.wantErrMessage != "" {
+				var gotErrMessage string
+				if gotErr != nil {
+					gotErrMessage = gotErr.Error()
+				}
+				if diff := cmp.Diff(tc.wantErrMessage, gotErrMessage); diff != "" {
+					t.Errorf("Unexpected error message (-want,+got):\n%s", diff)
+				}
 			}
 			if diff := cmp.Diff(cqOptions.ResourceGroups, tc.wantResourceGroups); diff != "" {
 				t.Errorf("Unexpected ResourceGroups (-want,+got):\n%s", diff)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`kueuectl create clusterqueue` merges the `--nominal-quota`, `--borrowing-limit` and `--lending-limit` flags per flavor, but the merge only iterates the nominal-quota side. A resource listed only in a limit flag is silently dropped from the created ClusterQueue, while a resource listed in `--nominal-quota` but omitted from a limit flag fails with a bare `invalid flavor` error even though per-resource limits are optional in the API.

This PR keeps every nominal-quota resource regardless of whether the limit flags mention it, and returns a descriptive error naming the flag and resource when a resource appears only in a limit flag or is specified more than once by the same flag.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
CLI: Fixed a bug where `create clusterqueue` silently dropped a `--borrowing-limit` or `--lending-limit` entry for a resource not listed in `--nominal-quota`, and rejected omitting a limit for some nominal-quota resources. Limits are now optional per resource, and a limit for a resource without a nominal quota is reported as an error naming the flag and resource.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## AI summary

`kueuectl create clusterqueue` now preserves nominal quota resources when borrowing or lending limits are not provided. It reports descriptive errors for duplicate resources, limit-only resources, and duplicate flavor declarations.

### Suggested release note

CLI: Fixed a bug that caused `kueuectl create clusterqueue` to omit nominal quota resources when no corresponding limit was provided. The command now preserves these resources and reports descriptive errors for invalid quota specifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->