### PR TITLE
Simplify FindMatchingWorkloads test comparison options

### DIFF
--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"slices"
 	"testing"
 	"time"
 
@@ -1267,14 +1266,11 @@ func TestFindMatchingWorkloads(t *testing.T) {
 				t.Errorf("match = %q, want %q", gotMatch, tc.wantMatch)
 			}
 
-			gotToDelete := make([]string, 0, len(toDelete))
+			var gotToDelete []string
 			for _, wl := range toDelete {
 				gotToDelete = append(gotToDelete, wl.Name)
 			}
-			slices.Sort(gotToDelete)
-			wantToDelete := slices.Clone(tc.wantToDelete)
-			slices.Sort(wantToDelete)
-			if diff := cmp.Diff(wantToDelete, gotToDelete, cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(tc.wantToDelete, gotToDelete, cmpopts.SortSlices(func(a, b string) bool { return a < b })); diff != "" {
 				t.Errorf("toDelete mismatch (-want +got):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

/area testing

#### What this PR does / why we need it?

Simplifies the comparison in `TestFindMatchingWorkloads` following the cleanup requested on the FindMatchingWorkloads change. It drops the pre-comparison `slices.Sort` calls and the `cmpopts.EquateEmpty` option, and expresses slice-order independence with a single `cmpopts.SortSlices` at the `cmp.Diff` call site instead of normalizing the values before the comparison.

Fixes #15528

#### Useful notes for your reviewer

No functional change; test-only.

#### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## AI summary

- Simplified `TestFindMatchingWorkloads` comparison logic.
- Replaced pre-comparison sorting with `cmpopts.SortSlices`.
- Removed `cmpopts.EquateEmpty()`, preserving nil-versus-empty distinctions.
- Test-only change with no user-facing impact.

### Suggested release note

NONE

<!-- end of auto-generated comment: release notes by coderabbit.ai -->