### PR TITLE
TAS: reject slice sizes that do not evenly divide the PodSet count

### DIFF
--- a/pkg/controller/jobframework/tas_validation.go
+++ b/pkg/controller/jobframework/tas_validation.go
@@ -195,6 +195,11 @@ func ValidateSliceSizeAnnotationUpperBound(replicaPath *field.Path, replicaMetad
 				annotationsPath.Key(kueue.PodSetSliceSizeAnnotation), sliceSizeValue,
 				fmt.Sprintf("must not be greater than pod set count %d", podSet.Count),
 			))
+		} else if features.Enabled(features.TASValidateWorkloadSliceSize) && podSet.Count > 0 && int32(val) > 0 && podSet.Count%int32(val) != 0 {
+			allErrs = append(allErrs, field.Invalid(
+				annotationsPath.Key(kueue.PodSetSliceSizeAnnotation), sliceSizeValue,
+				fmt.Sprintf("must evenly divide pod set count %d", podSet.Count),
+			))
 		}
 	}
 
@@ -208,6 +213,12 @@ func ValidateSliceSizeAnnotationUpperBound(replicaPath *field.Path, replicaMetad
 					annotationsPath.Key(kueue.PodSetSliceRequiredTopologyConstraintsAnnotation),
 					constraints[0].Size,
 					fmt.Sprintf("must not be greater than pod set count %d", podSet.Count),
+				))
+			} else if features.Enabled(features.TASValidateWorkloadSliceSize) && podSet.Count > 0 && constraints[0].Size > 0 && podSet.Count%constraints[0].Size != 0 {
+				allErrs = append(allErrs, field.Invalid(
+					annotationsPath.Key(kueue.PodSetSliceRequiredTopologyConstraintsAnnotation),
+					constraints[0].Size,
+					fmt.Sprintf("must evenly divide pod set count %d", podSet.Count),
 				))
 			}
 		}

