### PR TITLE
KEP-13502: Tracker controller should identify active WorkloadSlice

### DIFF
--- a/pkg/controller/unscheduledpods/tracker.go
+++ b/pkg/controller/unscheduledpods/tracker.go
@@ -110,9 +110,9 @@ func (t *Tracker) Reconcile(ctx context.Context, req reconcile.Request) (reconci
 	log := ctrl.LoggerFrom(ctx)
 	log.V(4).Info("Reconcile UnscheduledPodsTracker")
 
-	wl := &kueue.Workload{}
-	if err := t.client.Get(ctx, req.NamespacedName, wl); err != nil {
-		return reconcile.Result{}, client.IgnoreNotFound(err)
+	wl, err := workloadslicing.FindActiveWorkload(ctx, t.client, req.NamespacedName, true)
+	if err != nil || wl == nil {
+		return reconcile.Result{}, err
 	}
 	if workloadfinish.IsFinished(wl) || (features.Enabled(features.ConcurrentAdmission) && concurrentadmission.IsVariant(wl)) {
 		return reconcile.Result{}, nil

--- a/pkg/controller/unscheduledpods/tracker_test.go
+++ b/pkg/controller/unscheduledpods/tracker_test.go
@@ -4647,6 +4647,437 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 		},
+		"elastic job: the finished origin slice redirects to the admitted slice": {
+			features: map[featuregate.Feature]bool{
+				features.WaitForPodsReadyUnscheduledTimeout: true,
+				features.ElasticJobsViaWorkloadSlices:       true,
+			},
+			request: &types.NamespacedName{
+				Namespace: testNamespace,
+				Name:      "wl-1",
+			},
+			workloads: []*kueue.Workload{
+				utiltestingapi.MakeWorkload("wl-1", testNamespace).
+					UID(testWorkloadUID).
+					PodSets(*utiltestingapi.MakePodSet(testPodSetName, 1).
+						Request(corev1.ResourceCPU, "1").
+						Obj()).
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").
+						PodSets(utiltestingapi.MakePodSetAssignment(testPodSetName).
+							Count(1).
+							Obj()).
+						Obj(), muchEarlier).
+					AdmittedAt(true, muchEarlier).
+					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					FinishedAt(earlier).
+					Obj(),
+				utiltestingapi.MakeWorkload("wl-2", testNamespace).
+					UID(testWorkloadUID).
+					PodSets(*utiltestingapi.MakePodSet(testPodSetName, 2).
+						Request(corev1.ResourceCPU, "1").
+						Obj()).
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").
+						PodSets(utiltestingapi.MakePodSetAssignment(testPodSetName).
+							Count(2).
+							Obj()).
+						Obj(), earlier).
+					AdmittedAt(true, earlier).
+					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl-1").
+					Obj(),
+			},
+			pods: []*corev1.Pod{
+				testingpod.MakePod("p1", testNamespace).
+					Annotation(kueue.WorkloadAnnotation, "wl-1").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl-1").
+					Label(constants.PodSetLabel, string(testPodSetName)).
+					NodeName("node-a").
+					StatusConditions(corev1.PodCondition{
+						Type:   corev1.PodScheduled,
+						Status: corev1.ConditionTrue,
+					}).
+					Obj(),
+				testingpod.MakePod("p2", testNamespace).
+					Annotation(kueue.WorkloadAnnotation, "wl-2").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl-1").
+					Label(constants.PodSetLabel, string(testPodSetName)).
+					NodeName("node-a").
+					StatusConditions(corev1.PodCondition{
+						Type:   corev1.PodScheduled,
+						Status: corev1.ConditionTrue,
+					}).
+					Obj(),
+			},
+			wantWorkloadStatuses: map[string]kueue.WorkloadStatus{
+				"wl-1": {
+					Admission: &kueue.Admission{
+						ClusterQueue: "cq",
+						PodSetAssignments: []kueue.PodSetAssignment{
+							{
+								Name:  testPodSetName,
+								Count: new(int32(1)),
+							},
+						},
+					},
+					Conditions: []metav1.Condition{
+						{
+							Type:               kueue.WorkloadQuotaReserved,
+							Status:             metav1.ConditionTrue,
+							Reason:             "AdmittedByTest",
+							Message:            "Admitted by ClusterQueue cq",
+							LastTransitionTime: metav1.NewTime(muchEarlier),
+						},
+						{
+							Type:               kueue.WorkloadAdmitted,
+							Status:             metav1.ConditionTrue,
+							Reason:             "ByTest",
+							Message:            "Admitted by ClusterQueue cq",
+							LastTransitionTime: metav1.NewTime(muchEarlier),
+						},
+						{
+							Type:               kueue.WorkloadFinished,
+							Status:             metav1.ConditionTrue,
+							Reason:             "ByTest",
+							Message:            "Finished by test",
+							LastTransitionTime: metav1.NewTime(earlier),
+						},
+					},
+				},
+				"wl-2": {
+					Admission: &kueue.Admission{
+						ClusterQueue: "cq",
+						PodSetAssignments: []kueue.PodSetAssignment{
+							{
+								Name:  testPodSetName,
+								Count: new(int32(2)),
+							},
+						},
+					},
+					Conditions: []metav1.Condition{
+						quotaReservedCondition,
+						admittedCondition,
+						{
+							Type:               kueue.WorkloadPodsScheduled,
+							Status:             metav1.ConditionTrue,
+							Reason:             kueue.WorkloadAllRequiredPodsScheduled,
+							Message:            allPodsScheduledMessage,
+							LastTransitionTime: metav1.NewTime(fakeClock.Now()),
+						},
+					},
+				},
+			},
+		},
+		"elastic job: the replaced slice still admitted redirects to the replacement": {
+			features: map[featuregate.Feature]bool{
+				features.WaitForPodsReadyUnscheduledTimeout: true,
+				features.ElasticJobsViaWorkloadSlices:       true,
+			},
+			request: &types.NamespacedName{
+				Namespace: testNamespace,
+				Name:      "wl-1",
+			},
+			workloads: []*kueue.Workload{
+				utiltestingapi.MakeWorkload("wl-1", testNamespace).
+					UID(testWorkloadUID).
+					PodSets(*utiltestingapi.MakePodSet(testPodSetName, 1).
+						Request(corev1.ResourceCPU, "1").
+						Obj()).
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").
+						PodSets(utiltestingapi.MakePodSetAssignment(testPodSetName).
+							Count(1).
+							Obj()).
+						Obj(), muchEarlier).
+					AdmittedAt(true, muchEarlier).
+					UID("uid-1").
+					Creation(muchEarlier).
+					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadPodsScheduled,
+						Status:             metav1.ConditionTrue,
+						Reason:             kueue.WorkloadAllRequiredPodsScheduled,
+						Message:            allPodsScheduledMessage,
+						LastTransitionTime: metav1.NewTime(muchEarlier.Add(30 * time.Second)),
+					}).
+					Obj(),
+				utiltestingapi.MakeWorkload("wl-2", testNamespace).
+					UID(testWorkloadUID).
+					PodSets(*utiltestingapi.MakePodSet(testPodSetName, 2).
+						Request(corev1.ResourceCPU, "1").
+						Obj()).
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").
+						PodSets(utiltestingapi.MakePodSetAssignment(testPodSetName).
+							Count(2).
+							Obj()).
+						Obj(), earlier).
+					AdmittedAt(true, earlier).
+					UID("uid-2").
+					Creation(earlier).
+					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl-1").
+					Obj(),
+			},
+			pods: []*corev1.Pod{
+				testingpod.MakePod("p1", testNamespace).
+					Annotation(kueue.WorkloadAnnotation, "wl-1").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl-1").
+					Label(constants.PodSetLabel, string(testPodSetName)).
+					NodeName("node-a").
+					StatusConditions(corev1.PodCondition{
+						Type:   corev1.PodScheduled,
+						Status: corev1.ConditionTrue,
+					}).
+					Obj(),
+				testingpod.MakePod("p2", testNamespace).
+					Annotation(kueue.WorkloadAnnotation, "wl-2").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl-1").
+					Label(constants.PodSetLabel, string(testPodSetName)).
+					Obj(),
+			},
+			wantWorkloadStatuses: map[string]kueue.WorkloadStatus{
+				"wl-1": {
+					Admission: &kueue.Admission{
+						ClusterQueue: "cq",
+						PodSetAssignments: []kueue.PodSetAssignment{
+							{
+								Name:  testPodSetName,
+								Count: new(int32(1)),
+							},
+						},
+					},
+					Conditions: []metav1.Condition{
+						{
+							Type:               kueue.WorkloadQuotaReserved,
+							Status:             metav1.ConditionTrue,
+							Reason:             "AdmittedByTest",
+							Message:            "Admitted by ClusterQueue cq",
+							LastTransitionTime: metav1.NewTime(muchEarlier),
+						},
+						{
+							Type:               kueue.WorkloadAdmitted,
+							Status:             metav1.ConditionTrue,
+							Reason:             "ByTest",
+							Message:            "Admitted by ClusterQueue cq",
+							LastTransitionTime: metav1.NewTime(muchEarlier),
+						},
+						{
+							Type:               kueue.WorkloadPodsScheduled,
+							Status:             metav1.ConditionTrue,
+							Reason:             kueue.WorkloadAllRequiredPodsScheduled,
+							Message:            allPodsScheduledMessage,
+							LastTransitionTime: metav1.NewTime(muchEarlier.Add(30 * time.Second)),
+						},
+					},
+				},
+				"wl-2": {
+					Admission: &kueue.Admission{
+						ClusterQueue: "cq",
+						PodSetAssignments: []kueue.PodSetAssignment{
+							{
+								Name:  testPodSetName,
+								Count: new(int32(2)),
+							},
+						},
+					},
+					Conditions: []metav1.Condition{
+						quotaReservedCondition,
+						admittedCondition,
+						{
+							Type:               kueue.WorkloadPodsScheduled,
+							Status:             metav1.ConditionFalse,
+							Reason:             kueue.WorkloadWaitForScheduling,
+							Message:            unscheduledPodsMessage,
+							LastTransitionTime: metav1.NewTime(fakeClock.Now()),
+						},
+					},
+				},
+			},
+		},
+		"elastic job: a deleted origin slice resolves to the admitted slice": {
+			features: map[featuregate.Feature]bool{
+				features.WaitForPodsReadyUnscheduledTimeout: true,
+				features.ElasticJobsViaWorkloadSlices:       true,
+			},
+			request: &types.NamespacedName{
+				Namespace: testNamespace,
+				Name:      "wl-0",
+			},
+			workloads: []*kueue.Workload{
+				utiltestingapi.MakeWorkload("wl-2", testNamespace).
+					UID(testWorkloadUID).
+					PodSets(*utiltestingapi.MakePodSet(testPodSetName, 2).
+						Request(corev1.ResourceCPU, "1").
+						Obj()).
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").
+						PodSets(utiltestingapi.MakePodSetAssignment(testPodSetName).
+							Count(2).
+							Obj()).
+						Obj(), earlier).
+					AdmittedAt(true, earlier).
+					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl-0").
+					Obj(),
+			},
+			pods: []*corev1.Pod{
+				testingpod.MakePod("p1", testNamespace).
+					Annotation(kueue.WorkloadAnnotation, "wl-0").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl-0").
+					Label(constants.PodSetLabel, string(testPodSetName)).
+					NodeName("node-a").
+					StatusConditions(corev1.PodCondition{
+						Type:   corev1.PodScheduled,
+						Status: corev1.ConditionTrue,
+					}).
+					Obj(),
+				testingpod.MakePod("p2", testNamespace).
+					Annotation(kueue.WorkloadAnnotation, "wl-2").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl-0").
+					Label(constants.PodSetLabel, string(testPodSetName)).
+					Obj(),
+			},
+			wantWorkloadStatuses: map[string]kueue.WorkloadStatus{
+				"wl-2": {
+					Admission: &kueue.Admission{
+						ClusterQueue: "cq",
+						PodSetAssignments: []kueue.PodSetAssignment{
+							{
+								Name:  testPodSetName,
+								Count: new(int32(2)),
+							},
+						},
+					},
+					Conditions: []metav1.Condition{
+						quotaReservedCondition,
+						admittedCondition,
+						{
+							Type:               kueue.WorkloadPodsScheduled,
+							Status:             metav1.ConditionFalse,
+							Reason:             kueue.WorkloadWaitForScheduling,
+							Message:            unscheduledPodsMessage,
+							LastTransitionTime: metav1.NewTime(fakeClock.Now()),
+						},
+					},
+				},
+			},
+		},
+		"elastic job: a redirect to a variant slice is skipped": {
+			features: map[featuregate.Feature]bool{
+				features.WaitForPodsReadyUnscheduledTimeout: true,
+				features.ElasticJobsViaWorkloadSlices:       true,
+				features.ConcurrentAdmission:                true,
+			},
+			request: &types.NamespacedName{
+				Namespace: testNamespace,
+				Name:      "wl-1",
+			},
+			workloads: []*kueue.Workload{
+				utiltestingapi.MakeWorkload("wl-1", testNamespace).
+					UID(testWorkloadUID).
+					PodSets(*utiltestingapi.MakePodSet(testPodSetName, 1).
+						Request(corev1.ResourceCPU, "1").
+						Obj()).
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").
+						PodSets(utiltestingapi.MakePodSetAssignment(testPodSetName).
+							Count(1).
+							Obj()).
+						Obj(), muchEarlier).
+					AdmittedAt(true, muchEarlier).
+					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					FinishedAt(earlier).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadPodsScheduled,
+						Status:             metav1.ConditionTrue,
+						Reason:             kueue.WorkloadAllRequiredPodsScheduled,
+						Message:            allPodsScheduledMessage,
+						LastTransitionTime: metav1.NewTime(muchEarlier.Add(30 * time.Second)),
+					}).
+					Obj(),
+				utiltestingapi.MakeWorkload("wl-2", testNamespace).
+					UID(testWorkloadUID).
+					PodSets(*utiltestingapi.MakePodSet(testPodSetName, 2).
+						Request(corev1.ResourceCPU, "1").
+						Obj()).
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").
+						PodSets(utiltestingapi.MakePodSetAssignment(testPodSetName).
+							Count(2).
+							Obj()).
+						Obj(), earlier).
+					AdmittedAt(true, earlier).
+					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl-1").
+					OwnerReference(kueue.SchemeGroupVersion.WithKind("Workload"), "parent", "parent-uid").
+					Obj(),
+			},
+			pods: []*corev1.Pod{
+				testingpod.MakePod("p1", testNamespace).
+					Annotation(kueue.WorkloadAnnotation, "wl-1").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl-1").
+					Label(constants.PodSetLabel, string(testPodSetName)).
+					NodeName("node-a").
+					StatusConditions(corev1.PodCondition{
+						Type:   corev1.PodScheduled,
+						Status: corev1.ConditionTrue,
+					}).
+					Obj(),
+			},
+			wantWorkloadStatuses: map[string]kueue.WorkloadStatus{
+				"wl-1": {
+					Admission: &kueue.Admission{
+						ClusterQueue: "cq",
+						PodSetAssignments: []kueue.PodSetAssignment{
+							{
+								Name:  testPodSetName,
+								Count: new(int32(1)),
+							},
+						},
+					},
+					Conditions: []metav1.Condition{
+						{
+							Type:               kueue.WorkloadQuotaReserved,
+							Status:             metav1.ConditionTrue,
+							Reason:             "AdmittedByTest",
+							Message:            "Admitted by ClusterQueue cq",
+							LastTransitionTime: metav1.NewTime(muchEarlier),
+						},
+						{
+							Type:               kueue.WorkloadAdmitted,
+							Status:             metav1.ConditionTrue,
+							Reason:             "ByTest",
+							Message:            "Admitted by ClusterQueue cq",
+							LastTransitionTime: metav1.NewTime(muchEarlier),
+						},
+						{
+							Type:               kueue.WorkloadFinished,
+							Status:             metav1.ConditionTrue,
+							Reason:             "ByTest",
+							Message:            "Finished by test",
+							LastTransitionTime: metav1.NewTime(earlier),
+						},
+						{
+							Type:               kueue.WorkloadPodsScheduled,
+							Status:             metav1.ConditionTrue,
+							Reason:             kueue.WorkloadAllRequiredPodsScheduled,
+							Message:            allPodsScheduledMessage,
+							LastTransitionTime: metav1.NewTime(muchEarlier.Add(30 * time.Second)),
+						},
+					},
+				},
+				"wl-2": {
+					Admission: &kueue.Admission{
+						ClusterQueue: "cq",
+						PodSetAssignments: []kueue.PodSetAssignment{
+							{
+								Name:  testPodSetName,
+								Count: new(int32(2)),
+							},
+						},
+					},
+					Conditions: []metav1.Condition{
+						quotaReservedCondition,
+						admittedCondition,
+					},
+				},
+			},
+		},
 	}
 
 	for name, tc := range testCases {

--- a/pkg/workloadslicing/workloadslicing_test.go
+++ b/pkg/workloadslicing/workloadslicing_test.go
@@ -537,8 +537,9 @@ func TestFindLatestAdmittedWorkload(t *testing.T) {
 		"newer admitted variant does not hide the replacement slice": {
 			excludeVariants: true,
 			featureGates: map[featuregate.Feature]bool{
-				features.ElasticJobsViaWorkloadSlices: true,
-				features.ConcurrentAdmission:          true,
+				features.ElasticJobsViaWorkloadSlices:       true,
+				features.WaitForPodsReadyUnscheduledTimeout: true,
+				features.ConcurrentAdmission:                true,
 			},
 			workload: origin.Obj(),
 			workloads: []*kueue.Workload{
@@ -550,21 +551,32 @@ func TestFindLatestAdmittedWorkload(t *testing.T) {
 			},
 			wantName: "replacement",
 		},
-		"ungater lookup preserves variant selection": {
+		"scheduling feature gate disabled preserves variant selection": {
 			featureGates: map[featuregate.Feature]bool{
-				features.ElasticJobsViaWorkloadSlices: true,
-				features.ConcurrentAdmission:          true,
+				features.ElasticJobsViaWorkloadSlices:       true,
+				features.WaitForPodsReadyUnscheduledTimeout: false,
+				features.ConcurrentAdmission:                true,
 			},
 			workload:  origin.Obj(),
 			workloads: []*kueue.Workload{origin.Obj(), replacement.Obj(), variant.Obj()},
 			wantName:  "variant",
 		},
-
+		"ungater lookup preserves variant selection with the scheduling gate enabled": {
+			featureGates: map[featuregate.Feature]bool{
+				features.ElasticJobsViaWorkloadSlices:       true,
+				features.WaitForPodsReadyUnscheduledTimeout: true,
+				features.ConcurrentAdmission:                true,
+			},
+			workload:  origin.Obj(),
+			workloads: []*kueue.Workload{origin.Obj(), replacement.Obj(), variant.Obj()},
+			wantName:  "variant",
+		},
 		"concurrent admission disabled preserves variant selection": {
 			excludeVariants: true,
 			featureGates: map[featuregate.Feature]bool{
-				features.ElasticJobsViaWorkloadSlices: true,
-				features.ConcurrentAdmission:          false,
+				features.ElasticJobsViaWorkloadSlices:       true,
+				features.WaitForPodsReadyUnscheduledTimeout: true,
+				features.ConcurrentAdmission:                false,
 			},
 			workload:  origin.Obj(),
 			workloads: []*kueue.Workload{origin.Obj(), replacement.Obj(), variant.Obj()},

--- a/test/integration/singlecluster/controller/jobs/raycluster/raycluster_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/raycluster/raycluster_controller_test.go
@@ -50,6 +50,7 @@ import (
 	testingraycluster "sigs.k8s.io/kueue/pkg/util/testingjobs/raycluster"
 	testingrayjob "sigs.k8s.io/kueue/pkg/util/testingjobs/rayjob"
 	"sigs.k8s.io/kueue/pkg/workload"
+	"sigs.k8s.io/kueue/pkg/workload/concurrentadmission"
 	workloadfinish "sigs.k8s.io/kueue/pkg/workload/finish"
 	"sigs.k8s.io/kueue/pkg/workloadslicing"
 	"sigs.k8s.io/kueue/test/integration/framework"
@@ -1072,5 +1073,154 @@ var _ = ginkgo.Describe("RayCluster with elastic jobs via workload-slices suppor
 			g.Expect(got.Spec.SchedulingGates).ShouldNot(gomega.ContainElement(
 				corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}))
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+	})
+
+	ginkgo.It("Should track chain pods across origin slice deletion with Concurrent Admission", framework.SlowSpec, func() {
+		fwk.StopManager(ctx)
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.WaitForPodsReadyUnscheduledTimeout, true)
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ConcurrentAdmission, true)
+		waitForPodsReady := &configapi.WaitForPodsReady{
+			Timeout:            metav1.Duration{Duration: 5 * time.Minute},
+			UnscheduledTimeout: &metav1.Duration{Duration: time.Minute},
+			BlockAdmission:     new(false),
+		}
+		fwk.StartManager(ctx, cfg, managerAndSchedulerSetupWithConfig(
+			&configapi.Configuration{WaitForPodsReady: waitForPodsReady},
+			jobframework.WithWaitForPodsReady(waitForPodsReady),
+		))
+		ginkgo.DeferCleanup(fwk.StopManager, ctx)
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), clusterQueue)).To(gomega.Succeed())
+			clusterQueue.Spec.ConcurrentAdmissionPolicy = utiltestingapi.MakeClusterQueue(clusterQueue.Name).
+				ConcurrentAdmissionPolicy(kueue.ConcurrentAdmissionTryPreferredFlavors).
+				Obj().Spec.ConcurrentAdmissionPolicy
+			g.Expect(k8sClient.Update(ctx, clusterQueue)).To(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		testRayCluster := testingraycluster.MakeCluster("foo", ns.Name).
+			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			Queue(localQueue.Name).
+			Request(rayv1.HeadNode, corev1.ResourceCPU, "1").
+			RequestWorkerGroup(corev1.ResourceCPU, "1").
+			WithEnableAutoscaling(new(true)).
+			ScaleFirstWorkerGroup(1).
+			Obj()
+
+		ginkgo.By("creating and admitting the raycluster's origin workload slice")
+		util.MustCreate(ctx, k8sClient, testRayCluster)
+		var originSlice *kueue.Workload
+		gomega.Eventually(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+			originSlice = nil
+			for i := range workloads.Items {
+				if !concurrentadmission.IsVariant(&workloads.Items[i]) {
+					originSlice = &workloads.Items[i]
+				}
+			}
+			g.Expect(originSlice).ShouldNot(gomega.BeNil())
+			g.Expect(workload.IsAdmitted(originSlice)).Should(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		originSliceName := originSlice.Name
+
+		ginkgo.By("scaling up the worker replicas to create a second (active) slice")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testRayCluster), testRayCluster)).Should(gomega.Succeed())
+			testRayCluster.Spec.WorkerGroupSpecs[0].Replicas = new(int32(2))
+			g.Expect(k8sClient.Update(ctx, testRayCluster)).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		var activeSlice *kueue.Workload
+		gomega.Eventually(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+			activeSlice = nil
+			for i := range workloads.Items {
+				if !concurrentadmission.IsVariant(&workloads.Items[i]) && !workloadfinish.IsFinished(&workloads.Items[i]) {
+					activeSlice = &workloads.Items[i]
+				}
+			}
+			g.Expect(activeSlice).ShouldNot(gomega.BeNil())
+			g.Expect(activeSlice.Name).ShouldNot(gomega.Equal(originSliceName))
+			g.Expect(workload.IsAdmitted(activeSlice)).Should(gomega.BeTrue())
+			g.Expect(workloads.Items).To(gomega.ContainElement(gomega.Satisfy(func(wl kueue.Workload) bool {
+				return concurrentadmission.IsVariant(&wl) && workload.IsAdmitted(&wl) && !workloadfinish.IsFinished(&wl)
+			})))
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(originSlice), originSlice)).To(gomega.Succeed())
+			g.Expect(workloadfinish.IsFinished(originSlice)).To(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("tracking incomplete scheduling from a pod linked to the finished origin")
+		scheduledWorker := testingpod.MakePod("worker-1", ns.Name).
+			Annotation(kueue.WorkloadAnnotation, originSliceName).
+			Annotation(kueue.WorkloadSliceNameAnnotation, originSliceName).
+			Label(constants.PodSetLabel, string(activeSlice.Spec.PodSets[1].Name)).
+			Obj()
+		util.MustCreate(ctx, k8sClient, scheduledWorker)
+		util.BindPodWithNode(ctx, k8sClient, "node-a", scheduledWorker)
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(activeSlice), activeSlice)).To(gomega.Succeed())
+			g.Expect(activeSlice.Status.Conditions).To(utiltesting.HaveConditionStatusAndReason(
+				kueue.WorkloadPodsScheduled, metav1.ConditionFalse, kueue.WorkloadWaitForScheduling))
+			g.Expect(activeSlice.Status.Conditions).To(utiltesting.HaveConditionStatusAndReason(
+				kueue.WorkloadPodsReady, metav1.ConditionFalse, kueue.WorkloadWaitForScheduling))
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(originSlice), originSlice)).To(gomega.Succeed())
+			g.Expect(apimeta.FindStatusCondition(originSlice.Status.Conditions, kueue.WorkloadPodsScheduled)).To(gomega.BeNil())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("deleting the origin slice to emulate a RayService rollout GC of the old RayCluster's workloads")
+		util.DeleteWorkloadSliceAndAwaitDeletion(ctx, k8sClient, types.NamespacedName{Namespace: ns.Name, Name: originSliceName})
+
+		ginkgo.By("creating a still-gated pod that points at the now-deleted origin slice, owned by the RayCluster")
+		gatedPod := testingpod.MakePod("worker-0", ns.Name).
+			Annotation(kueue.WorkloadAnnotation, originSliceName).
+			Annotation(kueue.WorkloadSliceNameAnnotation, originSliceName).
+			Label(constants.PodSetLabel, string(activeSlice.Spec.PodSets[1].Name)).
+			Gate(kueue.ElasticJobSchedulingGate).
+			Obj()
+		gatedPod.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion:         rayv1.SchemeGroupVersion.String(),
+			Kind:               "RayCluster",
+			Name:               testRayCluster.Name,
+			UID:                testRayCluster.UID,
+			Controller:         new(true),
+			BlockOwnerDeletion: new(true),
+		}}
+		util.MustCreate(ctx, k8sClient, gatedPod)
+
+		ginkgo.By("the ungater removes the elastic scheduling gate despite the origin slice being gone")
+		gomega.Eventually(func(g gomega.Gomega) {
+			var got corev1.Pod
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(gatedPod), &got)).To(gomega.Succeed())
+			g.Expect(got.Spec.SchedulingGates).ShouldNot(gomega.ContainElement(
+				corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("observing all required pods scheduled through events linked to the deleted origin")
+		headPod := testingpod.MakePod("head", ns.Name).
+			Annotation(kueue.WorkloadAnnotation, originSliceName).
+			Annotation(kueue.WorkloadSliceNameAnnotation, originSliceName).
+			Label(constants.PodSetLabel, string(activeSlice.Spec.PodSets[0].Name)).
+			Obj()
+		util.MustCreate(ctx, k8sClient, headPod)
+		util.BindPodWithNode(ctx, k8sClient, "node-a", headPod, gatedPod)
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(activeSlice), activeSlice)).To(gomega.Succeed())
+			g.Expect(activeSlice.Status.Conditions).To(utiltesting.HaveConditionStatusAndReason(
+				kueue.WorkloadPodsScheduled, metav1.ConditionTrue, kueue.WorkloadAllRequiredPodsScheduled))
+			g.Expect(activeSlice.Status.Conditions).To(utiltesting.HaveConditionStatusAndReason(
+				kueue.WorkloadPodsReady, metav1.ConditionFalse, kueue.WorkloadWaitForStart))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("keeping scheduling observations off Concurrent Admission variants")
+		gomega.Consistently(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(ns.Name))).To(gomega.Succeed())
+			for _, wl := range workloads.Items {
+				if concurrentadmission.IsVariant(&wl) {
+					g.Expect(apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadPodsScheduled)).To(gomega.BeNil(), "variant %s", wl.Name)
+				}
+			}
+		}, util.LongConsistentDuration, util.Interval).Should(gomega.Succeed())
 	})
 })

