### PR TITLE
chore: manually bump stbenjam/skillsaw to 0.20.0

### DIFF
--- a/hack/make/verify.mk
+++ b/hack/make/verify.mk
@@ -187,7 +187,7 @@ endef
 # Validates skills against https://agentskills.io/specification
 define _skills_lint_recipe
 mkdir -p $(ARTIFACTS)
-$(CONTAINER_ENGINE) run --rm $(CONTAINER_SECURITY_OPTS) -v $(PROJECT_DIR):/workspace$(VOLUME_FLAGS) -v $(ARTIFACTS):/out$(VOLUME_FLAGS) $(SKILLSAW_IMAGE) --output /out/skillsaw-summary.html
+$(CONTAINER_ENGINE) run --rm --user "$(shell id -u):$(shell id -g)" $(CONTAINER_SECURITY_OPTS) -v $(PROJECT_DIR):/workspace$(VOLUME_FLAGS) -v $(ARTIFACTS):/out$(VOLUME_FLAGS) $(SKILLSAW_IMAGE) --output /out/skillsaw-summary.html
 endef
 
 

--- a/hack/testing/skillsaw/Dockerfile
+++ b/hack/testing/skillsaw/Dockerfile
@@ -1,1 +1,1 @@
-FROM ghcr.io/stbenjam/skillsaw:0.18.0
+FROM ghcr.io/stbenjam/skillsaw:0.20.0


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

/area testing

#### What this PR does / why we need it?

Manually bumps `stbenjam/skillsaw` from `0.18.0` to `0.20.0`, completing the update that PR #15478 (Dependabot) could not merge because its `pull-kueue-verify-main` check failed.

The failure was a permission error, not a lint issue: skillsaw 0.20.0's image now runs as a non-root `skillsaw` user instead of root, so it could no longer write `skillsaw-summary.html` into the host-mounted `$(ARTIFACTS)` output directory (`Permission denied`). Passing `--user "$(id -u):$(id -g)"` to the `docker run`/`podman run` invocation in `verify-skills-lint` runs the container as the invoking host user, who owns that directory, fixing the write.

Verified locally: `docker run --rm --user "$(id -u):$(id -g)" -v "$PWD":/workspace -v /tmp/out:/out ghcr.io/stbenjam/skillsaw:0.20.0 --output /out/skillsaw-summary.html` now exits 0 and writes the report.

Fixes #15489

#### Useful notes for your reviewer

- Root cause and fix are isolated to `hack/make/verify.mk` (added `--user`) and `hack/testing/skillsaw/Dockerfile` (version bump); no other generated files reference the skillsaw version.
- `.skillsaw.yaml` still references two rules skillsaw 0.20.0 marks as deprecated (`content-critical-position`, `content-actionability-score`). These only produce non-fatal warnings today (verify still exits 0), so I left them out of scope for this fix; happy to clean those up separately if preferred.

#### Release note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## AI summary

- Updated `stbenjam/skillsaw` from `0.18.0` to `0.20.0`.
- Runs skillsaw as the invoking host user so it can write `skillsaw-summary.html` to the mounted artifacts directory.
- The relevant verify check passes.

### Suggested release note

NONE

<!-- end of auto-generated comment: release notes by coderabbit.ai -->