### PR TITLE
Consolidate requeue adjusted-resources test into TestReconcileRequeue

### DIFF
--- a/pkg/controller/core/workload_controller_requeue_test.go
+++ b/pkg/controller/core/workload_controller_requeue_test.go
@@ -29,8 +29,10 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/resources"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/pkg/workload"
 )
 
 func TestReconcileRequeue(t *testing.T) {
@@ -1097,7 +1099,21 @@ func TestReconcileRequeue(t *testing.T) {
 				Limit(corev1.ResourceCPU, "3").
 				RequeueState(new(int32(1)), new(metav1.NewTime(now.Add(-time.Minute)))).
 				Obj(),
-			wantPendingCPURequest: new(int64(3000)),
+			wantPendingWorkloads: map[kueue.ClusterQueueReference]map[workload.Reference]*workload.Info{
+				"cq": {
+					"ns/wl": {
+						TotalRequests: []workload.PodSetResources{
+							{
+								Name:  kueue.DefaultPodSetName,
+								Count: 1,
+								Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+									corev1.ResourceCPU: 3000,
+								}),
+							},
+						},
+					},
+				},
+			},
 		},
 		"should use the biggest total time not the biggest RequeueAfterSeconds": {
 			workload: utiltestingapi.MakeWorkload("wl", "ns").

--- a/pkg/controller/core/workload_controller_requeue_test.go
+++ b/pkg/controller/core/workload_controller_requeue_test.go
@@ -28,11 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
-	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
-	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/features"
-	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 )
@@ -1092,6 +1088,17 @@ func TestReconcileRequeue(t *testing.T) {
 				Obj(),
 			wantResult: reconcile.Result{},
 		},
