### PR TITLE
kueuectl: List a standalone Pod itself for list pods --for pod/NAME

### DIFF
--- a/cmd/kueuectl/app/list/list_pods.go
+++ b/cmd/kueuectl/app/list/list_pods.go
@@ -19,6 +19,7 @@ package list
 import (
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -42,6 +43,7 @@ import (
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/flags"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobs"
+	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
 )
 
 var (
@@ -76,6 +78,7 @@ type PodOptions struct {
 	ForGVK                 schema.GroupVersionKind
 	ForObject              *unstructured.Unstructured
 	PodLabelSelector       string
+	PodFieldSelector       string
 	IntegrationManager     *jobframework.IntegrationManager
 
 	Clientset k8s.Interface
@@ -110,7 +113,7 @@ func NewPodCmd(clientGetter clientgetter.ClientGetter, streams genericiooptions.
 			if o.ForObject == nil {
 				return nil
 			}
-			if len(o.PodLabelSelector) == 0 {
+			if len(o.PodLabelSelector) == 0 && len(o.PodFieldSelector) == 0 {
 				return fmt.Errorf("unsupported kind: %s", o.ForObject.GetKind())
 			}
 			return o.Run(clientGetter)
@@ -186,7 +189,30 @@ func (o *PodOptions) Complete(clientGetter clientgetter.ClientGetter) error {
 		return err
 	}
 
+	standalone, err := o.isStandalonePod()
+	if err != nil {
+		return err
+	}
+	if standalone {
+		// A Pod without a group name has no label shared with other members,
+		// so a label selector cannot find it. Select it by name instead.
+		o.PodLabelSelector = ""
+		o.PodFieldSelector = fmt.Sprintf("metadata.namespace=%s,metadata.name=%s", o.ForObject.GetNamespace(), o.ForObject.GetName())
+	}
+
 	return nil
+}
+
+// isStandalonePod reports whether --for points to a Pod that is not part of a pod group.
+func (o *PodOptions) isStandalonePod() (bool, error) {
+	if o.ForGVK != corev1.SchemeGroupVersion.WithKind("Pod") {
+		return false, nil
+	}
+	var pod corev1.Pod
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(o.ForObject.UnstructuredContent(), &pod); err != nil {
+		return false, fmt.Errorf("failed to convert unstructured object: %w", err)
+	}
+	return !utilpod.IsPodGroup(&pod), nil
 }
 
 // getForObjectInfos builds and executes a dynamic client query for a resource specified in --for
@@ -250,6 +276,11 @@ func (o *PodOptions) getPodLabelSelector() (string, error) {
 	}
 
 	return jobWithPodLabelSelector.PodLabelSelector(), nil
+}
+
+// joinSelectors joins non-empty selector requirements with commas.
+func joinSelectors(selectors ...string) string {
+	return strings.Join(slices.DeleteFunc(selectors, func(s string) bool { return s == "" }), ",")
 }
 
 type trackingWriterWrapper struct {
@@ -357,15 +388,10 @@ func (o *PodOptions) getPodsInfos(clientGetter clientgetter.ClientGetter) ([]*re
 		namespace = ""
 	}
 
-	podLabelSelector := o.PodLabelSelector
-	if len(o.LabelSelector) != 0 {
-		podLabelSelector = "," + o.PodLabelSelector
-	}
-
 	r := clientGetter.NewResourceBuilder().Unstructured().
 		NamespaceParam(namespace).DefaultNamespace().AllNamespaces(o.AllNamespaces).
-		FieldSelectorParam(o.FieldSelector).
-		LabelSelectorParam(o.LabelSelector+podLabelSelector).
+		FieldSelectorParam(joinSelectors(o.FieldSelector, o.PodFieldSelector)).
+		LabelSelectorParam(joinSelectors(o.LabelSelector, o.PodLabelSelector)).
 		ResourceTypeOrNameArgs(true, "pods").
 		ContinueOnError().
 		RequestChunksOf(o.Limit).

--- a/cmd/kueuectl/app/list/list_pods_test.go
+++ b/cmd/kueuectl/app/list/list_pods_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"slices"
 	"strings"
 	"testing"
@@ -46,15 +47,19 @@ import (
 	"sigs.k8s.io/yaml"
 
 	kueuecmdtesting "sigs.k8s.io/kueue/cmd/kueuectl/app/testing"
+	"sigs.k8s.io/kueue/pkg/constants"
+	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
 	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
 )
 
 type podTestCase struct {
-	name             string
-	job              runtime.Object
-	pods             []corev1.Pod
-	mapperGVKs       []schema.GroupVersionKind
-	args             []string
+	name       string
+	job        runtime.Object
+	pods       []corev1.Pod
+	mapperGVKs []schema.GroupVersionKind
+	args       []string
+	// wantPodsQuery, when set, is compared against the query of the pods list request.
+	wantPodsQuery    map[string]string
 	wantOut          string
 	wantPodListNames []string
 	podListFormat    string
@@ -184,6 +189,96 @@ valid-pod-2   1/1     Running   0          <unknown>   <none>   <none>   <none> 
 			args:             []string{"--for", "job/test-job", "-o", "yaml"},
 			wantPodListNames: []string{"valid-pod-1", "valid-pod-2"},
 			podListFormat:    "yaml",
+		}, {
+			name: "list pods of a pod group",
+			job: &corev1.Pod{
+				TypeMeta: metav1.TypeMeta{Kind: "Pod"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "group-pod-1",
+					Namespace: metav1.NamespaceDefault,
+					Labels:    map[string]string{podconstants.GroupNameLabel: "test-group"},
+				},
+			},
+			pods: []corev1.Pod{
+				*basePod.Clone().Name("group-pod-1").Label(podconstants.GroupNameLabel, "test-group").Obj(),
+				*basePod.Clone().Name("group-pod-2").Label(podconstants.GroupNameLabel, "test-group").Obj(),
+			},
+			mapperGVKs: []schema.GroupVersionKind{{Group: "", Version: "v1", Kind: "Pod"}},
+			args:       []string{"--for", "pod/group-pod-1"},
+			wantPodsQuery: map[string]string{
+				"labelSelector": podconstants.GroupNameLabel + "=test-group",
+				"fieldSelector": "",
+			},
+			wantOut: `NAME          READY   STATUS    RESTARTS   AGE
+group-pod-1   1/1     Running   0          <unknown>
+group-pod-2   1/1     Running   0          <unknown>
+`,
+		}, {
+			name: "list pods of a pod group identified by annotation is not treated as standalone",
+			job: &corev1.Pod{
+				TypeMeta: metav1.TypeMeta{Kind: "Pod"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "group-pod-1",
+					Namespace:   metav1.NamespaceDefault,
+					Annotations: map[string]string{podconstants.GroupNameAnnotation: "test-group"},
+				},
+			},
+			pods: []corev1.Pod{
+				*basePod.Clone().Name("group-pod-1").GroupNameAnnotation("test-group").Obj(),
+				*basePod.Clone().Name("group-pod-2").GroupNameAnnotation("test-group").Obj(),
+			},
+			mapperGVKs: []schema.GroupVersionKind{{Group: "", Version: "v1", Kind: "Pod"}},
+			args:       []string{"--for", "pod/group-pod-1"},
+			wantPodsQuery: map[string]string{
+				"fieldSelector": "",
+			},
+			wantOut: `NAME          READY   STATUS    RESTARTS   AGE
+group-pod-1   1/1     Running   0          <unknown>
+group-pod-2   1/1     Running   0          <unknown>
+`,
+		}, {
+			name: "list a standalone pod by name",
+			job: &corev1.Pod{
+				TypeMeta: metav1.TypeMeta{Kind: "Pod"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "single-pod",
+					Namespace: metav1.NamespaceDefault,
+					Labels:    map[string]string{constants.ManagedByKueueLabelKey: constants.ManagedByKueueLabelValue},
+				},
+			},
+			pods: []corev1.Pod{
+				*basePod.Clone().Name("single-pod").Label(constants.ManagedByKueueLabelKey, constants.ManagedByKueueLabelValue).Obj(),
+			},
+			mapperGVKs: []schema.GroupVersionKind{{Group: "", Version: "v1", Kind: "Pod"}},
+			args:       []string{"--for", "pod/single-pod"},
+			wantPodsQuery: map[string]string{
+				"labelSelector": "",
+				"fieldSelector": "metadata.namespace=default,metadata.name=single-pod",
+			},
+			wantOut: `NAME         READY   STATUS    RESTARTS   AGE
+single-pod   1/1     Running   0          <unknown>
+`,
+		}, {
+			name: "list a standalone pod by name merged with user selectors",
+			job: &corev1.Pod{
+				TypeMeta: metav1.TypeMeta{Kind: "Pod"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "single-pod",
+					Namespace: metav1.NamespaceDefault,
+				},
+			},
+			pods: []corev1.Pod{
+				*basePod.Clone().Name("single-pod").Obj(),
+			},
+			mapperGVKs: []schema.GroupVersionKind{{Group: "", Version: "v1", Kind: "Pod"}},
+			args:       []string{"--for", "pod/single-pod", "--field-selector", "status.phase=Running", "--selector", "app=foo"},
+			wantPodsQuery: map[string]string{
+				"labelSelector": "app=foo",
+				"fieldSelector": "status.phase=Running,metadata.namespace=default,metadata.name=single-pod",
+			},
+			wantOut: `NAME         READY   STATUS    RESTARTS   AGE
+single-pod   1/1     Running   0          <unknown>
+`,
 		}, {
 			name: "list pods with JSONPath containing wide",
 			job: &batchv1.Job{
@@ -708,7 +803,8 @@ valid-pod-1   1/1     Running   0          <unknown>
 
 			codec := serializer.NewCodecFactory(scheme).LegacyCodec(scheme.PrioritizedVersionsAllGroups()...)
 
-			restClient, err := mockRESTClient(codec, tc)
+			var gotPodsQuery url.Values
+			restClient, err := mockRESTClient(codec, tc, &gotPodsQuery)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -766,6 +862,16 @@ valid-pod-1   1/1     Running   0          <unknown>
 			if diff := cmp.Diff(tc.wantOutErr, gotOutErr); diff != "" {
 				t.Errorf("Unexpected output (-want/+got)\n%s", diff)
 			}
+
+			if tc.wantPodsQuery != nil {
+				gotQuery := make(map[string]string, len(tc.wantPodsQuery))
+				for key := range tc.wantPodsQuery {
+					gotQuery[key] = gotPodsQuery.Get(key)
+				}
+				if diff := cmp.Diff(tc.wantPodsQuery, gotQuery); diff != "" {
+					t.Errorf("Unexpected pods list query (-want/+got)\n%s", diff)
+				}
+			}
 		})
 	}
 }
@@ -793,7 +899,11 @@ func buildTestRuntimeScheme() (*runtime.Scheme, error) {
 	return scheme, nil
 }
 
-func mockRESTClient(codec runtime.Codec, tc podTestCase) (*restfake.RESTClient, error) {
+// mockRESTClient serves the --for object and the pod list. The two requests
+// share a path when --for is a Pod, so the pod list is recognized by the
+// Table content negotiation that only the list request performs. The query
+// of the pod list request is stored in gotPodsQuery.
+func mockRESTClient(codec runtime.Codec, tc podTestCase, gotPodsQuery *url.Values) (*restfake.RESTClient, error) {
 	podList := &corev1.PodList{Items: tc.pods}
 
 	reqPathPrefix := fmt.Sprintf("/namespaces/%s", metav1.NamespaceDefault)
@@ -807,16 +917,19 @@ func mockRESTClient(codec runtime.Codec, tc podTestCase) (*restfake.RESTClient, 
 	mockRestClient := &restfake.RESTClient{
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: restfake.CreateHTTPClient(func(request *http.Request) (*http.Response, error) {
-			switch request.URL.Path {
-			case fmt.Sprintf("%s/%s", reqPathPrefix, reqJobKind):
+			isPodListRequest := request.URL.Path == fmt.Sprintf("%s/pods", reqPathPrefix) &&
+				strings.Contains(request.Header.Get("Accept"), "as=Table")
+			switch {
+			case !isPodListRequest && request.URL.Path == fmt.Sprintf("%s/%s", reqPathPrefix, reqJobKind):
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Header:     getDefaultHeader(),
 					Body:       io.NopCloser(strings.NewReader(runtime.EncodeOrDie(codec, tc.job))),
 				}, nil
-			case fmt.Sprintf("%s/pods", reqPathPrefix):
+			case request.URL.Path == fmt.Sprintf("%s/pods", reqPathPrefix):
+				*gotPodsQuery = request.URL.Query()
 				var podRespBody io.ReadCloser
-				if strings.Contains(request.Header.Get("Accept"), "as=Table") {
+				if isPodListRequest {
 					if len(podList.Items) == 0 {
 						podRespBody = emptyTableObjBody(codec)
 					} else {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`kueuectl list pods --for pod/NAME` derives the pod label selector from the Pod integration, which formats `kueue.x-k8s.io/pod-group-name=<value>` without checking that the label exists. For a standalone Pod (managed by Kueue but not part of a pod group) the selector becomes `kueue.x-k8s.io/pod-group-name=`, which only matches Pods carrying that label with an empty value. The command therefore prints `No resources found`, contradicting its help text, which says the Pod itself is included.

This PR detects a `--for` Pod without a group label on the CLI side and selects it by namespace and name through a field selector instead, merging with any user-provided `--field-selector` and `--selector`. The Pod integration's `PodLabelSelector()` is unchanged.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

- The fake REST client in `list_pods_test.go` previously served the same Pod list for any query, so it could not observe this bug. It now records the pod list request's query so cases can assert the exact `labelSelector` and `fieldSelector` sent. The new standalone-Pod cases fail on `main` with `labelSelector: kueue.x-k8s.io/pod-group-name=`.

#### Does this PR introduce a user-facing change?

```release-note
CLI: Fixed a bug where `list pods --for pod/NAME` printed `No resources found` for a Pod that is not part of a pod group. The command now lists that Pod itself.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## AI summary

- Fixed `kueuectl list pods --for pod/NAME` for standalone Pods managed by Kueue.
- The command now selects the Pod by namespace and name while preserving user-provided selectors.
- Added tests that verify the selectors sent in Pod list requests.

### Suggested release note

`CLI:` Fixed a bug where `kueuectl list pods --for pod/NAME` returned `No resources found` for standalone Pods. The command now lists the targeted Pod correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->