### PR TITLE
DQO: retry ClusterQueue takeover when the previous owner becomes inactive

### DIFF
--- a/pkg/controller/core/dqo/distribution.go
+++ b/pkg/controller/core/dqo/distribution.go
@@ -189,8 +189,7 @@ func (r *Reconciler) checkManagedConflict(
 		return nil
 	}
 
-	distCond := apimeta.FindStatusCondition(other.Status.Conditions, kueuealpha.DynamicQuotaOrchestratorDistributed)
-	if distCond != nil && distCond.Status == metav1.ConditionFalse {
+	if isDistributedFalse(other) {
 		// The other orchestrator is deactivated; its effective quota can be taken over.
 		return nil
 	}
@@ -207,6 +206,11 @@ func (r *Reconciler) checkManagedConflict(
 		return nil
 	}
 	return fmt.Errorf("%s %q already managed by %s/%s", kind, name, ref.Kind, ref.Name)
+}
+
+// isDistributedFalse reports whether Distributed is present and False.
+func isDistributedFalse(orchestrator *kueuealpha.DynamicQuotaOrchestrator) bool {
+	return apimeta.IsStatusConditionFalse(orchestrator.Status.Conditions, kueuealpha.DynamicQuotaOrchestratorDistributed)
 }
 
 // calculateAllocations distributes total capacity across all flavors and resources to participant nodes in the subtree.

--- a/pkg/controller/core/dqo/distribution_test.go
+++ b/pkg/controller/core/dqo/distribution_test.go
@@ -803,6 +803,87 @@ func TestDynamicQuotaOrchestratorDistribution(t *testing.T) {
 				}).
 				Obj(),
 		},
+		"soft validation: takeover when managing DQO is Distributed=False": {
+			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-1").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.ClusterQueueSubtreeRootRefKind, "cq-1").
+				Obj(),
+			capacityProviders: []*kueuealpha.CapacityProvider{
+				utiltestingalpha.MakeCapacityProvider("cp-1").
+					OrchestratedFlavors("default-flavor").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.CapacityProviderCapacitySynchronized,
+						Status: metav1.ConditionTrue,
+						Reason: kueuealpha.CapacityProviderReasonSynchronized,
+					}).
+					Capacity(utiltestingalpha.MakeNormalizedCapacity().
+						Flavors(
+							utiltestingalpha.MakeNormalizedCapacityFlavor("default-flavor").
+								Resource(corev1.ResourceCPU, "100").
+								Obj(),
+						).
+						Obj()).
+					Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq-1").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					EffectiveQuotaStatus(utiltestingapi.MakeEffectiveQuotaStatus().Name("other-dqo").Obj()).
+					Obj(),
+			},
+			otherDQOs: []*kueuealpha.DynamicQuotaOrchestrator{
+				utiltestingalpha.MakeDynamicQuotaOrchestrator("other-dqo").
+					DiscoveryProvider("cp-1", nil).
+					SubtreeRoot(kueuealpha.ClusterQueueSubtreeRootRefKind, "cq-other").
+					Condition(metav1.Condition{
+						Type:   kueuealpha.DynamicQuotaOrchestratorDistributed,
+						Status: metav1.ConditionFalse,
+						Reason: kueuealpha.DynamicQuotaOrchestratorReasonEffectiveCapacityNotComputed,
+					}).
+					Obj(),
+			},
+			wantDQO: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-1").
+				DiscoveryProvider("cp-1", nil).
+				SubtreeRoot(kueuealpha.ClusterQueueSubtreeRootRefKind, "cq-1").
+				EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(
+						*utiltestingalpha.MakeEffectiveCapacityFlavor("default-flavor").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj()).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorEffectiveCapacityComputed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonComputed,
+					Message: "Aggregated capacity successfully computed",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueuealpha.DynamicQuotaOrchestratorDistributed,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueuealpha.DynamicQuotaOrchestratorReasonQuotasDistributed,
+					Message: "Quotas successfully distributed",
+				}).
+				Obj(),
+			wantClusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq-1").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "50").Obj(),
+					).
+					EffectiveQuotaStatus(
+						utiltestingapi.MakeEffectiveQuotaStatus().
+							Name("dqo-1").
+							ResourceGroups(utiltestingapi.ResourceGroup(
+								*utiltestingapi.MakeFlavorQuotas("default-flavor").Resource(corev1.ResourceCPU, "100").Obj(),
+							)).
+							Obj(),
+					).
+					Obj(),
+			},
+			wantErr: false,
+		},
 		"transition: switch to discovery-only preserves stale effective quotas and removes Distributed condition": {
 			dqo: utiltestingalpha.MakeDynamicQuotaOrchestrator("dqo-discovery-only").
 				DiscoveryProvider("cp-1", nil).

--- a/pkg/controller/core/dqo/reconciler.go
+++ b/pkg/controller/core/dqo/reconciler.go
@@ -104,12 +104,14 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&kueuealpha.DynamicQuotaOrchestrator{},
 			handler.EnqueueRequestsFromMapFunc(r.mapOtherDistributingDQOs),
-			builder.WithPredicates(dqoSpecOrDeletionChangedPredicate),
+			builder.WithPredicates(otherDQOUpdatePredicate),
 		).
 		Complete(r)
 }
 