--- a/pkg/controller/jobframework/tas_validation_test.go
+++ b/pkg/controller/jobframework/tas_validation_test.go
@@ -272,13 +272,14 @@ func TestValidateSliceSizeAnnotationUpperBound(t *testing.T) {
 	replicaPath := field.NewPath("spec", "template", "metadata")
 
 	testCases := map[string]struct {
-		annotations map[string]string
-		podSetCount int32
-		wantErrNum  int
+		annotations  map[string]string
+		podSetCount  int32
+		featureGates map[featuregate.Feature]bool
+		wantErrNum   int
 	}{
 		"valid: PodSetSliceSizeAnnotation within bound": {
 			annotations: map[string]string{
-				kueue.PodSetSliceSizeAnnotation:             "16",
+				kueue.PodSetSliceSizeAnnotation:             "10",
 				kueue.PodSetSliceRequiredTopologyAnnotation: "cloud.com/rack",
 				kueue.PodSetRequiredTopologyAnnotation:      "cloud.com/block",
 			},
@@ -297,7 +298,7 @@ func TestValidateSliceSizeAnnotationUpperBound(t *testing.T) {
 		"valid: multi-layer outermost size within bound": {
 			annotations: map[string]string{
 				kueue.PodSetRequiredTopologyAnnotation:                 "cloud.com/block",
-				kueue.PodSetSliceRequiredTopologyConstraintsAnnotation: `[{"topology":"cloud.com/rack","size":16},{"topology":"kubernetes.io/hostname","size":4}]`,
+				kueue.PodSetSliceRequiredTopologyConstraintsAnnotation: `[{"topology":"cloud.com/rack","size":20},{"topology":"kubernetes.io/hostname","size":5}]`,
 			},
 			podSetCount: 20,
 			wantErrNum:  0,
@@ -310,10 +311,67 @@ func TestValidateSliceSizeAnnotationUpperBound(t *testing.T) {
 			podSetCount: 10,
 			wantErrNum:  1,
 		},
+		"invalid: PodSetSliceSizeAnnotation does not evenly divide pod count": {
+			annotations: map[string]string{
+				kueue.PodSetSliceSizeAnnotation:             "5",
+				kueue.PodSetSliceRequiredTopologyAnnotation: "cloud.com/rack",
+				kueue.PodSetRequiredTopologyAnnotation:      "cloud.com/block",
+			},
+			podSetCount: 19,
+			wantErrNum:  1,
+		},
+		"invalid: multi-layer outermost size does not evenly divide pod count": {
+			annotations: map[string]string{
+				kueue.PodSetRequiredTopologyAnnotation:                 "cloud.com/block",
+				kueue.PodSetSliceRequiredTopologyConstraintsAnnotation: `[{"topology":"cloud.com/rack","size":5},{"topology":"kubernetes.io/hostname","size":5}]`,
+			},
+			podSetCount: 19,
+			wantErrNum:  1,
+		},
+		"valid: PodSetSliceSizeAnnotation evenly divides pod count": {
+			annotations: map[string]string{
+				kueue.PodSetSliceSizeAnnotation:             "4",
+				kueue.PodSetSliceRequiredTopologyAnnotation: "cloud.com/rack",
+				kueue.PodSetRequiredTopologyAnnotation:      "cloud.com/block",
+			},
+			podSetCount: 16,
+			wantErrNum:  0,
+		},
+		"annotation zero is skipped by the divisibility check (non-positive is validated separately)": {
+			annotations: map[string]string{
+				kueue.PodSetSliceSizeAnnotation:             "0",
+				kueue.PodSetSliceRequiredTopologyAnnotation: "cloud.com/rack",
+				kueue.PodSetRequiredTopologyAnnotation:      "cloud.com/block",
+			},
+			podSetCount: 19,
+			wantErrNum:  0,
+		},
+		"annotation negative is skipped by the divisibility check (non-positive is validated separately)": {
+			annotations: map[string]string{
+				kueue.PodSetSliceSizeAnnotation:             "-5",
+				kueue.PodSetSliceRequiredTopologyAnnotation: "cloud.com/rack",
+				kueue.PodSetRequiredTopologyAnnotation:      "cloud.com/block",
+			},
+			podSetCount: 19,
+			wantErrNum:  0,
+		},
+		"valid: PodSetSliceSizeAnnotation does not evenly divide pod count when TASValidateWorkloadSliceSize is disabled": {
+			annotations: map[string]string{
+				kueue.PodSetSliceSizeAnnotation:             "5",
+				kueue.PodSetSliceRequiredTopologyAnnotation: "cloud.com/rack",
+				kueue.PodSetRequiredTopologyAnnotation:      "cloud.com/block",
+			},
+			podSetCount: 19,
+			featureGates: map[featuregate.Feature]bool{
+				features.TASValidateWorkloadSliceSize: false,
+			},
+			wantErrNum: 0,
+		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			meta := &metav1.ObjectMeta{
 				Annotations: tc.annotations,
 			}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -534,7 +534,9 @@ const (
 
 	// owner: mszadkow
 	//
-	// Rejects Workloads with non-positive TAS slice sizes in PodSet topology requests.
+	// Rejects Workloads with TAS slice sizes in PodSet topology requests that are
+	// non-positive or that do not evenly divide the PodSet count, where the count
+	// is known.
 	TASValidateWorkloadSliceSize featuregate.Feature = "TASValidateWorkloadSliceSize"
 
 	// owner: @Dasmat13

--- a/pkg/webhooks/workload_webhook.go
+++ b/pkg/webhooks/workload_webhook.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -113,10 +114,17 @@ func ValidateWorkload(obj, oldObj *kueue.Workload) field.ErrorList {
 	var allErrs field.ErrorList
 	specPath := field.NewPath("spec")
 
+	oldPodSets := map[kueue.PodSetReference]*kueue.PodSet{}
+	if oldObj != nil {
+		for i := range oldObj.Spec.PodSets {
+			oldPodSets[oldObj.Spec.PodSets[i].Name] = &oldObj.Spec.PodSets[i]
+		}
+	}
+
 	variableCountPodSets := 0
 	for i := range obj.Spec.PodSets {
 		ps := &obj.Spec.PodSets[i]
-		allErrs = append(allErrs, validatePodSet(ps, specPath.Child("podSets").Index(i))...)
+		allErrs = append(allErrs, validatePodSet(ps, oldPodSets[ps.Name], specPath.Child("podSets").Index(i))...)
 		if ps.MinCount != nil {
 			variableCountPodSets++
 		}
@@ -164,7 +172,10 @@ func ValidateWorkload(obj, oldObj *kueue.Workload) field.ErrorList {
 	return allErrs
 }
 
-func validatePodSet(ps *kueue.PodSet, path *field.Path) field.ErrorList {
+// validatePodSet validates the given PodSet. oldPS is the PodSet with the same
+// name from the previous version of the Workload, or nil on create or when the
+// PodSet was added by the update.
+func validatePodSet(ps, oldPS *kueue.PodSet, path *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
 	// validate metadata labels and annotations
@@ -191,7 +202,10 @@ func validatePodSet(ps *kueue.PodSet, path *field.Path) field.ErrorList {
 	}
 
 	if features.Enabled(features.TASValidateWorkloadSliceSize) {
-		allErrs = append(allErrs, validateTASSliceSize(ps.TopologyRequest, ps.Count, path.Child("topologyRequest"))...)
+		allErrs = append(allErrs, validateTASSliceSize(ps.TopologyRequest, path.Child("topologyRequest"))...)
+		if sliceSizeRequestChanged(ps, oldPS) {
+			allErrs = append(allErrs, validateTASSliceSizeAgainstCount(ps.TopologyRequest, ps.Count, path.Child("topologyRequest"))...)
+		}
 	}
 
 	return allErrs
@@ -510,12 +524,10 @@ func validateClusterNameUpdate(newObj, oldObj *kueue.Workload, statusPath *field
 // validateTASSliceSize enforces basic topology-slice invariants:
 //   - legacy fields must appear together (required-topology <-> slice-size)
 //   - slice sizes must be strictly positive (legacy and multi-layer constraints)
-//   - slice sizes must not exceed the pod set count (legacy and the first
-//     multi-layer constraint), matching the jobframework upper-bound check
 //
 // Kept in the Workload webhook as defense-in-depth for direct Workload writes,
 // including cases where CRDs or producer-side validators are older or bypassed.
-func validateTASSliceSize(tr *kueue.PodSetTopologyRequest, count int32, path *field.Path) field.ErrorList {
+func validateTASSliceSize(tr *kueue.PodSetTopologyRequest, path *field.Path) field.ErrorList {
 	if tr == nil {
 		return nil
 	}
@@ -527,29 +539,11 @@ func validateTASSliceSize(tr *kueue.PodSetTopologyRequest, count int32, path *fi
 			allErrs = append(allErrs, field.Required(path.Child("podSetSliceSize"), "must be set when podSetSliceRequiredTopology is specified"))
 		case *tr.PodSetSliceSize <= 0:
 			allErrs = append(allErrs, field.Invalid(path.Child("podSetSliceSize"), *tr.PodSetSliceSize, "must be greater than 0"))
-		case *tr.PodSetSliceSize > count:
-			allErrs = append(allErrs, field.Invalid(path.Child("podSetSliceSize"), *tr.PodSetSliceSize, fmt.Sprintf("must not be greater than pod set count %d", count)))
-		case count > 0 && count%*tr.PodSetSliceSize != 0:
-			allErrs = append(allErrs, field.Invalid(path.Child("podSetSliceSize"), *tr.PodSetSliceSize, fmt.Sprintf("must evenly divide pod set count %d", count)))
 		}
 	}
 
 	if tr.PodSetSliceRequiredTopology == nil && tr.PodSetSliceSize != nil {
 		allErrs = append(allErrs, field.Forbidden(path.Child("podSetSliceSize"), "may not be set when podSetSliceRequiredTopology is not specified"))
-	}
-
-	if len(tr.PodsetSliceRequiredTopologyConstraints) > 0 && tr.PodsetSliceRequiredTopologyConstraints[0].Size > count {
-		allErrs = append(allErrs,
-			field.Invalid(path.Child("podsetSliceRequiredTopologyConstraints").Index(0).Child("size"),
-				tr.PodsetSliceRequiredTopologyConstraints[0].Size,
-				fmt.Sprintf("must not be greater than pod set count %d", count)))
-	} else if len(tr.PodsetSliceRequiredTopologyConstraints) > 0 && count > 0 &&
-		tr.PodsetSliceRequiredTopologyConstraints[0].Size > 0 &&
-		count%tr.PodsetSliceRequiredTopologyConstraints[0].Size != 0 {
-		allErrs = append(allErrs,
-			field.Invalid(path.Child("podsetSliceRequiredTopologyConstraints").Index(0).Child("size"),
-				tr.PodsetSliceRequiredTopologyConstraints[0].Size,
-				fmt.Sprintf("must evenly divide pod set count %d", count)))
 	}
 
 	for i := range tr.PodsetSliceRequiredTopologyConstraints {
@@ -559,4 +553,57 @@ func validateTASSliceSize(tr *kueue.PodSetTopologyRequest, count int32, path *fi
 		}
 	}
 	return allErrs
+}
+
+// validateTASSliceSizeAgainstCount enforces the count-dependent topology-slice
+// invariants: slice sizes must not exceed the PodSet count and must evenly
+// divide it, for the legacy slice-size field and the first multi-layer
+// constraint, matching the jobframework upper-bound check. It is only called
+// for new PodSets and for PodSets whose count or topology request changed, so
+// that pre-existing non-divisible PodSets remain admissible on updates that do
+// not touch their slice request.
+func validateTASSliceSizeAgainstCount(tr *kueue.PodSetTopologyRequest, count int32, path *field.Path) field.ErrorList {
+	if tr == nil {
+		return nil
+	}
+
+	var allErrs field.ErrorList
+	if tr.PodSetSliceRequiredTopology != nil && tr.PodSetSliceSize != nil && *tr.PodSetSliceSize > 0 {
+		switch {
+		case *tr.PodSetSliceSize > count:
+			allErrs = append(allErrs, field.Invalid(path.Child("podSetSliceSize"), *tr.PodSetSliceSize, fmt.Sprintf("must not be greater than pod set count %d", count)))
+		case count > 0 && count%*tr.PodSetSliceSize != 0:
+			allErrs = append(allErrs, field.Invalid(path.Child("podSetSliceSize"), *tr.PodSetSliceSize, fmt.Sprintf("must evenly divide pod set count %d", count)))
+		}
+	}
+
+	if len(tr.PodsetSliceRequiredTopologyConstraints) > 0 {
+		switch {
+		case tr.PodsetSliceRequiredTopologyConstraints[0].Size > count:
+			allErrs = append(allErrs,
+				field.Invalid(path.Child("podsetSliceRequiredTopologyConstraints").Index(0).Child("size"),
+					tr.PodsetSliceRequiredTopologyConstraints[0].Size,
+					fmt.Sprintf("must not be greater than pod set count %d", count)))
+		case count > 0 && tr.PodsetSliceRequiredTopologyConstraints[0].Size > 0 &&
+			count%tr.PodsetSliceRequiredTopologyConstraints[0].Size != 0:
+			allErrs = append(allErrs,
+				field.Invalid(path.Child("podsetSliceRequiredTopologyConstraints").Index(0).Child("size"),
+					tr.PodsetSliceRequiredTopologyConstraints[0].Size,
+					fmt.Sprintf("must evenly divide pod set count %d", count)))
+		}
+	}
+
+	return allErrs
+}
+
+// sliceSizeRequestChanged returns true when the PodSet count or topology
+// request differs from the previous version of the PodSet, or when there is no
+// previous version. When the request is unchanged, the count-dependent
+// slice-size checks are skipped so that pre-existing PodSets with a
+// non-divisible slice size stay admissible on unrelated updates.
+func sliceSizeRequestChanged(ps, oldPS *kueue.PodSet) bool {
+	if oldPS == nil {
+		return true
+	}
+	return ps.Count != oldPS.Count || !equality.Semantic.DeepEqual(ps.TopologyRequest, oldPS.TopologyRequest)
 }

--- a/pkg/webhooks/workload_webhook.go
+++ b/pkg/webhooks/workload_webhook.go
@@ -191,7 +191,7 @@ func validatePodSet(ps *kueue.PodSet, path *field.Path) field.ErrorList {
 	}
 
 	if features.Enabled(features.TASValidateWorkloadSliceSize) {
-		allErrs = append(allErrs, validateTASSliceSize(ps.TopologyRequest, path.Child("topologyRequest"))...)
+		allErrs = append(allErrs, validateTASSliceSize(ps.TopologyRequest, ps.Count, path.Child("topologyRequest"))...)
 	}
 
 	return allErrs
@@ -508,11 +508,14 @@ func validateClusterNameUpdate(newObj, oldObj *kueue.Workload, statusPath *field
 }
 
 // validateTASSliceSize enforces basic topology-slice invariants:
-// - legacy fields must appear together (required-topology <-> slice-size)
-// - slice sizes must be strictly positive (legacy and multi-layer constraints)
+//   - legacy fields must appear together (required-topology <-> slice-size)
+//   - slice sizes must be strictly positive (legacy and multi-layer constraints)
+//   - slice sizes must not exceed the pod set count (legacy and the first
+//     multi-layer constraint), matching the jobframework upper-bound check
+//
 // Kept in the Workload webhook as defense-in-depth for direct Workload writes,
 // including cases where CRDs or producer-side validators are older or bypassed.
-func validateTASSliceSize(tr *kueue.PodSetTopologyRequest, path *field.Path) field.ErrorList {
+func validateTASSliceSize(tr *kueue.PodSetTopologyRequest, count int32, path *field.Path) field.ErrorList {
 	if tr == nil {
 		return nil
 	}
@@ -524,11 +527,29 @@ func validateTASSliceSize(tr *kueue.PodSetTopologyRequest, path *field.Path) fie
 			allErrs = append(allErrs, field.Required(path.Child("podSetSliceSize"), "must be set when podSetSliceRequiredTopology is specified"))
 		case *tr.PodSetSliceSize <= 0:
 			allErrs = append(allErrs, field.Invalid(path.Child("podSetSliceSize"), *tr.PodSetSliceSize, "must be greater than 0"))
+		case *tr.PodSetSliceSize > count:
+			allErrs = append(allErrs, field.Invalid(path.Child("podSetSliceSize"), *tr.PodSetSliceSize, fmt.Sprintf("must not be greater than pod set count %d", count)))
+		case count > 0 && count%*tr.PodSetSliceSize != 0:
+			allErrs = append(allErrs, field.Invalid(path.Child("podSetSliceSize"), *tr.PodSetSliceSize, fmt.Sprintf("must evenly divide pod set count %d", count)))
 		}
 	}
 
 	if tr.PodSetSliceRequiredTopology == nil && tr.PodSetSliceSize != nil {
 		allErrs = append(allErrs, field.Forbidden(path.Child("podSetSliceSize"), "may not be set when podSetSliceRequiredTopology is not specified"))
+	}
+
+	if len(tr.PodsetSliceRequiredTopologyConstraints) > 0 && tr.PodsetSliceRequiredTopologyConstraints[0].Size > count {
+		allErrs = append(allErrs,
+			field.Invalid(path.Child("podsetSliceRequiredTopologyConstraints").Index(0).Child("size"),
+				tr.PodsetSliceRequiredTopologyConstraints[0].Size,
+				fmt.Sprintf("must not be greater than pod set count %d", count)))
+	} else if len(tr.PodsetSliceRequiredTopologyConstraints) > 0 && count > 0 &&
+		tr.PodsetSliceRequiredTopologyConstraints[0].Size > 0 &&
+		count%tr.PodsetSliceRequiredTopologyConstraints[0].Size != 0 {
+		allErrs = append(allErrs,
+			field.Invalid(path.Child("podsetSliceRequiredTopologyConstraints").Index(0).Child("size"),
+				tr.PodsetSliceRequiredTopologyConstraints[0].Size,
+				fmt.Sprintf("must evenly divide pod set count %d", count)))
 	}
 
 	for i := range tr.PodsetSliceRequiredTopologyConstraints {

--- a/pkg/webhooks/workload_webhook_test.go
+++ b/pkg/webhooks/workload_webhook_test.go
@@ -1577,6 +1577,126 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 			after:   quotaReservedWithoutAdmission(now),
 			wantErr: nil,
 		},
+		"should accept an unrelated update of an unchanged podSet with a non-divisible slice size": {
+			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("legacy", 3).
+						SliceRequiredTopologyRequest("kubernetes.io/hostname").
+						SliceSizeTopologyRequest(2).
+						Obj(),
+				).
+				Obj(),
+			after: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				Annotations(map[string]string{"example.com/unrelated-update": "true"}).
+				PodSets(
+					*utiltestingapi.MakePodSet("legacy", 3).
+						SliceRequiredTopologyRequest("kubernetes.io/hostname").
+						SliceSizeTopologyRequest(2).
+						Obj(),
+				).
+				Obj(),
+			wantErr: nil,
+		},
+		"should reject an update that changes the count of a legacy podSet to another non-divisible value": {
+			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("legacy", 3).
+						SliceRequiredTopologyRequest("kubernetes.io/hostname").
+						SliceSizeTopologyRequest(2).
+						Obj(),
+				).
+				Obj(),
+			after: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("legacy", 5).
+						SliceRequiredTopologyRequest("kubernetes.io/hostname").
+						SliceSizeTopologyRequest(2).
+						Obj(),
+				).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(podSetsPath.Index(0).Child("topologyRequest", "podSetSliceSize"), nil, ""),
+			}.ToAggregate(),
+		},
+		"should reject an update that changes the slice request of a legacy podSet": {
+			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("legacy", 3).
+						SliceRequiredTopologyRequest("kubernetes.io/hostname").
+						SliceSizeTopologyRequest(2).
+						Obj(),
+				).
+				Obj(),
+			after: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("legacy", 3).
+						SliceRequiredTopologyRequest("kubernetes.io/zone").
+						SliceSizeTopologyRequest(2).
+						Obj(),
+				).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(podSetsPath.Index(0).Child("topologyRequest", "podSetSliceSize"), nil, ""),
+			}.ToAggregate(),
+		},
+		"should reject an update that adds a podSet with a non-divisible slice size": {
+			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("main", 1).Obj(),
+				).
+				Obj(),
+			after: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("main", 1).Obj(),
+					*utiltestingapi.MakePodSet("legacy", 3).
+						SliceRequiredTopologyRequest("kubernetes.io/hostname").
+						SliceSizeTopologyRequest(2).
+						Obj(),
+				).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(podSetsPath.Index(1).Child("topologyRequest", "podSetSliceSize"), nil, ""),
+			}.ToAggregate(),
+		},
+		"should accept an update that changes the count of a legacy podSet to a divisible value": {
+			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("legacy", 3).
+						SliceRequiredTopologyRequest("kubernetes.io/hostname").
+						SliceSizeTopologyRequest(2).
+						Obj(),
+				).
+				Obj(),
+			after: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("legacy", 4).
+						SliceRequiredTopologyRequest("kubernetes.io/hostname").
+						SliceSizeTopologyRequest(2).
+						Obj(),
+				).
+				Obj(),
+			wantErr: nil,
+		},
+		"should still reject an unchanged podSet that violates the slice-size invariants": {
+			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("bad", 1).
+						SliceSizeTopologyRequest(1).
+						Obj(),
+				).
+				Obj(),
+			after: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				Annotations(map[string]string{"example.com/unrelated-update": "true"}).
+				PodSets(
+					*utiltestingapi.MakePodSet("bad", 1).
+						SliceSizeTopologyRequest(1).
+						Obj(),
+				).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Forbidden(podSetsPath.Index(0).Child("topologyRequest", "podSetSliceSize"), ""),
+			}.ToAggregate(),
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/webhooks/workload_webhook_test.go
+++ b/pkg/webhooks/workload_webhook_test.go
@@ -354,6 +354,106 @@ func TestValidateWorkload(t *testing.T) {
 				field.Invalid(podSetsPath.Index(0).Child("topologyRequest", "podSetSliceSize"), nil, ""),
 			}.ToAggregate(),
 		},
