### PR TITLE
fix: reject out-of-range partial admission values

### DIFF
--- a/pkg/controller/jobs/job/job_controller.go
+++ b/pkg/controller/jobs/job/job_controller.go
@@ -457,12 +457,15 @@ func (j *Job) podsCount() int32 {
 }
 
 func (j *Job) minPodsCount() *int32 {
-	if strVal, found := j.GetAnnotations()[JobMinParallelismAnnotation]; found {
-		if iVal, err := strconv.Atoi(strVal); err == nil {
-			return new(int32(iVal))
-		}
+	strVal, found := j.GetAnnotations()[JobMinParallelismAnnotation]
+	if !found {
+		return nil
 	}
-	return nil
+	minCount, err := strconv.ParseInt(strVal, 10, 32)
+	if err != nil {
+		return nil
+	}
+	return new(int32(minCount))
 }
 
 func (j *Job) syncCompletionWithParallelism() bool {

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -394,6 +394,20 @@ func TestPodSets(t *testing.T) {
 					Obj(),
 			},
 		},
+		"invalid partial admission annotation is ignored": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			job: (*Job)(
+				jobTemplate.Clone().
+					Parallelism(3).
+					SetAnnotation(JobMinParallelismAnnotation, "2147483648").
+					Obj(),
+			),
+			wantPodSets: []kueue.PodSet{
+				*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 3).
+					PodSpec(*jobTemplate.Clone().Spec.Template.Spec.DeepCopy()).
+					Obj(),
+			},
+		},
 		"with required topology annotation": {
 			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 			job: (*Job)(

--- a/pkg/controller/jobs/job/job_webhook.go
+++ b/pkg/controller/jobs/job/job_webhook.go
@@ -154,11 +154,11 @@ func (w *JobWebhook) validateCreate(ctx context.Context, job *Job) (field.ErrorL
 func (w *JobWebhook) validatePartialAdmissionCreate(job *Job) field.ErrorList {
 	var allErrs field.ErrorList
 	if strVal, found := job.Annotations[JobMinParallelismAnnotation]; found {
-		v, err := strconv.Atoi(strVal)
+		v, err := strconv.ParseInt(strVal, 10, 32)
 		if err != nil {
 			allErrs = append(allErrs, field.Invalid(minPodsCountAnnotationsPath, job.Annotations[JobMinParallelismAnnotation], err.Error()))
 		} else if int32(v) >= job.podsCount() || v <= 0 {
-			allErrs = append(allErrs, field.Invalid(minPodsCountAnnotationsPath, v, fmt.Sprintf("should be between 0 and %d", job.podsCount()-1)))
+			allErrs = append(allErrs, field.Invalid(minPodsCountAnnotationsPath, int(v), fmt.Sprintf("should be between 0 and %d", job.podsCount()-1)))
 		}
 		if workloadslicing.Enabled(job.Object()) {
 			allErrs = append(allErrs, field.Invalid(minPodsCountAnnotationsPath, strVal, "partial admission and elastic job cannot be used together"))

--- a/pkg/controller/jobs/job/job_webhook_test.go
+++ b/pkg/controller/jobs/job/job_webhook_test.go
@@ -88,7 +88,7 @@ func TestValidateCreate(t *testing.T) {
 				SetAnnotation(JobMinParallelismAnnotation, "NaN").
 				Obj(),
 			wantValidationErrs: field.ErrorList{
-				field.Invalid(minPodsCountAnnotationsPath, "NaN", "strconv.Atoi: parsing \"NaN\": invalid syntax"),
+				field.Invalid(minPodsCountAnnotationsPath, "NaN", "strconv.ParseInt: parsing \"NaN\": invalid syntax"),
 			},
 		},
 		{
@@ -100,6 +100,17 @@ func TestValidateCreate(t *testing.T) {
 				Obj(),
 			wantValidationErrs: field.ErrorList{
 				field.Invalid(minPodsCountAnnotationsPath, 5, "should be between 0 and 3"),
+			},
+		},
+		{
+			name: "invalid partial admission annotation (outside int32 range)",
+			job: testingutil.MakeJob("job", "default").
+				Parallelism(4).
+				Completions(6).
+				SetAnnotation(JobMinParallelismAnnotation, "2147483648").
+				Obj(),
+			wantValidationErrs: field.ErrorList{
+				field.Invalid(minPodsCountAnnotationsPath, "2147483648", "strconv.ParseInt: parsing \"2147483648\": value out of range"),
 			},
 		},
 		{
@@ -875,7 +886,7 @@ func TestValidateUpdate(t *testing.T) {
 				SetAnnotation(JobMinParallelismAnnotation, "NaN").
 				Obj(),
 			wantValidationErrs: field.ErrorList{
-				field.Invalid(minPodsCountAnnotationsPath, "NaN", "strconv.Atoi: parsing \"NaN\": invalid syntax"),
+				field.Invalid(minPodsCountAnnotationsPath, "NaN", "strconv.ParseInt: parsing \"NaN\": invalid syntax"),
 			},
 		},
 		{


### PR DESCRIPTION
<!-- Thank you for contributing! Check CONTRIBUTING.md for details. -->

#### What type of PR is this?
/kind bug

<!-- Choose one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep
-->


<!-- Optionally choose one or more of the following kinds:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


<!-- Consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->


#### What this PR does / why we need it?
Reject `kueue.x-k8s.io/job-min-parallelism` values outside `int32` range. On 64-bit platforms, a value such as `"2147483648"` passed Job webhook validation after narrowing to `int32`. The job controller then propagated the negative value as Workload PodSet `mincount`, which the workload API rejects and leaves the job unable to create a workload.

<!--
Use `Fixes #123` for an issue addressed by this PR; it will be closed when the PR merges.
Use `Related:` or `Part of:` to reference an issue without closing it.
-->
Fixes #

#### Useful notes for your reviewer


#### Release note

<!-- Describe the behavior change accurately from the user's perspective. Hints:
- Do not leave this block blank.
- Use "NONE" when there is no user-facing change.
- When feasible use a prefix for the sub-component or feature, e.g. "FairSharing:" or "MultiKueue:".
- If upgrade steps are required, include an "ACTION REQUIRED:" section.
You may consider AI assistance using the skill: cmd/experimental/skills/kueue-release-notes/SKILL.md.
-->
```release-note
Job: Reject partial-admission minimum parallelism values outside the int32 range.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## AI summary

Kueue now rejects `job-min-parallelism` values outside the `int32` range. This prevents invalid negative Workload PodSet `mincount` values and workload creation failures. Tests cover validation and fallback behavior.

### Suggested release note

Job: Fixed a bug that caused out-of-range `job-min-parallelism` values to produce invalid Workload PodSet `mincount` values. Now Kueue rejects these values during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->