### PR TITLE
Propose the ScheduleWorkload interface.

### DIFF
--- a/pkg/cache/scheduler/scheduling_simulator_default.go
+++ b/pkg/cache/scheduler/scheduling_simulator_default.go
@@ -129,3 +129,14 @@ func (s *defaultSimulatorSnapshot) Simulate(_ context.Context, fn func()) error 
 	fn()
 	return nil
 }
+
+func (s *defaultSimulatorSnapshot) ScheduleWorkload(
+	ctx context.Context,
+	wlKey simulator.WorkloadKey,
+	preemptionCandidates []simulator.WorkloadKey,
+	preemptedWorkloads []simulator.WorkloadKey,
+) (result simulator.SchedulingResult, preemptionResult simulator.PreemptionResult, err error) {
+	return simulator.SchedulingResult{}, simulator.PreemptionResult{
+		PreemptionTargets: preemptedWorkloads,
+	}, nil
+}

--- a/pkg/cache/scheduler/simulator/interface.go
+++ b/pkg/cache/scheduler/simulator/interface.go
@@ -21,7 +21,6 @@ import (
 	"iter"
 
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // SchedulingSimulator acts as a factory for SimulatorSnapshots.
@@ -34,7 +33,7 @@ type SchedulingSimulator interface {
 	// TrackPod notifies the simulator that a pod is running on a node.
 	TrackPod(ctx context.Context, pod *corev1.Pod)
 	// UntrackPod notifies the simulator that a pod has been removed.
-	UntrackPod(ctx context.Context, key client.ObjectKey)
+	UntrackPod(ctx context.Context, key WorkloadKey)
 }
 
 // SimulatorSnapshot allows running simulations on a snapshotted cluster state.
@@ -53,7 +52,18 @@ type SimulatorSnapshot interface {
 	// When run inside Simulate, any changes made by the method or the returned revert function
 	// will be reverted regardless of their outcome (error vs success).
 	// The default implementation does not perform any logic here.
-	PreemptWorkload(ctx context.Context, wlKey client.ObjectKey) (revert func() error, err error)
+	PreemptWorkload(ctx context.Context, wlKey WorkloadKey) (revert func() error, err error)
+	// ScheduleWorkload finds Pod assignments and required preemptions' targets to fit the workload on the cluster.
+	// It pulls preemption targets from the preemptionCandidates slice.
+	// It simulates the preemptions of workloads listed in preemptedWorkloads.
+	// The result is the bindings of Pods to Nodes for the calculated placement
+	// and the information on which workloads need preempting to make the placement feasible.
+	ScheduleWorkload(
+		ctx context.Context,
+		wlKey WorkloadKey,
+		preemptionCandidates []WorkloadKey,
+		preemptedWorkloads []WorkloadKey,
+	) (SchedulingResult, PreemptionResult, error)
 }
 
 func AsCandidates[C Candidate](seq iter.Seq[C]) iter.Seq[Candidate] {

--- a/pkg/cache/scheduler/simulator/types.go
+++ b/pkg/cache/scheduler/simulator/types.go
@@ -20,6 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/component-helpers/scheduling/corev1/nodeaffinity"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 )
@@ -84,4 +85,19 @@ func (s *NodeExclusionStats) RecordExclusion(exclusionType NodeExclusionType, ta
 	case ExclusionAffinity:
 		s.Affinity++
 	}
+}
+
+type WorkloadKey = client.ObjectKey
+
+type SchedulingResult struct {
+	Bindings []PodBinding
+}
+
+type PodBinding struct {
+	Pod      *corev1.Pod
+	NodeName string
+}
+
+type PreemptionResult struct {
+	PreemptionTargets []WorkloadKey
 }

--- a/pkg/cache/scheduler/was/scheduling_simulator.go
+++ b/pkg/cache/scheduler/was/scheduling_simulator.go
@@ -242,3 +242,17 @@ func (s *wasSimulatorSnapshot) Simulate(ctx context.Context, fn func()) error {
 		return schedLibSnapshot.Revert, nil
 	})
 }
+
+func (s *wasSimulatorSnapshot) ScheduleWorkload(
+	ctx context.Context,
+	wlKey simulator.WorkloadKey,
+	preemptionCandidates []simulator.WorkloadKey,
+	preemptedWorkloads []simulator.WorkloadKey,
+) (result simulator.SchedulingResult, preemptionResult simulator.PreemptionResult, err error) {
+	// 1.1. Get list of pods mapped to the wlKey -> pods
+	// 1.2. Translate the keys of preemption candidates (workloads) to the sets of victim pods -> potentialVictims
+	// 1.3. Translate the keys of preempted workloads to the sets of victim pods -> existingVictims
+	// 2. Call s.wasSnapshot.ScheduleWorkload(ctx, opts, pods, potentialVictims, existingVictims)
+	// 3. Convert the results to: (A) a list of PodBindings for the scheduled pods and (B) a list of preempted workloads
+	panic("not implemented")
+}


### PR DESCRIPTION
<!-- Thank you for contributing! Check CONTRIBUTING.md for details. -->
/kind feature
/area was

#### What type of PR is this?
<!-- Choose one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep
-->


<!-- Optionally choose one or more of the following kinds:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


<!-- Consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->


#### What this PR does / why we need it?
Introduces the interface for the ScheduleWorkload method to abstract the WAS Scheduler Library's corresponding method.

Part of an effort to integrate WAS with core Kueue scheduler loop.

<!--
Use `Fixes #123` for an issue addressed by this PR; it will be closed when the PR merges.
Use `Related:` or `Part of:` to reference an issue without closing it.
-->
Contributes to #15333

#### Useful notes for your reviewer
NONE

#### Release note

<!-- Describe the behavior change accurately from the user's perspective. Hints:
- Do not leave this block blank.
- Use "NONE" when there is no user-facing change.
- When feasible use a prefix for the sub-component or feature, e.g. "FairSharing:" or "MultiKueue:".
- If upgrade steps are required, include an "ACTION REQUIRED:" section.
You may consider AI assistance using the skill: cmd/experimental/skills/kueue-release-notes/SKILL.md.
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## AI summary

Adds the `ScheduleWorkload` API and shared scheduling and preemption result types to the simulator interfaces. Updates workload identifiers to use `WorkloadKey`.

The default simulator returns the requested preemption targets without changing simulation state. The WAS implementation is currently not implemented and panics when called.

### Suggested release note

NONE
<!-- end of auto-generated comment: release notes by coderabbit.ai -->