+		"should reject podSetSliceSize greater than pod set count when TASValidateWorkloadSliceSize is enabled": {
+			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("bad", 1).
+						SliceRequiredTopologyRequest("kubernetes.io/hostname").
+						SliceSizeTopologyRequest(2).
+						Obj(),
+				).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(podSetsPath.Index(0).Child("topologyRequest", "podSetSliceSize"), nil, ""),
+			}.ToAggregate(),
+		},
+		"should accept podSetSliceSize greater than pod set count when TASValidateWorkloadSliceSize is disabled": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TASValidateWorkloadSliceSize: false,
+			},
+			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("bad", 1).
+						SliceRequiredTopologyRequest("kubernetes.io/hostname").
+						SliceSizeTopologyRequest(2).
+						Obj(),
+				).
+				Obj(),
+			wantErr: nil,
+		},
+		"should reject first podsetSliceRequiredTopologyConstraints layer size greater than pod set count when TASValidateWorkloadSliceSize is enabled": {
+			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("bad", 1).
+						SliceRequiredTopologyConstraints(kueue.PodsetSliceRequiredTopologyConstraint{Topology: "kubernetes.io/hostname", Size: 2}).
+						Obj(),
+				).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(podSetsPath.Index(0).Child("topologyRequest", "podsetSliceRequiredTopologyConstraints").Index(0).Child("size"), nil, ""),
+			}.ToAggregate(),
+		},
+		"should accept podSetSliceSize equal to pod set count when TASValidateWorkloadSliceSize is enabled": {
+			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("ok", 2).
+						SliceRequiredTopologyRequest("kubernetes.io/hostname").
+						SliceSizeTopologyRequest(2).
+						Obj(),
+				).
+				Obj(),
+			wantErr: nil,
+		},
+		"should reject podSetSliceSize that does not evenly divide pod set count when TASValidateWorkloadSliceSize is enabled": {
+			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("bad", 3).
+						SliceRequiredTopologyRequest("kubernetes.io/hostname").
+						SliceSizeTopologyRequest(2).
+						Obj(),
+				).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(podSetsPath.Index(0).Child("topologyRequest", "podSetSliceSize"), nil, ""),
+			}.ToAggregate(),
+		},
+		"should accept podSetSliceSize that evenly divides pod set count when TASValidateWorkloadSliceSize is enabled": {
+			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("ok", 16).
+						SliceRequiredTopologyRequest("kubernetes.io/hostname").
+						SliceSizeTopologyRequest(4).
+						Obj(),
+				).
+				Obj(),
+			wantErr: nil,
+		},
+		"should accept podSetSliceSize that does not evenly divide pod set count when TASValidateWorkloadSliceSize is disabled": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TASValidateWorkloadSliceSize: false,
+			},
+			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("legacy", 3).
+						SliceRequiredTopologyRequest("kubernetes.io/hostname").
+						SliceSizeTopologyRequest(2).
+						Obj(),
+				).
+				Obj(),
+			wantErr: nil,
+		},
+		"should reject first podsetSliceRequiredTopologyConstraints layer size that does not evenly divide pod set count when TASValidateWorkloadSliceSize is enabled": {
+			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("bad", 3).
+						SliceRequiredTopologyConstraints(kueue.PodsetSliceRequiredTopologyConstraint{Topology: "kubernetes.io/hostname", Size: 2}).
+						Obj(),
+				).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(podSetsPath.Index(0).Child("topologyRequest", "podsetSliceRequiredTopologyConstraints").Index(0).Child("size"), nil, ""),
+			}.ToAggregate(),
+		},
 		"should reject podSetSliceSize without podSetSliceRequiredTopology when TASValidateWorkloadSliceSize is enabled": {
 			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
 				PodSets(

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -4700,29 +4700,29 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				})
 			})
 
