### PR TITLE
Modularize FlavorAssigner logic

### DIFF
--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -698,8 +698,13 @@ func New(
 // FlavorAssignmentMode.
 func (a *FlavorAssigner) Assign(ctx context.Context, counts []int32) Assignment {
 	log := log.FromContext(ctx)
-
-	return a.assignFlavors(ctx, log, counts)
+	assignment, failed := a.PrepareAssignment(ctx, log, counts)
+	if failed {
+		return assignment
+	}
+	a.updateForTAS(ctx, log, &assignment)
+	assignment.ResolveNoFitReason(a.cq)
+	return assignment
 }
 
 type indexedPodSet struct {
@@ -708,7 +713,7 @@ type indexedPodSet struct {
 	podSetAssignment *PodSetAssignment
 }
 
-func (a *FlavorAssigner) assignFlavors(ctx context.Context, log logr.Logger, counts []int32) Assignment {
+func (a *FlavorAssigner) PrepareAssignment(ctx context.Context, log logr.Logger, counts []int32) (_ Assignment, failed bool) {
 	requests := make([]workload.PodSetResources, len(a.wl.TotalRequests))
 	if len(counts) == 0 {
 		for i, ps := range a.wl.TotalRequests {
@@ -851,19 +856,19 @@ func (a *FlavorAssigner) assignFlavors(ctx context.Context, log logr.Logger, cou
 			}
 		}
 		if atLeastOnePodsAssignmentFailed {
-			if features.Enabled(features.UnadmittedWorkloadsObservability) {
-				assignment.resolveNoFitReason(a.cq)
-			}
-			return assignment
+			assignment.ResolveNoFitReason(a.cq)
+			return assignment, true
 		}
 	}
 	if assignment.RepresentativeMode() == NoFit {
-		if features.Enabled(features.UnadmittedWorkloadsObservability) {
-			assignment.resolveNoFitReason(a.cq)
-		}
-		return assignment
+		assignment.ResolveNoFitReason(a.cq)
+		return assignment, true
 	}
 
+	return assignment, false
+}
+
+func (a *FlavorAssigner) updateForTAS(ctx context.Context, log logr.Logger, assignment *Assignment) {
 	if features.Enabled(features.TopologyAwareScheduling) {
 		tasRequests := assignment.WorkloadsTopologyRequests(log, a.wl, a.cq)
 		if assignment.RepresentativeMode() == Fit {
@@ -904,10 +909,6 @@ func (a *FlavorAssigner) assignFlavors(ctx context.Context, log logr.Logger, cou
 			}
 		}
 	}
-	if features.Enabled(features.UnadmittedWorkloadsObservability) {
-		assignment.resolveNoFitReason(a.cq)
-	}
-	return assignment
 }
 
 // resolvePodSetFlavors returns the flavors podSet should be assigned, given the flavors
@@ -947,7 +948,10 @@ func (a *FlavorAssigner) resolvePodSetFlavors(log logr.Logger, idxPodSet indexed
 	return nil
 }
 
-func (a *Assignment) resolveNoFitReason(cq *schdcache.ClusterQueueSnapshot) {
+func (a *Assignment) ResolveNoFitReason(cq *schdcache.ClusterQueueSnapshot) {
+	if !features.Enabled(features.UnadmittedWorkloadsObservability) {
+		return
+	}
 	if a.RepresentativeMode() != NoFit {
 		return
 	}


### PR DESCRIPTION


<!-- Thank you for contributing! Check CONTRIBUTING.md for details. -->

#### What type of PR is this?
/kind cleanup
/area was
<!-- Choose one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep
-->


<!-- Optionally choose one or more of the following kinds:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


<!-- Consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->


#### What this PR does / why we need it?
Prepares the FlavorAssigner logic to allow finding the Assignment using WAS SchedulerWorkload.

<!--
Use `Fixes #123` for an issue addressed by this PR; it will be closed when the PR merges.
Use `Related:` or `Part of:` to reference an issue without closing it.
-->
Contributes to https://github.com/kubernetes-sigs/kueue/issues/15333

#### Useful notes for your reviewer
The idea behind the change is to provide an alternative implementation of `getAssignments` using the `ScheduleWorkload` method from https://github.com/kubernetes-sigs/kueue/pull/15492:

```go
// Enabled FGs: TAS, WAS, ScheduleWorkloads
func (s *Scheduler) getAssignmentsWithWAS(ctx context.Context, wl *workload.Info, snap *schdcache.Snapshot, preemptedWorkloads []*workload.Info) (flavorassigner.Assignment, []*preemption.Target) {
	cq := snap.ClusterQueue(wl.ClusterQueue)
	// The flavor scan resumes from the progress recorded in FlavorScanState, so it has to be
	// dropped once it no longer describes the current state. Deciding that here rather than
	// inside the assigner keeps it to one place per Workload per cycle: the assigner runs
	// again for each reduced pod count when partial admission is in play.
	if wl.FlavorScanState != nil && flavorScanStateOutdated(wl.FlavorScanState, cq.AllocatableResourceGeneration, s.schedulingCycle, wl.SchedulingHash) {
		log.FromContext(ctx).V(6).Info("Clearing Workload's flavor scan state because it was outdated",
			"cq.AllocatableResourceGeneration", cq.AllocatableResourceGeneration,
			"wl.FlavorScanState.AllocatableResourceGeneration", wl.FlavorScanState.AllocatableResourceGeneration)
		wl.FlavorScanState = nil
	}

	preemptionTargets, replaceableWorkloadSlice := workloadslicing.ReplacedWorkloadSlice(wl, snap)

	flvAssigner := flavorassigner.New(
		wl, cq, snap.ResourceFlavors, fairsharing.Enabled(s.fairSharing),
		preemption.NewOracle(s.preemptor, snap), replaceableWorkloadSlice,
		s.quotaCheckStrategy, s.resourceFormatter, s.schedulingCycle,
	)
	assignment, _ := flvAssigner.PrepareAssignment(ctx, log.FromContext(ctx), nil)

	// Here perform the logic that updates the following for TAS calculation based on ScheduleWorkload:
	// - assignment <- apply Pod bindings to node selectors of the Pods
	// - preemptedWorkloads <- merge the targets returned by ScheduleWorkload into preemptedWorkloads

	assignment.ResolveNoFitReason(cq)
	return assignment, preemptionTargets
}
```


#### Release note

<!-- Describe the behavior change accurately from the user's perspective. Hints:
- Do not leave this block blank.
- Use "NONE" when there is no user-facing change.
- When feasible use a prefix for the sub-component or feature, e.g. "FairSharing:" or "MultiKueue:".
- If upgrade steps are required, include an "ACTION REQUIRED:" section.
You may consider AI assistance using the skill: cmd/experimental/skills/kueue-release-notes/SKILL.md.
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## AI summary

- Modularizes `FlavorAssigner` assignment preparation.
- Adds `PrepareAssignment` and `UpdateForTAS` to support alternative WAS `hetAssignments` implementations.
- Exports `ResolveNoFitReason` and centralizes feature-gate handling.
- Preserves flavor scan state, preemption setup, assignment resolution, and no-fit reason handling.

### Suggested release note

NONE
<!-- end of auto-generated comment: release notes by coderabbit.ai -->