### PR TITLE
kueuectl: Accept a trailing semicolon in create clusterqueue quota flags

### DIFF
--- a/cmd/kueuectl/app/create/create_clusterqueue.go
+++ b/cmd/kueuectl/app/create/create_clusterqueue.go
@@ -334,7 +334,9 @@ func parseUserSpecifiedResourceQuotas(resources []string, quotaType string) ([]k
 
 func toResourceGroup(spec, quotaType string) (kueue.ResourceGroup, error) {
 	flavorName, userSpecifiedResources := parseKeyValue(spec, ":")
-	resourceSpecs := strings.Split(userSpecifiedResources, ";")
+	// The spec regex allows a single trailing ";", which would otherwise
+	// produce an empty resource spec after splitting.
+	resourceSpecs := strings.Split(strings.TrimSuffix(userSpecifiedResources, ";"), ";")
 	flavorQuotas, err := toFlavorQuotas(flavorName, resourceSpecs, quotaType)
 	if err != nil {
 		return kueue.ResourceGroup{}, err

--- a/cmd/kueuectl/app/create/create_clusterqueue_test.go
+++ b/cmd/kueuectl/app/create/create_clusterqueue_test.go
@@ -312,6 +312,20 @@ func TestParseResourceQuotas(t *testing.T) {
 				},
 			},
 		},
+		"should create one resource group when the resources spec has a trailing semicolon": {
+			quotaArgs: []string{"alpha:cpu=1;memory=1;"},
+			wantResourceGroups: []kueue.ResourceGroup{
+				{
+					CoveredResources: []corev1.ResourceName{"cpu", "memory"},
+					Flavors: []kueue.FlavorQuotas{
+						*utiltestingapi.MakeFlavorQuotas("alpha").
+							Resource("cpu", "1").
+							Resource("memory", "1").
+							Obj(),
+					},
+				},
+			},
+		},
 		"should fail to create a resource group with an invalid flavor and one quota set": {
 			quotaArgs: []string{"alpha:cpu=1;memory=1", "alpha:example.com/gpu=2"},
 			wantErr:   errInvalidFlavor,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it?

The regex that pre-validates `--nominal-quota`, `--borrowing-limit` and `--lending-limit` ends with `;?$`, so a single trailing semicolon such as `alpha:cpu=1;` is accepted. The value is then split on `;` without trimming, which yields an empty resource spec that fails `resource.ParseQuantity`, and the command is rejected with `invalid resource quota`. The error points at the quantity, while the actual cause is the trailing separator the regex said was fine.

This PR trims the trailing `;` before splitting, so the format the regex accepts parses the same as the input without it. Both the quota list and `coveredResources` are built from the same split, so both are fixed. A unit test covers the trailing-semicolon input.

None

#### Useful notes for your reviewer


#### Release note

```release-note
CLI: Fixed a bug where `kueuectl create clusterqueue` rejected a quota flag value with a trailing semicolon, such as `--nominal-quota "alpha:cpu=1;"`, with a misleading `invalid resource quota` error. The trailing semicolon is now accepted, as the flag's format validation already allowed it.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## AI summary

`kueuectl create clusterqueue` now accepts quota values with a trailing semicolon. Parsing no longer creates an empty resource specification.

### Suggested release note

CLI: Fixed a bug that caused `kueuectl create clusterqueue` to reject valid quota flags with a trailing semicolon. Kueue now parses these quota values successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->