+		"requeue after backoff accounts for the effective cpu request": {
+			cq: utiltestingapi.MakeClusterQueue("cq").Obj(),
+			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				Queue("lq").
+				Active(true).
+				Limit(corev1.ResourceCPU, "3").
+				RequeueState(new(int32(1)), new(metav1.NewTime(now.Add(-time.Minute)))).
+				Obj(),
+			wantPendingCPURequest: new(int64(3000)),
+		},
 		"should use the biggest total time not the biggest RequeueAfterSeconds": {
 			workload: utiltestingapi.MakeWorkload("wl", "ns").
 				AdmissionCheck(kueue.AdmissionCheckState{
@@ -1141,51 +1148,4 @@ func TestReconcileRequeue(t *testing.T) {
 		},
 	}
 	runReconcileTestCases(t, cases, fakeClock)
-}
-
-// The requeue-after-backoff path must account the workload by its effective
-// resources: a container that declares only a cpu limit is charged that limit
-// (mirroring the requests the created Pods will carry), not the raw empty
-// requests.
-func TestRequeueAfterBackoffUsesAdjustedResources(t *testing.T) {
-	now := time.Now().Truncate(time.Second)
-	fakeClock := testingclock.NewFakeClock(now)
-
-	wl := utiltestingapi.MakeWorkload("wl", "ns").
-		Queue("lq").
-		Active(true).
-		Limit(corev1.ResourceCPU, "3").
-		RequeueState(new(int32(1)), new(metav1.NewTime(now.Add(-time.Minute)))).
-		Obj()
-
-	cl := utiltesting.NewClientBuilder().
-		WithObjects(wl).
-		WithStatusSubresource(wl).
-		WithIndex(&corev1.LimitRange{}, indexer.LimitRangeHasContainerOrPodType, indexer.IndexLimitRangeHasContainerOrPodType).
-		Build()
-	recorder := &utiltesting.EventRecorder{}
-	cqCache := schdcache.New(cl)
-	qManager := qcache.NewManagerForUnitTests(cl, cqCache,
-		qcache.WithClock(fakeClock),
-		qcache.WithPreemptionExpectations(preemptexpectations.New()))
-	reconciler := NewWorkloadReconciler(cl, qManager, cqCache, recorder)
-
-	ctx, _ := utiltesting.ContextWithLog(t)
-
-	setupClusterQueue(ctx, t, cl, qManager, cqCache, utiltestingapi.MakeClusterQueue("cq").Obj(), false)
-	setupLocalQueue(ctx, t, cl, qManager, utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(), false)
-
-	if _, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "wl"}}); err != nil {
-		t.Fatalf("Reconcile() failed: %v", err)
-	}
-
-	pending := qManager.PendingWorkloadsInfo("cq")
-	if len(pending) != 1 {
-		t.Fatalf("expected 1 pending workload after the backoff requeue, got %d", len(pending))
-	}
-	// The effective cpu request is the limit (3 CPU = 3000m); raw accounting
-	// would report 0.
-	if got := pending[0].TotalRequests[0].Requests.ResourceValue(corev1.ResourceCPU); got != 3000 {
-		t.Errorf("requeued workload accounted cpu=%dm, want 3000m", got)
-	}
 }

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -55,6 +55,7 @@ import (
 	utilindexer "sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/dra"
 	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/resources"
 	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
 	afs "sigs.k8s.io/kueue/pkg/util/admissionfairsharing"
 	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
@@ -1008,6 +1009,15 @@ var (
 		cmpopts.IgnoreFields(kueue.RequeueState{}, "RequeueAt"),
 		cmpopts.SortSlices(func(a, b metav1.Condition) bool { return a.Type < b.Type }),
 	}
+
+	pendingWorkloadsCmpOpts = cmp.Options{
+		cmpopts.EquateEmpty(),
+		cmpopts.IgnoreFields(workload.Info{},
+			"Obj", "FlavorScanState", "LocalQueueFSUsage", "SecondPassIteration",
+			"LastEvaluatedGeneration", "SchedulingHash", "NominationMapping",
+		),
+		cmp.Comparer(resources.Equal),
+	}
 )
 
 type reconcileTestCase struct {
@@ -1032,7 +1042,7 @@ type reconcileTestCase struct {
 	wantWorkloadsInQueue      *int
 	wantWorkloadInHeap        *bool
 	wantWorkloadInadmissible  *bool
-	wantPendingCPURequest     *int64
+	wantPendingWorkloads      map[kueue.ClusterQueueReference]map[workload.Reference]*workload.Info
 	wantWorkload              *kueue.Workload
 	wantWorkloadUseMergePatch *kueue.Workload // workload version to compensate for the difference between use of Apply and Merge patch in FakeClient
 	wantError                 error
@@ -2675,26 +2685,18 @@ func runReconcileTestCases(t *testing.T, cases map[string]reconcileTestCase, fak
 					t.Errorf("unexpected events (-want/+got):\n%s", diff)
 				}
 
-				if tc.wantPendingCPURequest != nil {
-					cqName, found := qManager.ClusterQueueFromLocalQueue(utilqueue.KeyFromWorkload(testWl))
-					if !found {
-						t.Errorf("expected workload's LocalQueue to be tracked by the queue manager")
-					} else {
-						var foundPending bool
+				if tc.wantPendingWorkloads != nil {
+					gotPendingWorkloads := make(map[kueue.ClusterQueueReference]map[workload.Reference]*workload.Info)
+					for _, cqName := range qManager.GetClusterQueueNames() {
 						for _, wlInfo := range qManager.PendingWorkloadsInfo(cqName) {
-							if wlInfo.Obj.Name == testWl.Name && wlInfo.Obj.Namespace == testWl.Namespace {
-								foundPending = true
-								if len(wlInfo.TotalRequests) == 0 {
-									t.Errorf("expected TotalRequests for the pending workload, got none")
-								} else if got := wlInfo.TotalRequests[0].Requests.ResourceValue(corev1.ResourceCPU); got != *tc.wantPendingCPURequest {
-									t.Errorf("pending workload cpu request = %dm, want %dm", got, *tc.wantPendingCPURequest)
-								}
-								break
+							if gotPendingWorkloads[cqName] == nil {
+								gotPendingWorkloads[cqName] = make(map[workload.Reference]*workload.Info)
 							}
+							gotPendingWorkloads[cqName][workload.Key(wlInfo.Obj)] = wlInfo
 						}
-						if !foundPending {
-							t.Errorf("expected workload to be pending in ClusterQueue %q", cqName)
-						}
+					}
+					if diff := cmp.Diff(tc.wantPendingWorkloads, gotPendingWorkloads, pendingWorkloadsCmpOpts...); diff != "" {
+						t.Errorf("unexpected pending workloads (-want,+got):\n%s", diff)
 					}
 				}
 

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -1011,7 +1011,6 @@ var (
 	}
 
 	pendingWorkloadsCmpOpts = cmp.Options{
-		cmpopts.EquateEmpty(),
 		cmpopts.IgnoreFields(workload.Info{},
 			"Obj", "FlavorScanState", "LocalQueueFSUsage", "SecondPassIteration",
 			"LastEvaluatedGeneration", "SchedulingHash", "NominationMapping",

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -1032,6 +1032,7 @@ type reconcileTestCase struct {
 	wantWorkloadsInQueue      *int
 	wantWorkloadInHeap        *bool
 	wantWorkloadInadmissible  *bool
+	wantPendingCPURequest     *int64
 	wantWorkload              *kueue.Workload
 	wantWorkloadUseMergePatch *kueue.Workload // workload version to compensate for the difference between use of Apply and Merge patch in FakeClient
 	wantError                 error
@@ -2672,6 +2673,29 @@ func runReconcileTestCases(t *testing.T, cases map[string]reconcileTestCase, fak
 				}
 				if diff := cmp.Diff(tc.wantEvents, recorder.RecordedEvents); diff != "" {
 					t.Errorf("unexpected events (-want/+got):\n%s", diff)
+				}
+
+				if tc.wantPendingCPURequest != nil {
+					cqName, found := qManager.ClusterQueueFromLocalQueue(utilqueue.KeyFromWorkload(testWl))
+					if !found {
+						t.Errorf("expected workload's LocalQueue to be tracked by the queue manager")
+					} else {
+						var foundPending bool
+						for _, wlInfo := range qManager.PendingWorkloadsInfo(cqName) {
+							if wlInfo.Obj.Name == testWl.Name && wlInfo.Obj.Namespace == testWl.Namespace {
+								foundPending = true
+								if len(wlInfo.TotalRequests) == 0 {
+									t.Errorf("expected TotalRequests for the pending workload, got none")
+								} else if got := wlInfo.TotalRequests[0].Requests.ResourceValue(corev1.ResourceCPU); got != *tc.wantPendingCPURequest {
+									t.Errorf("pending workload cpu request = %dm, want %dm", got, *tc.wantPendingCPURequest)
+								}
+								break
+							}
+						}
+						if !foundPending {
+							t.Errorf("expected workload to be pending in ClusterQueue %q", cqName)
+						}
+					}
 				}
 
 				// For DRA tests, verify that workloads are properly queued/cached


### PR DESCRIPTION
<!-- Thank you for contributing! Check CONTRIBUTING.md for details. -->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it?

Consolidates the CPU-limit-as-request accounting scenario from the standalone `TestRequeueAfterBackoffUsesAdjustedResources` into the existing `TestReconcileRequeue` table in `pkg/controller/core/workload_controller_requeue_test.go`, avoiding a dedicated test function for a single reconciliation scenario. Adds a generic `wantPendingCPURequest` assertion field to the shared reconcile test harness (`pkg/controller/core/workload_controller_test.go`) to support the new table case, which still verifies that a container specifying only a CPU limit is accounted for at the effective CPU request of `3000m`.

This change was made with AI assistance (Claude Code) per the [Kubernetes AI Tool Usage Policy](https://www.kubernetes.dev/docs/guide/pull-requests/#ai-guidance); all changes were reviewed and tested by me.

Fixes #15378

#### Useful notes for your reviewer

- `TestRequeueAfterBackoffUsesAdjustedResources` is removed; equivalent coverage now lives in `TestReconcileRequeue` under the case `"requeue after backoff accounts for the effective cpu request"`.
- Verified via `go test ./pkg/controller/core/... -run TestReconcileRequeue -v` and `golangci-lint run ./pkg/controller/core/...` (test-only change).

#### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## AI summary

- Consolidates adjusted-resource coverage into `TestReconcileRequeue`.
- Verifies an effective CPU request of `3000m` for CPU-limit-only containers.
- Adds pending workload assertions to the shared test harness.
- Removes `TestRequeueAfterBackoffUsesAdjustedResources`.

### Suggested release note

NONE
<!-- end of auto-generated comment: release notes by coderabbit.ai -->