-var dqoSpecOrDeletionChangedPredicate = predicate.Funcs{
+// otherDQOUpdatePredicate filters updates that can affect other orchestrators.
+// Changes to Distributed=False affect takeover of retained effective quotas.
+var otherDQOUpdatePredicate = predicate.Funcs{
 	UpdateFunc: func(e event.UpdateEvent) bool {
 		if e.ObjectOld == nil || e.ObjectNew == nil {
 			return false
@@ -117,7 +119,12 @@ var dqoSpecOrDeletionChangedPredicate = predicate.Funcs{
 		if e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() {
 			return true
 		}
-		return e.ObjectOld.GetDeletionTimestamp().IsZero() != e.ObjectNew.GetDeletionTimestamp().IsZero()
+		if e.ObjectOld.GetDeletionTimestamp().IsZero() != e.ObjectNew.GetDeletionTimestamp().IsZero() {
+			return true
+		}
+		oldDQO, oldOK := e.ObjectOld.(*kueuealpha.DynamicQuotaOrchestrator)
+		newDQO, newOK := e.ObjectNew.(*kueuealpha.DynamicQuotaOrchestrator)
+		return oldOK && newOK && isDistributedFalse(oldDQO) != isDistributedFalse(newDQO)
 	},
 }
 

--- a/pkg/controller/core/dqo/reconciler_test.go
+++ b/pkg/controller/core/dqo/reconciler_test.go
@@ -18,6 +18,7 @@ package dqo
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -26,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
@@ -430,6 +432,167 @@ func TestDynamicQuotaOrchestratorReconcile(t *testing.T) {
 				if diff := cmp.Diff(wantCohort.Status.EffectiveQuotas, gotCohort.Status.EffectiveQuotas, cmpopts.EquateEmpty()); diff != "" {
 					t.Errorf("Unexpected EffectiveQuotas for Cohort %s (-want +got):\n%s", wantCohort.Name, diff)
 				}
+			}
+		})
+	}
+}
+
+func TestOtherDQOUpdatePredicate(t *testing.T) {
+	now := metav1.Now()
+	later := metav1.NewTime(now.Time.Add(time.Minute))
+
+	trueDistributed := utiltestingalpha.MakeDynamicQuotaOrchestrator("a").
+		DiscoveryProvider("cp-1", nil).
+		SubtreeRoot(kueuealpha.ClusterQueueSubtreeRootRefKind, "cq-x").
+		EffectiveCapacity(utiltestingalpha.MakeEffectiveCapacity().
+			Flavors(*utiltestingalpha.MakeEffectiveCapacityFlavor("f1").Resource(corev1.ResourceCPU, "100").Obj()).
+			Obj()).
+		Condition(metav1.Condition{
+			Type:               kueuealpha.DynamicQuotaOrchestratorDistributed,
+			Status:             metav1.ConditionTrue,
+			Reason:             kueuealpha.DynamicQuotaOrchestratorReasonQuotasDistributed,
+			Message:            "Quotas successfully distributed",
+			LastTransitionTime: now,
+		}).
+		Obj()
+	trueDistributed.Generation = 2
+
+	cases := map[string]struct {
+		old  client.Object
+		new  client.Object
+		want bool
+	}{
+		"generation change": {
+			old: trueDistributed,
+			new: func() *kueuealpha.DynamicQuotaOrchestrator {
+				d := trueDistributed.DeepCopy()
+				d.Generation = 3
+				d.Spec.CapacityDistribution.SubtreeRootQuotaRef.Name = "cq-y"
+				return d
+			}(),
+			want: true,
+		},
+		"deletion timestamp set": {
+			old: trueDistributed,
+			new: func() *kueuealpha.DynamicQuotaOrchestrator {
+				d := trueDistributed.DeepCopy()
+				d.DeletionTimestamp = &now
+				return d
+			}(),
+			want: true,
+		},
+		"distributed true to false": {
+			old: trueDistributed,
+			new: func() *kueuealpha.DynamicQuotaOrchestrator {
+				d := trueDistributed.DeepCopy()
+				d.Status.Conditions[0].Status = metav1.ConditionFalse
+				d.Status.Conditions[0].Reason = kueuealpha.DynamicQuotaOrchestratorReasonEffectiveCapacityNotComputed
+				d.Status.Conditions[0].Message = "Capacity discovery not ready"
+				d.Status.Conditions[0].LastTransitionTime = later
+				return d
+			}(),
+			want: true,
+		},
+		"distributed false to true": {
+			old: func() *kueuealpha.DynamicQuotaOrchestrator {
+				d := trueDistributed.DeepCopy()
+				d.Status.Conditions[0].Status = metav1.ConditionFalse
+				d.Status.Conditions[0].Reason = kueuealpha.DynamicQuotaOrchestratorReasonEffectiveCapacityNotComputed
+				return d
+			}(),
+			new:  trueDistributed,
+			want: true,
+		},
+		"absent distributed to false": {
+			old: func() *kueuealpha.DynamicQuotaOrchestrator {
+				d := utiltestingalpha.MakeDynamicQuotaOrchestrator("a").
+					DiscoveryProvider("cp-1", nil).
+					SubtreeRoot(kueuealpha.ClusterQueueSubtreeRootRefKind, "cq-x").
+					Obj()
+				d.Generation = 2
+				return d
+			}(),
+			new: func() *kueuealpha.DynamicQuotaOrchestrator {
+				d := trueDistributed.DeepCopy()
+				d.Status.Conditions[0].Status = metav1.ConditionFalse
+				d.Status.Conditions[0].Reason = kueuealpha.DynamicQuotaOrchestratorReasonEffectiveCapacityNotComputed
+				return d
+			}(),
+			want: true,
+		},
+		"false reason change only": {
+			old: func() *kueuealpha.DynamicQuotaOrchestrator {
+				d := trueDistributed.DeepCopy()
+				d.Status.Conditions[0].Status = metav1.ConditionFalse
+				d.Status.Conditions[0].Reason = kueuealpha.DynamicQuotaOrchestratorReasonEffectiveCapacityNotComputed
+				d.Status.Conditions[0].Message = "Capacity discovery not ready"
+				return d
+			}(),
+			new: func() *kueuealpha.DynamicQuotaOrchestrator {
+				d := trueDistributed.DeepCopy()
+				d.Status.Conditions[0].Status = metav1.ConditionFalse
+				d.Status.Conditions[0].Reason = kueuealpha.DynamicQuotaOrchestratorReasonMisconfigured
+				d.Status.Conditions[0].Message = "Capacity discovery not ready"
+				return d
+			}(),
+			want: false,
+		},
+		"false message change only": {
+			old: func() *kueuealpha.DynamicQuotaOrchestrator {
+				d := trueDistributed.DeepCopy()
+				d.Status.Conditions[0].Status = metav1.ConditionFalse
+				d.Status.Conditions[0].Reason = kueuealpha.DynamicQuotaOrchestratorReasonEffectiveCapacityNotComputed
+				d.Status.Conditions[0].Message = "old"
+				return d
+			}(),
+			new: func() *kueuealpha.DynamicQuotaOrchestrator {
+				d := trueDistributed.DeepCopy()
+				d.Status.Conditions[0].Status = metav1.ConditionFalse
+				d.Status.Conditions[0].Reason = kueuealpha.DynamicQuotaOrchestratorReasonEffectiveCapacityNotComputed
+				d.Status.Conditions[0].Message = "new"
+				return d
+			}(),
+			want: false,
+		},
+		"false timestamp change only": {
+			old: func() *kueuealpha.DynamicQuotaOrchestrator {
+				d := trueDistributed.DeepCopy()
+				d.Status.Conditions[0].Status = metav1.ConditionFalse
+				d.Status.Conditions[0].LastTransitionTime = now
+				return d
+			}(),
+			new: func() *kueuealpha.DynamicQuotaOrchestrator {
+				d := trueDistributed.DeepCopy()
+				d.Status.Conditions[0].Status = metav1.ConditionFalse
+				d.Status.Conditions[0].LastTransitionTime = later
+				return d
+			}(),
+			want: false,
+		},
+		"true with effective capacity rewrite": {
+			old: trueDistributed,
+			new: func() *kueuealpha.DynamicQuotaOrchestrator {
+				d := trueDistributed.DeepCopy()
+				d.Status.EffectiveCapacity = utiltestingalpha.MakeEffectiveCapacity().
+					Flavors(*utiltestingalpha.MakeEffectiveCapacityFlavor("f1").Resource(corev1.ResourceCPU, "150").Obj()).
+					Obj()
+				return d
+			}(),
+			want: false,
+		},
+		"nil objects": {
+			want: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := otherDQOUpdatePredicate.Update(event.UpdateEvent{
+				ObjectOld: tc.old,
+				ObjectNew: tc.new,
+			})
+			if got != tc.want {
+				t.Errorf("Update() = %v, want %v", got, tc.want)
 			}
 		})
 	}

