### PR TITLE
TAS: answer feasibility against the cluster preemption would leave behind

### DIFF
--- a/pkg/cache/scheduler/simulator/types.go
+++ b/pkg/cache/scheduler/simulator/types.go
@@ -60,6 +60,11 @@ type PodRequirements struct {
 	// Used for SchedulerLibraryIntegration to compose the requirements in
 	// the form of `corev1.Pod`, which is accepted by the `scheduler-library`.
 	PodTemplate *corev1.PodTemplateSpec
+
+	// SimulateEmpty asks what would fit if no Workload were running. TAS uses it
+	// to check whether preemption could help, and to reserve capacity for a
+	// Workload that is waiting for preemption candidates.
+	SimulateEmpty bool
 }
 
 type NodeExclusionType int

--- a/pkg/cache/scheduler/snapshot.go
+++ b/pkg/cache/scheduler/snapshot.go
@@ -110,6 +110,16 @@ func (s *Snapshot) SimulateWorkloadRemoval(workloads []*workload.Info) func() {
 	}
 }
 
+// ForgetSimulatedFeasibility drops every cached node-feasibility result. Callers must
+// use it after changing what the scheduling simulator reports.
+func (s *Snapshot) ForgetSimulatedFeasibility() {
+	for _, cq := range s.ClusterQueues() {
+		for _, tasSnapshot := range cq.TASFlavors {
+			tasSnapshot.forgetMatchingLeaves()
+		}
+	}
+}
+
 func (s *Snapshot) Log(log logr.Logger) {
 	for name, cq := range s.ClusterQueues() {
 		cohortName := "<none>"

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -229,6 +229,9 @@ func (s *TASFlavorSnapshot) shallowCloneWithState(d *domain) *domain {
 type podSetMatchKey struct {
 	WorkloadUID types.UID
 	PodSetName  string
+	// EmptyCluster marks the entry holding what would fit if every Workload were
+	// preempted, so it cannot answer what fits now.
+	EmptyCluster bool
 }
 
 // matchingLeavesCacheEntry stores the cached list of matching leaves and accumulated
@@ -604,7 +607,6 @@ type topologyAssignmentPodRequirements struct {
 	leaderRequests            resources.Requests
 	assumedUsage              *assumedUsage
 	requiredReplacementDomain utiltas.TopologyDomainID
-	simulateEmpty             bool
 	matchKey                  *podSetMatchKey
 }
 
@@ -1101,9 +1103,9 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 	assumedUsage *assumedUsage,
 	simulateEmpty bool, requiredReplacementDomain utiltas.TopologyDomainID, wl *kueue.Workload) (assignments, leafAssignments map[kueue.PodSetReference]*utiltas.TopologyAssignment, reason string) {
 	requirements := &topologyAssignmentPodRequirements{
+		podRequirements:           simulator.PodRequirements{SimulateEmpty: simulateEmpty},
 		assumedUsage:              assumedUsage,
 		requiredReplacementDomain: requiredReplacementDomain,
-		simulateEmpty:             simulateEmpty,
 	}
 	state := &findTopologyAssignmentState{
 		topologyAssignmentParameters: topologyAssignmentParameters{
@@ -1181,6 +1183,9 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 			requirements.matchKey = &podSetMatchKey{
 				WorkloadUID: wl.UID,
 				PodSetName:  string(workersTasPodSetRequests.PodSet.Name),
+				// The default simulator answers both the same way, so it keeps one
+				// entry for both.
+				EmptyCluster: simulateEmpty && features.Enabled(features.SchedulerLibraryIntegration),
 			}
 		}
 	} else {
@@ -2101,7 +2106,7 @@ func (s *TASFlavorSnapshot) fillInCounts(ctx context.Context, requirements *topo
 // fillInCountsHelper applies the bounds when it rolls the leaves up.
 func (s *TASFlavorSnapshot) recordUsageDomainCaps(requirements *topologyAssignmentPodRequirements) {
 	for domainID, dom := range s.usageDomains() {
-		remaining := s.domainRemainingCapacity(dom, requirements.assumedUsage.perDomain[domainID], requirements.simulateEmpty)
+		remaining := s.domainRemainingCapacity(dom, requirements.assumedUsage.perDomain[domainID], requirements.podRequirements.SimulateEmpty)
 		domainState := s.domainStateOf(dom)
 		domainState.capacityBound.podCount = requirements.requests.CountIn(remaining.Get())
 
@@ -2112,6 +2117,12 @@ func (s *TASFlavorSnapshot) recordUsageDomainCaps(requirements *topologyAssignme
 		}
 		domainState.capacityBound.podCountWithLeader = requirements.requests.CountIn(remaining.Get())
 	}
+}
+
+// forgetMatchingLeaves drops the cached leaf sets. The simulator's answers feed them,
+// so anything that changes what it reports has to call this.
+func (s *TASFlavorSnapshot) forgetMatchingLeaves() {
+	clear(s.matchingLeavesCache)
 }
 
 func (s *TASFlavorSnapshot) getMatchingLeaves(ctx context.Context, requirements *topologyAssignmentPodRequirements) ([]simulator.MatchedCandidate, *tasExclusionStats, error) {
@@ -2174,7 +2185,7 @@ func (s *TASFlavorSnapshot) fillLeafCounts(leaf *leafDomain, requirements *topol
 		state.stats.TopologyDomain++
 		return
 	}
-	remainingCapacity := s.remainingCapacityForLeaf(leaf, requirements.simulateEmpty, cachingRemainingResourcesEnabled)
+	remainingCapacity := s.remainingCapacityForLeaf(leaf, requirements.podRequirements.SimulateEmpty, cachingRemainingResourcesEnabled)
 
 	// In-cycle assignments are keyed by leaf, so this picks up the exact nodes
 	// an earlier PodSet took. Domain-keyed entries, which come from assignments

--- a/pkg/cache/scheduler/tas_flavor_snapshot_was_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_was_test.go
@@ -1,0 +1,147 @@
+//go:build !exclude_scheduler_library
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/cache/scheduler/simulator"
+	"sigs.k8s.io/kueue/pkg/cache/scheduler/was"
+	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/resources"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	"sigs.k8s.io/kueue/pkg/util/testingjobs/node"
+	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
+)
+
+const wasRackLabel = "cloud.provider.com/topology-rack"
+
+// wasSnapshotWithVictim builds a TAS snapshot over one node whose single host port
+// is taken by victimKey, using the scheduler-library simulator rather than a stand-in.
+func wasSnapshotWithVictim(t *testing.T, victimKey client.ObjectKey) (*TASFlavorSnapshot, simulator.SimulatorSnapshot) {
+	t.Helper()
+	ctx, log := utiltesting.ContextWithLog(t)
+
+	nodes := []*corev1.Node{
+		node.MakeNode("n1").
+			Label(corev1.LabelHostname, "n1").
+			Label(wasRackLabel, "r1").
+			StatusAllocatable(corev1.ResourceList{
+				corev1.ResourceCPU:  resource.MustParse("4"),
+				corev1.ResourcePods: resource.MustParse("10"),
+			}).Ready().Obj(),
+	}
+	sim, err := was.NewWASSimulator(ctx, nil)
+	if err != nil {
+		t.Fatalf("NewWASSimulator() error = %v", err)
+	}
+	sim.TrackPod(ctx, testingpod.MakePod("victim-pod", victimKey.Namespace).
+		UID("victim-pod").
+		Annotation(kueue.WorkloadAnnotation, victimKey.Name).
+		NodeName("n1").
+		StatusPhase(corev1.PodRunning).
+		Port(8080, 8080, corev1.ProtocolTCP).
+		Obj())
+	simSnapshot, err := sim.Snapshot(ctx, nodes)
+	if err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+	tree := newTopologyTree([]string{wasRackLabel, corev1.LabelHostname}, nodes, 0)
+	return newTASFlavorSnapshot(log, "tas-topology", tree, nil, simSnapshot), simSnapshot
+}
+
+// wantsTheSamePort is a PodSet asking for the host port the victim holds.
+func wantsTheSamePort() FlavorTASRequests {
+	unconstrained := true
+	return FlavorTASRequests{{
+		PodSet: &kueue.PodSet{
+			Name:            "main",
+			TopologyRequest: &kueue.PodSetTopologyRequest{Unconstrained: &unconstrained},
+			Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name:  "c",
+					Ports: []corev1.ContainerPort{{ContainerPort: 8080, HostPort: 8080, Protocol: corev1.ProtocolTCP}},
+				}},
+			}},
+		},
+		SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000}),
+		Count:             1,
+	}}
+}
+
+// The matching-leaves cache must not answer an empty-cluster question with the result
+// of a normal one. TAS asks both in the same cycle for the same PodSet.
+func TestMatchingLeavesCacheSeparatesSimulateEmpty(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TASCacheNodeMatchResults, true)
+	features.SetFeatureGateDuringTest(t, features.SchedulerLibraryIntegration, true)
+	ctx, _ := utiltesting.ContextWithLog(t)
+	snapshot, _ := wasSnapshotWithVictim(t, client.ObjectKey{Namespace: "default", Name: "victim"})
+	requests := wantsTheSamePort()
+	wl := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "wl", UID: "wl-uid"}}
+
+	if snapshot.FindTopologyAssignmentsForFlavor(ctx, requests, WithWorkload(wl)).Failure() == nil {
+		t.Fatal("FindTopologyAssignmentsForFlavor() found a fit, want none while the victim holds the port")
+	}
+	if failure := snapshot.FindTopologyAssignmentsForFlavor(ctx, requests, WithWorkload(wl), WithSimulateEmpty(true)).Failure(); failure != nil {
+		t.Errorf("FindTopologyAssignmentsForFlavor(simulateEmpty) = %v, want a fit once the port is assumed free", failure)
+	}
+}
+
+// Releasing a Workload changes what the simulator reports, and so does putting it
+// back, so the cached leaf sets cannot outlive either.
+func TestMatchingLeavesCacheFollowsPreemption(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TASCacheNodeMatchResults, true)
+	features.SetFeatureGateDuringTest(t, features.SchedulerLibraryIntegration, true)
+	ctx, _ := utiltesting.ContextWithLog(t)
+	victim := client.ObjectKey{Namespace: "default", Name: "victim"}
+	snapshot, simSnapshot := wasSnapshotWithVictim(t, victim)
+	requests := wantsTheSamePort()
+	wl := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "wl", UID: "wl-uid"}}
+	fits := func() bool {
+		return snapshot.FindTopologyAssignmentsForFlavor(ctx, requests, WithWorkload(wl)).Failure() == nil
+	}
+
+	// The flavor assigner asks first, while the victim still holds the port.
+	if fits() {
+		t.Fatal("FindTopologyAssignmentsForFlavor() found a fit, want none while the victim holds the port")
+	}
+	revert, err := simSnapshot.PreemptWorkload(ctx, victim)
+	if err != nil {
+		t.Fatalf("PreemptWorkload() error = %v", err)
+	}
+	snapshot.forgetMatchingLeaves()
+	// The scheduler asks again once the victim is released.
+	if !fits() {
+		t.Error("FindTopologyAssignmentsForFlavor() found no fit after the victim was released, want a fit")
+	}
+	if err := revert(); err != nil {
+		t.Fatalf("revert() error = %v", err)
+	}
+	snapshot.forgetMatchingLeaves()
+	// And the answer given while it was released must not outlive it.
+	if fits() {
+		t.Error("FindTopologyAssignmentsForFlavor() found a fit after the victim was restored, want none")
+	}
+}

