### PR TITLE
Move PR/issue workflow guidance from AGENTS.md to a skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,26 +42,8 @@ Kueue follows the [Kubernetes AI Tool Usage Policy](https://www.kubernetes.dev/d
 - **No AI authorship markers.** Do not add AI co-author lines, `assisted-by`, `co-developed`, or similar commit trailers.
 - **No auto-close keywords or `#` mentions in commit messages.** [Keywords which can automatically close issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) (for example `Fixes #123`) and `#` mentions are not allowed in commit messages — Prow flags them with the `do-not-merge/invalid-commit-message` label. Put issue references in the PR description instead.
 
-### Opening pull requests
-
-- Read `.github/PULL_REQUEST_TEMPLATE.md` and fill its existing sections.
- Preserve their titles and order; do not add, remove, rename, or combine
- sections.
-- Before submitting or updating the description, check it against the template.
-- CodeRabbit AI (@coderabbitai) may append its `AI summary` section,
- including `Suggested release note`.
-
-### Opening issues
-
-- Inspect `.github/ISSUE_TEMPLATE/`, select the single template that best
- matches the issue type, and read it in full.
-- Apply all labels specified in the selected template's `labels` field,
- including every `kind/*` label when multiple are listed.
-- Fill its existing sections. Preserve their titles and order; do not add,
- remove, rename, or combine sections.
-- Start the title with the emoji from the template's `title` field.
-- When CodeRabbit AI (@coderabbitai) opens an issue on behalf of a contributor,
-  mention the requester as @username and include a link to the comment requesting the issue.
+For step-by-step guidance on opening pull requests and issues, follow the
+[kueue-pr-issue-workflow](cmd/experimental/skills/kueue-pr-issue-workflow/SKILL.md) skill.
 
 ## Skills
 

--- a/cmd/experimental/skills/README.md
+++ b/cmd/experimental/skills/README.md
@@ -4,6 +4,7 @@
 |---|---|
 | [kueue-go-lint](kueue-go-lint/SKILL.md) | "lint my Go changes", "run Go lint", final lint validation after modifying Kueue Go code |
 | [kueue-verify](kueue-verify/SKILL.md) | final validation before pushing changes or opening/updating a PR |
+| [kueue-pr-issue-workflow](kueue-pr-issue-workflow/SKILL.md) | "open a pull request", "open an issue", "what template, labels, or title should I use", PR/issue contribution workflow |
 | [kueue-who-preempted](kueue-who-preempted/SKILL.md) | "who preempted my workload", "why was my workload evicted", "what kicked out my job", preemption investigation |
 | [kueue-lineage](kueue-lineage/SKILL.md) | "what pods are running for my workload", "trace workload to pods", "show me the jobs for this workload", lineage/ownership questions |
 | [kueue-flake-debugger](kueue-flake-debugger/SKILL.md) | "debug a flake", "investigate test failure", "test timed out", "CI flake" |
@@ -24,6 +25,8 @@
 @kueue-go-lint/SKILL.md
 
 @kueue-verify/SKILL.md
+
+@kueue-pr-issue-workflow/SKILL.md
 
 @kueue-who-preempted/SKILL.md
 

--- a/cmd/experimental/skills/kueue-pr-issue-workflow/SKILL.md
+++ b/cmd/experimental/skills/kueue-pr-issue-workflow/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: kueue-pr-issue-workflow
+description: Open or update Kueue pull requests and issues following the required templates, labels, titles, and AI disclosure rules.
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+# Skill: Open Pull Requests and Issues
+
+Follow this guidance whenever opening or updating a Kueue pull request or issue. The
+requirements below come from `.github/PULL_REQUEST_TEMPLATE.md` and `.github/ISSUE_TEMPLATE/`.
+
+## Opening pull requests
+
+- Read `.github/PULL_REQUEST_TEMPLATE.md` and fill its existing sections.
+  Preserve their titles and order; do not add, remove, rename, or combine
+  sections.
+- Before submitting or updating the description, check it against the template.
+- CodeRabbit AI (@coderabbitai) may append its `AI summary` section,
+  including `Suggested release note`.
+
+## Opening issues
+
+- Inspect `.github/ISSUE_TEMPLATE/`, select the single template that best
+  matches the issue type, and read it in full.
+- Apply all labels specified in the selected template's `labels` field,
+  including every `kind/*` label when multiple are listed.
+- Fill its existing sections. Preserve their titles and order; do not add,
+  remove, rename, or combine sections.
+- Start the title with the emoji from the template's `title` field.
+- When CodeRabbit AI (@coderabbitai) opens an issue on behalf of a contributor,
+  mention the requester as @username and include a link to the comment requesting the issue.


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it?

Moves the detailed pull request and issue workflow instructions out of `AGENTS.md` into a new `kueue-pr-issue-workflow` skill, so that `AGENTS.md` stays concise.

The step-by-step guidance now lives in `cmd/experimental/skills/kueue-pr-issue-workflow/SKILL.md`, and `AGENTS.md` links to it. The workflow requirements are preserved: PR and issue template usage, label selection, and title formatting all remain documented in the skill.

Fixes #15428

#### Useful notes for your reviewer

The new skill is also registered in `cmd/experimental/skills/README.md`, in both the index table and the agent-readable references section.

#### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## AI summary

- Moved pull request and issue workflow guidance to the `kueue-pr-issue-workflow` skill.
- Kept `AGENTS.md` concise while preserving template, label, and title requirements.
- Registered the skill in the skills README.

### Suggested release note

`AgentSkills: Added guidance for pull request and issue templates, labels, titles, and AI disclosure requirements.`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->