-			ginkgo.It("place the leader and workers in block b2 when 19 workers with slice size 5 and 1 leader fit best in b2", func() {
+			ginkgo.It("place the leader and workers in block b1 when 18 workers with slice size 6 leave 2 full slices per node", func() {
 				var wl *kueue.Workload
 
-				ginkgo.By("creating a workload with 1 leader and 19 workers with slice size 5", func() {
-					wl = utiltestingapi.MakeWorkload("wl-grouped-sliced-19-workers", ns.Name).
+				ginkgo.By("creating a workload with 1 leader and 18 workers with slice size 6", func() {
+					wl = utiltestingapi.MakeWorkload("wl-grouped-sliced-18-workers", ns.Name).
 						PodSets(
 							*utiltestingapi.MakePodSet("leader", 1).
 								PodSetGroup("group-2level").
 								RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
 								Request(resourceGPU, "1").
 								Obj(),
-							*utiltestingapi.MakePodSet("worker", 19).
+							*utiltestingapi.MakePodSet("worker", 18).
 								PodSetGroup("group-2level").
 								RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
 								SliceRequiredTopologyRequest(corev1.LabelHostname).
-								SliceSizeTopologyRequest(5).
+								SliceSizeTopologyRequest(6).
 								Request(resourceGPU, "1").
 								Obj()).
 						Queue(kueue.LocalQueueName(localQueue.Name)).Obj()
 					util.MustCreate(ctx, k8sClient, wl)
 				})
 
-				ginkgo.By("verifying the workload is admitted in block b2 with 15 sliced worker pods assigned", func() {
+				ginkgo.By("verifying the workload is admitted in block b1 with all 18 sliced worker pods assigned", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
 					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
 					gomega.Expect(wl.Status.Admission.PodSetAssignments[0].TopologyAssignment).ShouldNot(gomega.BeNil())
@@ -4736,23 +4736,25 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 					// Leader pod assigned matches request
 					gomega.Expect(assignedPodCount(wl.Status.Admission.PodSetAssignments[0].TopologyAssignment)).To(gomega.Equal(int32(1)))
-					// 19 workers with slice size 5 yields 3 full slices = 15 pods assigned
-					gomega.Expect(assignedPodCount(wl.Status.Admission.PodSetAssignments[1].TopologyAssignment)).To(gomega.Equal(int32(15)))
+					// 18 workers with slice size 6 yields 3 full slices = 18 pods assigned
+					gomega.Expect(assignedPodCount(wl.Status.Admission.PodSetAssignments[1].TopologyAssignment)).To(gomega.Equal(int32(18)))
 
 					for _, domain := range workerTA.Domains {
-						gomega.Expect(domain.Count % 5).To(gomega.Equal(int32(0)))
+						gomega.Expect(domain.Count % 6).To(gomega.Equal(int32(0)))
 					}
 
-					// Verify best-fit places leader and workers in block b2 (closer fit: 3 slices in b2 vs 4 in b1)
+					// Verify best-fit places leader and workers in block b1: with slice size 6 each
+					// 12-GPU node of b1 fits exactly 2 slices, while the 10-GPU nodes of b2 fit only 1,
+					// so b1 offers the most complete slices and holds all pods of the group.
 					nodeMap := make(map[string]*corev1.Node, len(nodes))
 					for i := range nodes {
 						nodeMap[nodes[i].Name] = &nodes[i]
 					}
 					leaderBlock := nodeMap[leaderTA.Domains[0].Values[0]].Labels[utiltesting.DefaultBlockTopologyLevel]
-					gomega.Expect(leaderBlock).To(gomega.Equal("b2"))
+					gomega.Expect(leaderBlock).To(gomega.Equal("b1"))
 					for _, domain := range workerTA.Domains {
 						workerBlock := nodeMap[domain.Values[0]].Labels[utiltesting.DefaultBlockTopologyLevel]
-						gomega.Expect(workerBlock).To(gomega.Equal("b2"))
+						gomega.Expect(workerBlock).To(gomega.Equal("b1"))
 					}
 				})
 			})
@@ -4973,11 +4975,12 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 			})
 		})
 		ginkgo.When("PodSet slice size does not divide the PodSet count", func() {
-			// When a slice-topology PodSet's slice size does not evenly divide its
-			// count, the scheduler places floor(count/sliceSize)*sliceSize pods but
-			// keeps the full Count, so the TopologyAssignment covers fewer pods than
-			// Count. The first spec asserts the scheduler produces that state; the
-			// second checks the ungater handles it with greedy assignment.
+			// TASValidateWorkloadSliceSize rejects a slice size that does not evenly
+			// divide the PodSet count where the count is known, so the scheduler no
+			// longer admits such Workloads. The first spec asserts the rejection; the
+			// second keeps the legacy behavior covered with the gate disabled, since
+			// the gate exists precisely so that users can still create such Workloads
+			// while migrating.
 			var (
 				nodes []corev1.Node
 			)
@@ -5041,10 +5044,29 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				}
 			})
 