--- a/pkg/cache/scheduler/was/scheduling_simulator.go
+++ b/pkg/cache/scheduler/was/scheduling_simulator.go
@@ -22,8 +22,12 @@ import (
 	"context"
 	"fmt"
 	"iter"
+	"maps"
+	"slices"
+	"sync"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
@@ -55,8 +59,32 @@ type wasSimulator struct {
 }
 
 type wasSimulatorSnapshot struct {
-	wasSnapshot    *schedLibSnapshot.ClusterSnapshot
+	// wasSnapshot is the cluster as it stands, with every tracked Pod on its node.
+	wasSnapshot *schedLibSnapshot.ClusterSnapshot
+	// podsByWorkload indexes the tracked Pods by the Workload that owns them, which
+	// is the only set PreemptWorkload can release.
 	podsByWorkload podsByWorkload
+	// emptyCluster holds the same nodes with no Pods, for callers asking what would
+	// fit if nothing were running.
+	emptyCluster lazyCluster
+}
+
+// lazyCluster builds its cluster on first use, so cycles that never ask do not
+// pay for it.
+type lazyCluster struct {
+	// build produces the cluster. It runs at most once.
+	build func(context.Context) (*schedLibSnapshot.ClusterSnapshot, error)
+	once  sync.Once
+	// value and err hold what build returned, and are only read after once has run.
+	value *schedLibSnapshot.ClusterSnapshot
+	err   error
+}
+
+func (l *lazyCluster) get(ctx context.Context) (*schedLibSnapshot.ClusterSnapshot, error) {
+	l.once.Do(func() {
+		l.value, l.err = l.build(ctx)
+	})
+	return l.value, l.err
 }
 
 var _ simulator.SimulatorSnapshot = (*wasSimulatorSnapshot)(nil)
@@ -147,10 +175,31 @@ func (s *wasSimulator) Snapshot(ctx context.Context, nodes []*corev1.Node) (simu
 	if err != nil {
 		return nil, err
 	}
-	return &wasSimulatorSnapshot{
+	snapshot := &wasSimulatorSnapshot{
 		wasSnapshot:    clusterSnap,
 		podsByWorkload: podsByWorkload,
-	}, nil
+	}
+	snapshot.emptyCluster.build = func(ctx context.Context) (*schedLibSnapshot.ClusterSnapshot, error) {
+		return s.newSnapshot(ctx, podsNotManagedByKueue(allPods, podsByWorkload), nodes)
+	}
+	return snapshot, nil
+}
+
+// podsNotManagedByKueue returns the Pods that belong to no Workload. Preemption
+// cannot remove them, so they keep occupying their node even when the caller assumes
+// every Workload is gone.
+func podsNotManagedByKueue(allPods []*corev1.Pod, byWorkload podsByWorkload) []*corev1.Pod {
+	managed := sets.New[client.ObjectKey]()
+	for _, pods := range byWorkload {
+		managed.Insert(slices.Collect(maps.Keys(pods))...)
+	}
+	var kept []*corev1.Pod
+	for _, pod := range allPods {
+		if !managed.Has(client.ObjectKeyFromObject(pod)) {
+			kept = append(kept, pod)
+		}
+	}
+	return kept
 }
 
 func (s *wasSimulator) TrackPod(ctx context.Context, pod *corev1.Pod) {
@@ -194,11 +243,18 @@ func (s *wasSimulatorSnapshot) FindFeasibleNodes(
 		ObjectMeta: requirements.PodTemplate.ObjectMeta,
 		Spec:       requirements.PodTemplate.Spec,
 	}
-	placement, err := s.wasSnapshot.MakePlacement(candidateNodeNames)
+	cluster := s.wasSnapshot
+	if requirements.SimulateEmpty {
+		var err error
+		if cluster, err = s.emptyCluster.get(ctx); err != nil {
+			return nil, err
+		}
+	}
+	placement, err := cluster.MakePlacement(candidateNodeNames)
 	if err != nil {
 		return nil, err
 	}
-	feasibleNodeNames, _, err := s.wasSnapshot.CanSchedulePod(ctx, dummyPod, placement)
+	feasibleNodeNames, _, err := cluster.CanSchedulePod(ctx, dummyPod, placement)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cache/scheduler/was/scheduling_simulator_test.go
+++ b/pkg/cache/scheduler/was/scheduling_simulator_test.go
@@ -20,6 +20,7 @@ package was
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"strings"
 	"testing"
@@ -30,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/cache/scheduler/simulator"
@@ -78,11 +80,58 @@ func TestNodePortsFeasibility(t *testing.T) {
 		Port(8080, 8080, corev1.ProtocolTCP).
 		Obj()
 
+	// No Workload annotation, so nothing can preempt it.
+	unmanagedPod := testingpod.MakePod("unmanaged-pod", "default").
+		UID("uid-2").
+		NodeName("node1").
+		StatusPhase(corev1.PodRunning).
+		Port(8080, 8080, corev1.ProtocolTCP).
+		Obj()
+
 	tests := map[string]struct {
-		addExistingPod bool
-		candidateSpec  corev1.PodSpec
-		wantFeasible   map[string]bool
+		addExistingPod  bool
+		addUnmanagedPod bool
+		simulateEmpty   bool
+		candidateSpec   corev1.PodSpec
+		wantFeasible    map[string]bool
 	}{
+		// Preemption cannot remove a Pod that no Workload owns, so it still holds
+		// its host port even when the caller assumes every Workload is gone.
+		"hostPort held by a Pod outside any Workload still excludes the node": {
+			addUnmanagedPod: true,
+			simulateEmpty:   true,
+			candidateSpec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name:  "c",
+					Image: "busybox",
+					Ports: []corev1.ContainerPort{{
+						ContainerPort: 8080,
+						HostPort:      8080,
+						Protocol:      corev1.ProtocolTCP,
+					}},
+				}},
+			},
+			wantFeasible: map[string]bool{"node2": true},
+		},
+		// TAS asks this while deciding whether preemption could help. The Pod
+		// holding the port is one of the Workloads that would be preempted, so
+		// it must not count against the candidate.
+		"hostPort conflict is ignored when the cluster is assumed empty": {
+			addExistingPod: true,
+			simulateEmpty:  true,
+			candidateSpec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name:  "c",
+					Image: "busybox",
+					Ports: []corev1.ContainerPort{{
+						ContainerPort: 8080,
+						HostPort:      8080,
+						Protocol:      corev1.ProtocolTCP,
+					}},
+				}},
+			},
+			wantFeasible: map[string]bool{"node1": true, "node2": true},
+		},
 		"hostPort conflict excludes node with occupied port": {
 			addExistingPod: true,
 			candidateSpec: corev1.PodSpec{
@@ -163,6 +212,9 @@ func TestNodePortsFeasibility(t *testing.T) {
 			if tc.addExistingPod {
 				sim.TrackPod(ctx, existingPod)
 			}
+			if tc.addUnmanagedPod {
+				sim.TrackPod(ctx, unmanagedPod)
+			}
 			snapshot, err := sim.Snapshot(ctx, nodes)
 			if err != nil {
 				t.Fatalf("CreateSnapshot failed: %v", err)
@@ -170,7 +222,8 @@ func TestNodePortsFeasibility(t *testing.T) {
 
 			stats := &simulator.NodeExclusionStats{}
 			results, err := snapshot.FindFeasibleNodes(ctx, candidates, &simulator.PodRequirements{
-				PodTemplate: &corev1.PodTemplateSpec{Spec: tc.candidateSpec},
+				PodTemplate:   &corev1.PodTemplateSpec{Spec: tc.candidateSpec},
+				SimulateEmpty: tc.simulateEmpty,
 			}, stats)
 			if err != nil {
 				t.Fatalf("FindFeasibleNodes failed: %v", err)
@@ -435,5 +488,81 @@ func TestSimulate(t *testing.T) {
 
 	if checkFeasible(snapshot) {
 		t.Errorf("Expected node1 to be unfeasible after simulation completed (auto-reverted)")
+	}
+}
+
+// TestPreemptWorkloadReleasesPodsOnEveryNode checks that PreemptWorkload releases
+// every Pod of the victim, not just the first, and that the revert puts all of them
+// back. TestPreemptWorkload covers one Pod on one node; a real victim spans many.
+func TestPreemptWorkloadReleasesPodsOnEveryNode(t *testing.T) {
+	ctx := t.Context()
+	for _, nNodes := range []int{2, 3, 5} {
+		t.Run(fmt.Sprintf("%d-nodes", nNodes), func(t *testing.T) {
+			var nodes []*corev1.Node
+			var cands []simulator.Candidate
+			for i := range nNodes {
+				name := fmt.Sprintf("n%d", i)
+				n := testingnode.MakeNode(name).
+					Label(corev1.LabelHostname, name).
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("4"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).Ready().Obj()
+				nodes = append(nodes, n)
+				cands = append(cands, &testCandidate{node: n, id: utiltas.TopologyDomainID(name)})
+			}
+			sim, err := NewWASSimulator(ctx, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			victim := client.ObjectKey{Namespace: "default", Name: "victim"}
+			// One Pod per node, each holding the same host port, so every node is
+			// blocked until the whole victim is released.
+			for i := range nodes {
+				sim.TrackPod(ctx, testingpod.MakePod(fmt.Sprintf("victim-%d", i), victim.Namespace).
+					UID(fmt.Sprintf("uid-%d", i)).
+					Annotation(kueue.WorkloadAnnotation, victim.Name).
+					NodeName(nodes[i].Name).
+					StatusPhase(corev1.PodRunning).
+					Port(8080, 8080, corev1.ProtocolTCP).
+					Obj())
+			}
+			snap, err := sim.Snapshot(ctx, nodes)
+			if err != nil {
+				t.Fatal(err)
+			}
+			probe := testingpod.MakePod("probe", "default").Obj()
+			probe.Spec.Containers[0].Ports = []corev1.ContainerPort{{ContainerPort: 8080, HostPort: 8080, Protocol: corev1.ProtocolTCP}}
+			feasible := func() []string {
+				var stats simulator.NodeExclusionStats
+				got, err := snap.FindFeasibleNodes(ctx, slices.Values(cands),
+					&simulator.PodRequirements{PodTemplate: &corev1.PodTemplateSpec{ObjectMeta: probe.ObjectMeta, Spec: probe.Spec}}, &stats)
+				if err != nil {
+					t.Fatal(err)
+				}
+				names := make([]string, 0, len(got))
+				for _, c := range got {
+					names = append(names, c.GetNode().Name)
+				}
+				slices.Sort(names)
+				return names
+			}
+			if got := feasible(); len(got) != 0 {
+				t.Fatalf("before preemption: want no feasible node, got %v", got)
+			}
+			revert, err := snap.PreemptWorkload(ctx, victim)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := feasible(); len(got) != nNodes {
+				t.Errorf("after preempting the victim: want all %d nodes free, got %v", nNodes, got)
+			}
+			if err := revert(); err != nil {
+				t.Fatal(err)
+			}
+			if got := feasible(); len(got) != 0 {
+				t.Errorf("after revert: want no feasible node, got %v", got)
+			}
+		})
 	}
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -976,6 +976,42 @@ func (s *Scheduler) evictWorkloadAfterFailedTASReplacement(ctx context.Context, 
 	return nil
 }
 
+// simulatePodRemoval removes the Workloads' Pods from the scheduling simulator and
+// returns a function that puts them back.
+func simulatePodRemoval(ctx context.Context, log logr.Logger, snapshot *schdcache.Snapshot, workloads []*workload.Info) func() {
+	// The default simulator reports the same cluster whatever is running, so there is
+	// nothing to take out of it and nothing cached to drop.
+	if snapshot.SimulatorSnapshot == nil || !features.Enabled(features.SchedulerLibraryIntegration) {
+		return func() {}
+	}
+	reverts := make([]func() error, 0, len(workloads))
+	for _, w := range workloads {
+		revert, err := snapshot.SimulatorSnapshot.PreemptWorkload(ctx, client.ObjectKeyFromObject(w.Obj))
+		if err != nil {
+			// The simulation still holds this victim's Pods, so it can only be
+			// stricter than reality. Log it and keep scheduling.
+			log.V(2).Info("Could not remove a preempted Workload from the scheduling simulator",
+				"workload", klog.KObj(w.Obj), "error", err)
+			continue
+		}
+		reverts = append(reverts, revert)
+	}
+	if len(reverts) == 0 {
+		return func() {}
+	}
+	// The simulator reports a different cluster now, so results cached before this
+	// no longer hold. The revert changes it back, so they are dropped again there.
+	snapshot.ForgetSimulatedFeasibility()
+	return func() {
+		for _, revert := range reverts {
+			if err := revert(); err != nil {
+				log.V(2).Info("Could not restore a preempted Workload in the scheduling simulator", "error", err)
+			}
+		}
+		snapshot.ForgetSimulatedFeasibility()
+	}
+}
+
 func updateAssignmentForTAS(
 	ctx context.Context,
 	snapshot *schdcache.Snapshot,
@@ -998,11 +1034,15 @@ func updateAssignmentForTAS(
 				targetWorkloads = append(targetWorkloads, target.WorkloadInfo)
 			}
 			revertUsage := snapshot.SimulateWorkloadUsageRemoval(targetWorkloads)
+			// Freeing the victims' quota is not enough. Until the simulator is told,
+			// it still reports their Pods and their nodes still look occupied.
+			revertPods := simulatePodRemoval(ctx, log, snapshot, targetWorkloads)
 			tasResult = cq.FindTopologyAssignmentsForWorkload(
 				ctx,
 				tasRequests,
 				schdcache.WithWorkload(wl.Obj),
 			)
+			revertPods()
 			revertUsage()
 		} else {
 			// In this scenario we don't have any preemption candidates, yet we need

--- a/pkg/scheduler/scheduler_tas_test.go
+++ b/pkg/scheduler/scheduler_tas_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"iter"
 	"sync"
 	"testing"
 	"time"
@@ -43,6 +44,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	"sigs.k8s.io/kueue/pkg/cache/scheduler/simulator"
 	"sigs.k8s.io/kueue/pkg/cache/scheduler/was"
 	tasindexer "sigs.k8s.io/kueue/pkg/controller/tas/indexer"
 	"sigs.k8s.io/kueue/pkg/features"
@@ -4064,10 +4066,70 @@ type tasScheduleTestCase struct {
 	eventCmpOpts cmp.Options
 
 	featureGates map[featuregate.Feature]bool
+
+	// wantSimulatorPreemptions are the Workloads the scheduler must tell the
+	// simulator to preempt. Setting it installs a recording simulator.
+	wantSimulatorPreemptions []string
+
+	// failSimulatorPreemption makes that simulator refuse to release Workloads.
+	failSimulatorPreemption bool
 }
 
 // tasScheduleTestConfig carries the per-suite fixtures shared by the TAS preemption
 // and cohort scheduling run procedure.
+// recordingSimulator records which Workloads the scheduler asked the simulator to
+// preempt. Feasibility is a pass-through, since the point is the preemption wiring.
+type recordingSimulator struct {
+	snapshot recordingSimulatorSnapshot
+}
+
+func (s *recordingSimulator) Snapshot(context.Context, []*corev1.Node) (simulator.SimulatorSnapshot, error) {
+	return &s.snapshot, nil
+}
+func (s *recordingSimulator) TrackPod(context.Context, *corev1.Pod)        {}
+func (s *recordingSimulator) UntrackPod(context.Context, client.ObjectKey) {}
+
+type recordingSimulatorSnapshot struct {
+	// failPreempt makes PreemptWorkload return an error.
+	failPreempt bool
+	// asked holds every Workload the scheduler tried to release, released holds the
+	// ones it managed to. They differ when failPreempt is set.
+	asked    []string
+	released int
+	reverted int
+}
+
+func (s *recordingSimulatorSnapshot) Simulate(_ context.Context, fn func()) error {
+	fn()
+	return nil
+}
+
+func (s *recordingSimulatorSnapshot) PreemptWorkload(_ context.Context, wlKey client.ObjectKey) (func() error, error) {
+	s.asked = append(s.asked, wlKey.String())
+	if s.failPreempt {
+		return nil, errors.New("simulated failure")
+	}
+	s.released++
+	return func() error {
+		s.reverted++
+		return nil
+	}, nil
+}
+
+func (s *recordingSimulatorSnapshot) FindFeasibleNodes(
+	_ context.Context,
+	candidates iter.Seq[simulator.Candidate],
+	_ *simulator.PodRequirements,
+	stats *simulator.NodeExclusionStats,
+) ([]simulator.MatchedCandidate, error) {
+	var feasible []simulator.MatchedCandidate
+	for candidate := range candidates {
+		stats.TotalNodes++
+		feasible = append(feasible, candidate.(simulator.MatchedCandidate))
+	}
+	return feasible, nil
+}
+
 type tasScheduleTestConfig struct {
 	queues []kueue.LocalQueue
 	now    time.Time
@@ -4170,13 +4232,26 @@ func runTASScheduleTestCases(t *testing.T, cfg tasScheduleTestConfig, cases map[
 					_ = tasindexer.SetupIndexes(ctx, utiltesting.AsIndexer(clientBuilder))
 					cl := clientBuilder.Build()
 					recorder := &utiltesting.EventRecorder{}
-					cqCache := schdcache.New(cl)
+					var simRecorder *recordingSimulator
+					cacheOptions := []schdcache.Option{}
+					if tc.wantSimulatorPreemptions != nil {
+						// main.go only installs a simulator behind this gate, so a test
+						// that installs one has to set it too.
+						features.SetFeatureGateDuringTest(t, features.SchedulerLibraryIntegration, true)
+						simRecorder = &recordingSimulator{}
+						simRecorder.snapshot.failPreempt = tc.failSimulatorPreemption
+						cacheOptions = append(cacheOptions, schdcache.WithSchedulingSimulator(simRecorder))
+					}
+					cqCache := schdcache.New(cl, cacheOptions...)
 					qManager := qcache.NewManagerForUnitTests(cl, cqCache)
 					topologyByName := slices.ToMap(tc.topologies, func(i int) (kueue.TopologyReference, kueue.Topology) {
 						return kueue.TopologyReference(tc.topologies[i].Name), tc.topologies[i]
 					})
 					for i := range tc.nodes {
 						cqCache.TASCache().SyncNode(&tc.nodes[i])
+					}
+					for i := range tc.pods {
+						cqCache.TASCache().TrackPod(ctx, &tc.pods[i])
 					}
 					for _, flavor := range tc.resourceFlavors {
 						cqCache.AddOrUpdateResourceFlavor(log, &flavor)
@@ -4272,6 +4347,16 @@ func runTASScheduleTestCases(t *testing.T, cfg tasScheduleTestConfig, cases map[
 						t.Errorf("Unexpected elements left in the queue (-want,+got):\n%s", diff)
 					}
 					qDumpInadmissible := qManager.DumpInadmissible()
+					if simRecorder != nil {
+						sortStrings := cmpopts.SortSlices(func(a, b string) bool { return a < b })
+						gotPreemptions := simRecorder.snapshot.asked
+						if diff := cmp.Diff(tc.wantSimulatorPreemptions, gotPreemptions, cmpopts.EquateEmpty(), sortStrings); diff != "" {
+							t.Errorf("unexpected preemptions reported to the simulator (-want/+got):\n%s", diff)
+						}
+						if got, want := simRecorder.snapshot.reverted, simRecorder.snapshot.released; got != want {
+							t.Errorf("simulator preemptions reverted = %d, want %d: the simulated cluster must be restored", got, want)
+						}
+					}
 					if diff := cmp.Diff(tc.wantInadmissibleLeft, qDumpInadmissible, cmpDump...); diff != "" {
 						t.Errorf("Unexpected elements left in inadmissible workloads (-want,+got):\n%s", diff)
 					}
@@ -4616,13 +4701,145 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					Obj(),
 			},
 		},
+		"a simulator that will not release the victim does not stop the cycle": {
+			// A simulator that cannot release the victim leaves the cycle stricter
+			// than reality, which is safe. It must not stop the cycle.
+			failSimulatorPreemption:  true,
+			wantSimulatorPreemptions: []string{"default/low-priority-admitted"},
+			nodes:                    defaultSingleNode,
+			topologies:               []kueue.Topology{defaultSingleLevelTopology},
+			resourceFlavors:          []kueue.ResourceFlavor{defaultTASFlavor},
+			clusterQueues:            []kueue.ClusterQueue{defaultClusterQueueWithPreemption},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("foo", "default").
+					UID("wl-foo").
+					JobUID("job-foo").
+					Queue("tas-main").
+					Priority(3).
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						PreferredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "2").
+						Obj()).
+					Obj(),
+				*utiltestingapi.MakeWorkload("low-priority-admitted", "default").
+					UID("low-priority-admitted-uid").
+					Queue("tas-main").
+					Priority(1).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("tas-main").
+							PodSets(utiltestingapi.MakePodSetAssignment("one").
+								Assignment(corev1.ResourceCPU, "tas-default", "5").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(),
+						now,
+					).
+					AdmittedAt(true, now).
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "5").
+						Obj()).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("foo", "default").
+					UID("wl-foo").
+					JobUID("job-foo").
+					Queue("tas-main").
+					Priority(3).
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						PreferredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "2").
+						Obj()).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads,
+						Message:            `couldn't assign flavors to pod set one: topology "tas-single-level" doesn't allow to fit any of 1 pod(s). Total nodes: 1; excluded: resource "cpu": 1. Pending the preemption of 1 workload(s)`,
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadAdmittedReasonNoReservation,
+						Message:            "The workload has no reservation",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "one",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("2"),
+						},
+					}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("low-priority-admitted", "default").
+					UID("low-priority-admitted-uid").
+					Queue("tas-main").
+					Priority(1).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("tas-main").
+							PodSets(utiltestingapi.MakePodSetAssignment("one").
+								Assignment(corev1.ResourceCPU, "tas-default", "5").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(),
+						now,
+					).
+					AdmittedAt(true, now).
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "5").
+						Obj()).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadEvicted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Preempted",
+						Message:            "Preempted to accommodate a workload (UID: wl-foo, JobUID: job-foo) due to prioritization in the ClusterQueue; preemptor path: /tas-main; preemptee path: /tas-main",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadPreempted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "InClusterQueue",
+						Message:            "Preempted to accommodate a workload (UID: wl-foo, JobUID: job-foo) due to prioritization in the ClusterQueue; preemptor path: /tas-main; preemptee path: /tas-main",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Preempted", Count: 1}).
+					Obj(),
+			},
+			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+				"tas-main": {"default/foo"},
+			},
+			wantEvents: []utiltesting.EventRecord{
+				utiltesting.MakeEventRecord("default", "low-priority-admitted", "EvictedDueToPreempted", "Normal").
+					Message("Preempted to accommodate a workload (UID: wl-foo, JobUID: job-foo) due to prioritization in the ClusterQueue; preemptor path: /tas-main; preemptee path: /tas-main").
+					Obj(),
+				utiltesting.MakeEventRecord("default", "low-priority-admitted", "Preempted", "Normal").
+					Message("Preempted to accommodate a workload (UID: wl-foo, JobUID: job-foo) due to prioritization in the ClusterQueue; preemptor path: /tas-main; preemptee path: /tas-main; preemptor effective priority: 3 (base: 3, boost: 0); preemptee effective priority: 1 (base: 1, boost: 0)").
+					Obj(),
+				utiltesting.MakeEventRecord("default", "foo", "PreemptedWorkload", "Normal").
+					Message("Preempted workload default/low-priority-admitted (UID: low-priority-admitted-uid) in ClusterQueue tas-main; preemptor effective priority: 3 (base: 3, boost: 0); preemptee effective priority: 1 (base: 1, boost: 0)").
+					Obj(),
+				utiltesting.MakeEventRecord("default", "foo", kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads, "Warning").
+					Message(`couldn't assign flavors to pod set one: topology "tas-single-level" doesn't allow to fit any of 1 pod(s). Total nodes: 1; excluded: resource "cpu": 1. Pending the preemption of 1 workload(s)`).
+					Obj(),
+			},
+		},
 		"only low priority workload is preempted": {
 			// This test case demonstrates the baseline scenario where there
 			// is only one low-priority workload and it gets preempted.
-			nodes:           defaultSingleNode,
-			topologies:      []kueue.Topology{defaultSingleLevelTopology},
-			resourceFlavors: []kueue.ResourceFlavor{defaultTASFlavor},
-			clusterQueues:   []kueue.ClusterQueue{defaultClusterQueueWithPreemption},
+			//
+			// The simulated cluster has to lose the victim's Pods too, or a host
+			// port it holds keeps the node looking unusable.
+			wantSimulatorPreemptions: []string{"default/low-priority-admitted"},
+			nodes:                    defaultSingleNode,
+			topologies:               []kueue.Topology{defaultSingleLevelTopology},
+			resourceFlavors:          []kueue.ResourceFlavor{defaultTASFlavor},
+			clusterQueues:            []kueue.ClusterQueue{defaultClusterQueueWithPreemption},
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("foo", "default").
 					UID("wl-foo").


### PR DESCRIPTION

<!-- Thank you for contributing! Check CONTRIBUTING.md for details. -->

#### What type of PR is this?
<!-- Choose one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep
-->

 /kind bug
 /area tas
 /area was

<!-- Optionally choose one or more of the following kinds:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


<!-- Consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->


#### What this PR does / why we need it?
TAS decides whether preemption could help by asking the simulator what would fit if every Workload were preempted, but that question was answered against the cluster as it is now. A host port held by the Workload that preemption would remove therefore made the node look unusable, TAS reported no fit, and no preemption was attempted at all.

Part of: #12422

<!--
Use `Fixes #123` for an issue addressed by this PR; it will be closed when the PR merges.
Use `Related:` or `Part of:` to reference an issue without closing it.
-->

#### Useful notes for your reviewer
I hit this while adding per-node DRA device feasibility, where a node whose device is held by a preemption candidate still looked unusable. It reproduces today with host ports, so the fix stands on its own.

#### Release note

<!-- Describe the behavior change accurately from the user's perspective. Hints:
- Do not leave this block blank.
- Use "NONE" when there is no user-facing change.
- When feasible use a prefix for the sub-component or feature, e.g. "FairSharing:" or "MultiKueue:".
- If upgrade steps are required, include an "ACTION REQUIRED:" section.
You may consider AI assistance using the skill: cmd/experimental/skills/kueue-release-notes/SKILL.md.
-->
```release-note
TAS: Fixed a bug where preemption was not attempted when the only thing blocking a Workload was a conflict held by the Workload that would be preempted, such as a host port. Affects clusters with SchedulerLibraryIntegration enabled.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## AI summary

Fixes TAS preemption checks when `SchedulerLibraryIntegration` is enabled. Kueue now evaluates placement after removing candidate Workload Pods, while preserving unmanaged Pod occupancy. This enables preemption when conflicts are held by Workloads that would be removed, such as host ports or DRA devices.

### Suggested release note

TAS: Fixed a bug that could prevent preemption when a candidate Workload held a conflicting host port or DRA device. Kueue now evaluates placement after removing the candidate Workload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->