### PR TITLE
importer: Reject --concurrent-workers=0

### DIFF
--- a/cmd/importer/main.go
+++ b/cmd/importer/main.go
@@ -81,7 +81,7 @@ func setFlags(cmd *cobra.Command) {
 	cmd.Flags().String(QueueMappingFileFlag, "", "yaml file containing extra mappings from \""+QueueLabelFlag+"\" label values to local queue names")
 	cmd.Flags().Float32(QPSFlag, 50, "client QPS, as described in https://kubernetes.io/docs/reference/config-api/apiserver-eventratelimit.v1alpha1/#eventratelimit-admission-k8s-io-v1alpha1-Limit")
 	cmd.Flags().Int(BurstFlag, 50, "client Burst, as described in https://kubernetes.io/docs/reference/config-api/apiserver-eventratelimit.v1alpha1/#eventratelimit-admission-k8s-io-v1alpha1-Limit")
-	cmd.Flags().UintP(ConcurrencyFlag, ConcurrencyFlagShort, 8, "number of concurrent import workers")
+	cmd.Flags().UintP(ConcurrencyFlag, ConcurrencyFlagShort, 8, "number of concurrent import workers (must be at least 1)")
 	cmd.Flags().Bool(DryRunFlag, true, "don't import, check the config only")
 
 	_ = cmd.MarkFlagRequired(NamespaceFlag)
@@ -205,6 +205,9 @@ func importCmd(cmd *cobra.Command, _ []string) error {
 	log := ctrl.Log.WithName("import")
 	ctx := ctrl.LoggerInto(context.Background(), log)
 	cWorkers, _ := cmd.Flags().GetUint(ConcurrencyFlag)
+	if cWorkers == 0 {
+		return fmt.Errorf("--%s must be at least 1", ConcurrencyFlag)
+	}
 	c, err := getKubeClient(cmd)
 	if err != nil {
 		return err

--- a/cmd/importer/main_test.go
+++ b/cmd/importer/main_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestImportCmdRejectsZeroWorkers(t *testing.T) {
+	cmd := &cobra.Command{Use: "import", RunE: importCmd}
+	setFlags(cmd)
+	cmd.SetArgs([]string{"-n", "default", "--queuelabel", "q", "--queuemapping", "a=b", "-c", "0"})
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected an error for --%s=0, got nil", ConcurrencyFlag)
+	}
+	if !strings.Contains(err.Error(), ConcurrencyFlag) {
+		t.Errorf("error %q should mention the --%s flag", err, ConcurrencyFlag)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it?

`importer import --concurrent-workers=0` (`-c 0`) reports `Check done checked=0` and `Import done checked=0` and exits 0, but no pod is checked or imported. The flag is a `uint` with no lower bound, and `ProcessConcurrently` spawns one worker per job, so with zero jobs it returns immediately with an empty summary while the `ListPods` goroutine blocks on the unread channel.

This PR validates the flag at the start of `importCmd`, before the kube client is created, and fails with `--concurrent-workers must be at least 1`. The flag help text now states the lower bound and a unit test covers the rejection.

None

#### Useful notes for your reviewer


#### Release note

```release-note
Importer: Fixed a bug where `importer import --concurrent-workers=0` could report success without checking or importing any pod. The importer now rejects the flag with an error asking for at least 1 worker.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## AI summary

- Validate that `--concurrent-workers` is at least 1 before importer setup.
- Document the minimum value in the flag help text.
- Add a unit test for zero-worker rejection.

### Suggested release note

Importer: Fixed a bug that allowed imports to report success without checking or importing pods when `--concurrent-workers=0`. The importer now rejects values below 1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->