-			ginkgo.It("scheduler persists Count greater than the sum of TopologyAssignment domains", func() {
+			ginkgo.It("rejects a slice-topology workload whose count is not divisible by the slice size", func() {
+				ginkgo.By("creating a slice-topology workload whose count (3) is not divisible by the slice size (2)", func() {
+					wl := utiltestingapi.MakeWorkload("wl-non-divisible", ns.Name).
+						PodSets(*utiltestingapi.MakePodSet("worker", 3).
+							PreferredTopologyRequest(utiltesting.DefaultRackTopologyLevel).
+							SliceRequiredTopologyRequest(corev1.LabelHostname).
+							SliceSizeTopologyRequest(2).
+							Obj()).
+						Queue(kueue.LocalQueueName(localQueue.Name)).
+						Request("nvidia.com/gpu", "1").
+						Obj()
+					gomega.Expect(k8sClient.Create(ctx, wl)).Should(gomega.SatisfyAll(
+						utiltesting.BeForbiddenError(),
+						gomega.MatchError(gomega.ContainSubstring("must evenly divide pod set count 3")),
+					))
+				})
+			})
+
+			ginkgo.It("scheduler persists Count greater than the sum of TopologyAssignment domains when TASValidateWorkloadSliceSize is disabled", func() {
 				var wl *kueue.Workload
 
 				ginkgo.By("creating a slice-topology workload whose count (3) is not divisible by the slice size (2)", func() {
+					features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.TASValidateWorkloadSliceSize, false)
 					wl = utiltestingapi.MakeWorkload("wl-short-assignment", ns.Name).
 						PodSets(*utiltestingapi.MakePodSet("worker", 3).
 							PreferredTopologyRequest(utiltesting.DefaultRackTopologyLevel).
@@ -5075,15 +5097,17 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				})
 			})
 
-			ginkgo.It("ungater falls back to greedy assignment when a rank is out of range", func() {
+			ginkgo.It("ungater falls back to greedy assignment when a rank is out of range and TASValidateWorkloadSliceSize is disabled", func() {
 				// The scheduler admits count 3 with an assignment covering only 2 pods
 				// (see the sibling spec), so the gated Pod at completion index 2 has a
 				// rank beyond rankToDomainID. The ungater falls back to greedy assignment
 				// and ungates the two Pods that fit onto the domain, leaving the extra
-				// Pod gated.
+				// Pod gated. Kept for the gate disabled, since validation rejects such
+				// Workloads when TASValidateWorkloadSliceSize is enabled.
 				var wl *kueue.Workload
 
 				ginkgo.By("creating and admitting a rank-ordered slice-topology workload (count 3, slice size 2)", func() {
+					features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.TASValidateWorkloadSliceSize, false)
 					wl = utiltestingapi.MakeWorkload("wl-ungater-oob", ns.Name).
 						PodSets(*utiltestingapi.MakePodSet("worker", 3).
 							PodIndexLabel(new(batchv1.JobCompletionIndexAnnotation)).


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area tas

#### What this PR does / why we need it?

KEP-2724 requires that a slice size evenly divide the size of a PodSet, and that the outermost multi-layer constraint divide the PodSet count as well. The rule was documented but never enforced, so a Workload with count 3 and slice size 2 was admitted, and the scheduler placed only floor(3/2)*2 = 2 pods while the assignment kept Count 3. The short TopologyAssignment was handled defensively by the ungater (#13223) instead of being rejected at admission time.

This PR enforces the divisibility rule for new Workloads at both layers:

1. `jobframework.ValidateSliceSizeAnnotationUpperBound` now also rejects a slice size that does not evenly divide the PodSet count, both for the legacy `podset-slice-size` annotation and for the outermost multi-layer constraint. This covers every job type that already calls the function from its webhook.
2. The Workload webhook (`validateTASSliceSize`) enforces the same divisibility rule as defense in depth for direct Workload writes, and adds the upper bound check (the slice size must not be greater than the PodSet count).

Both checks reuse the existing `TASValidateWorkloadSliceSize` feature gate, which already guards the non-positive slice size validation in the Workload webhook, so no new gate is introduced. The gate stays Beta and enabled by default, so new non-divisible Workloads are rejected; cluster admins can temporarily disable the gate to keep creating them.

Fixes #15277

#### Useful notes for your reviewer

- The pre-existing jobframework upper-bound check is unchanged; the divisibility check is added only where the count is known. Job webhooks revalidate on update, so a pre-existing job whose slice size does not evenly divide its count is rejected on updates until the slice request is corrected or removed. I can add the same unchanged-PodSet exemption on the job path here or in a follow-up if you prefer.
- Pre-existing Workloads: the validation is not retroactive. A PodSet that is left unchanged (same count and topology request) is still accepted on updates, so a pre-existing Workload with a non-divisible slice size keeps working and unrelated updates to it are not blocked. The count-dependent checks run again when the PodSet is added, or when its count or topology request changes; the ungater keeps handling such Workloads defensively in the meantime (#13223).
- Elastic jobs: the TAS integration with elastic workload slices is behind `ElasticJobsViaWorkloadSlicesWithTAS` (Alpha, off by default), so slice topologies on elastic jobs are not supported yet. A future scale-down could produce a non-divisible count for an already admitted Workload; this PR does not change the elastic path and leaves that case to follow-up work.
- Alternatives considered: rounding up the last partial slice in the scheduler (viable, but no known business case today), and admitting only the pods that fit, `floor(count/sliceSize) * sliceSize` (would admit fewer pods than requested and needs explicit partial-admission semantics). The divisibility was already agreed in the KEP, so this PR enforces it at admission validation instead.
- The integration block `PodSet slice size does not divide the PodSet count` now asserts the rejection and keeps the gate-disabled behavior of the scheduler and the ungater covered; the ungater fallback itself stays unit tested in `pkg/controller/tas/topology_ungater_test.go`.

This PR was written in part with the assistance of generative AI.

#### Release note

```release-note
TAS: Slice sizes that do not evenly divide the PodSet count, or exceed it, are now rejected at admission time when TASValidateWorkloadSliceSize is enabled.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## AI summary

- Enforce TAS slice-size divisibility for new Workloads and legacy annotation validation.
- Reject slice sizes greater than the PodSet count for direct Workload writes.
- Apply validation through the `TASValidateWorkloadSliceSize` feature gate.
- Add unit and integration coverage, including legacy behavior when the gate is disabled.

### Suggested release note

TAS: Fixed a bug that allowed Workloads with invalid slice sizes to be admitted or enter scheduler retry loops. Kueue now rejects slice sizes that do not evenly divide the PodSet count or exceed it. This behavior is gated by the `TASValidateWorkloadSliceSize` feature gate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
