### PR TITLE
kueuectl: Prevent extra Workload suggestions in stop and resume commands

### DIFF
--- a/cmd/kueuectl/app/resume/resume_workload.go
+++ b/cmd/kueuectl/app/resume/resume_workload.go
@@ -46,7 +46,7 @@ func NewWorkloadCmd(clientGetter clientgetter.ClientGetter, streams genericioopt
 		Long:                  wlLong,
 		Example:               wlExample,
 		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
-		ValidArgsFunction:     completion.WorkloadNameFunc(clientGetter, new(false)),
+		ValidArgsFunction:     completion.SingleArg(completion.WorkloadNameFunc(clientGetter, new(false))),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 			err := o.Complete(clientGetter, cmd, args)

--- a/cmd/kueuectl/app/resume/resume_workload_test.go
+++ b/cmd/kueuectl/app/resume/resume_workload_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resume
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"sigs.k8s.io/kueue/client-go/clientset/versioned/fake"
+	cmdtesting "sigs.k8s.io/kueue/cmd/kueuectl/app/testing"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+)
+
+func TestWorkloadCompletionStopsAfterFirstArgument(t *testing.T) {
+	clientGetter := cmdtesting.NewTestClientGetter().WithKueueClientset(fake.NewSimpleClientset(
+		utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).Active(false).Obj(),
+		utiltestingapi.MakeWorkload("wl2", metav1.NamespaceDefault).Active(false).Obj(),
+	))
+	streams, _, _, _ := genericiooptions.NewTestIOStreams()
+	cmd := NewWorkloadCmd(clientGetter, streams)
+
+	names, directive := cmd.ValidArgsFunction(cmd, []string{"wl1"}, "")
+	if len(names) != 0 {
+		t.Errorf("Unexpected names: %v", names)
+	}
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("Unexpected directive: %v", directive)
+	}
+}

--- a/cmd/kueuectl/app/stop/stop_workload.go
+++ b/cmd/kueuectl/app/stop/stop_workload.go
@@ -50,7 +50,7 @@ func NewWorkloadCmd(clientGetter clientgetter.ClientGetter, streams genericioopt
 		Long:                  wlLong,
 		Example:               wlExample,
 		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
-		ValidArgsFunction:     completion.WorkloadNameFunc(clientGetter, new(true)),
+		ValidArgsFunction:     completion.SingleArg(completion.WorkloadNameFunc(clientGetter, new(true))),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 			err := o.Complete(clientGetter, cmd, args)

--- a/cmd/kueuectl/app/stop/stop_workload_test.go
+++ b/cmd/kueuectl/app/stop/stop_workload_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stop
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"sigs.k8s.io/kueue/client-go/clientset/versioned/fake"
+	cmdtesting "sigs.k8s.io/kueue/cmd/kueuectl/app/testing"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+)
+
+func TestWorkloadCompletionStopsAfterFirstArgument(t *testing.T) {
+	clientGetter := cmdtesting.NewTestClientGetter().WithKueueClientset(fake.NewSimpleClientset(
+		utiltestingapi.MakeWorkload("wl1", metav1.NamespaceDefault).Active(true).Obj(),
+		utiltestingapi.MakeWorkload("wl2", metav1.NamespaceDefault).Active(true).Obj(),
+	))
+	streams, _, _, _ := genericiooptions.NewTestIOStreams()
+	cmd := NewWorkloadCmd(clientGetter, streams)
+
+	names, directive := cmd.ValidArgsFunction(cmd, []string{"wl1"}, "")
+	if len(names) != 0 {
+		t.Errorf("Unexpected names: %v", names)
+	}
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("Unexpected directive: %v", directive)
+	}
+}


### PR DESCRIPTION
<!-- Thank you for contributing! Check CONTRIBUTING.md for details. -->

#### What type of PR is this?

/kind bug



<!-- Optionally choose one or more of the following kinds:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


<!-- Consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->


#### What this PR does / why we need it?

A follow-up to PR #15375 .

Since `stop workload` and `resume workload` accept exactly one Workload name, resulting command would be rejected.

After an administrator entered first Workload name and pressed `<TAB>`, CLI could still suggest another Workload:

```
kueuectl stop workload running-a <TAB>
# Could become:
kueuectl stop workload running-a running-b
```

After this fix, no additional Workload or file-name suggestions are shown once first name has been entered:

```
kueuectl stop workload running-a <TAB>
kueuectl resume workload stopped-a <TAB>
```



<!--
Use `Fixes #123` for an issue addressed by this PR; it will be closed when the PR merges.
Use `Related:` or `Part of:` to reference an issue without closing it.
-->
Fixes #

#### Useful notes for your reviewer


#### Release note

<!-- Describe the behavior change accurately from the user's perspective. Hints:
- Do not leave this block blank.
- Use "NONE" when there is no user-facing change.
- When feasible use a prefix for the sub-component or feature, e.g. "FairSharing:" or "MultiKueue:".
- If upgrade steps are required, include an "ACTION REQUIRED:" section.
You may consider AI assistance using the skill: cmd/experimental/skills/kueue-release-notes/SKILL.md.
-->
```release-note
CLI: Fixed shell completion for  `kueuectl stop workload`  and  `kueuectl resume workload` , which continued suggesting additional Workload names after the single required name was entered, potentially producing commands rejected for too many arguments
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## AI summary

Updated `kueuectl stop workload` and `kueuectl resume workload` completion to stop after the first Workload name. Added tests for this behavior.

### Suggested release note

CLI: Fixed a bug that caused `kueuectl stop workload` and `kueuectl resume workload` to suggest extra arguments after a Workload name. Completion now stops after the first Workload name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->