--- a/test/integration/singlecluster/controller/dynamicquotaorchestrator/dynamicquotaorchestrator_test.go
+++ b/test/integration/singlecluster/controller/dynamicquotaorchestrator/dynamicquotaorchestrator_test.go
@@ -1104,6 +1104,138 @@ var _ = ginkgo.Describe("DynamicQuotaOrchestrator controller", ginkgo.Label("con
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})
+
+	ginkgo.It("Should take over leftover ClusterQueue ownership when the managing DQO becomes inactive", func() {
+		cpA := utiltestingalpha.MakeCapacityProvider("leftover-cp-a").
+			ControllerName("example.com/test-provider").
+			OrchestratedFlavors("f1").
+			Capacity(
+				utiltestingalpha.MakeNormalizedCapacity().
+					Flavors(
+						utiltestingalpha.MakeNormalizedCapacityFlavor("f1").
+							Resource(corev1.ResourceCPU, "100").
+							Obj(),
+					).
+					Obj(),
+			).
+			Condition(metav1.Condition{
+				Type:    kueuealpha.CapacityProviderCapacitySynchronized,
+				Status:  metav1.ConditionTrue,
+				Reason:  kueuealpha.CapacityProviderReasonSynchronized,
+				Message: "Capacity synchronized successfully",
+			}).
+			Obj()
+		cpB := utiltestingalpha.MakeCapacityProvider("leftover-cp-b").
+			ControllerName("example.com/test-provider").
+			OrchestratedFlavors("f1").
+			Capacity(
+				utiltestingalpha.MakeNormalizedCapacity().
+					Flavors(
+						utiltestingalpha.MakeNormalizedCapacityFlavor("f1").
+							Resource(corev1.ResourceCPU, "200").
+							Obj(),
+					).
+					Obj(),
+			).
+			Condition(metav1.Condition{
+				Type:    kueuealpha.CapacityProviderCapacitySynchronized,
+				Status:  metav1.ConditionTrue,
+				Reason:  kueuealpha.CapacityProviderReasonSynchronized,
+				Message: "Capacity synchronized successfully",
+			}).
+			Obj()
+		cps = append(cps, cpA, cpB)
+		createCapacityProvider(ctx, k8sClient, cpA)
+		createCapacityProvider(ctx, k8sClient, cpB)
+
+		cq1 = utiltestingapi.MakeClusterQueue("leftover-cq-x").
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas("f1").Resource(corev1.ResourceCPU, "10").Obj(),
+			).
+			Obj()
+		util.MustCreate(ctx, k8sClient, cq1)
+		cq2 = utiltestingapi.MakeClusterQueue("leftover-cq-y").
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas("f1").Resource(corev1.ResourceCPU, "10").Obj(),
+			).
+			Obj()
+		util.MustCreate(ctx, k8sClient, cq2)
+
+		dqo = utiltestingalpha.MakeDynamicQuotaOrchestrator("leftover-a").
+			DiscoveryProvider("leftover-cp-a", nil).
+			SubtreeRoot(kueuealpha.ClusterQueueSubtreeRootRefKind, "leftover-cq-x").
+			Obj()
+		util.MustCreate(ctx, k8sClient, dqo)
+
+		cqXKey := types.NamespacedName{Name: cq1.Name}
+		cqYKey := types.NamespacedName{Name: cq2.Name}
+		dqoAKey := types.NamespacedName{Name: dqo.Name}
+
+		gomega.Eventually(func(g gomega.Gomega) {
+			expectClusterQueueOwnedBy(g, cqXKey, "leftover-a", "100")
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("Retargeting A to Y and leaving X's orchestratorRef", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				latestA := &kueuealpha.DynamicQuotaOrchestrator{}
+				g.Expect(k8sClient.Get(ctx, dqoAKey, latestA)).Should(gomega.Succeed())
+				latestA.Spec.CapacityDistribution.SubtreeRootQuotaRef.Name = cq2.Name
+				g.Expect(k8sClient.Update(ctx, latestA)).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			gomega.Eventually(func(g gomega.Gomega) {
+				expectClusterQueueOwnedBy(g, cqYKey, "leftover-a", "100")
+				expectClusterQueueOwnedBy(g, cqXKey, "leftover-a", "100")
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		childDQO = utiltestingalpha.MakeDynamicQuotaOrchestrator("leftover-b").
+			DiscoveryProvider("leftover-cp-b", nil).
+			SubtreeRoot(kueuealpha.ClusterQueueSubtreeRootRefKind, "leftover-cq-x").
+			Obj()
+		util.MustCreate(ctx, k8sClient, childDQO)
+		dqoBKey := types.NamespacedName{Name: childDQO.Name}
+		gomega.Eventually(func(g gomega.Gomega) {
+			latestB := &kueuealpha.DynamicQuotaOrchestrator{}
+			g.Expect(k8sClient.Get(ctx, dqoBKey, latestB)).Should(gomega.Succeed())
+			g.Expect(latestB.Status.Conditions).Should(utiltesting.HaveConditionStatusFalseAndReason(
+				kueuealpha.DynamicQuotaOrchestratorDistributed,
+				kueuealpha.DynamicQuotaOrchestratorReasonEffectiveQuotasConflict,
+			))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("Marking A's provider unsynchronized so B can take X", func() {
+			setCapacityProviderSyncCondition(ctx, k8sClient, cpA, metav1.ConditionFalse, kueuealpha.CapacityProviderReasonSourceUnavailable, "Backend source is unreachable")
+			gomega.Eventually(func(g gomega.Gomega) {
+				latestA := &kueuealpha.DynamicQuotaOrchestrator{}
+				g.Expect(k8sClient.Get(ctx, dqoAKey, latestA)).Should(gomega.Succeed())
+				g.Expect(latestA.Status.Conditions).Should(utiltesting.HaveConditionStatusFalseAndReason(
+					kueuealpha.DynamicQuotaOrchestratorDistributed,
+					kueuealpha.DynamicQuotaOrchestratorReasonEffectiveCapacityNotComputed,
+				))
+				latestB := &kueuealpha.DynamicQuotaOrchestrator{}
+				g.Expect(k8sClient.Get(ctx, dqoBKey, latestB)).Should(gomega.Succeed())
+				g.Expect(latestB.Status.Conditions).Should(utiltesting.HaveConditionStatusTrueAndReason(
+					kueuealpha.DynamicQuotaOrchestratorDistributed,
+					kueuealpha.DynamicQuotaOrchestratorReasonQuotasDistributed,
+				))
+				expectClusterQueueOwnedBy(g, cqXKey, "leftover-b", "200")
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("Restoring A's provider; A keeps Y and B keeps X", func() {
+			setCapacityProviderSyncCondition(ctx, k8sClient, cpA, metav1.ConditionTrue, kueuealpha.CapacityProviderReasonSynchronized, "Capacity synchronized successfully")
+			gomega.Eventually(func(g gomega.Gomega) {
+				latestA := &kueuealpha.DynamicQuotaOrchestrator{}
+				g.Expect(k8sClient.Get(ctx, dqoAKey, latestA)).Should(gomega.Succeed())
+				g.Expect(latestA.Status.Conditions).Should(utiltesting.HaveConditionStatusTrueAndReason(
+					kueuealpha.DynamicQuotaOrchestratorDistributed,
+					kueuealpha.DynamicQuotaOrchestratorReasonQuotasDistributed,
+				))
+				expectClusterQueueOwnedBy(g, cqYKey, "leftover-a", "100")
+				expectClusterQueueOwnedBy(g, cqXKey, "leftover-b", "200")
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
 })
 
 func createCapacityProvider(
@@ -1189,4 +1321,25 @@ func expectCohortEffectiveResourceGroups(
 	g.Expect(k8sClient.Get(ctx, key, &cohort)).Should(gomega.Succeed())
 	g.Expect(cohort.Status.EffectiveQuotas).ShouldNot(gomega.BeNil())
 	g.Expect(cmp.Diff(want, cohort.Status.EffectiveQuotas.ResourceGroups, cmpopts.EquateEmpty())).Should(gomega.BeEmpty())
+}
+
+func expectClusterQueueOwnedBy(
+	g gomega.Gomega,
+	key types.NamespacedName,
+	owner, cpu string,
+) {
+	ginkgo.GinkgoHelper()
+	var cq kueue.ClusterQueue
+	g.Expect(k8sClient.Get(ctx, key, &cq)).Should(gomega.Succeed())
+	g.Expect(cq.Status.EffectiveQuotas).ShouldNot(gomega.BeNil())
+	g.Expect(cq.Status.EffectiveQuotas.OrchestratorRef).Should(gomega.Equal(kueue.EffectiveQuotaStatusOrchestratorRef{
+		APIGroup: "kueue.x-k8s.io",
+		Kind:     "DynamicQuotaOrchestrator",
+		Name:     owner,
+	}))
+	g.Expect(cmp.Diff([]kueue.ResourceGroup{
+		utiltestingapi.ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("f1").Resource(corev1.ResourceCPU, cpu).Obj(),
+		),
+	}, cq.Status.EffectiveQuotas.ResourceGroups, cmpopts.EquateEmpty())).Should(gomega.BeEmpty())
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it?

A DynamicQuotaOrchestrator (DQO) waiting to take over a ClusterQueue can remain blocked after the previous owner’s Distributed condition becomes False. The existing ownership check allows takeover, but the watch filters out this status-only update, so the waiting DQO doesn't reconcile.

This PR lets waiting DQOs retry when another DQO’s Distributed condition becomes or stops being False.

Related to #12382.

#### Useful notes for your reviewer
The integration test verifies that a waiting DQO takes over a queue left behind by another DQO when that DQO stops distributing after a provider failure, without a manual update to trigger the retry.

This patch follows the existing ownership check, which allows takeover when Distributed is False, including after a provider failure.

#### Release note
```release-note
DynamicQuotaOrchestration: Fixed a bug where a waiting DQO could stay blocked from taking over a ClusterQueue after the previous owner's Distributed condition became False.
```

This PR was written in part with the assistance of generative AI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## AI summary

Fixed DynamicQuotaOrchestrator takeover when the previous owner stops distributing. Waiting DQOs now retry when another DQO’s `Distributed` condition changes to or from `False`. Added unit and integration coverage for provider-failure takeover.

### Suggested release note

**DynamicQuotaOrchestrator:** Fixed a bug where a waiting DQO could remain blocked after the previous owner stopped distributing. Kueue now retries the takeover automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->