--- a/test/integration/singlecluster/controller/jobs/raycluster/suite_test.go
+++ b/test/integration/singlecluster/controller/jobs/raycluster/suite_test.go
@@ -30,6 +30,7 @@ import (
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	"sigs.k8s.io/kueue/pkg/constants"
+	"sigs.k8s.io/kueue/pkg/controller/concurrentadmission"
 	"sigs.k8s.io/kueue/pkg/controller/core"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/controller/elasticjobs"
@@ -37,9 +38,11 @@ import (
 	jobcontrollers "sigs.k8s.io/kueue/pkg/controller/jobs"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/raycluster"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/rayjob"
+	"sigs.k8s.io/kueue/pkg/controller/unscheduledpods"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/scheduler"
 	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
+	"sigs.k8s.io/kueue/pkg/util/waitforpodsready"
 	"sigs.k8s.io/kueue/pkg/webhooks"
 	"sigs.k8s.io/kueue/test/integration/framework"
 	"sigs.k8s.io/kueue/test/util"
@@ -97,8 +100,17 @@ func managerSetup(opts ...jobframework.Option) framework.ManagerSetup {
 }
 
 func managerAndSchedulerSetup(opts ...jobframework.Option) framework.ManagerSetup {
+	return managerAndSchedulerSetupWithConfig(&config.Configuration{}, opts...)
+}
+
+func managerAndSchedulerSetupWithConfig(configuration *config.Configuration, opts ...jobframework.Option) framework.ManagerSetup {
 	return func(ctx context.Context, mgr manager.Manager) {
-		err := indexer.Setup(ctx, mgr.GetFieldIndexer())
+		mgr.GetScheme().Default(configuration)
+		var indexerOptions []indexer.Option
+		if waitforpodsready.PodsScheduledTrackingEnabled(configuration.WaitForPodsReady) {
+			indexerOptions = append(indexerOptions, indexer.WithPodWorkloadSliceNameIndex())
+		}
+		err := indexer.Setup(ctx, mgr.GetFieldIndexer(), indexerOptions...)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		cCache := schdcache.New(mgr.GetClient())
@@ -111,10 +123,15 @@ func managerAndSchedulerSetup(opts ...jobframework.Option) framework.ManagerSetu
 			mgr,
 			queues,
 			cCache,
-			&config.Configuration{},
+			configuration,
 			core.SetupControllersOpts{PreemptionExpectations: preemptionExpectations},
 		)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
+
+		if features.Enabled(features.ConcurrentAdmission) {
+			failedCtrl, err := concurrentadmission.SetupControllers(mgr, queues, configuration, nil)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
+		}
 
 		failedWebhook, err := webhooks.Setup(mgr, nil)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
@@ -130,6 +147,11 @@ func managerAndSchedulerSetup(opts ...jobframework.Option) framework.ManagerSetu
 
 		if features.Enabled(features.ElasticJobsViaWorkloadSlices) {
 			failedCtrl, err := elasticjobs.SetupWithManager(mgr, &config.Configuration{}, nil, nil)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
+		}
+
+		if waitforpodsready.PodsScheduledTrackingEnabled(configuration.WaitForPodsReady) {
+			failedCtrl, err := unscheduledpods.NewTracker(mgr.GetClient(), nil, configuration.WaitForPodsReady).SetupWithManager(mgr, configuration)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
 		}
 


### PR DESCRIPTION
<!-- Thank you for contributing! Check CONTRIBUTING.md for details. -->

#### What type of PR is this?

/kind feature


<!-- Consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->


#### What this PR does / why we need it?

I implemented a tracking mechanism for the WorkloadSlices (ElasticJobsViaWorkloadSlices).
Since this PR, the tracker controller appropriately tracks only active WorkloadSlices.

Also, I implemented integration tests for UnscheduledTimeout and KubeRay to verify this Workload Slicing behavior.

<!--
Use `Fixes #123` for an issue addressed by this PR; it will be closed when the PR merges.
Use `Related:` or `Part of:` to reference an issue without closing it.
-->
part-of https://github.com/kubernetes-sigs/kueue/issues/13502

#### Useful notes for your reviewer


#### Release note

<!-- Describe the behavior change accurately from the user's perspective. Hints:
- Do not leave this block blank.
- Use "NONE" when there is no user-facing change.
- When feasible use a prefix for the sub-component or feature, e.g. "FairSharing:" or "MultiKueue:".
- If upgrade steps are required, include an "ACTION REQUIRED:" section.
You may consider AI assistance using the skill: cmd/experimental/skills/kueue-release-notes/SKILL.md.
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## AI summary

- Track pods against only active WorkloadSlices.
- Add unit and integration tests for slice replacement, deletion, unscheduled timeouts, and ConcurrentAdmission.
- Extend RayCluster test setup for the related feature gates and tracker.

### Suggested release note

**Detailed:** ElasticJobsViaWorkloadSlices: Fixed a bug where pod tracking could follow a completed or deleted WorkloadSlice instead of the active slice. Kueue now tracks pods against the active WorkloadSlice.

**Concise:** ElasticJobsViaWorkloadSlices: Fixed pod tracking after WorkloadSlice replacement or deletion.

**Balanced:** ElasticJobsViaWorkloadSlices: Fixed pod tracking when an origin WorkloadSlice is replaced or deleted. Kueue now follows the active WorkloadSlice.

**Rationale:** This is a bug fix scoped to ElasticJobsViaWorkloadSlices. The note describes the user-visible tracking behavior and does not require user action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->