### PR TITLE
kueuectl: Reject duplicate resources within ClusterQueue quota flags

### DIFF
--- a/cmd/kueuectl/app/create/create_clusterqueue.go
+++ b/cmd/kueuectl/app/create/create_clusterqueue.go
@@ -28,6 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
@@ -360,11 +361,16 @@ func getCoveredResources(resourceSpecs []string) []corev1.ResourceName {
 
 func toFlavorQuotas(name string, resourceSpecs []string, quotaType string) (kueue.FlavorQuotas, error) {
 	resourceQuotas := make([]kueue.ResourceQuota, 0, len(resourceSpecs))
+	seen := sets.New[corev1.ResourceName]()
 	for _, spec := range resourceSpecs {
 		rq, err := toResourceQuota(spec, quotaType)
 		if err != nil {
 			return kueue.FlavorQuotas{}, err
 		}
+		if seen.Has(rq.Name) {
+			return kueue.FlavorQuotas{}, fmt.Errorf("%w %q: resource %q is specified more than once in --%s", errMisconfiguredFlavor, name, rq.Name, quotaType)
+		}
+		seen.Insert(rq.Name)
 
 		resourceQuotas = append(resourceQuotas, rq)
 	}

--- a/cmd/kueuectl/app/create/create_clusterqueue_test.go
+++ b/cmd/kueuectl/app/create/create_clusterqueue_test.go
@@ -411,6 +411,28 @@ func TestParseResourceQuotas(t *testing.T) {
 			quotaArgs: []string{"alpha:cpu=1.5.5;memory=1"},
 			wantErr:   errInvalidResourceQuota,
 		},
+		"should fail when a resource is duplicated within a single nominalQuota spec": {
+			quotaArgs:      []string{"alpha:cpu=1;cpu=2;memory=1Gi"},
+			wantErr:        errMisconfiguredFlavor,
+			wantErrMessage: `misconfigured flavor "alpha": resource "cpu" is specified more than once in --nominal-quota`,
+		},
+		"should fail when a resource is duplicated within a single borrowingLimit spec": {
+			quotaArgs:      []string{"alpha:cpu=1;memory=1Gi"},
+			borrowingArgs:  []string{"alpha:cpu=1;cpu=2;memory=1Gi"},
+			wantErr:        errMisconfiguredFlavor,
+			wantErrMessage: `misconfigured flavor "alpha": resource "cpu" is specified more than once in --borrowing-limit`,
+		},
+		"should fail when a resource is duplicated within a single lendingLimit spec": {
+			quotaArgs:      []string{"alpha:cpu=1;memory=1Gi"},
+			lendingArgs:    []string{"alpha:cpu=1;memory=1Gi;memory=2Gi"},
+			wantErr:        errMisconfiguredFlavor,
+			wantErrMessage: `misconfigured flavor "alpha": resource "memory" is specified more than once in --lending-limit`,
+		},
+		"should fail when a resource is duplicated within a single borrowingLimit spec without nominalQuota": {
+			borrowingArgs:  []string{"alpha:cpu=1;cpu=2;memory=1Gi"},
+			wantErr:        errMisconfiguredFlavor,
+			wantErrMessage: `misconfigured flavor "alpha": resource "cpu" is specified more than once in --borrowing-limit`,
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it?

`kueuectl create clusterqueue` accepts a resource listed more than once in the same `--nominal-quota`, `--borrowing-limit` or `--lending-limit` flag, for example `--borrowing-limit "alpha:cpu=1;cpu=2;memory=1Gi"`. The per-flag parser appends every entry without checking for repeats, so the duplicate is either silently dropped during merging or emitted as two `ResourceQuota` items for the same name. This PR detects the repeat while parsing the flag and returns an error naming the resource and the flag.

Fixes #15510

#### Useful notes for your reviewer


#### Release note

```release-note
CLI: Fixed a bug where `kueuectl create clusterqueue` accepted a resource listed more than once in the same `--nominal-quota`, `--borrowing-limit` or `--lending-limit` flag. The command now rejects the input with an error naming the resource and the flag.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## AI summary

`kueuectl create clusterqueue` now rejects duplicate resources in the same `--nominal-quota`, `--borrowing-limit`, or `--lending-limit` flag. Errors identify the affected flag and resource. Tests cover all three flags.

### Suggested release note

CLI: Fixed a bug where `kueuectl create clusterqueue` accepted duplicate resources in a quota or limit flag. Kueue now rejects duplicate resource names and identifies the affected flag and resource.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->